### PR TITLE
WIP: Add example consensus mode

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,6 +13,7 @@ packages: ./typed-protocols
           ./ouroboros-consensus-byronspec
           ./ouroboros-consensus-cardano
           ./ouroboros-consensus-cardano-test
+          ./ouroboros-consensus-example
           ./ouroboros-consensus-mock
           ./ouroboros-consensus-mock-test
           ./ouroboros-consensus-shelley
@@ -74,6 +75,9 @@ package ouroboros-consensus-byron
 
 package ouroboros-consensus-byron-test
   tests: True
+
+package ouroboros-consensus-example
+  flags: +asserts
 
 package ouroboros-consensus-shelley
   flags: +asserts
@@ -173,8 +177,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 653dadcc70cd6456784f597866dd44a952cfbfb9
-  --sha256: 03dc6qf9w5xi8psz6sd14w7y1fa6dxf356c0nfp1q8qlg8ndix1r
+  tag: 071e0e52ba04fde04cdbf59a901ed756c43b6488
+  --sha256: 1c006rv7q4z042nx501y87n5ib016rdw0m5nfl30wbf6ygy311gd
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -182,6 +186,7 @@ source-repository-package
     byron/ledger/executable-spec
     byron/ledger/impl
     byron/ledger/impl/test
+    example-shelley/impl
     semantics/executable-spec
     semantics/small-steps-test
     shelley/chain-and-ledger/dependencies/non-integer

--- a/ouroboros-consensus-example/LICENSE
+++ b/ouroboros-consensus-example/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/ouroboros-consensus-example/NOTICE
+++ b/ouroboros-consensus-example/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/ouroboros-consensus-example/README.md
+++ b/ouroboros-consensus-example/README.md
@@ -1,0 +1,8 @@
+# ouroboros-consensus-cardano
+
+This package contains:
+
+* `src` : Support for Hard Fork between Cardano eras.
+
+* `tools/db-analyser`: tool to analyse or validate a database containing blocks
+  of some Cardano era.

--- a/ouroboros-consensus-example/Setup.hs
+++ b/ouroboros-consensus-example/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/ouroboros-consensus-example/ouroboros-consensus-example.cabal
+++ b/ouroboros-consensus-example/ouroboros-consensus-example.cabal
@@ -1,0 +1,70 @@
+name:                  ouroboros-consensus-example
+version:               0.1.0.0
+synopsis:              An instantation of the Ouroboros consensus layer intended as a template for prototype consensus protocols based on Shelley
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2020 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+  exposed-modules:
+                       Ouroboros.Consensus.Example
+                       Ouroboros.Consensus.Example.Block
+                       Ouroboros.Consensus.Example.Eras
+                       Ouroboros.Consensus.Example.Condense
+                       Ouroboros.Consensus.Example.CanHardFork
+                       Ouroboros.Consensus.Example.Node
+                       Ouroboros.Consensus.Example.ShelleyBased
+
+  build-depends:       base              >=4.9   && <4.15
+                     , bytestring        >=0.10  && <0.11
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , mtl               >=2.2   && <2.3
+                     , nothunks
+                     , serialise         >=0.2   && <0.3
+                     , text              >=1.2   && <1.3
+                     , these             >=1.1   && <1.2
+
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger-byron
+                     , cardano-prelude
+                     , cardano-slotting
+                     , shelley-spec-ledger
+                     , cardano-ledger-shelley-ma
+                     , cardano-ledger-example-shelley
+                     , ouroboros-network
+                     , ouroboros-consensus
+                     , ouroboros-consensus-shelley
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Werror
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus-example/src/Ouroboros/Consensus/Example.hs
+++ b/ouroboros-consensus-example/src/Ouroboros/Consensus/Example.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Ouroboros.Consensus.Example (
+    -- * The block type of the Example block chain
+    ExampleBlock
+  , ProtocolExample
+  ) where
+
+import           Ouroboros.Consensus.HardFork.Combinator
+
+import           Ouroboros.Consensus.Shelley.Ledger
+
+import           Ouroboros.Consensus.Example.Block
+
+type ProtocolExample = HardForkProtocol '[ ShelleyBlock StandardShelley
+                                         , ShelleyBlock StandardExample
+                                         ]

