### PR TITLE
Added tracer to warn about clampToLimit

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -516,7 +516,7 @@ peerSelectionGovernorLoop tracer debugTracer actions policy jobPool =
                      -> Guarded (STM m) (TimedDecision m peeraddr peerconn)
     guardedDecisions blockedAt st =
       -- All the alternative non-blocking internal decisions.
-         RootPeers.belowTarget        actions blockedAt  st
+         RootPeers.belowTarget       actions blockedAt  st
       <> KnownPeers.belowTarget       actions     policy st
       <> KnownPeers.aboveTarget                   policy st
       <> EstablishedPeers.belowTarget actions     policy st
@@ -525,8 +525,8 @@ peerSelectionGovernorLoop tracer debugTracer actions policy jobPool =
       <> ActivePeers.aboveTarget      actions     policy st
 
       -- All the alternative potentially-blocking decisions.
-      <> Monitor.targetPeers          actions st
-      <> Monitor.localRoots           actions st
+      <> Monitor.targetPeers          tracer actions st
+      <> Monitor.localRoots           tracer actions st
       <> Monitor.jobs                 jobPool st
       <> Monitor.connections          actions st
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -497,6 +497,10 @@ data TracePeerSelection peeraddr =
      | TraceDemoteHotDone      Int Int peeraddr
      | TraceDemoteAsynchronous (Map peeraddr PeerStatus)
      | TraceGovernorWakeup
+     -- | Number of root peers is more than the target number of known peers
+     --
+     -- number of target known peers, number of root peers
+     | TraceClampToLimit !Int !Int
   deriving Show
 
 data DebugPeerSelection peeraddr peerconn =


### PR DESCRIPTION
This adds the tracer for warning if the number of root peers is not more than the target number of known peers (as it was suggested in the TODOs)