### PR TITLE
Upgrade haskell.nix and bind nixpkgs to what haskell.nix exposes for better cache hits

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,22 +7,14 @@ let
   sources = import ./sources.nix { pkgs = import iohkNixMain.nixpkgs { }; }
     // sourcesOverride;
   iohkNixMain = import sources.iohk-nix { };
-  haskellNix = (import sources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs;
-  # use our own nixpkgs if it exists in our sources,
-  # otherwise use iohkNix default nixpkgs.
-  nixpkgs =
-    if (sources ? nixpkgs)
-    then
-      (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
-        sources.nixpkgs)
-    else
-      (builtins.trace "Using IOHK default nixpkgs"
-        iohkNixMain.nixpkgs);
+  haskellNix = import sources."haskell.nix" { inherit system sourcesOverride; };
+  haskellNixArgs = haskellNix.nixpkgsArgs;
+  nixpkgs = haskellNix.sources.nixpkgs-2009;
 
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
-    haskellNix.overlays
+    haskellNixArgs.overlays
     # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
     ++ iohkNixMain.overlays.haskell-nix-extra
     ++ iohkNixMain.overlays.crypto
@@ -44,7 +36,7 @@ let
 
   pkgs = import nixpkgs {
     inherit system crossSystem overlays;
-    config = haskellNix.config // config;
+    config = haskellNixArgs.config // config;
   };
 
 in

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,8 +9,17 @@ let
   iohkNixMain = import sources.iohk-nix { };
   haskellNix = import sources."haskell.nix" { inherit system sourcesOverride; };
   haskellNixArgs = haskellNix.nixpkgsArgs;
-  nixpkgs = haskellNix.sources.nixpkgs-2009;
-
+  nixpkgs =
+    if (sources ? nixpkgs)
+    then
+      (builtins.trace "Not using nixpkgs that haskell.nix is exposing.
+        * This means that you've added entry to 'sources.json' via niv.
+        * This is fine, but please be aware that you might be getting less cache hits.
+        * Use 'niv drop nixpkgs' to use haskell.nix's nixpkgs"
+        sources.nixpkgs)
+    else
+      (builtins.trace "Using haskell.nix's nixpkgs. Good. Sharing is caring"
+        haskellNix.sources.nixpkgs-2009);
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "958e9d3e9ec53fbce72ac720b10a6418f3b477f0",
-        "sha256": "0j9p3xyck636gv87rwd6yl7w9ssv3jwrfqyxvhpchszkj097qwi6",
+        "rev": "1b9b05beed75a1be98405501fbb33ac1f080069e",
+        "sha256": "0679ymbjm7z3qbiv9wf7f22rxdwzkpk0jlh1by0rswdmbwqi5786",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/958e9d3e9ec53fbce72ac720b10a6418f3b477f0.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/1b9b05beed75a1be98405501fbb33ac1f080069e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -33,18 +33,6 @@
         "sha256": "0jn88ahv6mycxdkzihy1v0dz2110q0d42q4ggyj68l2lyba6y0yy",
         "type": "tarball",
         "url": "https://github.com/input-output-hk/niv/archive/89da7b2e7ae0779fd351618fc74df1b1da5e6214.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs": {
-        "branch": "nixpkgs-20.09-darwin",
-        "description": "Nix Packages collection",
-        "homepage": null,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fbc078d2451d67b3091ead72ddece78a3d48c226",
-        "sha256": "01fysh7bnbwr135qn0j9rs77widi4isznj8arda5f6dpab24pyki",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fbc078d2451d67b3091ead72ddece78a3d48c226.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
We've upgraded haskell.nix to latest revision.

Also instead of explicitly pointing to nixpkgs (in sources.json) -
which requires us to manually updated it each time we upgrade
haskell.nix in order to get cache hits - we've modified the
default.nix so that it explicitly picks haskell.nix's nixpkgs.

In other words, next time some one wants to update haskell.nix it should be a matter
of just calling 'niv update haskell.nix' and commiting changes. Script
will automatically pick the right nixpkgs.

In this commit we did not modified iohk-nix entry. It might be the
case that it should also be updated.

Co-authored-by: Javier Sagredo <javier.sagredo@iohk.io>