--- a/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Block.hs
+++ b/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Block.hs
@@ -1,0 +1,565 @@
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DeriveGeneric            #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE PatternSynonyms          #-}
+{-# LANGUAGE ViewPatterns             #-}
+module Ouroboros.Consensus.Example.Block (
+    -- * Eras
+    -- XXX
+    ExampleEras
+  , module Ouroboros.Consensus.Example.Eras
+  , ShelleyBasedExampleEras
+    -- * Block
+  , ExampleBlock
+    -- Note: by exporting the pattern synonyms as part of the matching data
+    -- type (instead of as separate patterns), we get better exhaustiveness
+    -- checks from GHC. But GHC expects a data type, not a type family, that's
+    -- why we sometimes mention the data type of the instance in these exports
+    -- instead of the abstract type family.
+  , HardForkBlock (BlockShelley, BlockExample)
+    -- * Headers
+  , ExampleHeader
+  , Header (HeaderShelley, HeaderExample)
+    -- * Generalised transactions
+  , ExampleApplyTxErr
+  , ExampleGenTx
+  , ExampleGenTxId
+  , GenTx (GenTxShelley, GenTxExample)
+  , HardForkApplyTxErr (ApplyTxErrShelley, ApplyTxErrExample, ApplyTxErrWrongEra)
+  , TxId (GenTxIdShelley, GenTxIdExample)
+    -- * LedgerError
+  , ExampleLedgerError
+  , HardForkLedgerError (LedgerErrorShelley, LedgerErrorExample, LedgerErrorWrongEra)
+    -- * OtherEnvelopeError
+  , ExampleOtherHeaderEnvelopeError
+  , HardForkEnvelopeErr (OtherHeaderEnvelopeErrorShelley, OtherHeaderEnvelopeErrorExample, OtherHeaderEnvelopeErrorWrongEra)
+    -- * TipInfo
+  , ExampleTipInfo
+  , OneEraTipInfo (TipInfoShelley, TipInfoExample)
+    -- * Query
+  , Either (QueryResultSuccess, QueryResultEraMismatch)
+  , ExampleQuery
+  , ExampleQueryResult
+  , Query (QueryIfCurrentShelley, QueryIfCurrentExample, QueryAnytimeShelley, QueryAnytimeExample, QueryHardFork)
+    -- * CodecConfig
+  , CodecConfig (ExampleCodecConfig)
+  , ExampleCodecConfig
+    -- * BlockConfig
+  , BlockConfig (ExampleBlockConfig)
+  , ExampleBlockConfig
+    -- * StorageConfig
+  , ExampleStorageConfig
+  , StorageConfig (ExampleStorageConfig)
+    -- * ConsensusConfig
+  , ConsensusConfig (ExampleConsensusConfig)
+  , ExampleConsensusConfig
+    -- * LedgerConfig
+  , ExampleLedgerConfig
+  , HardForkLedgerConfig (ExampleLedgerConfig)
+    -- * LedgerState
+  , ExampleLedgerState
+  , LedgerState (LedgerStateShelley, LedgerStateExample)
+    -- * ChainDepState
+  , ExampleChainDepState
+  , HardForkState (ChainDepStateShelley, ChainDepStateExample)
+    -- * EraMismatch
+  , EraMismatch (..)
+  ) where
+
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Block (BlockProtocol)
+import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError,
+                     TipInfo)
+import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr,
+                     GenTxId)
+import           Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
+import           Ouroboros.Consensus.TypeFamilyWrappers
+
+import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+
+import           Ouroboros.Consensus.Example.Eras
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+
+{-------------------------------------------------------------------------------
+  The eras of the Example block chain
+-------------------------------------------------------------------------------}
+
+-- | The eras in the Example blockchain.
+--
+-- We parameterise over the crypto: @c@.
+type ExampleEras c =
+  '[ ShelleyBlock (ShelleyEra c)
+   , ShelleyBlock (ExampleEra c)
+   ]
+
+type ShelleyBasedExampleEras c =
+  '[ ShelleyEra c
+   , ExampleEra c
+   ]
+
+{-------------------------------------------------------------------------------
+  The block type of the Example block chain
+-------------------------------------------------------------------------------}
+
+-- | /The/ Example block.
+--
+-- Thanks to the pattern synonyms, you can treat this as a sum type with
+-- constructors 'BlockShelley' and 'BlockExample'.
+--
+-- > f :: ExampleBlock c -> _
+-- > f (BlockShelley s) = _
+-- > f (BlockExample a) = _
+--
+type ExampleBlock c = HardForkBlock (ExampleEras c)
+
+pattern BlockShelley :: ShelleyBlock (ShelleyEra c) -> ExampleBlock c
+pattern BlockShelley b = HardForkBlock (OneEraBlock (Z (I b)))
+
+pattern BlockExample :: ShelleyBlock (ExampleEra c) -> ExampleBlock c
+pattern BlockExample b = HardForkBlock (OneEraBlock (S (Z (I b))))
+
+{-# COMPLETE BlockShelley, BlockExample #-}
+
+{-------------------------------------------------------------------------------
+  Headers
+-------------------------------------------------------------------------------}
+
+-- | The Example header.
+type ExampleHeader c = Header (ExampleBlock c)
+
+pattern HeaderShelley ::
+     Header (ShelleyBlock (ShelleyEra c))
+  -> ExampleHeader c
+pattern HeaderShelley h = HardForkHeader (OneEraHeader (Z h))
+
+pattern HeaderExample ::
+     Header (ShelleyBlock (ExampleEra c))
+  -> ExampleHeader c
+pattern HeaderExample h = HardForkHeader (OneEraHeader (S (Z h)))
+
+{-# COMPLETE HeaderShelley, HeaderExample #-}
+
+{-------------------------------------------------------------------------------
+  Generalised transactions
+-------------------------------------------------------------------------------}
+
+-- | The Example transaction.
+type ExampleGenTx c = GenTx (ExampleBlock c)
+
+pattern GenTxShelley :: GenTx (ShelleyBlock (ShelleyEra c)) -> ExampleGenTx c
+pattern GenTxShelley tx = HardForkGenTx (OneEraGenTx (Z tx))
+
+pattern GenTxExample :: GenTx (ShelleyBlock (ExampleEra c)) -> ExampleGenTx c
+pattern GenTxExample tx = HardForkGenTx (OneEraGenTx (S (Z tx)))
+
+{-# COMPLETE GenTxShelley, GenTxExample #-}
+
+-- | The ID of an Example transaction.
+type ExampleGenTxId c = GenTxId (ExampleBlock c)
+
+pattern GenTxIdShelley ::
+     GenTxId (ShelleyBlock (ShelleyEra c))
+  -> ExampleGenTxId c
+pattern GenTxIdShelley txid =
+    HardForkGenTxId (OneEraGenTxId (Z (WrapGenTxId txid)))
+
+pattern GenTxIdExample ::
+     GenTxId (ShelleyBlock (ExampleEra c))
+  -> ExampleGenTxId c
+pattern GenTxIdExample txid =
+    HardForkGenTxId (OneEraGenTxId (S (Z (WrapGenTxId txid))))
+
+{-# COMPLETE GenTxIdShelley, GenTxIdExample #-}
+
+-- | An error resulting from applying a 'ExampleGenTx' to the ledger.
+--
+-- Thanks to the pattern synonyms, you can treat this as a sum type with
+-- constructors 'ApplyTxErrShelley', 'ApplyTxErrExample', and
+-- 'ApplyTxErrWrongEra'.
+--
+-- > toText :: ExampleApplyTxErr c -> Text
+-- > toText (ApplyTxErrShelley s) = shelleyApplyTxErrToText s
+-- > tlText (ApplyTxErrExample a) = exampleApplyTxErrToText a
+-- > toText (ApplyTxErrWrongEra eraMismatch) =
+-- >   "Transaction from the " <> otherEraName eraMismatch <>
+-- >   " era applied to a ledger from the " <>
+-- >   ledgerEraName eraMismatch <> " era"
+--
+type ExampleApplyTxErr c = HardForkApplyTxErr (ExampleEras c)
+
+pattern ApplyTxErrShelley ::
+     ApplyTxErr (ShelleyBlock (ShelleyEra c))
+  -> ExampleApplyTxErr c
+pattern ApplyTxErrShelley err =
+    HardForkApplyTxErrFromEra (OneEraApplyTxErr (Z (WrapApplyTxErr err)))
+
+pattern ApplyTxErrExample ::
+     ApplyTxErr (ShelleyBlock (ExampleEra c))
+  -> ExampleApplyTxErr c
+pattern ApplyTxErrExample err =
+    HardForkApplyTxErrFromEra (OneEraApplyTxErr (S (Z (WrapApplyTxErr err))))
+
+pattern ApplyTxErrWrongEra :: EraMismatch -> ExampleApplyTxErr c
+pattern ApplyTxErrWrongEra eraMismatch <-
+    HardForkApplyTxErrWrongEra (mkEraMismatch -> eraMismatch)
+
+{-# COMPLETE ApplyTxErrShelley
+           , ApplyTxErrExample
+           , ApplyTxErrWrongEra #-}
+
+{-------------------------------------------------------------------------------
+  LedgerError
+-------------------------------------------------------------------------------}
+
+-- | An error resulting from applying a 'ExampleBlock' to the ledger.
+--
+-- Thanks to the pattern synonyms, you can treat this as a sum type with
+-- constructors 'LedgerErrorShelley', 'LedgerErrorExample', and
+-- 'LedgerErrorWrongEra'.
+--
+-- > toText :: ExampleLedgerError c -> Text
+-- > toText (LedgerErrorShelley s) = shelleyLedgerErrorToText s
+-- > toText (LedgerErrorExample a) = allegraLedgerErrorToText a
+-- > toText (LedgerErrorWrongEra eraMismatch) =
+-- >   "Block from the " <> otherEraName eraMismatch <>
+-- >   " era applied to a ledger from the " <>
+-- >   ledgerEraName eraMismatch <> " era"
+--
+type ExampleLedgerError c = HardForkLedgerError (ExampleEras c)
+
+pattern LedgerErrorShelley ::
+     LedgerError (ShelleyBlock (ShelleyEra c))
+  -> ExampleLedgerError c
+pattern LedgerErrorShelley err =
+    HardForkLedgerErrorFromEra
+      (OneEraLedgerError (Z (WrapLedgerErr err)))
+
+pattern LedgerErrorExample ::
+     LedgerError (ShelleyBlock (ExampleEra c))
+  -> ExampleLedgerError c
+pattern LedgerErrorExample err =
+    HardForkLedgerErrorFromEra
+      (OneEraLedgerError (S (Z (WrapLedgerErr err))))
+
+pattern LedgerErrorWrongEra :: EraMismatch -> ExampleLedgerError c
+pattern LedgerErrorWrongEra eraMismatch <-
+    HardForkLedgerErrorWrongEra (mkEraMismatch -> eraMismatch)
+
+{-# COMPLETE LedgerErrorShelley
+           , LedgerErrorExample
+           , LedgerErrorWrongEra #-}
+
+{-------------------------------------------------------------------------------
+  OtherEnvelopeError
+-------------------------------------------------------------------------------}
+
+-- | An error resulting from validating a 'ExampleHeader'.
+type ExampleOtherHeaderEnvelopeError c = HardForkEnvelopeErr (ExampleEras c)
+
+pattern OtherHeaderEnvelopeErrorShelley
+  :: OtherHeaderEnvelopeError (ShelleyBlock (ShelleyEra c))
+  -> ExampleOtherHeaderEnvelopeError c
+pattern OtherHeaderEnvelopeErrorShelley err =
+    HardForkEnvelopeErrFromEra (OneEraEnvelopeErr (Z (WrapEnvelopeErr err)))
+
+pattern OtherHeaderEnvelopeErrorExample
+  :: OtherHeaderEnvelopeError (ShelleyBlock (ExampleEra c))
+  -> ExampleOtherHeaderEnvelopeError c
+pattern OtherHeaderEnvelopeErrorExample err =
+    HardForkEnvelopeErrFromEra (OneEraEnvelopeErr (S (Z (WrapEnvelopeErr err))))
+
+pattern OtherHeaderEnvelopeErrorWrongEra
+  :: EraMismatch
+  -> ExampleOtherHeaderEnvelopeError c
+pattern OtherHeaderEnvelopeErrorWrongEra eraMismatch <-
+    HardForkEnvelopeErrWrongEra (mkEraMismatch -> eraMismatch)
+
+{-# COMPLETE OtherHeaderEnvelopeErrorShelley
+           , OtherHeaderEnvelopeErrorExample
+           , OtherHeaderEnvelopeErrorWrongEra #-}
+
+{-------------------------------------------------------------------------------
+  TipInfo
+-------------------------------------------------------------------------------}
+
+-- | The 'TipInfo' of the Example chain.
+type ExampleTipInfo c = OneEraTipInfo (ExampleEras c)
+
+pattern TipInfoShelley ::
+     TipInfo (ShelleyBlock (ShelleyEra c))
+  -> ExampleTipInfo c
+pattern TipInfoShelley ti = OneEraTipInfo (Z (WrapTipInfo ti))
+
+pattern TipInfoExample ::
+     TipInfo (ShelleyBlock (ExampleEra c))
+  -> ExampleTipInfo c
+pattern TipInfoExample ti = OneEraTipInfo (S (Z (WrapTipInfo ti)))
+
+{-# COMPLETE TipInfoShelley, TipInfoExample #-}
+
+{-------------------------------------------------------------------------------
+  Query
+-------------------------------------------------------------------------------}
+
+-- | The 'Query' of Example chain.
+type ExampleQuery c = Query (ExampleBlock c)
+
+-- | Shelley-specific query that can only be answered when the ledger is in the
+-- Shelley era.
+pattern QueryIfCurrentShelley
+  :: ()
+  => ExampleQueryResult c result ~ a
+  => Query (ShelleyBlock (ShelleyEra c)) result
+  -> ExampleQuery c a
+pattern QueryIfCurrentShelley q = QueryIfCurrent (QZ q)
+
+-- | Example-specific query that can only be answered when the ledger is in the
+-- Example era.
+pattern QueryIfCurrentExample
+  :: ()
+  => ExampleQueryResult c result ~ a
+  => Query (ShelleyBlock (ExampleEra c)) result
+  -> ExampleQuery c a
+pattern QueryIfCurrentExample q = QueryIfCurrent (QS (QZ q))
+
+-- | Query about the Shelley era that can be answered anytime, i.e.,
+-- independent from where the tip of the ledger is.
+--
+-- For example, to ask for the start of the Shelley era (whether the tip of the
+-- ledger is in the Shelley, Example, ... era), use:
+--
+-- > QueryAnytimeShelley EraStart
+--
+pattern QueryAnytimeShelley
+  :: QueryAnytime result
+  -> ExampleQuery c result
+pattern QueryAnytimeShelley q = QueryAnytime q (EraIndex (Z (K ())))
+
+-- | Query about the Shelley era that can be answered anytime, i.e.,
+-- independent from where the tip of the ledger is.
+--
+-- For example, to ask for the start of the Shelley era (whether the tip of the
+-- ledger is in the Shelley, Example, ... era), use:
+--
+-- > QueryAnytimeShelley EraStart
+--
+pattern QueryAnytimeExample
+  :: QueryAnytime result
+  -> ExampleQuery c result
+pattern QueryAnytimeExample q = QueryAnytime q (EraIndex (S (Z (K ()))))
+
+{-# COMPLETE QueryIfCurrentShelley
+           , QueryIfCurrentExample
+           , QueryAnytimeShelley
+           , QueryAnytimeExample
+           , QueryHardFork #-}
+
+-- | The result of a 'ExampleQuery'
+--
+-- Thanks to the pattern synonyms, you can treat this as a sum type with
+-- constructors 'QueryResultSuccess' and 'QueryResultEraMismatch'.
+type ExampleQueryResult c = HardForkQueryResult (ExampleEras c)
+
+pattern QueryResultSuccess :: result -> ExampleQueryResult c result
+pattern QueryResultSuccess result = Right result
+
+-- | A query from a different era than the ledger's era was sent.
+pattern QueryResultEraMismatch :: EraMismatch -> ExampleQueryResult c result
+pattern QueryResultEraMismatch eraMismatch <- Left (mkEraMismatch -> eraMismatch)
+
+{-# COMPLETE QueryResultSuccess, QueryResultEraMismatch #-}
+
+{-------------------------------------------------------------------------------
+  CodecConfig
+-------------------------------------------------------------------------------}
+
+-- | The 'CodecConfig' for 'ExampleBlock'.
+--
+-- Thanks to the pattern synonyms, you can treat this as the product of
+-- the Shelley, Example ... 'CodecConfig's.
+type ExampleCodecConfig c = CodecConfig (ExampleBlock c)
+
+pattern ExampleCodecConfig
+  :: CodecConfig (ShelleyBlock (ShelleyEra c))
+  -> CodecConfig (ShelleyBlock (ExampleEra c))
+  -> ExampleCodecConfig c
+pattern ExampleCodecConfig cfgShelley cfgExample =
+    HardForkCodecConfig {
+        hardForkCodecConfigPerEra = PerEraCodecConfig
+          (  cfgShelley
+          :* cfgExample
+          :* Nil
+          )
+      }
+
+{-# COMPLETE ExampleCodecConfig #-}
+
+{-------------------------------------------------------------------------------
+  BlockConfig
+-------------------------------------------------------------------------------}
+
+-- | The 'BlockConfig' for 'ExampleBlock'.
+--
+-- Thanks to the pattern synonyms, you can treat this as the product of
+-- the Shelley, Example, ... 'BlockConfig's.
+type ExampleBlockConfig c = BlockConfig (ExampleBlock c)
+
+pattern ExampleBlockConfig
+  :: BlockConfig (ShelleyBlock (ShelleyEra c))
+  -> BlockConfig (ShelleyBlock (ExampleEra c))
+  -> ExampleBlockConfig c
+pattern ExampleBlockConfig cfgShelley cfgExample =
+    HardForkBlockConfig {
+        hardForkBlockConfigPerEra = PerEraBlockConfig
+          (  cfgShelley
+          :* cfgExample
+          :* Nil
+          )
+      }
+
+{-# COMPLETE ExampleBlockConfig #-}
+
+{-------------------------------------------------------------------------------
+  StorageConfig
+-------------------------------------------------------------------------------}
+
+-- | The 'StorageConfig' for 'ExampleBlock'.
+--
+-- Thanks to the pattern synonyms, you can treat this as the product of
+-- the Shelley, Example, ... 'StorageConfig's.
+type ExampleStorageConfig c = StorageConfig (ExampleBlock c)
+
+pattern ExampleStorageConfig
+  :: StorageConfig (ShelleyBlock (ShelleyEra c))
+  -> StorageConfig (ShelleyBlock (ExampleEra c))
+  -> ExampleStorageConfig c
+pattern ExampleStorageConfig cfgShelley cfgExample =
+    HardForkStorageConfig {
+        hardForkStorageConfigPerEra = PerEraStorageConfig
+          (  cfgShelley
+          :* cfgExample
+          :* Nil
+          )
+      }
+
+{-# COMPLETE ExampleStorageConfig #-}
+
+{-------------------------------------------------------------------------------
+  ConsensusConfig
+-------------------------------------------------------------------------------}
+
+-- | The 'ConsensusConfig' for 'ExampleBlock'.
+--
+-- Thanks to the pattern synonyms, you can treat this as the product of the
+-- Shelley, Example, ... 'PartialConsensusConfig's.
+--
+-- NOTE: not 'ConsensusConfig', but 'PartialConsensusConfig'.
+type ExampleConsensusConfig c =
+  ConsensusConfig (HardForkProtocol (ExampleEras c))
+
+pattern ExampleConsensusConfig
+  :: PartialConsensusConfig (BlockProtocol (ShelleyBlock (ShelleyEra c)))
+  -> PartialConsensusConfig (BlockProtocol (ShelleyBlock (ExampleEra c)))
+  -> ExampleConsensusConfig c
+pattern ExampleConsensusConfig cfgShelley cfgExample <-
+    HardForkConsensusConfig {
+        hardForkConsensusConfigPerEra = PerEraConsensusConfig
+          (  WrapPartialConsensusConfig cfgShelley
+          :* WrapPartialConsensusConfig cfgExample
+          :* Nil
+          )
+      }
+
+{-# COMPLETE ExampleConsensusConfig #-}
+
+{-------------------------------------------------------------------------------
+  LedgerConfig
+-------------------------------------------------------------------------------}
+
+-- | The 'LedgerConfig' for 'ExampleBlock'.
+--
+-- Thanks to the pattern synonyms, you can treat this as the product of the
+-- Shelley, Example, ... 'PartialLedgerConfig's.
+--
+-- NOTE: not 'LedgerConfig', but 'PartialLedgerConfig'.
+type ExampleLedgerConfig c = HardForkLedgerConfig (ExampleEras c)
+
+pattern ExampleLedgerConfig
+  :: PartialLedgerConfig (ShelleyBlock (ShelleyEra c))
+  -> PartialLedgerConfig (ShelleyBlock (ExampleEra c))
+  -> ExampleLedgerConfig c
+pattern ExampleLedgerConfig cfgShelley cfgExample <-
+    HardForkLedgerConfig {
+        hardForkLedgerConfigPerEra = PerEraLedgerConfig
+          ( WrapPartialLedgerConfig cfgShelley
+          :* WrapPartialLedgerConfig cfgExample
+          :* Nil
+          )
+      }
+
+{-# COMPLETE ExampleLedgerConfig #-}
+
+{-------------------------------------------------------------------------------
+  LedgerState
+-------------------------------------------------------------------------------}
+
+-- | The 'LedgerState' for 'ExampleBlock'.
+--
+-- NOTE: the 'ExampleLedgerState' contains more than just the current era's
+-- 'LedgerState'. We don't give access to those internal details through the
+-- pattern synonyms. This is also the reason the pattern synonyms are not
+-- bidirectional.
+type ExampleLedgerState c = LedgerState (ExampleBlock c)
+
+pattern LedgerStateShelley
+  :: LedgerState (ShelleyBlock (ShelleyEra c))
+  -> ExampleLedgerState c
+pattern LedgerStateShelley st <-
+    HardForkLedgerState
+      (State.HardForkState
+        (TZ (State.Current { currentState = st })))
+
+pattern LedgerStateExample
+  :: LedgerState (ShelleyBlock (ExampleEra c))
+  -> ExampleLedgerState c
+pattern LedgerStateExample st <-
+    HardForkLedgerState
+      (State.HardForkState
+        (TS _ (TZ (State.Current { currentState = st }))))
+
+{-# COMPLETE LedgerStateShelley
+           , LedgerStateExample #-}
+
+{-------------------------------------------------------------------------------
+  ChainDepState
+-------------------------------------------------------------------------------}
+
+-- | The 'ChainDepState' for 'ExampleBlock'.
+--
+-- NOTE: the 'ExampleChainDepState' contains more than just the current era's
+-- 'ChainDepState'. We don't give access to those internal details through the
+-- pattern synonyms. This is also the reason the pattern synonyms are not
+-- bidirectional.
+type ExampleChainDepState c = HardForkChainDepState (ExampleEras c)
+
+pattern ChainDepStateShelley
+  :: ChainDepState (BlockProtocol (ShelleyBlock (ShelleyEra c)))
+  -> ExampleChainDepState c
+pattern ChainDepStateShelley st <-
+    State.HardForkState
+      (TZ (State.Current { currentState = WrapChainDepState st }))
+
+pattern ChainDepStateExample
+  :: ChainDepState (BlockProtocol (ShelleyBlock (ExampleEra c)))
+  -> ExampleChainDepState c
+pattern ChainDepStateExample st <-
+    State.HardForkState
+      (TS _ (TZ (State.Current { currentState = WrapChainDepState st })))
+
+{-# COMPLETE ChainDepStateShelley
+           , ChainDepStateExample #-}

--- a/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/CanHardFork.hs
+++ b/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/CanHardFork.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DeriveAnyClass           #-}
+{-# LANGUAGE DeriveGeneric            #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE NamedFieldPuns           #-}
+{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE RecordWildCards          #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE TupleSections            #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ouroboros.Consensus.Example.CanHardFork (
+    ExampleHardForkConstraints
+  , ShelleyPartialLedgerConfig (..)
+  , TriggerHardFork (..)
+  , forecastAcrossShelley
+  , translateChainDepStateAcrossShelley
+  ) where
+
+import           Control.Monad.Except (runExcept)
+import           Data.SOP.Strict (NP (..), unComp, (:.:) (..))
+
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.TypeFamilyWrappers
+import           Ouroboros.Consensus.Util (eitherToMaybe)
+
+import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+                     (RequiringBoth (..), ignoringBoth)
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Tails (Tails (..))
+import           Ouroboros.Consensus.HardFork.Simple
+
+import           Ouroboros.Consensus.Shelley.Ledger
+import           Ouroboros.Consensus.Shelley.Node ()
+import           Ouroboros.Consensus.Shelley.Protocol
+import           Ouroboros.Consensus.Shelley.ShelleyHFC
+
+import qualified Cardano.Ledger.Era as SL
+import           Cardano.Ledger.Example.Translation ()
+
+import           Ouroboros.Consensus.Example.Block
+
+{-------------------------------------------------------------------------------
+  CanHardFork
+-------------------------------------------------------------------------------}
+
+type ExampleHardForkConstraints c =
+  ( PraosCrypto c
+  , ShelleyBasedEra (ShelleyEra c)
+  , ShelleyBasedEra (ExampleEra c)
+  )
+
+instance ExampleHardForkConstraints c => CanHardFork (ExampleEras c) where
+  hardForkEraTranslation = EraTranslation {
+      translateLedgerState   =
+          PCons translateLedgerStateShelleyToExampleWrapper
+        $ PNil
+    , translateChainDepState =
+          PCons translateChainDepStateAcrossShelley
+        $ PNil
+    , translateLedgerView    =
+          PCons translateLedgerViewAcrossShelley
+        $ PNil
+    }
+  hardForkChainSel =
+        -- Shelley <-> Example, ...
+        TCons (SelectSameProtocol :* Nil)
+        -- Example <-> ...
+      $ TCons Nil
+      $ TNil
+  hardForkInjectTxs =
+        PCons (ignoringBoth translateTxShelleyToExampleWrapper)
+      $ PNil
+
+{-------------------------------------------------------------------------------
+  Translation from Shelley to Example
+-------------------------------------------------------------------------------}
+
+translateLedgerStateShelleyToExampleWrapper ::
+     PraosCrypto c
+  => RequiringBoth
+       WrapLedgerConfig
+       (Translate LedgerState)
+       (ShelleyBlock (ShelleyEra c))
+       (ShelleyBlock (ExampleEra c))
+translateLedgerStateShelleyToExampleWrapper =
+    ignoringBoth $
+      Translate $ \_epochNo ->
+        unComp . SL.translateEra' () . Comp
+
+translateTxShelleyToExampleWrapper ::
+     PraosCrypto c
+  => InjectTx
+       (ShelleyBlock (ShelleyEra c))
+       (ShelleyBlock (ExampleEra c))
+translateTxShelleyToExampleWrapper = InjectTx $
+    fmap unComp . eitherToMaybe . runExcept . SL.translateEra () . Comp

--- a/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Condense.hs
+++ b/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Condense.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ouroboros.Consensus.Example.Condense () where
+
+import           Ouroboros.Consensus.HardFork.Combinator.Condense
+
+import           Ouroboros.Consensus.Shelley.Ledger
+
+import           Ouroboros.Consensus.Example.Block
+import           Ouroboros.Consensus.Example.CanHardFork
+
+{-------------------------------------------------------------------------------
+  Condense
+
+  TODO where to put this?
+-------------------------------------------------------------------------------}
+
+instance ShelleyBasedEra era => CondenseConstraints (ShelleyBlock era)
+
+instance ExampleHardForkConstraints c => CondenseConstraints (ExampleBlock c)

--- a/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Eras.hs
+++ b/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Eras.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds               #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE OverloadedStrings       #-}
+{-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Ouroboros.Consensus.Example.Eras (
+    -- * Eras based on the Shelley ledger
+    ExampleEra
+    -- * Eras instantiated with standard crypto
+  , StandardExample
+    -- * Re-exports
+  , EraCrypto
+  , ShelleyBasedEra (..)
+  , ShelleyEra
+  , StandardCrypto
+  , StandardShelley
+  ) where
+
+import           Cardano.Ledger.Example (ExampleEra)
+
+import           Ouroboros.Consensus.Shelley.Eras
+import qualified Shelley.Spec.Ledger.API as SL
+
+{-------------------------------------------------------------------------------
+  Eras instantiated with standard crypto
+-------------------------------------------------------------------------------}
+
+-- | The Example era with standard crypto
+type StandardExample = ExampleEra StandardCrypto
+
+instance SL.PraosCrypto c => ShelleyBasedEra (ExampleEra c) where
+  shelleyBasedEraName _ = "Example"

--- a/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Node.hs
+++ b/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/Node.hs
@@ -1,0 +1,470 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ouroboros.Consensus.Example.Node (
+    ExampleHardForkConstraints
+  , MaxMajorProtVer (..)
+  , ProtocolParamsExample (..)
+  , ProtocolParamsTransition (..)
+  , TriggerHardFork (..)
+  , protocolClientInfoExample
+  , protocolInfoExample
+    -- * SupportedNetworkProtocolVersion
+  , pattern ExampleNodeToClientVersion1
+  , pattern ExampleNodeToClientVersion2
+  , pattern ExampleNodeToNodeVersion1
+  , pattern ExampleNodeToNodeVersion2
+  ) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import           Codec.CBOR.Encoding (Encoding)
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Data.ByteString.Short as Short
+import qualified Data.Map.Strict as Map
+import           Data.SOP.Strict hiding (shape, shift)
+import           Data.Word (Word16)
+
+import           Cardano.Binary (DecoderError (..), enforceSize)
+import           Cardano.Prelude (cborError)
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.Node.Run
+import           Ouroboros.Consensus.Storage.Serialisation
+import           Ouroboros.Consensus.Util.Assert
+import           Ouroboros.Consensus.Util.Counting
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
+import qualified Ouroboros.Consensus.Util.OptNP as OptNP
+
+import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
+
+import qualified Cardano.Ledger.Era as SL
+import           Cardano.Ledger.Val (coin, (<->))
+import qualified Cardano.Ledger.Val as Val
+import           Ouroboros.Consensus.Example.ShelleyBased
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
+import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+import           Ouroboros.Consensus.Shelley.Node
+import           Ouroboros.Consensus.Shelley.Protocol (TPraosParams (..))
+import qualified Ouroboros.Consensus.Shelley.Protocol as Shelley
+import           Ouroboros.Consensus.Shelley.ShelleyBased
+import qualified Shelley.Spec.Ledger.API as SL
+
+import           Ouroboros.Consensus.Example.Block
+import           Ouroboros.Consensus.Example.CanHardFork
+
+{-------------------------------------------------------------------------------
+  SerialiseHFC
+-------------------------------------------------------------------------------}
+
+instance ExampleHardForkConstraints c => SerialiseHFC (ExampleEras c) where
+  encodeDiskHfcBlock (ExampleCodecConfig ccfgShelley ccfgExample) = \case
+      -- For Shelley and later eras, we need to prepend the hard fork envelope.
+      BlockShelley blockShelley -> prependTag 2 $ encodeDisk ccfgShelley blockShelley
+      BlockExample blockExample -> prependTag 99 $ encodeDisk ccfgExample blockExample
+  decodeDiskHfcBlock (ExampleCodecConfig ccfgShelley ccfgExample) = do
+      enforceSize "ExampleBlock" 2
+      CBOR.decodeWord >>= \case
+        -- We don't have to drop the first two bytes from the 'ByteString'
+        -- passed to the decoder as slicing already takes care of this.
+        2  -> fmap BlockShelley <$> decodeDisk ccfgShelley
+        99 -> fmap BlockExample <$> decodeDisk ccfgExample
+        t  -> cborError $ DecoderErrorUnknownTag "ExampleBlock" (fromIntegral t)
+
+  reconstructHfcPrefixLen _ = PrefixLen 2
+
+  reconstructHfcNestedCtxt _ prefix _ =
+      case Short.index prefix 1 of
+        2  -> SomeSecond $ NestedCtxt (NCZ Shelley.CtxtShelley)
+        99 -> SomeSecond $ NestedCtxt (NCS (NCZ Shelley.CtxtShelley))
+        _  -> error $ "ExampleBlock: invalid prefix " <> show prefix
+
+  getHfcBinaryBlockInfo = \case
+      -- For Shelley and the later eras, we need to account for the two extra
+      -- bytes of the envelope.
+      BlockShelley blockShelley ->
+        shiftHeaderOffset 2 $ getBinaryBlockInfo blockShelley
+      BlockExample blockExample ->
+        shiftHeaderOffset 2 $ getBinaryBlockInfo blockExample
+    where
+      shiftHeaderOffset :: Word16 -> BinaryBlockInfo -> BinaryBlockInfo
+      shiftHeaderOffset shift binfo = binfo {
+            headerOffset = headerOffset binfo + shift
+          }
+
+  estimateHfcBlockSize = \case
+      -- For Shelley and later eras, we add two extra bytes, see the
+      -- 'SerialiseHFC' instance.
+      HeaderShelley headerShelley -> estimateBlockSize headerShelley + 2
+      HeaderExample headerExample -> estimateBlockSize headerExample + 2
+
+-- | Prepend the given tag by creating a CBOR 2-tuple with the tag as the
+-- first element and the given 'Encoding' as the second.
+prependTag :: Word -> Encoding -> Encoding
+prependTag tag payload = mconcat [
+      CBOR.encodeListLen 2
+    , CBOR.encodeWord tag
+    , payload
+    ]
+
+{-------------------------------------------------------------------------------
+  SupportedNetworkProtocolVersion instance
+-------------------------------------------------------------------------------}
+
+-- | The hard fork enabled with the Shelley and Example eras enabled.
+pattern ExampleNodeToNodeVersion1 :: BlockNodeToNodeVersion (ExampleBlock c)
+pattern ExampleNodeToNodeVersion1 =
+    HardForkNodeToNodeEnabled
+      HardForkSpecificNodeToNodeVersion1
+      (  EraNodeToNodeEnabled ShelleyNodeToNodeVersion1
+      :* EraNodeToNodeDisabled
+      :* Nil
+      )
+
+-- | The hard fork enabled with the Shelley and Example eras enabled.
+pattern ExampleNodeToNodeVersion2 :: BlockNodeToNodeVersion (ExampleBlock c)
+pattern ExampleNodeToNodeVersion2 =
+    HardForkNodeToNodeEnabled
+      HardForkSpecificNodeToNodeVersion1
+      (  EraNodeToNodeEnabled ShelleyNodeToNodeVersion1
+      :* EraNodeToNodeEnabled ShelleyNodeToNodeVersion1
+      :* Nil
+      )
+
+-- | The hard fork enabled, and the Shelley era enabled using 'ShelleyNodeToClientVersion3' protocol.
+pattern ExampleNodeToClientVersion1 :: BlockNodeToClientVersion (ExampleBlock c)
+pattern ExampleNodeToClientVersion1 =
+    HardForkNodeToClientEnabled
+      HardForkSpecificNodeToClientVersion2
+      (  EraNodeToClientEnabled ShelleyNodeToClientVersion3
+      :* EraNodeToClientDisabled
+      :* Nil
+      )
+
+-- | The hard fork enabled, and the Shelley and Example eras enabled using 'ShelleyNodeToClientVersion3' protocol.
+pattern ExampleNodeToClientVersion2 :: BlockNodeToClientVersion (ExampleBlock c)
+pattern ExampleNodeToClientVersion2 =
+    HardForkNodeToClientEnabled
+      HardForkSpecificNodeToClientVersion2
+      (  EraNodeToClientEnabled ShelleyNodeToClientVersion3
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion3
+      :* Nil
+      )
+
+instance ExampleHardForkConstraints c
+      => SupportedNetworkProtocolVersion (ExampleBlock c) where
+  supportedNodeToNodeVersions _ = Map.fromList $
+      [ (NodeToNodeV_3, ExampleNodeToNodeVersion1)
+      , (NodeToNodeV_3, ExampleNodeToNodeVersion2)
+      ]
+
+  supportedNodeToClientVersions _ = Map.fromList $
+      [ (NodeToClientV_4, ExampleNodeToClientVersion1)
+      , (NodeToClientV_4, ExampleNodeToClientVersion2)
+      ]
+
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
+{-------------------------------------------------------------------------------
+  ProtocolInfo
+-------------------------------------------------------------------------------}
+
+-- | Parameters needed to transition between two eras.
+--
+-- The two eras are phantom type parameters of this type to avoid mixing up
+-- multiple 'ProtocolParamsTransition's
+data ProtocolParamsTransition eraFrom eraTo = ProtocolParamsTransition {
+      transitionTrigger    :: TriggerHardFork
+    }
+
+-- | Parameters needed to run Shelley
+data ProtocolParamsExample = ProtocolParamsExample {
+      exampleProtVer :: SL.ProtVer
+    }
+
+-- | Create a 'ProtocolInfo' for 'ExampleBlock'
+--
+-- NOTE: the initial staking and funds in the 'ShelleyGenesis' are ignored,
+-- /unless/ configured to skip the Shelley era and hard fork to Example
+-- era from the start using @TriggerHardForkAtEpoch 0@ for testing purposes.
+--
+-- PRECONDITION: only a single set of Shelley credentials is allowed when used
+-- for mainnet (check against @'SL.gNetworkId' 'shelleyBasedGenesis'@).
+protocolInfoExample ::
+     forall c m. (IOLike m, ExampleHardForkConstraints c)
+  => ProtocolParamsShelleyBased (ShelleyEra c)
+  -> ProtocolParamsShelley
+  -> ProtocolParamsExample
+  -> ProtocolParamsTransition
+       (ShelleyBlock (ShelleyEra c))
+       (ShelleyBlock (ExampleEra c))
+  -> ProtocolInfo m (ExampleBlock c)
+protocolInfoExample ProtocolParamsShelleyBased {
+                        shelleyBasedGenesis           = genesisShelley
+                      , shelleyBasedInitialNonce      = initialNonceShelley
+                      , shelleyBasedLeaderCredentials = credssShelleyBased
+                      }
+                    ProtocolParamsShelley {
+                        shelleyProtVer = protVerShelley
+                      }
+                    ProtocolParamsExample {
+                        exampleProtVer = protVerExample
+                      }
+                    ProtocolParamsTransition {
+                        transitionTrigger = triggerHardForkShelleyExample
+                      }
+  | SL.Mainnet <- SL.sgNetworkId genesisShelley
+  , length credssShelleyBased > 1
+  = error "Multiple Shelley-based credentials not allowed for mainnet"
+  | otherwise
+  = assertWithMsg (validateGenesis genesisShelley) $
+    ProtocolInfo {
+        pInfoConfig       = cfg
+      , pInfoInitLedger   = initExtLedgerStateExample
+      , pInfoBlockForging = blockForging
+      }
+  where
+    -- The major protocol version of the last era is the maximum major protocol
+    -- version we support.
+    maxMajorProtVer :: MaxMajorProtVer
+    maxMajorProtVer = MaxMajorProtVer (pvMajor protVerExample)
+
+    -- Shelley
+
+    tpraosParams :: TPraosParams
+    tpraosParams@TPraosParams { tpraosSlotsPerKESPeriod } =
+        Shelley.mkTPraosParams
+          maxMajorProtVer
+          initialNonceShelley
+          genesisShelley
+
+    blockConfigShelley :: BlockConfig (ShelleyBlock (ShelleyEra c))
+    blockConfigShelley =
+        Shelley.mkShelleyBlockConfig
+          protVerShelley
+          genesisShelley
+          (tpraosBlockIssuerVKey <$> credssShelleyBased)
+
+    partialConsensusConfigShelley ::
+         PartialConsensusConfig (BlockProtocol (ShelleyBlock (ShelleyEra c)))
+    partialConsensusConfigShelley = tpraosParams
+
+    partialLedgerConfigShelley :: PartialLedgerConfig (ShelleyBlock (ShelleyEra c))
+    partialLedgerConfigShelley =
+        mkPartialLedgerConfigShelley
+          genesisShelley
+          maxMajorProtVer
+          triggerHardForkShelleyExample
+
+    kShelley :: SecurityParam
+    kShelley = SecurityParam $ sgSecurityParam genesisShelley
+
+    -- Allegra
+
+    genesisExample :: ShelleyGenesis (ExampleEra c)
+    genesisExample = SL.translateEra' () genesisShelley
+
+    blockConfigExample :: BlockConfig (ShelleyBlock (ExampleEra c))
+    blockConfigExample =
+        Shelley.mkShelleyBlockConfig
+          protVerExample
+          genesisExample
+          (tpraosBlockIssuerVKey <$> credssShelleyBased)
+
+    partialConsensusConfigExample ::
+         PartialConsensusConfig (BlockProtocol (ShelleyBlock (ExampleEra c)))
+    partialConsensusConfigExample = tpraosParams
+
+    partialLedgerConfigExample :: PartialLedgerConfig (ShelleyBlock (ExampleEra c))
+    partialLedgerConfigExample =
+        mkPartialLedgerConfigShelley
+          genesisExample
+          maxMajorProtVer
+          TriggerHardForkNever
+    --
+    -- Cardano
+
+    k :: SecurityParam
+    k = kShelley
+
+    shape :: History.Shape (ExampleEras c)
+    shape = History.Shape $ Exactly $
+           K (Shelley.shelleyEraParams genesisShelley)
+        :* K (Shelley.shelleyEraParams genesisExample)
+        :* Nil
+
+    cfg :: TopLevelConfig (ExampleBlock c)
+    cfg = TopLevelConfig {
+        topLevelConfigProtocol = HardForkConsensusConfig {
+            hardForkConsensusConfigK      = k
+          , hardForkConsensusConfigShape  = shape
+          , hardForkConsensusConfigPerEra = PerEraConsensusConfig
+              (  WrapPartialConsensusConfig partialConsensusConfigShelley
+              :* WrapPartialConsensusConfig partialConsensusConfigExample
+              :* Nil
+              )
+          }
+      , topLevelConfigLedger = HardForkLedgerConfig {
+            hardForkLedgerConfigShape  = shape
+          , hardForkLedgerConfigPerEra = PerEraLedgerConfig
+              (  WrapPartialLedgerConfig partialLedgerConfigShelley
+              :* WrapPartialLedgerConfig partialLedgerConfigExample
+              :* Nil
+              )
+          }
+      , topLevelConfigBlock =
+          ExampleBlockConfig
+            blockConfigShelley
+            blockConfigExample
+      , topLevelConfigCodec =
+          ExampleCodecConfig
+            Shelley.ShelleyCodecConfig
+            Shelley.ShelleyCodecConfig
+      , topLevelConfigStorage =
+          ExampleStorageConfig
+            (Shelley.ShelleyStorageConfig tpraosSlotsPerKESPeriod k)
+            (Shelley.ShelleyStorageConfig tpraosSlotsPerKESPeriod k)
+      }
+
+    -- Register the initial staking and initial funds (if provided in the genesis config) in
+    -- the ledger state.
+    initExtLedgerStateExample :: ExtLedgerState (ExampleBlock c)
+    initExtLedgerStateExample = ExtLedgerState {
+          headerState = initHeaderState
+        , ledgerState = overShelleyBasedLedgerState register initLedgerState
+        }
+      where
+        initHeaderState :: HeaderState (ExampleBlock c)
+        initLedgerState :: LedgerState (ExampleBlock c)
+        ExtLedgerState initLedgerState initHeaderState =
+          injectInitialExtLedgerState cfg $ ExtLedgerState {
+            ledgerState = Shelley.ShelleyLedgerState {
+              Shelley.shelleyLedgerTip        = Origin
+            , Shelley.shelleyLedgerState      = SL.chainNes initShelleyState
+            , Shelley.shelleyLedgerTransition = Shelley.ShelleyTransitionInfo {Shelley.shelleyAfterVoting = 0}
+            }
+          , headerState = genesisHeaderState initChainDepState
+          }
+
+        initChainDepState :: Shelley.TPraosState c
+        initChainDepState = Shelley.TPraosState Origin $
+          SL.ChainDepState {
+              SL.csProtocol = SL.PrtclState
+                (SL.chainOCertIssue     initShelleyState)
+                (SL.chainEvolvingNonce  initShelleyState)
+                (SL.chainCandidateNonce initShelleyState)
+            , SL.csTickn = SL.TicknState
+                (SL.chainEpochNonce     initShelleyState)
+                (SL.chainPrevEpochNonce initShelleyState)
+            , SL.csLabNonce =
+                (SL.chainPrevEpochNonce initShelleyState)
+            }
+
+        initShelleyState :: SL.ChainState (ShelleyEra c)
+        initShelleyState =
+            overNewEpochState
+              (registerGenesisStaking (SL.sgStaking genesisShelley)) $
+              SL.initialShelleyState
+                Origin
+                0
+                (SL.genesisUTxO genesisShelley)
+                (coin $ Val.inject (SL.word64ToCoin (SL.sgMaxLovelaceSupply genesisShelley))
+                    <-> SL.balance (SL.genesisUTxO genesisShelley))
+                (SL.sgGenDelegs genesisShelley)
+                (SL.sgProtocolParams genesisShelley)
+                initialNonceShelley
+
+        overNewEpochState ::
+             (SL.NewEpochState era -> SL.NewEpochState era)
+          -> (SL.ChainState    era -> SL.ChainState    era)
+        overNewEpochState f cs = cs { SL.chainNes = f (SL.chainNes cs) }
+
+        register ::
+             (EraCrypto era ~ c, ShelleyBasedEra era)
+          => LedgerState (ShelleyBlock era)
+          -> LedgerState (ShelleyBlock era)
+        register st = st {
+              Shelley.shelleyLedgerState =
+                -- We must first register the initial funds, because the stake
+                -- information depends on it.
+                  registerGenesisStaking
+                    (SL.sgStaking genesisShelley)
+                . registerInitialFunds
+                    (SL.sgInitialFunds genesisShelley)
+                $ Shelley.shelleyLedgerState st
+            }
+
+    -- | For each element in the list, a block forging thread will be started.
+    --
+    -- When no credentials are passed, there will be no threads.
+    --
+    -- Typically, there will only be a single set of credentials for Shelley.
+    --
+    -- In case there are multiple credentials for Shelley, which is only done
+    -- for testing/benchmarking purposes, we'll have a separate thread for each
+    -- of them.
+    blockForging :: m [BlockForging m (ExampleBlock c)]
+    blockForging = do
+        shelleyBased :: [ OptNP 'False (BlockForging m) (ExampleEras c) ] <- blockForgingShelleyBased
+        return $ hardForkBlockForging "Example" <$> shelleyBased
+
+    blockForgingShelleyBased :: m [OptNP 'False (BlockForging m) (ExampleEras c)]
+    blockForgingShelleyBased = do
+        shelleyBased <-
+          traverse
+            (shelleySharedBlockForging (Proxy @(ShelleyBasedExampleEras c)) tpraosParams)
+            credssShelleyBased
+        return $ reassoc <$> shelleyBased
+      where
+        reassoc ::
+             NP (BlockForging m :.: ShelleyBlock) (ShelleyBasedExampleEras c)
+          -> OptNP 'False (BlockForging m) (ExampleEras c)
+        reassoc = injectShelleyOptNP unComp . OptNP.fromNonEmptyNP
+
+protocolClientInfoExample
+  :: forall c.  ProtocolClientInfo (ExampleBlock c)
+protocolClientInfoExample = ProtocolClientInfo {
+      pClientInfoCodecConfig =
+        ExampleCodecConfig
+          (pClientInfoCodecConfig protocolClientInfoShelley)
+          (pClientInfoCodecConfig protocolClientInfoShelley)
+    }
+
+{-------------------------------------------------------------------------------
+  Helpers
+-------------------------------------------------------------------------------}
+
+mkPartialLedgerConfigShelley ::
+     ShelleyGenesis era
+  -> MaxMajorProtVer
+  -> TriggerHardFork
+  -> PartialLedgerConfig (ShelleyBlock era)
+mkPartialLedgerConfigShelley genesisShelley maxMajorProtVer shelleyTriggerHardFork =
+    ShelleyPartialLedgerConfig {
+          shelleyLedgerConfig =
+            Shelley.mkShelleyLedgerConfig
+              genesisShelley
+              -- 'completeLedgerConfig' will replace the 'History.dummyEpochInfo'
+              -- in the partial ledger config with the correct one.
+              History.dummyEpochInfo
+              maxMajorProtVer
+        , shelleyTriggerHardFork = shelleyTriggerHardFork
+        }

--- a/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/ShelleyBased.hs
+++ b/ouroboros-consensus-example/src/Ouroboros/Consensus/Example/ShelleyBased.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+module Ouroboros.Consensus.Example.ShelleyBased (overShelleyBasedLedgerState) where
+
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.HardFork.Combinator
+
+import           Ouroboros.Consensus.Example.Block
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.Protocol (PraosCrypto)
+import           Ouroboros.Consensus.Shelley.ShelleyBased
+
+-- | When the given ledger state corresponds to a Shelley-based era, apply the
+-- given function to it.
+overShelleyBasedLedgerState ::
+     forall c. PraosCrypto c
+  => (   forall era. (EraCrypto era ~ c, ShelleyBasedEra era)
+      => LedgerState (ShelleyBlock era)
+      -> LedgerState (ShelleyBlock era)
+     )
+  -> LedgerState (ExampleBlock c)
+  -> LedgerState (ExampleBlock c)
+overShelleyBasedLedgerState f (HardForkLedgerState st) =
+    HardForkLedgerState $ hap fs st
+  where
+    fs :: NP (LedgerState -.-> LedgerState)
+             (ExampleEras c)
+    fs = injectShelleyNP
+           reassoc
+           (hcpure
+             (Proxy @(And (HasCrypto c) ShelleyBasedEra))
+             (fn (Comp . f . unComp)))
+
+    reassoc ::
+         (     LedgerState :.: ShelleyBlock
+          -.-> LedgerState :.: ShelleyBlock
+         ) shelleyEra
+      -> (     LedgerState
+          -.-> LedgerState
+         ) (ShelleyBlock shelleyEra)
+    reassoc g = fn $ unComp . apFn g . Comp


### PR DESCRIPTION
The example consensus mode is intended for prototype eras that are not
intended on being available in mainnet. It currently transitions from
Shelley to Example, a duplicate of Shelley, but it is intended to be
used to test transitioning to and from eras in development and in testing.