### PR TITLE
p2p governor test improvements

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -274,6 +274,7 @@ test-suite test
                        Test.Socket
                        Test.PeerState
                        Test.Version
+                       Test.QuickCheck.Utils
   default-language:    Haskell2010
   build-depends:       base,
                        QuickCheck,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -254,6 +254,7 @@ test-suite test
   other-modules:       Ouroboros.Network.BlockFetch.Examples
                        Ouroboros.Network.MockNode
 
+                       Data.Signal
                        Test.AnchoredFragment
                        Test.Chain
                        Test.LedgerPeers
@@ -274,6 +275,7 @@ test-suite test
                        Test.Socket
                        Test.PeerState
                        Test.Version
+                       Test.QuickCheck.Signal
                        Test.QuickCheck.Utils
   default-language:    Haskell2010
   build-depends:       base,
@@ -286,6 +288,7 @@ test-suite test
                        containers,
                        directory,
                        dns,
+                       deque,
                        fingertree,
                        hashable,
                        iproute,
@@ -293,6 +296,7 @@ test-suite test
                        network,
                        pipes,
                        process,
+                       pqueue,
                        psqueues,
                        random,
                        serialise,

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -28,6 +28,7 @@ module Ouroboros.Network.PeerSelection.Governor (
     peerChurnGovernor,
 
     -- * Internals exported for testing
+    assertPeerSelectionState,
     sanePeerSelectionTargets,
     establishedPeersStatus,
     PeerSelectionState(..),

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -32,6 +32,8 @@ module Ouroboros.Network.PeerSelection.Governor (
     sanePeerSelectionTargets,
     establishedPeersStatus,
     PeerSelectionState(..),
+    nullPeerSelectionTargets,
+    emptyPeerSelectionState,
 ) where
 
 import           Data.Void (Void)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -88,11 +88,13 @@ jobs jobPool st =
 --
 reconnectDelay :: DiffTime
 reconnectDelay = 10
+--TODO: make this a policy param
 
 -- | Activation delay after a peer was asynchronously demoted to warm state.
 --
 activateDelay :: DiffTime
 activateDelay = 60
+--TODO: make this a policy param
 
 
 -- | Monitor connections.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -500,7 +500,7 @@ data TracePeerSelection peeraddr =
   deriving Show
 
 data DebugPeerSelection peeraddr peerconn =
-       TraceGovernorState Time
-                          (Maybe DiffTime)
+       TraceGovernorState Time              -- blocked time
+                          (Maybe DiffTime)  -- wait time
                           (PeerSelectionState peeraddr peerconn)
   deriving (Show, Functor)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
@@ -352,7 +352,7 @@ minConnectTime KnownPeers { nextConnectTimes }
 
 
 setConnectTime :: Ord peeraddr
-               => Set peeraddr
+               => Set peeraddr --TODO: make this a single entry
                -> Time
                -> KnownPeers peeraddr
                -> KnownPeers peeraddr

--- a/ouroboros-network/test/Data/Signal.hs
+++ b/ouroboros-network/test/Data/Signal.hs
@@ -1,0 +1,424 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.Signal (
+  -- * Events
+  Events,
+  eventsFromList,
+  eventsFromListUpToTime,
+  eventsToList,
+  selectEvents,
+
+  -- * Low level access
+  primitiveTransformEvents,
+  TS(..),
+  E(..),
+
+  -- * Signals
+  Signal,
+  -- ** Construction and conversion
+  fromChangeEvents,
+  toChangeEvents,
+  fromEvents,
+
+  -- * Simple signal transformations
+  truncateAt,
+  stable,
+  nub,
+
+  -- * Temporal operations
+  linger,
+  timeout,
+  until,
+  difference,
+
+  -- * Set-based temporal operations
+  keyedTimeout,
+  keyedLinger,
+  keyedUntil,
+
+  ) where
+
+import           Prelude hiding (until)
+
+import           Data.Maybe (maybeToList)
+import           Data.List (groupBy)
+import qualified Data.Set as Set
+import           Data.Set (Set)
+import qualified Data.OrdPSQ as PSQ
+import           Data.OrdPSQ (OrdPSQ)
+
+import           Control.Monad.Class.MonadTime (Time(..), DiffTime, addTime)
+
+
+--
+-- Time stamps and events
+--
+
+-- The instance Applicative Signal relies on merging event streams.
+-- The IO simulator's treatment of time means that we can have many
+-- events that occur at the same virtual time, though they are stil
+-- causually ordered.
+--
+-- We need these compound time stamps to be able to resolve the order
+-- of the events that have the same Time when merging event streams.
+-- The compound time stamp records the event number from the original
+-- trace, for events derivied from the original trace. For artificially
+-- constructed events, they can use small or big counters to be ordered
+-- before or after other events at the same time. Negative counters are
+-- permitted for this purpose.
+
+data TS = TS !Time !Int
+  deriving (Eq, Ord, Show)
+
+-- A single event or entry in a time series, annotated with its timestamp.
+--
+data E a = E {-# UNPACK #-} !TS a
+  deriving (Show, Functor)
+
+
+--
+-- Events
+--
+
+-- | A time-ordered trace of discrete events that occur at specific times.
+--
+-- This corresponds for example to a trace of events or observations from a
+-- simulation.
+--
+newtype Events a = Events [E a]
+  deriving (Show, Functor)
+
+-- | Construct 'Events' from a time series.
+--
+eventsFromList :: [(Time, a)] -> Events a
+eventsFromList txs =
+    Events [ E (TS t i) x
+           | ((t, x), i) <- zip txs [100, 102..] ]
+
+
+-- | Construct 'Events' from a time series.
+--
+-- The time series is truncated at (but not including) the given time. This is
+-- necessary to check properties over finite prefixes of infinite time series.
+--
+eventsFromListUpToTime :: Time -> [(Time, a)] -> Events a
+eventsFromListUpToTime horizon txs =
+    Events [ E (TS t i) x
+           | let txs' = takeWhile (\(t,_) -> t < horizon) txs
+           , ((t, x), i) <- zip txs' [100, 102..] ]
+
+
+eventsToList :: Events a -> [(Time, a)]
+eventsToList (Events txs) = [ (t, x) | E (TS t _i) x <- txs ]
+
+selectEvents :: (a -> Maybe b) -> Events a -> Events b
+selectEvents select (Events txs) =
+    Events [ E t y | E t x <- txs, y <- maybeToList (select x) ]
+
+primitiveTransformEvents :: ([E a] -> [E b]) -> Events a -> Events b
+primitiveTransformEvents f (Events txs) = Events (f txs)
+
+
+--
+-- Signals
+--
+
+-- | A signal is a time-varying value. It has a value at all times. It changes
+-- value at discrete times, i.e. it is not continuous.
+--
+data Signal a = Signal a [E a]
+  deriving (Show, Functor)
+
+instance Applicative Signal where
+    pure  x = Signal x []
+    f <*> x = mergeSignals f x
+
+mergeSignals :: Signal (a -> b) -> Signal a -> Signal b
+mergeSignals (Signal f0 fs0) (Signal x0 xs0) =
+    Signal (f0 x0) (go f0 x0 (mergeBy compareTimestamp fs0 xs0))
+  where
+    go :: (a -> b) -> a -> [MergeResult (E (a -> b)) (E a)] -> [E b]
+    go _ _ [] = []
+    go _ x (OnlyInLeft   (E t f)         : rs) = E t (f x) : go f x rs
+    go f _ (OnlyInRight          (E t x) : rs) = E t (f x) : go f x rs
+    go _ _ (InBoth       (E t f) (E _ x) : rs) = E t (f x) : go f x rs
+
+compareTimestamp :: E a -> E b -> Ordering
+compareTimestamp (E ts _) (E ts' _) = compare ts ts'
+
+
+-- | Construct a 'Signal' from an initial value and a time series of events
+-- that represent new values of the signal.
+--
+-- This only makes sense for events that sample a single time-varying value.
+--
+fromChangeEvents :: a -> Events a -> Signal a
+fromChangeEvents x (Events xs) = Signal x xs
+
+
+-- | Convert a 'Signal' into a time series of events when the signal value
+-- changes.
+--
+toChangeEvents :: Signal a -> Events a
+toChangeEvents = Events . toTimeSeries
+
+toTimeSeries :: Signal a -> [E a]
+toTimeSeries (Signal x xs) = E (TS (Time 0) 0) x : xs
+
+
+-- | Construct a 'Signal' that represents a time series of discrete events. The
+-- signal is @Just@ the event value at the time of the event, and is @Nothing@
+-- at all other times.
+--
+-- Note that this signal \"instantaneously\" takes the event value and reverts
+-- to @Nothing@ before time moves on. Therefore this kind of signal is not
+-- \"stable\" in the sense of 'stableSignal'.
+--
+fromEvents :: Events a -> Signal (Maybe a)
+fromEvents (Events txs) =
+    Signal Nothing
+           [ E (TS t i') s
+           | E (TS t i) x <- txs
+           , (i', s) <- [(i, Just x), (i+1, Nothing)]
+           ]
+
+
+-- | A signal can change value more than once at a single point of time.
+--
+-- Sometimes we are interested only in the final \"stable\" value of the signal
+-- before time moves on. This function discards the other values, keeping only
+-- the final value at each time.
+--
+stable :: Signal a -> Signal a
+stable (Signal x xs) =
+    Signal x ((map last . groupBy sameTime) xs)
+  where
+    sameTime (E (TS t _) _) (E (TS t' _) _) = t == t'
+
+-- Truncate a 'Signal' after a given time. This is typically necessary to
+-- check properties over finite prefixes of infinite signals.
+--
+truncateAt :: Time -> Signal a -> Signal a
+truncateAt horizon (Signal x txs) =
+    Signal x (takeWhile (\(E (TS t _) _) -> t < horizon) txs)
+
+
+-- | Sometimes the way a signal is constructed leads to duplicate signal values
+-- which can slow down signal processing. This tidies up the signal by
+-- eliminating the duplicates. This does not change the meaning (provided the
+-- 'Eq' instance is true equality).
+--
+nub :: Eq a => Signal a -> Signal a
+nub (Signal x0 xs0) =
+    Signal x0 (go x0 xs0)
+  where
+    go _ [] = []
+    go x (E t x' : xs)
+      | x == x'   = go x xs
+      | otherwise = E t x' : go x' xs
+
+
+-- | A linger signal remains @True@ for the given time after the underlying
+-- signal is @True@.
+--
+linger :: DiffTime
+       -> (a -> Bool)
+       -> Signal a
+       -> Signal Bool
+linger = error "TODO: Signal.linger"
+
+
+-- | Make a timeout signal, based on observing an underlying signal.
+--
+-- The timeout signal takes the value @True@ when the timeout has occurred, and
+-- @False@ otherwise.
+--
+-- The timeout is controlled by an \"arming\" function on the underlying signal.
+-- The arming function should return @True@ when the timeout should be started,
+-- and it returns the time to wait before the timeout fires. The arming function
+-- should return @False@ when the timeout should be cancelled or not started.
+--
+-- The output signal becomes @True@ when the arming function has been
+-- continuously active (i.e. returning @True@) for the given duration.
+--
+timeout :: forall a.
+           DiffTime    -- ^ timeout duration
+        -> (a -> Bool) -- ^ the arming function
+        -> Signal a
+        -> Signal Bool
+timeout d arm =
+    Signal False
+  . disarmed
+  . toTimeSeries
+  where
+    disarmed :: [E a] -> [E Bool]
+    disarmed []          = []
+    disarmed (E ts@(TS t _) x : txs)
+      | arm x     = armed (d `addTime` t) (E ts x : txs)
+      | otherwise = E ts False : disarmed txs
+
+    armed :: Time -> [E a] -> [E Bool]
+    armed !expiry [] = [E expiryTS True] where expiryTS = TS expiry 0
+
+    armed !expiry (E ts@(TS t _) x : txs)
+      | t > expiry  = E expiryTS True  : expired (E ts x : txs)
+      | not (arm x) = E ts       False : disarmed txs 
+      | t < expiry  = E ts       False : armed expiry txs
+      | otherwise   = E expiryTS True  : expired txs
+      where
+        expiryTS = TS expiry 0
+
+    expired :: [E a] -> [E Bool]
+    expired [] = []
+    expired (E t x : txs)
+      | arm x      = E t True  : expired  txs
+      | otherwise  = E t False : disarmed txs
+
+
+until :: (a -> Bool) -- ^ Start
+      -> (a -> Bool) -- ^ Stop
+      -> Signal a
+      -> Signal Bool
+until _ = error "TODO: Signal.until"
+
+
+-- | Make a signal that keeps track of recent activity, based on observing an
+-- underlying signal.
+--
+-- The underlying signal is scrutinised with the provided \"activity interest\"
+-- function that tells us if the signal value is activity of interest to track.
+-- If it is, the given key is entered into the result signal set for the given
+-- time duration. If the same activity occurs again before the duration expires
+-- then the expiry will be extended to the new deadline (it is not cumulative).
+-- The key will be removed from the result signal set when it expires.
+--
+keyedLinger :: forall a b. Ord b
+            => DiffTime
+            -> (a -> Set b)  -- ^ The activity set signal
+            -> Signal a
+            -> Signal (Set b)
+keyedLinger d activity =
+    Signal Set.empty
+  . go Set.empty PSQ.empty
+  . toTimeSeries
+  where
+    go :: Set b
+       -> OrdPSQ b Time ()
+       -> [E a]
+       -> [E (Set b)]
+    go _ _ [] = []
+
+    go lingerSet lingerPSQ (E ts@(TS t _) xs : txs)
+      | Just (x, t', _, lingerPSQ') <- PSQ.minView lingerPSQ
+      , t' < t
+      , let lingerSet' = Set.delete x lingerSet
+      = E (TS t' 0) lingerSet' : go lingerSet' lingerPSQ' (E ts xs : txs)
+
+    go lingerSet lingerPSQ (E ts@(TS t _) x : txs) =
+      let ys         = activity x
+          lingerSet' = lingerSet <> ys
+          lingerPSQ' = Set.foldl' (\s y -> PSQ.insert y t' () s) lingerPSQ ys
+          t'         = addTime d t
+       in if lingerSet' /= lingerSet
+            then E ts lingerSet' : go lingerSet' lingerPSQ' txs
+            else                   go lingerSet' lingerPSQ' txs
+
+
+keyedTimeout :: forall a b. Ord b
+             => DiffTime
+             -> (a -> Set b)  -- ^ The timeout arming set signal
+             -> Signal a
+             -> Signal (Set b)
+keyedTimeout d arm =
+    Signal Set.empty
+  . go Set.empty PSQ.empty Set.empty
+  . toTimeSeries
+  where
+    go :: Set b
+       -> OrdPSQ b Time ()
+       -> Set b
+       -> [E a]
+       -> [E (Set b)]
+    go _ _ _ [] = []
+
+    go armedSet armedPSQ timedout (E ts@(TS t _) x : txs)
+      | Just (y, t', _, armedPSQ') <- PSQ.minView armedPSQ
+      , t' < t
+      , let armedSet' = Set.delete y armedSet
+            timedout' = Set.insert y timedout
+      = E (TS t' 0) timedout' : go armedSet' armedPSQ' timedout' (E ts x : txs)
+
+    go armedSet armedPSQ timedout (E ts@(TS t _) x : txs) =
+      let armedSet' = arm x
+          armedAdd  = armedSet' Set.\\ armedSet
+          armedDel  = armedSet  Set.\\ armedSet'
+          armedPSQ' = flip (Set.foldl' (\s y -> PSQ.insert y t' () s)) armedAdd
+                    . flip (Set.foldl' (\s y -> PSQ.delete y       s)) armedDel
+                    $ armedPSQ
+          t'        = addTime d t
+          timedout' = timedout `Set.intersection` armedSet'
+       in if timedout' /= timedout
+            then E ts timedout' : go armedSet' armedPSQ' timedout' txs
+            else                  go armedSet' armedPSQ' timedout' txs
+
+
+keyedUntil :: forall a b. Ord b
+           => (a -> Set b)   -- ^ Start set signal
+           -> (a -> Set b)   -- ^ Stop set signal
+           -> (a -> Bool)    -- ^ Stop all signal
+           -> Signal a
+           -> Signal (Set b)
+keyedUntil start stop stopAll =
+    Signal Set.empty
+  . go Set.empty
+  . toTimeSeries
+  where
+
+    go :: Set b
+       -> [E a]
+       -> [E (Set b)]
+    go _ [] = []
+    go active (E t x : txs)
+       | active' /= active = E t active' : go active' txs
+       | otherwise         =               go active' txs
+      where
+        active'
+          | stopAll x = Set.empty
+          | otherwise = (active <> start x) Set.\\ stop x
+
+
+difference :: (a -> a -> b)
+           -> Signal a
+           -> Signal (Maybe b)
+difference diff (Signal x0 txs0) =
+    Signal Nothing (go x0 txs0)
+  where
+    go _ []                    = []
+    go x (E (TS t i) x' : txs) = E (TS t i)    (Just (diff x x'))
+                               : E (TS t (i+1)) Nothing
+                               : go x' txs
+
+
+
+--
+-- Utils
+--
+
+-- | Generic merging utility. For sorted input lists this is a full outer join.
+--
+mergeBy :: (a -> b -> Ordering) -> [a] -> [b] -> [MergeResult a b]
+mergeBy cmp = merge
+  where
+    merge []     ys     = [ OnlyInRight y | y <- ys]
+    merge xs     []     = [ OnlyInLeft  x | x <- xs]
+    merge (x:xs) (y:ys) =
+      case x `cmp` y of
+        GT -> OnlyInRight   y : merge (x:xs) ys
+        EQ -> InBoth      x y : merge xs     ys
+        LT -> OnlyInLeft  x   : merge xs  (y:ys)
+
+data MergeResult a b = OnlyInLeft a | InBoth a b | OnlyInRight b
+  deriving (Eq, Show)
+

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1591,6 +1591,12 @@ selectEnvTargets f =
 -- Live examples
 --
 
+-- | Run the 'publicRootPeersProvider' in IO with a stdout tracer to observe
+-- what it does.
+--
+-- This is a manual test that runs in IO and has to be observed to see that it
+-- is doing something sensible. It is not run automatically.
+--
 _governorFindingPublicRoots :: Int -> [DomainAddress] -> IO Void
 _governorFindingPublicRoots targetNumberOfRootPeers domains =
     withTimeoutSerial $ \timeout ->

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -381,7 +381,13 @@ envEventCredits (TraceEnvSetTargets PeerSelectionTargets {
 envEventCredits (TraceEnvPeersDemote Noop   _) = 10
 envEventCredits (TraceEnvPeersDemote ToWarm _) = 30
 envEventCredits (TraceEnvPeersDemote ToCold _) = 30
-envEventCredits (TraceEnvPeersStatus _)        = 0
+
+envEventCredits  TraceEnvPeersStatus{}         = 0
+-- These events are visible in the environment but are the result of actions
+-- initiated by the governor, hence the get no credit.
+envEventCredits  TraceEnvRootsResult{}         = 0
+envEventCredits  TraceEnvGossipRequest{}       = 0
+envEventCredits  TraceEnvGossipResult{}        = 0
 
 
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -52,7 +52,7 @@ import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Signal
-import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup, after, DependencyType(..))
 import           Test.Tasty.QuickCheck (testProperty)
 
 
@@ -61,15 +61,23 @@ tests =
   testGroup "Ouroboros.Network.PeerSelection"
   [ Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
-  , testGroup "safety"
+  , testGroup "basic"
     [ testProperty "has output"         prop_governor_hasoutput
     , testProperty "no failure"         prop_governor_nofail
     , testProperty "no livelock"        prop_governor_nolivelock
-    , testProperty "no excess busyness" prop_governor_nobusyness
+    ]
+
+    -- The no livelock property is needed to ensure other tests terminate
+  , after AllSucceed "Ouroboros.Network.PeerSelection.basic" $
+    testGroup "safety"
+    [ testProperty "no excess busyness" prop_governor_nobusyness
     , testProperty "event coverage"     prop_governor_trace_coverage
     , testProperty "connection status"  prop_governor_connstatus
     ]
-  , testGroup "progress"
+
+    -- The no livelock property is needed to ensure other tests terminate
+  , after AllSucceed "Ouroboros.Network.PeerSelection.basic" $
+    testGroup "progress"
     [ testProperty "gossip reachable"    prop_governor_gossip_1hr
 
 --  , testProperty "progresses towards public root peers target (from below)"

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -152,10 +152,10 @@ tests =
 --
 -- * A public root peers target property: that the governor hits its target for
 --   for the number of public root peers (or as near as possible), and does
---   note "grossly" overshoot. Since the public roots is a one sided target, but
+--   not "grossly" overshoot. Since the public roots is a one sided target, but
 --   we don't want to overshoot excessively.
 --
--- * A local root peers target property: that the governor hits it target for
+-- * A local root peers target property: that the governor hits its target for
 --   getting all its local root peers into the established state, and a target
 --   number of them into the active state (or as near as possible).
 --
@@ -445,6 +445,8 @@ prop_governor_trace_coverage env =
      in coverTable "trace events" [ (n, 1) | n <- Map.elems allTraceNames ] $
         tabulate   "trace events" (Map.elems traceNamesSeen)
         True
+        --TODO: use cover to check we do indeed get them all. There are a few
+        -- cases we do not cover yet. These should be fixed first.
 
 collectTraces :: [(Time, TestTraceEvent)] -> Set Int
 collectTraces trace =

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -125,6 +125,10 @@ tests =
 --   into a busy cycle. See also the "no excessive busyness" property for a
 --   more advanced version.
 --
+-- * A "no excessive busyness" property. This checks that the governor does not
+--   remain too busy for too long. It's quite easy to write bugs that don't
+--   cause the governor to fail, but cause it to go into fairly-busy cycles.
+--
 -- * A state consistency property that the governor's view of part of the state
 --   and the "true" state of the mock environment are maintained in an
 --   appropriate correspondence.
@@ -136,22 +140,20 @@ tests =
 -- * A cold peer gossip "reachable" property: that the governor either hits
 --   its target for the number of cold peers, or finds all the reachable peers.
 --
--- Properties that we would like to have:
+-- * A known peer target progress property: that the governor makes progress
+--   within a bounded time towards its known peers target, from below and above.
 --
--- * A "no excessive busyness" property. This checks that the governor does not
---   remain too busy for too long. It's quite easy to write bugs that don't
---   cause the governor to fail, but cause it to go into fairly-busy cycles.
+-- * An established peer target property: the same as above but for established
+--   peers.
+--
+-- * An active peer target property: the same as above but for active peers.
+--
+-- Properties that we would like to have:
 --
 -- * A public root peers target property: that the governor hits its target for
 --   for the number of public root peers (or as near as possible), and does
 --   note "grossly" overshoot. Since the public roots is a one sided target, but
 --   we don't want to overshoot excessively.
---
--- * A warm peer target property: that the governor hits its established peers
---   target (or as near as possible).
---
--- * A hot peer target property: that the governor hits its active peers
---   target (or as near as possible).
 --
 -- * A local root peers target property: that the governor hits it target for
 --   getting all its local root peers into the established state, and a target
@@ -159,8 +161,6 @@ tests =
 --
 -- Other properties we might like to think about
 --
--- * for vaguely stable envs, we do stablise at our target number of cold peers
--- * time to stabilise after a change is not crazy
 -- * time to find new nodes after a graph change is ok
 -- * targets or root peer set dynamic
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -538,8 +538,8 @@ prop_governor_gossip_1hr env@GovernorMockEnvironment {
 -- | Check the governor's view of connection status does not lag behind reality
 -- by too much.
 --
-prop_governor_connstatus :: GovernorMockEnvironmentWithoutAsyncDemotion -> Bool
-prop_governor_connstatus (GovernorMockEnvironmentWAD env) =
+prop_governor_connstatus :: GovernorMockEnvironment -> Bool
+prop_governor_connstatus env =
     let trace = takeFirstNHours 1
               . selectPeerSelectionTraceEvents $
                   runGovernorInMockEnvironment env
@@ -557,12 +557,15 @@ prop_governor_connstatus (GovernorMockEnvironmentWAD env) =
         case (lastTrueStatus, lastTestStatus) of
           (Nothing, _)                       -> True
           (Just trueStatus, Just testStatus) -> trueStatus == testStatus
-          (Just _,          Nothing)         -> False
+          (Just trueStatus, Nothing)         -> trueStatus == Map.empty
       where
         lastTrueStatus =
           listToMaybe
-            [ status
+            [ Map.filter (not . isPeerCold) status
             | (_, MockEnvEvent (TraceEnvPeersStatus status)) <- reverse trace ]
+
+        isPeerCold PeerCold = True
+        isPeerCold _        = False
 
         lastTestStatus =
           listToMaybe

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE NumericUnderscores         #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -17,12 +18,16 @@ module Test.Ouroboros.Network.PeerSelection (tests) where
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function (on)
 import           Data.List (groupBy, foldl')
-import           Data.Maybe (listToMaybe)
+import           Data.Maybe (listToMaybe, isNothing, fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Void (Void)
+
+import qualified Data.Signal as Signal
+import           Data.Signal (Signal, Events, E(E), TS(TS))
+import qualified Data.OrdPSQ as PSQ
 
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer (..))
@@ -36,6 +41,7 @@ import           Ouroboros.Network.PeerSelection.Governor hiding
 import qualified Ouroboros.Network.PeerSelection.Governor as Governor
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
+import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
 
 import           Test.Ouroboros.Network.PeerSelection.Instances
@@ -45,6 +51,7 @@ import qualified Test.Ouroboros.Network.PeerSelection.MockEnvironment
 import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Signal
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
@@ -54,14 +61,37 @@ tests =
   testGroup "Ouroboros.Network.PeerSelection"
   [ Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
-  , testGroup "governor"
+  , testGroup "safety"
     [ testProperty "has output"         prop_governor_hasoutput
     , testProperty "no failure"         prop_governor_nofail
     , testProperty "no livelock"        prop_governor_nolivelock
     , testProperty "no excess busyness" prop_governor_nobusyness
     , testProperty "event coverage"     prop_governor_trace_coverage
-    , testProperty "gossip reachable"   prop_governor_gossip_1hr
     , testProperty "connection status"  prop_governor_connstatus
+    ]
+  , testGroup "progress"
+    [ testProperty "gossip reachable"    prop_governor_gossip_1hr
+
+--  , testProperty "progresses towards public root peers target (from below)"
+--                 prop_governor_target_publicroots
+
+    , testProperty "progresses towards known peers target (from below)"
+                   prop_governor_target_known_below
+    , testProperty "progresses towards known peers target (from above)"
+                   (expectFailure prop_governor_target_known_above)
+                   --TODO: for the moment this correctly fails because it finds
+                   -- a nice corner case in the space, that we've not yet
+                   -- decided how we wish to resolve.
+
+    , testProperty "progresses towards established peers target (from below)"
+                   prop_governor_target_established_below
+    , testProperty "progresses towards established peers target (from above)"
+                   prop_governor_target_established_above
+
+    , testProperty "progresses towards active peers target (from below)"
+                   prop_governor_target_active_below
+    , testProperty "progresses towards active peers target (from above)"
+                   prop_governor_target_active_above
     ]
   ]
 
@@ -581,11 +611,980 @@ prop_governor_connstatus env =
 
 
 --
+-- Progress properties
+--
+
+-- | The main progress property for known peers: that we make progress towards
+-- the target for known peers from below. See 'prop_governor_target_known_above'
+-- for the (simpler) corresponding property for hitting the target from above.
+--
+-- Intuitively the property we want is that the governor either hits its target
+-- for the number of known peers, or gets as close as reasonably possible. The
+-- environment may be such that it prevents the governor from reaching its
+-- target, e.g. because the target is too high, or not all peers may be
+-- reachable by the gossip graph.
+--
+-- We approach this property as the conjunction of several simpler properties.
+-- We take this approach for three main reasons.
+-- 
+-- 1. Firstly modularity help us break down a complex problem into simpler
+--    problems. Overall this progress idea turns out to be quite subtle and
+--    tricky to express precisely in a way that actually works.
+-- 2. Secondly, modularity can give us opportunities to reuse code in other
+--    properties and we want to have progress properties for all the governor
+--    targets.
+-- 3. Thirdly, it turns out to be hard to dictate in a universal way precisely
+--    what the governor can be expected to do. It is simpler to specify looser
+--    constraints on what it must and must not do. We can then argue informally
+--    that the combination of properties must lead to the kinds of outcomes we
+--    intend.
+-- 
+-- We decompose the progress property into the following (informally stated)
+-- properties:
+-- 
+-- 1. The set of peers the governor knows about is a subset of the peers the
+--    environment has told the governor about.
+--
+--    This is a weak property since it simply says that the governor does not
+--    invent things out of thin air. We might expect that we could strengthen
+--    this property to require that the subset be maximal in some sense however
+--    such a property is violated by dynamic targets. There are also timing
+--    issues which would complicate such a strengthened property: the governor
+--    has legitimate reasons to update its internal state some time after the
+--    environment informs it about new peers.
+-- 
+-- 2. If the governor is below target and has the opportunity to gossip then
+--    within a bounded time it should perform a gossip with one of its known
+--    peers.
+-- 
+--    This is the primary progress property. It is a relatively weak property:
+--    we do not require that progress is actually made, just that opportunities
+--    for progress are taken when available. We cannot always demand actual
+--    progress since there are environments where it is not possible to make
+--    progress, even though opportunities for gossip remain available. Examples
+--    include environments where the total set of peers in the graph is less
+--    than the target for known peers.
+-- 
+-- 3. The governor should not gossip too frequently with any individual peer,
+--    except when the governor forgets known peers.
+-- 
+--    This is both useful in its own right, but it also helps to strengthen the
+--    primary property by helping to ensure that the choices of which peers to
+--    gossip with are reasonable. In the primary property we do not require that
+--    the peer the  the governor chooses to gossip with is one of the
+--    opportunities as defined by the property. We do not require this because
+--    the set of opportunities is a lower bound not an upper bound, and trying
+--    to make it a tight bound becomes complex and over-specifies behaviour.
+--    There is the danger however that the governor could appear to try to make
+--    progress by gossiping but always picking useless choices that avoid making
+--    actual progress. By requiring that the governor not gossip with any
+--    individual peer too often we can shrink the set of peers the governor can
+--    choose and thus force the governor to eventually pick other peers to
+--    gossip with, which should mean the governor eventually picks peers that
+--    can enable progress.
+-- 
+-- 4. When the governor does perform a gossip, within a bounded time it should
+--    include the results into its known peer set, or the known peer set should
+--    reach its target size.
+-- 
+--    This helps to strengthen the primary progress property by ensuring the
+--    results of gossip are used to make progress when that is possible.
+-- 
+-- 5. The governor should not shrink its known peer set except when it is above
+--    the target size.
+-- 
+--    This also helps to strengthen the second property by ensuring monotonic
+--    progress, except when we overshoot targets or when targets are reduced.
+--
+-- The overall progress argument is then an semi-formal argument, structured
+-- much like classic proofs about loops. A classic loop proof has two parts: 1.
+-- if the loop does terminate it gets the right result, and 2. it must
+-- eventually terminate because it makes progress in some measure that is
+-- bounded.
+-- 
+-- Of course in our setting there is no termination, but we can reach a goal
+-- and remain in a steady state until the environment changes. Our argument is
+-- that the governor makes progress to increase the size of its set of known
+-- peers until either it hits its target number of known peers, or it reaches a
+-- maximal possible set. As a corollary if the targets do not change too
+-- frequently then it will eventually hit the target or reach a maximal set.
+-- 
+-- Property number 1 above tells us that if we do reach our goal condition that
+-- we will have a correct result, as property 1 tells us that all the governors'
+-- known peers are ones supplied by the environment.
+-- 
+-- Progress from below relies on the combination of property 2, 3, 4 and 5.
+-- Property 2 tells us that we eventually do some gossip with some peer, but
+-- does not by itself establish that we make progress in a bounded measure.
+-- Property 3 gives us the bounded measure. Property 3 gives us a set of peers
+-- that we have not gossiped with recently. When the governor does gossip with
+-- a peer then it is removed from this set (but scheduled to be added back some
+-- time later). So the measure is the size of this set of peers. It is clearly
+-- bounded below by the empty set. So the combination of 2 and 3 tells us we
+-- make progress in this bounded measure, but that does not directly translate
+-- into increasing the size of the known peers set. Properties 4 and 5 tell us
+-- that progress with gossiping will eventually translate into increasing the
+-- size of the known peers set if that is possible.
+-- 
+-- There is one known wrinkle to this argument to do with property 3 that when
+-- the governor gossips with a peer it is removed from the tracking set however
+-- it gets added back some time later. If they get added back too soon then it
+-- would undermine the progress argument because it would break the argument
+-- about decreasing the bounded measure. This is readily solved however: we
+-- simply need to make sure the time scale for gossip frequency is relatively
+-- long, and the other progress bounds are relatively short.
+-- 
+prop_governor_target_known_below :: GovernorMockEnvironment -> Property
+prop_governor_target_known_below env =
+      prop_governor_target_known_1_valid_subset      env
+ .&&. prop_governor_target_known_2_opportunity_taken env
+ .&&. prop_governor_target_known_3_not_too_chatty    env
+ .&&. prop_governor_target_known_4_results_used      env
+ .&&. prop_governor_target_known_5_no_shrink_below   env
+
+
+-- | The set of peers the governor knows about is a subset of the peers the
+-- environment has told the governor about.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the accumulation of all the peers the environment has ever
+--    told the governor about, based on the environment trace.
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- Based on these signals we check:
+--
+-- * That the governor known peers is a subset of the accumulated environment
+--   known peers.
+--
+prop_governor_target_known_1_valid_subset :: GovernorMockEnvironment
+                                          -> Property
+prop_governor_target_known_1_valid_subset env =
+    let events = Signal.eventsFromListUpToTime (Time (60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envKnownPeersSig :: Signal (Set PeerAddr)
+        envKnownPeersSig =
+            environmentAllKnownPeers
+              (LocalRootPeers.keysSet (localRootPeers env))
+          . selectEnvEvents
+          $ events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        validState :: Set PeerAddr -> Set PeerAddr -> Bool
+        validState knownPeersEnv knownPeersGov =
+          knownPeersGov `Set.isSubsetOf` knownPeersEnv
+
+     in signalProperty 20 show (uncurry validState) $
+          (,) <$> envKnownPeersSig
+              <*> govKnownPeersSig
+
+
+-- | Look at the trace of events from the mock environment and produce a
+-- derived trace of the set of peers that could in principle be known by the
+-- governor at any point in time. It is maximal in the sense it is all such
+-- peers, without respect for any governor targets as limits.
+--
+-- This trace depends on what the governor actually does, it is not about what
+-- it could do. The set starts with the root peers and is extended each time
+-- the governor successfully gossips with a peer and finds new peers.
+--
+-- This trace transformer assumes the root peers do not change. It will need
+-- to be adjusted when the the mock environment is extended with dynamic root
+-- peers.
+--
+environmentAllKnownPeers :: Set PeerAddr
+                         -> Events TraceMockEnv
+                         -> Signal (Set PeerAddr)
+environmentAllKnownPeers localRootPeers =
+  --TODO: implement this as a generic signalScanl style combinator
+    Signal.stable
+  . Signal.fromChangeEvents localRootPeers
+  . Signal.primitiveTransformEvents (go localRootPeers)
+  where
+    go :: Set PeerAddr -> [E TraceMockEnv] -> [E (Set PeerAddr)]
+    go !_ [] = []
+
+    go !known (E t (TraceEnvRootsResult peeraddrs) : es)
+      | let known' = Set.union known (Set.fromList peeraddrs)
+      , Set.size known' > Set.size known
+      = E t known' : go known' es
+
+    go !known (E t (TraceEnvGossipResult _ peeraddrs) : es)
+      | let known' = Set.union known (Set.fromList peeraddrs)
+      , Set.size known' > Set.size known
+      = E t known' : go known' es
+
+    go !known (_ : es) = go known es
+
+
+-- | If the governor is below target and has the opportunity to gossip then
+-- within a bounded time it should perform a gossip with one of its known peers.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the target for known peers from the environment
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. A signal of the set of peers with which the governor has gossiped
+--    recently, based on the requests to the environment
+--
+-- 4. Based on 2 and 3, a signal of the set of gossip opportunities: the
+--    current known peers that are not in the recent gossip set.
+--
+-- 5. A signal of the environment gossip request events.
+--
+-- 6. Based on 1, 2, 4 and 5, a signal that becomes False if for 30 seconds:
+--    the number of known peers is below target; the set of opportunities is
+--    non empty; and no gossip request event has occurred.
+--
+-- Based on these signals we check:
+--
+-- * That the signal 6 remains True at all times.
+--
+prop_governor_target_known_2_opportunity_taken :: GovernorMockEnvironment
+                                               -> Property
+prop_governor_target_known_2_opportunity_taken env =
+
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfKnownPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        envGossipUnavailableSig :: Signal (Set PeerAddr)
+        envGossipUnavailableSig =
+            Signal.keyedLinger
+              -- peers are unavailable for gossip for at least an
+              -- hour after each gossip interaction
+              (60 * 60)
+              (maybe Set.empty Set.singleton)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TraceEnvGossipRequest peer _ -> Just peer
+                     _                            -> Nothing)
+          . selectEnvEvents
+          $ events
+
+        -- We define the governor's gossip opportunities at any point in time
+        -- to be the governor's set of known peers, less the ones we can see
+        -- that it has gossiped with recently.
+        --
+        gossipOpportunitiesSig :: Signal (Set PeerAddr)
+        gossipOpportunitiesSig =
+          (Set.\\) <$> govKnownPeersSig <*> envGossipUnavailableSig
+
+        -- Note that we only require that the governor try to gossip, it does
+        -- not have to succeed.
+        envGossipsEventsAsSig :: Signal (Maybe PeerAddr)
+        envGossipsEventsAsSig =
+            Signal.fromEvents
+          . Signal.selectEvents
+              (\case TraceEnvGossipRequest addr _ -> Just addr
+                     _                            -> Nothing)
+          . selectEnvEvents
+          $ events
+
+        -- The signal of all the things of interest for this property.
+        -- This is used to compute the final predicate, and is also what
+        -- we want to report if there is a property violation.
+        combinedSig :: Signal (Int,
+                               Set PeerAddr,
+                               Set PeerAddr,
+                               Maybe PeerAddr)
+        combinedSig =
+          (,,,) <$> envTargetsSig
+                <*> govKnownPeersSig
+                <*> gossipOpportunitiesSig
+                <*> envGossipsEventsAsSig
+
+        -- This is the ultimate predicate signal
+        gossipOpportunitiesOkSig :: Signal Bool
+        gossipOpportunitiesOkSig =
+          Signal.truncateAt (Time (60 * 60 * 10)) $
+          governorEventuallyTakesGossipOpportunities combinedSig
+
+     in counterexample
+          "Signal key: (target, known peers, opportunities, gossip event)" $
+
+        -- Check the predicate signal but for failures report the input signal
+        signalProperty 20 (show . snd) fst $
+          (,) <$> gossipOpportunitiesOkSig
+              <*> combinedSig
+
+
+governorEventuallyTakesGossipOpportunities
+  :: Signal (Int, Set PeerAddr, Set PeerAddr, Maybe PeerAddr)
+  -> Signal Bool
+
+governorEventuallyTakesGossipOpportunities =
+    -- Time out and fail after 30 seconds if we enter and remain in a bad state
+    fmap not
+  . Signal.timeout timeLimit badState
+  where
+    timeLimit :: DiffTime
+    timeLimit = 30
+
+    badState (target, govKnownPeers, gossipOpportunities, gossipEvent) =
+
+        -- A bad state is one where we are below target;
+        Set.size govKnownPeers < target
+
+        -- where we do have opportunities; and
+     && not (Set.null gossipOpportunities)
+
+        -- are not performing an action to take the opportunity.
+     && isNothing gossipEvent
+
+        -- Note that if a gossip does take place, we do /not/ require the gossip
+        -- target to be a member of the gossipOpportunities. This is because
+        -- the gossip opportunities set is a lower bound not an upper bound.
+        -- There is a separate property to check that we do not gossip too
+        -- frequently with any individual peer.
+
+
+
+-- | The governor should not gossip too frequently with any individual peer,
+-- except when the governor forgets known peers.
+--
+-- We derive a number of signals:
+--
+-- Based on these signals we check:
+--
+prop_governor_target_known_3_not_too_chatty :: GovernorMockEnvironment
+                                            -> Property
+prop_governor_target_known_3_not_too_chatty env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        gossipOk Nothing      _           = True
+        gossipOk (Just peers) unavailable =
+          Set.null (peers `Set.intersection` unavailable)
+
+     in signalProperty 20 show (uncurry gossipOk) $
+          recentGossipActivity 3600 events
+
+
+recentGossipActivity :: DiffTime
+                     -> Events TestTraceEvent
+                     -> Signal (Maybe (Set PeerAddr), Set PeerAddr)
+recentGossipActivity d =
+    Signal.fromChangeEvents (Nothing, Set.empty)
+  . Signal.primitiveTransformEvents (go Set.empty PSQ.empty)
+  where
+    go :: Set PeerAddr
+       -> PSQ.OrdPSQ PeerAddr Time ()
+       -> [E TestTraceEvent]
+       -> [E (Maybe (Set PeerAddr), Set PeerAddr)]
+    go !recentSet !recentPSQ txs@(E (TS t _) _ : _)
+      | Just (k, t', _, recentPSQ') <- PSQ.minView recentPSQ
+      , t' <= t
+      , let recentSet' = Set.delete k recentSet
+      = E (TS t' 0) (Nothing, recentSet')
+      : go recentSet' recentPSQ' txs
+
+    -- When we see a gossip request we add it to the recent set and schedule
+    -- it to be removed again at time d+t. We arrange for the change in the
+    -- recent set to happen after the gossip event.
+    go !recentSet !recentPSQ
+        (E (TS t i) (GovernorEvent (TraceGossipRequests _ _ _ addrs)) : txs) =
+      let recentSet' = recentSet <> addrs
+          recentPSQ' = foldl' (\q a -> PSQ.insert a t' () q) recentPSQ addrs
+          t'         = d `addTime` t
+       in E (TS t i)     (Just addrs, recentSet)
+        : E (TS t (i+1)) (Nothing, recentSet') -- updated in next change at same time
+        : go recentSet' recentPSQ' txs
+
+    -- When the governor is forced to forget known peers, we drop it from
+    -- the recent activity tracking, which means if it is added back again
+    -- later then we can gossip with it again earlier than the normal limit.
+    --
+    -- Alternatively we could track this more coarsely by dropping all tracking
+    -- when the targets are adjusted downwards, but we use small target
+    -- adjustments to perform churn.
+    --
+    -- There is a separate property to check that the governor does not forget
+    -- peers unnecessarily.
+    --
+    go !recentSet !recentPSQ
+        (E t (GovernorEvent (TraceForgetColdPeers _ _ addrs)) : txs) =
+      let recentSet' = foldl' (flip Set.delete) recentSet addrs
+          recentPSQ' = foldl' (flip PSQ.delete) recentPSQ addrs
+       in E t (Nothing, recentSet')
+        : go recentSet' recentPSQ' txs
+
+    go !recentSet !recentPSQ (_ : txs) =
+      go recentSet recentPSQ txs
+
+    go !_ !_ [] = []
+
+
+-- | When the governor does perform a gossip, within a bounded time it should
+-- include the results into its known peer set, or the known peer set should
+-- reach its target size.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the target for known peers from the environment
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. A signal of the environment gossip result events, as the set of results
+--    at any point in time.
+--
+-- 4. Based on 1, 2 and 3, a signal that tracks a set of peers that we have
+--    gossiped with, such that the peers remain in the set until either they
+--    appear in the governor known peers set or until the known peer set
+--    reaches its target size.
+--
+-- 5. Based on 4, a signal of the subset of elements that have been a member
+--    continuously for at least X seconds duration.
+--
+-- Based on these signals we assert:
+--
+-- * That the signal 4 above is always empty.
+--
+prop_governor_target_known_4_results_used :: GovernorMockEnvironment -> Property
+prop_governor_target_known_4_results_used env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfKnownPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        envGossipResultsSig :: Signal (Set PeerAddr)
+        envGossipResultsSig =
+            fmap (maybe Set.empty Set.fromList)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TraceEnvGossipResult _ addrs -> Just addrs
+                     _                            -> Nothing)
+          . selectEnvEvents
+          $ events
+
+        gossipResultsUntilKnown :: Signal (Set PeerAddr)
+        gossipResultsUntilKnown =
+          Signal.keyedUntil
+            (\(_, _, gossips)    -> gossips) -- start set
+            (\(_, known, _)      -> known)   -- stop set
+            (\(target, known, _) -> Set.size known <= target) -- reset condition
+            ((,,) <$> envTargetsSig
+                  <*> govKnownPeersSig
+                  <*> envGossipResultsSig)
+
+        gossipResultsUnknownTooLong :: Signal (Set PeerAddr)
+        gossipResultsUnknownTooLong =
+          Signal.keyedTimeout
+            (10 + 1) -- policyGossipOverallTimeout
+            id
+            gossipResultsUntilKnown
+
+     in counterexample
+          ("\nSignal key: (known peers, gossip result, results unknown, " ++ 
+           "results unknown too long)") $
+
+        signalProperty 20 show
+          (\(_,_,_,_,x) -> Set.null x) $
+          (,,,,) <$> envTargetsSig
+                 <*> govKnownPeersSig
+                 <*> envGossipResultsSig
+                 <*> gossipResultsUntilKnown
+                 <*> gossipResultsUnknownTooLong
+
+
+-- | The governor should not shrink its known peer set except when it is above
+-- the target size.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the target for known peers from the environment
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. Based on 2, a signal of change events when the set of known peers shrinks.
+--
+-- 4. Based on 1, 2 and 3, a signal of unexpected shrink events: a signal that
+--    is True when there is a shrink event and the new size of the set of known
+--    peers is below the target.
+--
+-- Based on these signals we assert:
+--
+-- * That the signal 4 above is always False.
+--
+prop_governor_target_known_5_no_shrink_below :: GovernorMockEnvironment -> Property
+prop_governor_target_known_5_no_shrink_below env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfKnownPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        knownPeersShrinksSig :: Signal (Set PeerAddr)
+        knownPeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govKnownPeersSig
+
+        unexpectedShrink :: Signal Bool
+        unexpectedShrink =
+          -- Note that when we observe a shrink, the known peers set at the
+          -- same time is the new shrunk value. This means our test has to be
+          -- Set.size known < target rather than Set.size known <= target
+          -- It also has the bonus of checking that we are checking that the
+          -- size of the known peer set after the shrink is not strictly
+          -- smaller than the target, which means we're checking that we do
+          -- not undershoot the target: from above we hit the target exactly.
+          (\target known shrinks ->
+                not (Set.null shrinks)
+             && Set.size known < target
+          ) <$> envTargetsSig
+            <*> govKnownPeersSig
+            <*> knownPeersShrinksSig
+
+     in counterexample
+          "\nSignal key: (target, known peers, shrinks, unexpected)" $
+
+        signalProperty 20 show
+          (\(_,_,_,unexpected) -> not unexpected)
+          ((,,,) <$> envTargetsSig
+                 <*> govKnownPeersSig
+                 <*> knownPeersShrinksSig
+                 <*> unexpectedShrink)
+
+
+
+-- | The governor should shrink its known peer set within a bounded time when
+-- it is above the target size.
+--
+-- This deals with hitting the target from above. We have to allow some bounded
+-- time rather than demand instant shrinking because in some situation the
+-- governor must demote active or established peers before it can forget known
+-- peers.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the effective target for known peers from the environment,
+--    based on both the given target and the local root peers.
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. Based on 2, a signal of change events when the set of known peers shrinks.
+--
+-- 5. Based on 1, 2 and 3, a signal that becomes True if for X seconds, the
+--    known peers is above target and there is no shrink event.
+--
+-- Based on these signals we check:
+--
+-- * That the signal 5 above is always False.
+--
+prop_governor_target_known_above :: GovernorMockEnvironment -> Property
+prop_governor_target_known_above env =
+    --TODO: this property is currently not true. There are cases involving
+    -- local root peers where we are over target for known peers, but the only
+    -- known peer that is not established is a local root peer, which we are
+    -- not allowed to forget. The established peer in this case is not a local
+    -- root, and if it were to be demoted then we would be able to forget it
+    -- instead. Alternatively if we promoted the local root peer to established
+    -- then things would also resolve (but promoting is of course something that
+    -- can fail so that's not a full solution).
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          max <$> selectEnvTargets targetNumberOfKnownPeers events
+              <*> (Signal.fromChangeEvents 0
+                 . fmap LocalRootPeers.size
+                 . Signal.selectEvents (\case TraceEnvSetLocalRoots l -> Just l
+                                              _                       -> Nothing)
+                 . selectEnvEvents
+                 $ events)
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        knownPeersShrinksSig :: Signal (Set PeerAddr)
+        knownPeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govKnownPeersSig
+
+        aboveTargetTooLong :: Signal Bool
+        aboveTargetTooLong =
+          Signal.timeout 15
+            (\(target, known, shrinks) ->
+                  Set.size known > target
+               && Set.null shrinks)
+            ((,,) <$> envTargetsSig
+                  <*> govKnownPeersSig
+                  <*> knownPeersShrinksSig)
+
+     in counterexample
+          "\nSignal key: (target, known peers, shrinks, above target too long)" $
+
+        signalProperty 20 show
+          (\(_,_,_,toolong) -> not toolong)
+          ((,,,) <$> envTargetsSig
+                 <*> govKnownPeersSig
+                 <*> knownPeersShrinksSig
+                 <*> aboveTargetTooLong)
+
+
+-- | Check that the governor can hit (but not overshoot) its target for the
+-- number of warm peers. This has to be bounded by what is possible: we cannot
+-- always find enough peers, and when we can, some of them fail.
+--
+-- This is a somewhat tricky property to express because it is non-trivial to
+-- find the maximum number of possible established connections by inspecting
+-- the mock environment.
+--
+-- We approach it in three parts: from above, from below and statistically.
+--
+-- The simplest is from above: the environment knows how many established
+-- connections there are at any point in (virtual) time, and what the targets
+-- are. So we can easily compare the two. This can be a tight bound above.
+-- When the target is stable, the governor should never overshoot the target.
+-- When the target changes to be smaller, the governor should shrink the number
+-- of established connections to be within the target within a relatively short
+-- period of time.
+--
+--
+--
+-- Tracking very precisely the maximum number of peers we could reasonably
+-- establish connections to is tricky and hence prone to mistakes in the test
+-- definition. So as an extra sanity check we take a simpler but fuzzy approach.
+-- In some fraction of test runs, the environment should be such that it is
+-- possible to actually hit the target for the number of established peers. So
+-- we label the cases where this happens, and then we can use a statistical
+-- test to assert that this happens in some fraction of test cases.
+--
+prop_governor_target_established_below :: GovernorMockEnvironment -> Property
+prop_governor_target_established_below env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfEstablishedPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        govEstablishedPeersSig :: Signal (Set PeerAddr)
+        govEstablishedPeersSig =
+          selectGovState
+            (EstablishedPeers.toSet . Governor.establishedPeers)
+            events
+
+        govEstablishedFailuresSig :: Signal (Set PeerAddr)
+        govEstablishedFailuresSig =
+            Signal.keyedLinger
+              180 -- 3 minutes  -- TODO: too eager to reconnect?
+              (fromMaybe Set.empty)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TracePromoteColdFailed _ _ peer _ _ ->
+                       --TODO: the environment does not yet cause this to happen
+                       -- it requires synchronous failure in the establish action
+                       Just (Set.singleton peer)
+                     --TODO: what about TraceDemoteWarmDone ?
+                     -- these are also not immediate candidates
+                     -- why does the property not fail for not tracking these?
+                     TraceDemoteAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerCold) status)
+                     _ -> Nothing
+              )
+          . selectGovEvents
+          $ events
+
+        promotionOpportunities :: Signal (Set PeerAddr)
+        promotionOpportunities =
+          (\target known established recentFailures ->
+              -- There are no opportunities if we're at or above target
+              if Set.size established >= target
+                then Set.empty
+                else known Set.\\ established
+                           Set.\\ recentFailures
+          ) <$> envTargetsSig
+            <*> govKnownPeersSig
+            <*> govEstablishedPeersSig
+            <*> govEstablishedFailuresSig
+
+        promotionOpportunitiesIgnoredTooLong :: Signal (Set PeerAddr)
+        promotionOpportunitiesIgnoredTooLong =
+          Signal.keyedTimeout
+            10 -- seconds
+            id
+            promotionOpportunities
+
+     in counterexample
+          ("\nSignal key: (target, known peers, established peers, recent failures, " ++ 
+           "opportunities, ignored too long)") $
+
+        signalProperty 20 show
+          (\(_,_,_,_,_,toolong) -> Set.null toolong)
+          ((,,,,,) <$> envTargetsSig
+                   <*> govKnownPeersSig
+                   <*> govEstablishedPeersSig
+                   <*> govEstablishedFailuresSig
+                   <*> promotionOpportunities
+                   <*> promotionOpportunitiesIgnoredTooLong)
+
+
+
+prop_governor_target_active_below :: GovernorMockEnvironment -> Property
+prop_governor_target_active_below env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfActivePeers events
+
+        govEstablishedPeersSig :: Signal (Set PeerAddr)
+        govEstablishedPeersSig =
+          selectGovState
+            (EstablishedPeers.toSet . Governor.establishedPeers)
+            events
+
+        govActivePeersSig :: Signal (Set PeerAddr)
+        govActivePeersSig =
+          selectGovState Governor.activePeers events
+
+        govActiveFailuresSig :: Signal (Set PeerAddr)
+        govActiveFailuresSig =
+            Signal.keyedLinger
+              180 -- 3 minutes  -- TODO: too eager to reconnect?
+              (fromMaybe Set.empty)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TracePromoteWarmFailed _ _ peer _ ->
+                       --TODO: the environment does not yet cause this to happen
+                       -- it requires synchronous failure in the establish action
+                       Just (Set.singleton peer)
+                     --TODO
+                     TraceDemoteAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerWarm) status)
+                     _ -> Nothing
+              )
+          . selectGovEvents
+          $ events
+
+        promotionOpportunities :: Signal (Set PeerAddr)
+        promotionOpportunities =
+          (\target established active recentFailures ->
+              -- There are no opportunities if we're at or above target
+              if Set.size active >= target
+                then Set.empty
+                else established Set.\\ active
+                                 Set.\\ recentFailures
+          ) <$> envTargetsSig
+            <*> govEstablishedPeersSig
+            <*> govActivePeersSig
+            <*> govActiveFailuresSig
+
+        promotionOpportunitiesIgnoredTooLong :: Signal (Set PeerAddr)
+        promotionOpportunitiesIgnoredTooLong =
+          Signal.keyedTimeout
+            10 -- seconds
+            id
+            promotionOpportunities
+
+     in counterexample
+          ("\nSignal key: (target, known peers, active peers, recent failures, " ++ 
+           "opportunities, ignored too long)") $
+
+        signalProperty 20 show
+          (\(_,_,_,_,_,toolong) -> Set.null toolong)
+          ((,,,,,) <$> envTargetsSig
+                   <*> govEstablishedPeersSig
+                   <*> govActivePeersSig
+                   <*> govActiveFailuresSig
+                   <*> promotionOpportunities
+                   <*> promotionOpportunitiesIgnoredTooLong)
+
+
+prop_governor_target_established_above :: GovernorMockEnvironment -> Property
+prop_governor_target_established_above env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfEstablishedPeers events
+
+        govEstablishedPeersSig :: Signal (Set PeerAddr)
+        govEstablishedPeersSig =
+          selectGovState
+            (EstablishedPeers.toSet . Governor.establishedPeers)
+            events
+
+        establishedPeersShrinksSig :: Signal (Set PeerAddr)
+        establishedPeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govEstablishedPeersSig
+
+        aboveTargetTooLong :: Signal Bool
+        aboveTargetTooLong =
+          Signal.timeout 15
+            (\(target, established, shrinks) ->
+                  Set.size established > target
+               && Set.null shrinks)
+            ((,,) <$> envTargetsSig
+                  <*> govEstablishedPeersSig
+                  <*> establishedPeersShrinksSig)
+
+     in counterexample
+          "\nSignal key: (target, established peers, shrinks, above target too long)" $
+
+        signalProperty 20 show
+          (\(_,_,_,toolong) -> not toolong)
+          ((,,,) <$> envTargetsSig
+                 <*> govEstablishedPeersSig
+                 <*> establishedPeersShrinksSig
+                 <*> aboveTargetTooLong)
+
+
+prop_governor_target_active_above :: GovernorMockEnvironment -> Property
+prop_governor_target_active_above env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfActivePeers events
+
+        govActivePeersSig :: Signal (Set PeerAddr)
+        govActivePeersSig =
+          selectGovState Governor.activePeers events
+
+        activePeersShrinksSig :: Signal (Set PeerAddr)
+        activePeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govActivePeersSig
+
+        aboveTargetTooLong :: Signal Bool
+        aboveTargetTooLong =
+          Signal.timeout 15
+            (\(target, active, shrinks) ->
+                  Set.size active > target
+               && Set.null shrinks)
+            ((,,) <$> envTargetsSig
+                  <*> govActivePeersSig
+                  <*> activePeersShrinksSig)
+
+     in counterexample
+          "\nSignal key: (target, active peers, shrinks, above target too long)" $
+
+        signalProperty 20 show
+          (\(_,_,_,toolong) -> not toolong)
+          ((,,,) <$> envTargetsSig
+                 <*> govActivePeersSig
+                 <*> activePeersShrinksSig
+                 <*> aboveTargetTooLong)
+
+
+--
 -- Utils for properties
 --
 
 takeFirstNHours :: DiffTime -> [(Time, a)] -> [(Time, a)]
 takeFirstNHours h = takeWhile (\(t,_) -> t < Time (60*60*h))
+
+
+selectEnvEvents :: Events TestTraceEvent -> Events TraceMockEnv
+selectEnvEvents = Signal.selectEvents
+                    (\case MockEnvEvent e -> Just e
+                           _              -> Nothing)
+
+selectGovEvents :: Events TestTraceEvent
+                -> Events (TracePeerSelection PeerAddr)
+selectGovEvents = Signal.selectEvents
+                    (\case GovernorEvent e -> Just e
+                           _               -> Nothing)
+
+selectGovState :: Eq a
+               => (Governor.PeerSelectionState PeerAddr () -> a)
+               -> Events TestTraceEvent
+               -> Signal a
+selectGovState f =
+    Signal.nub
+  . fmap f
+  . Signal.fromChangeEvents Governor.emptyPeerSelectionState
+  . Signal.selectEvents
+      (\case GovernorDebug (TraceGovernorState _ _ st) -> Just st
+             _                                         -> Nothing)
+
+selectEnvTargets :: Eq a
+                 => (PeerSelectionTargets -> a)
+                 -> Events TestTraceEvent
+                 -> Signal a
+selectEnvTargets f =
+    Signal.nub
+  . fmap f
+  . Signal.fromChangeEvents nullPeerSelectionTargets
+  . Signal.selectEvents
+      (\case TraceEnvSetTargets targets -> Just targets
+             _                          -> Nothing)
+  . selectEnvEvents
 
 
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -473,13 +473,13 @@ allTraceNames =
 -- must find all the reachable ones, or if the target for the number of known
 -- peers to find is too low then it should at least find the target number.
 --
-prop_governor_gossip_1hr :: GovernorMockEnvironmentWithoutAsyncDemotion -> Property
-prop_governor_gossip_1hr (GovernorMockEnvironmentWAD env@GovernorMockEnvironment{
-                              peerGraph,
-                              localRootPeers,
-                              publicRootPeers,
-                              targets
-                            }) =
+prop_governor_gossip_1hr :: GovernorMockEnvironment -> Property
+prop_governor_gossip_1hr env@GovernorMockEnvironment {
+                               peerGraph,
+                               localRootPeers,
+                               publicRootPeers,
+                               targets
+                             } =
     let trace      = selectPeerSelectionTraceEvents $
                        runGovernorInMockEnvironment env {
                          targets = singletonScript (targets', NoDelay)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -16,10 +16,12 @@ module Test.Ouroboros.Network.PeerSelection (tests) where
 
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function (on)
-import           Data.List (groupBy)
+import           Data.List (groupBy, foldl')
 import           Data.Maybe (listToMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Void (Void)
 
 import           Control.Monad.Class.MonadTime
@@ -51,9 +53,14 @@ tests =
   testGroup "Ouroboros.Network.PeerSelection"
   [ Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
-  , testProperty "governor gossip reachable in 1hr" prop_governor_gossip_1hr
-  , testProperty "governor connection status"       prop_governor_connstatus
-  , testProperty "governor no livelock"             prop_governor_nolivelock
+  , testGroup "governor"
+    [ testProperty "has output"         prop_governor_hasoutput
+    , testProperty "no failure"         prop_governor_nofail
+    , testProperty "no livelock"        prop_governor_nolivelock
+    , testProperty "event coverage"     prop_governor_trace_coverage
+    , testProperty "gossip reachable"   prop_governor_gossip_1hr
+    , testProperty "connection status"  prop_governor_connstatus
+    ]
   ]
 
 
@@ -61,88 +68,79 @@ tests =
 -- QuickCheck properties
 --
 
--- Things we might like to test...
+-- We start with basic properties in the style of "never does bad things"
+-- and progress to properties that check that it "eventually does good things".
 --
--- * for even insane environments, there is no insane behaviour
---   trace properties:
---   * progress: all actions should make monotonic progress
---   * no busy work: limit on number of governor iterations before time advances
---   * trace sanity: model of state can be reconstructed from trace events
+-- In the "never does bad things" category we have:
+--
+-- * A basic state space exploration property that checks we don't encounter
+--   internal errors. This includes some limited checking that we get adequate
+--   coverage of the different actions, by looking for coverage of all the
+--   trace events. The coverage checks here are useful to give us confidence
+--   about coverage for some of the other properties.
+--
+-- * A no-livelock property. This checks that the governor does not get stuck
+--   doing too many steps at a single moment in (virtual) time. It's quite easy
+--   to write bugs that don't cause the governor to fail, but cause it to go
+--   into a busy cycle. See also the "no excessive busyness" property for a
+--   more advanced version.
+--
+-- * A state consistency property that the governor's view of part of the state
+--   and the "true" state of the mock environment are maintained in an
+--   appropriate correspondence.
+--
+-- In the "eventually does good things" category we have:
+--
+-- * A basic property to check the governor does produce non-trivial traces.
+--
+-- * A cold peer gossip "reachable" property: that the governor either hits
+--   its target for the number of cold peers, or finds all the reachable peers.
+--
+-- Properties that we would like to have:
+--
+-- * A "no excessive busyness" property. This checks that the governor does not
+--   remain too busy for too long. It's quite easy to write bugs that don't
+--   cause the governor to fail, but cause it to go into fairly-busy cycles.
+--
+-- * A public root peers target property: that the governor hits its target for
+--   for the number of public root peers (or as near as possible), and does
+--   note "grossly" overshoot. Since the public roots is a one sided target, but
+--   we don't want to overshoot excessively.
+--
+-- * A warm peer target property: that the governor hits its established peers
+--   target (or as near as possible).
+--
+-- * A hot peer target property: that the governor hits its active peers
+--   target (or as near as possible).
+--
+-- * A local root peers target property: that the governor hits it target for
+--   getting all its local root peers into the established state, and a target
+--   number of them into the active state (or as near as possible).
+--
+-- Other properties we might like to think about
 --
 -- * for vaguely stable envs, we do stablise at our target number of cold peers
--- * we stabilise without going insane even if the available nodes are fewer than the target
 -- * time to stabilise after a change is not crazy
 -- * time to find new nodes after a graph change is ok
 -- * targets or root peer set dynamic
--- * check local root peers are what we expect
--- * check governor view of connection status does not lag reality too much
 
 
--- | Run the governor for up to 24 hours (simulated obviously) and see if it
--- throws any exceptions (assertions such as invariant violations) or if it
--- encounters a livelock situation.
+-- | As the most basic property we run the governor and check that it produces
+-- any trace output at all. It should elicit some activity, unless the test
+-- environment is actually empty.
 --
--- | It is easy to get bugs where the governor is stuck in a busy loop working
--- but not making progress. This kind of bug would result in the governor
--- thread consuming all the cpu, but wouldn't actually stop the node, so might
--- not be easily noticed.
---
--- We check for this condition by requiring that trace events a certain number
--- of events apart are sufficiently far apart in time too. This will be
--- violated if the governor starts making very slow forward progress.
---
--- This uses static targets and root peers.
---
--- TODO: Reenable this testcase.
-prop_governor_nolivelock :: GovernorMockEnvironment -> Property
-prop_governor_nolivelock env =
-    within 10_000_000 $
-    let trace = takeFirstNHours 24 .
-                selectGovernorEvents .
-                selectPeerSelectionTraceEvents $
+prop_governor_hasoutput :: GovernorMockEnvironment -> Bool
+prop_governor_hasoutput env =
+    let trace = selectPeerSelectionTraceEvents $
                   runGovernorInMockEnvironment env
 
-     in
-{-
-       -- uncomment to check expected distribution
-       tabulate  "env size"   [renderRanges 10 envSize] $
-       tabulate  "max events" [renderRanges 10 (maxEvents 5 trace)] $
-       tabulate  "events/graph ratio"
-                 [show (maxEvents 5 trace `div` envSize)] $
--}
-       hasOutput trace
+     in hasOutput env (selectGovernorEvents trace)
 
-       -- Check we don't get too many events within a given time span.
-       -- How many events is too many? It scales with the graph size.
-       -- The ratio between them is from experimental evidence.
-  .&&. let maxevents = (2+envSize) * 8 -- ratio from experiments
-           timespan  = 5               -- seconds
-           actual    = maxEvents (floor timespan) trace
-        in counterexample ("Too many events in a span of time!\n"
-                        ++ "  time span:  " ++ show timespan ++ " seconds\n"
-                        ++ "  env size:   " ++ show envSize ++ "\n"
-                        ++ "  num events: " ++ show actual) $
-
-           property (makesAdequateProgress maxevents timespan
-                                           (map fst trace))
-  where
-    hasOutput :: [(Time, TracePeerSelection PeerAddr)] -> Property
-    hasOutput (_:_) = property True
-    hasOutput []    = counterexample "no trace output" $
-                      property (isEmptyEnv env)
-
-    envSize         = length g + length (targets env)
-                        where PeerGraph g = peerGraph env
-    maxEvents n     = maximum
-                    . (0:)
-                    . map length
-                    . timeSpans n
-
-    timeSpans :: Int -> [(Time, a)] -> [[(Time, a)]]
-    timeSpans _ []           = []
-    timeSpans n (x@(t,_):xs) =
-      let (xs', xs'') = span (\(t',_) -> t' <= addTime (fromIntegral n) t) (x:xs)
-       in xs' : timeSpans n xs''
+hasOutput :: GovernorMockEnvironment
+          -> [(Time, TracePeerSelection PeerAddr)]
+          -> Bool
+hasOutput _   (_:_) = True
+hasOutput env []    = isEmptyEnv env
 
 isEmptyEnv :: GovernorMockEnvironment -> Bool
 isEmptyEnv GovernorMockEnvironment {
@@ -156,16 +154,151 @@ isEmptyEnv GovernorMockEnvironment {
       || all (\(t,_) -> targetNumberOfRootPeers  t == 0) targets)
 
 
--- Check that events that are 100 events apart have an adequate time
--- between them, to indicate we're not in a busy livelock situation.
-makesAdequateProgress :: Int -> DiffTime -> [Time] -> Bool
-makesAdequateProgress n adequate ts =
-    go ts (drop n ts)
+-- | As a basic property we run the governor to explore its state space a bit
+-- and check it does not throw any exceptions (assertions such as invariant
+-- violations).
+--
+-- We do /not/ assume freedom from livelock for this property, so we run the
+-- governor for a maximum number of trace events rather than for a fixed
+-- simulated time.
+--
+prop_governor_nofail :: GovernorMockEnvironment -> Bool
+prop_governor_nofail env =
+    let trace = take 5000 .
+                selectPeerSelectionTraceEvents $
+                  runGovernorInMockEnvironment env
+
+     in foldl' (flip seq) True
+          [ assertPeerSelectionState st ()
+          | (_, GovernorDebug (TraceGovernorState _ _ st)) <- trace ]
+
+
+-- | It is relatively easy to write bugs where the governor is stuck in a tight
+-- cycle of continuous activity. Due to the way the I\/O simulator manages
+-- virtual time, these bugs exhibits themselves by infinite trace activity
+-- without time advancing.
+--
+-- It is important to catch these bugs early in the set of tests, since it is
+-- hard to write many of the other more interesting properties if there are
+-- these kinds of livelock bugs. Or to put it another way, the other properties
+-- can be expressed more simply if they can assume within event traces that the
+-- time always advances after some finite number of events.
+--
+prop_governor_nolivelock :: GovernorMockEnvironment -> Property
+prop_governor_nolivelock env =
+    let trace = take 5000 .
+                selectGovernorEvents .
+                selectPeerSelectionTraceEvents $
+                  runGovernorInMockEnvironment env
+     in case tooManyEventsBeforeTimeAdvances 1000 trace of
+          Nothing -> property True
+          Just (t, es) ->
+            counterexample
+              ("over 1000 events at time: " ++ show t ++ "\n" ++
+               "first 50 events: " ++ (unlines . map show . take 50 $ es)) $
+            property False
+
+
+-- | Scan the trace and return any occurrence where we have at least threshold
+-- events before virtual time moves on. Return the tail of the trace from that
+-- point on.
+--
+tooManyEventsBeforeTimeAdvances :: Int -> [(Time, e)] -> Maybe (Time, [e])
+tooManyEventsBeforeTimeAdvances _         []     = Nothing
+tooManyEventsBeforeTimeAdvances threshold trace0 =
+    go [ (t, diffTime t' t, e)
+       | ((t, e), (t', _)) <- zip trace0 (tail trace0) ]
   where
-    go (a:as) (b:bs)
-      | diffTime b a < adequate = False
-      | otherwise               = go as bs
-    go _ _ = True
+    go []                = Nothing
+    go trace@((t,_,_):_) = case countdown threshold trace of
+                             Just es' -> go es'
+                             Nothing  -> Just (t, trace')
+                               where
+                                 trace' = take threshold [ e | (_,_,e) <- trace ]
+
+    countdown 0 _  = Nothing
+    countdown _ [] = Just []
+    countdown n ((_t,dt,_e):es)
+      | dt == 0    = countdown (n-1) es
+      | otherwise  = Just es
+
+
+-- | A coverage property, much like 'prop_governor_nofail' but we look to see
+-- that we get adequate coverage of the state space. We look for all the trace
+-- events that the governor can produce, and tabules which ones we see.
+--
+prop_governor_trace_coverage :: GovernorMockEnvironment -> Property
+prop_governor_trace_coverage env =
+    let trace = take 5000 .
+                selectPeerSelectionTraceEvents $
+                  runGovernorInMockEnvironment env
+
+        traceNumsSeen  = collectTraces trace
+        traceNamesSeen = allTraceNames `Map.restrictKeys` traceNumsSeen
+
+     in coverTable "trace events" [ (n, 1) | n <- Map.elems allTraceNames ] $
+        tabulate   "trace events" (Map.elems traceNamesSeen)
+        True
+
+collectTraces :: [(Time, TestTraceEvent)] -> Set Int
+collectTraces trace =
+    Set.fromList [ traceNum e | (_, GovernorEvent e) <- trace ]
+
+traceNum :: TracePeerSelection peeraddr -> Int
+traceNum TraceLocalRootPeersChanged{} = 00
+traceNum TraceTargetsChanged{}        = 01
+traceNum TracePublicRootsRequest{}    = 02
+traceNum TracePublicRootsResults{}    = 03
+traceNum TracePublicRootsFailure{}    = 04
+traceNum TraceGossipRequests{}        = 05
+traceNum TraceGossipResults{}         = 06
+traceNum TraceForgetColdPeers{}       = 07
+traceNum TracePromoteColdPeers{}      = 08
+--traceNum TracePromoteColdLocalPeers{} = 09
+traceNum TracePromoteColdFailed{}     = 10
+traceNum TracePromoteColdDone{}       = 11
+traceNum TracePromoteWarmPeers{}      = 12
+--traceNum TracePromoteWarmLocalPeers{} = 13
+traceNum TracePromoteWarmFailed{}     = 14
+traceNum TracePromoteWarmDone{}       = 15
+traceNum TraceDemoteWarmPeers{}       = 16
+traceNum TraceDemoteWarmFailed{}      = 17
+traceNum TraceDemoteWarmDone{}        = 18
+traceNum TraceDemoteHotPeers{}        = 19
+traceNum TraceDemoteHotFailed{}       = 20
+traceNum TraceDemoteHotDone{}         = 21
+traceNum TraceDemoteAsynchronous{}    = 22
+traceNum TraceGovernorWakeup{}        = 23
+
+allTraceNames :: Map Int String
+allTraceNames =
+  Map.fromList
+   [ (00, "TraceLocalRootPeersChanged")
+   , (01, "TraceTargetsChanged")
+   , (02, "TracePublicRootsRequest")
+   , (03, "TracePublicRootsResults")
+   , (04, "TracePublicRootsFailure")
+   , (05, "TraceGossipRequests")
+   , (06, "TraceGossipResults")
+   , (07, "TraceForgetColdPeers")
+   , (08, "TracePromoteColdPeers")
+-- , (09, "TracePromoteColdLocalPeers")
+   , (10, "TracePromoteColdFailed")
+   , (11, "TracePromoteColdDone")
+   , (12, "TracePromoteWarmPeers")
+-- , (13, "TracePromoteWarmLocalPeers")
+   , (14, "TracePromoteWarmFailed")
+   , (15, "TracePromoteWarmDone")
+   , (16, "TraceDemoteWarmPeers")
+   , (17, "TraceDemoteWarmFailed")
+   , (18, "TraceDemoteWarmDone")
+   , (19, "TraceDemoteHotPeers")
+   , (20, "TraceDemoteHotFailed")
+   , (21, "TraceDemoteHotDone")
+   , (22, "TraceDemoteAsynchronous")
+   , (23, "TraceGovernorWakeup")
+   ]
+
 
 -- | Run the governor for up to 1 hour (simulated obviously) and look at the
 -- set of known peers it has selected. This uses static targets and root peers.

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -538,13 +538,13 @@ prop_governor_gossip_1hr env@GovernorMockEnvironment {
 -- | Check the governor's view of connection status does not lag behind reality
 -- by too much.
 --
-prop_governor_connstatus :: GovernorMockEnvironment -> Bool
+prop_governor_connstatus :: GovernorMockEnvironment -> Property
 prop_governor_connstatus env =
     let trace = takeFirstNHours 1
               . selectPeerSelectionTraceEvents $
                   runGovernorInMockEnvironment env
         --TODO: check any actually get a true status output and try some deliberate bugs
-     in all ok (groupBy ((==) `on` fst) trace)
+     in conjoin (map ok (groupBy ((==) `on` fst) trace))
   where
     -- We look at events when the environment's view of the state of all the
     -- peer connections changed, and check that before simulated time advances
@@ -552,14 +552,15 @@ prop_governor_connstatus env =
     --
     -- We do that by finding the env events and then looking for the last
     -- governor state event before time moves on.
-    ok :: [(Time, TestTraceEvent)] -> Bool
+    ok :: [(Time, TestTraceEvent)] -> Property
     ok trace =
-        case (lastTrueStatus, lastTestStatus) of
-          (Nothing, _)                       -> True
-          (Just trueStatus, Just testStatus) -> trueStatus == testStatus
-          (Just trueStatus, Nothing)         -> trueStatus == Map.empty
+        counterexample ("last few events:\n" ++ (unlines . map show) trace) $
+        case (lastEnvStatus, lastGovStatus) of
+          (Nothing, _)                     -> property True
+          (Just envStatus, Just govStatus) -> envStatus === govStatus
+          (Just envStatus, Nothing)        -> envStatus === Map.empty
       where
-        lastTrueStatus =
+        lastEnvStatus =
           listToMaybe
             [ Map.filter (not . isPeerCold) status
             | (_, MockEnvEvent (TraceEnvPeersStatus status)) <- reverse trace ]
@@ -567,7 +568,7 @@ prop_governor_connstatus env =
         isPeerCold PeerCold = True
         isPeerCold _        = False
 
-        lastTestStatus =
+        lastGovStatus =
           listToMaybe
             [ Governor.establishedPeersStatus st
             | (_, GovernorDebug (TraceGovernorState _ _ st)) <- reverse trace ]

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -7,9 +7,6 @@ module Test.Ouroboros.Network.PeerSelection.Instances (
     -- test types
     PeerAddr(..),
 
-    -- test utils
-    renderRanges,
-
     -- generator tests
     prop_arbitrary_PeerSelectionTargets,
     prop_shrink_PeerSelectionTargets,
@@ -89,15 +86,4 @@ prop_arbitrary_PeerSelectionTargets =
 prop_shrink_PeerSelectionTargets :: PeerSelectionTargets -> Bool
 prop_shrink_PeerSelectionTargets =
     all sanePeerSelectionTargets . shrink
-
-
---
--- QuickCheck utils
---
-
-renderRanges :: Int -> Int -> String
-renderRanges r n = show lower ++ " -- " ++ show upper
-  where
-    lower = n - n `mod` r
-    upper = lower + (r-1)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -34,7 +34,7 @@ newtype PeerAddr = PeerAddr Int
 -- here for the few cases that need it, and it is used for (lack-of) shrinking.
 --
 instance Arbitrary PeerAddr where
-  arbitrary = PeerAddr . getNonNegative <$> arbitrary
+  arbitrary = PeerAddr <$> arbitrarySizedNatural
   shrink _  = []
 
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -18,6 +18,7 @@ import           Ouroboros.Network.PeerSelection.Governor
 import           Ouroboros.Network.PeerSelection.Types
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Utils
 
 
 --
@@ -70,7 +71,8 @@ prop_arbitrary_PeerSelectionTargets :: PeerSelectionTargets -> Bool
 prop_arbitrary_PeerSelectionTargets =
     sanePeerSelectionTargets
 
-prop_shrink_PeerSelectionTargets :: PeerSelectionTargets -> Bool
-prop_shrink_PeerSelectionTargets =
-    all sanePeerSelectionTargets . shrink
+prop_shrink_PeerSelectionTargets :: Fixed PeerSelectionTargets -> Property
+prop_shrink_PeerSelectionTargets x =
+      prop_shrink_valid sanePeerSelectionTargets x
+ .&&. prop_shrink_nonequal x
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -13,8 +13,6 @@ module Test.Ouroboros.Network.PeerSelection.Instances (
 
   ) where
 
-import           Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NonEmpty
 
 import           Ouroboros.Network.PeerSelection.Governor
 import           Ouroboros.Network.PeerSelection.Types
@@ -39,17 +37,6 @@ instance Arbitrary PeerAddr where
   arbitrary = PeerAddr . getNonNegative <$> arbitrary
   shrink _  = []
 
-
-instance Arbitrary a => Arbitrary (NonEmpty a) where
-  arbitrary = NonEmpty.fromList <$> listOf1 arbitrary
-
-  shrink = shrinkMap from to
-    where
-      to :: NonEmpty a -> NonEmptyList a
-      to xs = NonEmpty (NonEmpty.toList xs)
-
-      from :: NonEmptyList a -> NonEmpty a
-      from (NonEmpty xs) = NonEmpty.fromList xs
 
 
 instance Arbitrary PeerAdvertise where

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -24,6 +24,7 @@ import           Test.Ouroboros.Network.PeerSelection.Instances
 
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Utils
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -59,7 +58,8 @@ prop_clampToLimit localRootPeers targets =
                  (LocalRootPeers.size localRootPeers)
 
 
-arbitraryLocalRootPeers :: Set PeerAddr -> Gen (LocalRootPeers PeerAddr)
+arbitraryLocalRootPeers :: Ord peeraddr
+                        => Set peeraddr -> Gen (LocalRootPeers peeraddr)
 arbitraryLocalRootPeers peeraddrs = do
     -- divide into a few disjoint groups
     ngroups     <- choose (1, 5 :: Int)
@@ -77,10 +77,10 @@ arbitraryLocalRootPeers peeraddrs = do
     return (LocalRootPeers.fromGroups (zip targets groups))
 
 
-instance Arbitrary (LocalRootPeers PeerAddr) where
+instance (Arbitrary peeraddr, Ord peeraddr) =>
+         Arbitrary (LocalRootPeers peeraddr) where
     arbitrary = do
-        peeraddrs <- Set.map (PeerAddr . getNonNegative)
-                 <$> scale (`div` 4) arbitrary
+        peeraddrs <- scale (`div` 4) arbitrary
         arbitraryLocalRootPeers peeraddrs
 
     shrink lrps =

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -115,9 +115,10 @@ prop_arbitrary_LocalRootPeers lrps =
                  | (t, g) <- LocalRootPeers.toGroupSets lrps ]
 
 
-prop_shrink_LocalRootPeers :: LocalRootPeers PeerAddr -> Bool
-prop_shrink_LocalRootPeers =
-    all LocalRootPeers.invariant . shrink
+prop_shrink_LocalRootPeers :: Fixed (LocalRootPeers PeerAddr) -> Property
+prop_shrink_LocalRootPeers x =
+      prop_shrink_valid LocalRootPeers.invariant x
+ .&&. prop_shrink_nonequal x
 
 prop_fromGroups :: [(Int, Map PeerAddr PeerAdvertise)] -> Bool
 prop_fromGroups = LocalRootPeers.invariant . LocalRootPeers.fromGroups

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -65,6 +65,7 @@ import           Test.Ouroboros.Network.PeerSelection.LocalRootPeers
                    as LocalRootPeers hiding (tests)
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Utils
 import           Test.Tasty (TestTree, localOption, testGroup)
 import           Test.Tasty.QuickCheck (QuickCheckMaxSize (..), testProperty)
 
@@ -99,12 +100,12 @@ data GovernorMockEnvironment = GovernorMockEnvironment {
        localRootPeers          :: LocalRootPeers PeerAddr,
        publicRootPeers         :: Set PeerAddr,
        targets                 :: TimedScript PeerSelectionTargets,
-       pickKnownPeersForGossip :: PickScript,
-       pickColdPeersToPromote  :: PickScript,
-       pickWarmPeersToPromote  :: PickScript,
-       pickHotPeersToDemote    :: PickScript,
-       pickWarmPeersToDemote   :: PickScript,
-       pickColdPeersToForget   :: PickScript
+       pickKnownPeersForGossip :: PickScript PeerAddr,
+       pickColdPeersToPromote  :: PickScript PeerAddr,
+       pickWarmPeersToPromote  :: PickScript PeerAddr,
+       pickHotPeersToDemote    :: PickScript PeerAddr,
+       pickWarmPeersToDemote   :: PickScript PeerAddr,
+       pickColdPeersToForget   :: PickScript PeerAddr
      }
   deriving Show
 
@@ -426,17 +427,20 @@ instance Arbitrary GovernorMockEnvironment where
   arbitrary = do
       -- Dependency of the root set on the graph
       peerGraph         <- arbitrary
+      let peersSet       = allPeers peerGraph
       (localRootPeers,
-       publicRootPeers) <- arbitraryRootPeers (allPeers peerGraph)
+       publicRootPeers) <- arbitraryRootPeers peersSet
 
       -- But the others are independent
       targets                 <- arbitrary
-      pickKnownPeersForGossip <- arbitrary
-      pickColdPeersToPromote  <- arbitrary
-      pickWarmPeersToPromote  <- arbitrary
-      pickHotPeersToDemote    <- arbitrary
-      pickWarmPeersToDemote   <- arbitrary
-      pickColdPeersToForget   <- arbitrary
+
+      let arbitrarySubsetOfPeers = arbitrarySubset peersSet
+      pickKnownPeersForGossip <- arbitraryPickScript arbitrarySubsetOfPeers
+      pickColdPeersToPromote  <- arbitraryPickScript arbitrarySubsetOfPeers
+      pickWarmPeersToPromote  <- arbitraryPickScript arbitrarySubsetOfPeers
+      pickHotPeersToDemote    <- arbitraryPickScript arbitrarySubsetOfPeers
+      pickWarmPeersToDemote   <- arbitraryPickScript arbitrarySubsetOfPeers
+      pickColdPeersToForget   <- arbitraryPickScript arbitrarySubsetOfPeers
       return GovernorMockEnvironment{..}
     where
       arbitraryRootPeers :: Set PeerAddr

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -283,6 +283,7 @@ mockPeerSelectionActions' tracer
         traceWith tracer (TraceEnvGossipTTL addr)
       case mgossip of
         Nothing                -> do
+          threadDelay 1
           traceWith tracer (TraceEnvGossipResult addr [])
           fail "no peers"
         Just (peeraddrs, time) -> do
@@ -292,6 +293,7 @@ mockPeerSelectionActions' tracer
 
     establishPeerConnection :: PeerAddr -> m (PeerConn m)
     establishPeerConnection peeraddr = do
+      --TODO: add support for variable delays and synchronous failure
       threadDelay 1
       (conn@(PeerConn _ v), snapshot) <- atomically $ do
         conn  <- newTVar PeerWarm

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -73,7 +73,9 @@ import           Test.Tasty.QuickCheck (QuickCheckMaxSize (..), testProperty)
 tests :: TestTree
 tests =
   testGroup "Mock environment"
-    [ testProperty "arbitrary for PeerSelectionTargets"    prop_arbitrary_PeerSelectionTargets
+    [ testProperty "shrink for Script"                     prop_shrink_Script
+    , testProperty "shrink for GovernorScripts"            prop_shrink_GovernorScripts
+    , testProperty "arbitrary for PeerSelectionTargets"    prop_arbitrary_PeerSelectionTargets
     , testProperty "shrink for PeerSelectionTargets"       prop_shrink_PeerSelectionTargets
     , testProperty "arbitrary for PeerGraph"               prop_arbitrary_PeerGraph
     , localOption (QuickCheckMaxSize 30) $
@@ -107,7 +109,7 @@ data GovernorMockEnvironment = GovernorMockEnvironment {
        pickWarmPeersToDemote   :: PickScript PeerAddr,
        pickColdPeersToForget   :: PickScript PeerAddr
      }
-  deriving Show
+  deriving (Show, Eq)
 
 data PeerConn m = PeerConn !PeerAddr !(TVar m PeerStatus)
 
@@ -549,7 +551,8 @@ prop_arbitrary_GovernorMockEnvironment env =
           (LocalRootPeers.keysSet (localRootPeers env))
           (publicRootPeers env)
 
-prop_shrink_GovernorMockEnvironment :: GovernorMockEnvironment -> Bool
-prop_shrink_GovernorMockEnvironment =
-    all validGovernorMockEnvironment . shrink
+prop_shrink_GovernorMockEnvironment :: Fixed GovernorMockEnvironment -> Property
+prop_shrink_GovernorMockEnvironment x =
+      prop_shrink_valid validGovernorMockEnvironment x
+ .&&. prop_shrink_nonequal x
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -222,7 +222,7 @@ mockPeerSelectionActions' tracer
                           targetsVar
                           connsVar =
     PeerSelectionActions {
-      readLocalRootPeers       = return (LocalRootPeers.toGroups' localRootPeers),
+      readLocalRootPeers       = return (LocalRootPeers.toGroups localRootPeers),
       requestPublicRootPeers   = \_ -> return (publicRootPeers, 60),
       readPeerSelectionTargets = readTVar targetsVar,
       requestPeerGossip,

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -28,7 +28,6 @@ module Test.Ouroboros.Network.PeerSelection.MockEnvironment (
   ) where
 
 import           Data.Dynamic (fromDynamic)
-import           Data.Functor (($>))
 import           Data.List (nub)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -38,6 +37,7 @@ import           Data.Typeable (Typeable)
 import           Data.Void (Void)
 
 import           Control.Exception (throw)
+import           Control.Monad (forM_)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
@@ -210,6 +210,8 @@ mockPeerSelectionActions tracer
     traceWith tracer (TraceEnvAddPeers peerGraph)
     traceWith tracer (TraceEnvSetLocalRoots localRootPeers)   --TODO: make dynamic
     traceWith tracer (TraceEnvSetPublicRoots publicRootPeers) --TODO: make dynamic
+    snapshot <- atomically (snapshotPeersStatus peerConns)
+    traceWith tracer (TraceEnvPeersStatus snapshot)
     return $ mockPeerSelectionActions'
                tracer env policy
                scripts targetsVar peerConns
@@ -287,7 +289,7 @@ mockPeerSelectionActions' tracer
         conns <- readTVar connsVar
         let !conns' = Map.insert peeraddr conn conns
         writeTVar connsVar conns'
-        snapshot <- traverse readTVar conns'
+        snapshot <- snapshotPeersStatus connsVar
         return (PeerConn peeraddr conn, snapshot)
       traceWith tracer (TraceEnvPeersStatus snapshot)
       let Just (_, connectScript) = Map.lookup peeraddr scripts
@@ -303,22 +305,32 @@ mockPeerSelectionActions' tracer
               let interpretScriptDelay NoDelay    = 1
                   interpretScriptDelay ShortDelay = 60
                   interpretScriptDelay LongDelay  = 600
-              done <-
+              (done, msnapshot) <-
                 case demotion of
-                  Noop   -> return True
+                  Noop   -> return (True, Nothing)
                   ToWarm -> do
                     threadDelay (interpretScriptDelay delay)
                     atomically $ do
                       s <- readTVar v
                       case s of
-                        PeerHot -> writeTVar v PeerWarm
-                                $> False
-                        _       -> return (PeerCold == s)
+                        PeerHot -> do writeTVar v PeerWarm
+                                      snapshot' <- snapshotPeersStatus connsVar
+                                      return (False, Just snapshot')
+                        PeerWarm -> return (False, Nothing)
+                        PeerCold -> return (True,  Nothing)
                   ToCold -> do
                     threadDelay (interpretScriptDelay delay)
-                    atomically $  writeTVar v PeerCold
-                               $> True
+                    atomically $ do
+                      s <- readTVar v
+                      case s of
+                        PeerCold -> return (True, Nothing)
+                        _        -> do writeTVar v PeerCold
+                                       snapshot' <- snapshotPeersStatus connsVar
+                                       return (True, Just snapshot')
+
               traceWith tracer (TraceEnvPeersDemote demotion peeraddr)
+              forM_ msnapshot $ \snapshot' ->
+                traceWith tracer (TraceEnvPeersStatus snapshot')
 
               if done
                 then return ()
@@ -344,8 +356,7 @@ mockPeerSelectionActions' tracer
           -- state as if the transition went fine which will violate
           -- 'invariantPeerSelectionState'.
           PeerCold -> throwIO ActivationError
-        conns <- readTVar connsVar
-        traverse readTVar conns
+        snapshotPeersStatus connsVar
       traceWith tracer (TraceEnvPeersStatus snapshot)
 
     deactivatePeerConnection :: PeerConn m -> m ()
@@ -359,8 +370,7 @@ mockPeerSelectionActions' tracer
           -- See the note in 'activatePeerConnection' why we throw an exception
           -- here.
           PeerCold -> throwIO DeactivationError
-        conns <- readTVar connsVar
-        traverse readTVar conns
+        snapshotPeersStatus connsVar
       traceWith tracer (TraceEnvPeersStatus snapshot)
 
     closePeerConnection :: PeerConn m -> m ()
@@ -375,11 +385,19 @@ mockPeerSelectionActions' tracer
         conns <- readTVar connsVar
         let !conns' = Map.delete peeraddr conns
         writeTVar connsVar conns'
-        traverse readTVar conns'
+        snapshotPeersStatus connsVar
       traceWith tracer (TraceEnvPeersStatus snapshot)
 
     monitorPeerConnection :: PeerConn m -> STM m PeerStatus
     monitorPeerConnection (PeerConn _peeraddr conn) = readTVar conn
+
+
+snapshotPeersStatus :: MonadSTMTx stm
+                    => TVar_ stm (Map PeerAddr (TVar_ stm PeerStatus))
+                    -> stm (Map PeerAddr PeerStatus)
+snapshotPeersStatus connsVar = do
+    conns <- readTVar connsVar
+    traverse readTVar conns
 
 
 mockPeerSelectionPolicy  :: MonadSTM m

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -177,6 +177,10 @@ data TraceMockEnv = TraceEnvAddPeers       PeerGraph
                   | TraceEnvGossipTTL      PeerAddr
                   | TraceEnvSetTargets     PeerSelectionTargets
                   | TraceEnvPeersDemote    AsyncDemotion PeerAddr
+
+                  | TraceEnvRootsResult    [PeerAddr]
+                  | TraceEnvGossipRequest  PeerAddr (Maybe ([PeerAddr], GossipTime))
+                  | TraceEnvGossipResult   PeerAddr [PeerAddr]
                   | TraceEnvPeersStatus    (Map PeerAddr PeerStatus)
   deriving Show
 
@@ -267,18 +271,23 @@ mockPeerSelectionActions' tracer
       _ <- async $ do
         threadDelay ttl
         traceWith tracer TraceEnvPublicRootTTL
+      traceWith tracer (TraceEnvRootsResult (Set.toList publicRootPeers))
       return (publicRootPeers, ttl)
 
     requestPeerGossip addr = do
+      let Just (gossipScript, _) = Map.lookup addr scripts
+      mgossip <- stepScript gossipScript
+      traceWith tracer (TraceEnvGossipRequest addr mgossip)
       _ <- async $ do
         threadDelay policyGossipRetryTime
         traceWith tracer (TraceEnvGossipTTL addr)
-      let Just (gossipScript, _) = Map.lookup addr scripts
-      mgossip <- stepScript gossipScript
       case mgossip of
-        Nothing                -> fail "no peers"
+        Nothing                -> do
+          traceWith tracer (TraceEnvGossipResult addr [])
+          fail "no peers"
         Just (peeraddrs, time) -> do
           threadDelay (interpretGossipTime time)
+          traceWith tracer (TraceEnvGossipResult addr peeraddrs)
           return peeraddrs
 
     establishPeerConnection :: PeerAddr -> m (PeerConn m)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -450,6 +450,13 @@ mockPeerSelectionPolicy GovernorMockEnvironment {
 data TestTraceEvent = GovernorDebug (DebugPeerSelection PeerAddr ())
                     | GovernorEvent (TracePeerSelection PeerAddr)
                     | MockEnvEvent   TraceMockEnv
+                   -- Warning: be careful with writing properties that rely
+                   -- on trace events from both the governor and from the
+                   -- environment. These events typically occur in separate
+                   -- threads and so are not casually ordered. It is ok to use
+                   -- them for timeout/eventually properties, but not for
+                   -- properties that check conditions synchronously.
+                   -- The governor debug vs other events are fully ordered.
   deriving Show
 
 tracerTracePeerSelection :: Tracer (IOSim s) (TracePeerSelection PeerAddr)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -20,11 +20,8 @@ module Test.Ouroboros.Network.PeerSelection.MockEnvironment (
     selectPeerSelectionTraceEvents,
     firstGossipReachablePeers,
 
-    Script,
-    ScriptDelay(..),
-    TimedScript,
-    scriptHead,
-    singletonScript,
+    module Test.Ouroboros.Network.PeerSelection.Script,
+    module Ouroboros.Network.PeerSelection.Types,
 
     tests,
 
@@ -33,7 +30,6 @@ module Test.Ouroboros.Network.PeerSelection.MockEnvironment (
 import           Data.Dynamic (fromDynamic)
 import           Data.Functor (($>))
 import           Data.List (nub)
-import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
@@ -166,36 +162,56 @@ validGovernorMockEnvironment GovernorMockEnvironment {
 runGovernorInMockEnvironment :: GovernorMockEnvironment -> Trace Void
 runGovernorInMockEnvironment mockEnv =
     runSimTrace $ do
-      actions <- mockPeerSelectionActions tracerMockEnv mockEnv
       policy  <- mockPeerSelectionPolicy                mockEnv
+      actions <- mockPeerSelectionActions tracerMockEnv mockEnv policy
       peerSelectionGovernor
         tracerTracePeerSelection
         tracerDebugPeerSelection
         actions
         policy
 
-data TraceMockEnv = TraceEnvPeersStatus (Map PeerAddr PeerStatus)
+data TraceMockEnv = TraceEnvAddPeers       PeerGraph
+                  | TraceEnvSetLocalRoots  (LocalRootPeers PeerAddr)
+                  | TraceEnvSetPublicRoots (Set PeerAddr)
+                  | TraceEnvPublicRootTTL
+                  | TraceEnvGossipTTL      PeerAddr
+                  | TraceEnvSetTargets     PeerSelectionTargets
+                  | TraceEnvPeersDemote    AsyncDemotion PeerAddr
+                  | TraceEnvPeersStatus    (Map PeerAddr PeerStatus)
   deriving Show
 
 mockPeerSelectionActions :: (MonadAsync m, MonadTimer m, Fail.MonadFail m,
                              MonadThrow (STM m))
                          => Tracer m TraceMockEnv
                          -> GovernorMockEnvironment
+                         -> PeerSelectionPolicy PeerAddr m
                          -> m (PeerSelectionActions PeerAddr (PeerConn m) m)
 mockPeerSelectionActions tracer
                          env@GovernorMockEnvironment {
-                           peerGraph = PeerGraph adjacency,
+                           peerGraph,
+                           localRootPeers,
+                           publicRootPeers,
                            targets
-                         } = do
+                         }
+                         policy = do
     scripts <- Map.fromList <$>
-                       sequence [ (\a b -> (addr, (a, b)))
-                                  <$> initScript gossipScript
-                                  <*> initScript connectionScript
-                                | (addr, _, GovernorScripts { gossipScript, connectionScript }) <- adjacency ]
-    targetsVar <- playTimedScript targets
+                 sequence
+                   [ (\a b -> (addr, (a, b)))
+                     <$> initScript gossipScript
+                     <*> initScript connectionScript
+                   | let PeerGraph adjacency = peerGraph
+                   , (addr, _, GovernorScripts {
+                                 gossipScript,
+                                 connectionScript
+                               }) <- adjacency
+                   ]
+    targetsVar <- playTimedScript (contramap TraceEnvSetTargets tracer) targets
     peerConns  <- newTVarIO Map.empty
+    traceWith tracer (TraceEnvAddPeers peerGraph)
+    traceWith tracer (TraceEnvSetLocalRoots localRootPeers)   --TODO: make dynamic
+    traceWith tracer (TraceEnvSetPublicRoots publicRootPeers) --TODO: make dynamic
     return $ mockPeerSelectionActions'
-               tracer env
+               tracer env policy
                scripts targetsVar peerConns
 
 
@@ -212,6 +228,7 @@ mockPeerSelectionActions' :: forall m.
                               MonadThrow (STM m))
                           => Tracer m TraceMockEnv
                           -> GovernorMockEnvironment
+                          -> PeerSelectionPolicy PeerAddr m
                           -> Map PeerAddr (TVar m GossipScript, TVar m ConnectionScript)
                           -> TVar m PeerSelectionTargets
                           -> TVar m (Map PeerAddr (TVar m PeerStatus))
@@ -221,12 +238,15 @@ mockPeerSelectionActions' tracer
                             localRootPeers,
                             publicRootPeers
                           }
+                          PeerSelectionPolicy {
+                            policyGossipRetryTime
+                          }
                           scripts
                           targetsVar
                           connsVar =
     PeerSelectionActions {
       readLocalRootPeers       = return (LocalRootPeers.toGroups localRootPeers),
-      requestPublicRootPeers   = \_ -> return (publicRootPeers, 60),
+      requestPublicRootPeers,
       readPeerSelectionTargets = readTVar targetsVar,
       requestPeerGossip,
       peerStateActions         = PeerStateActions {
@@ -238,7 +258,19 @@ mockPeerSelectionActions' tracer
         }
     }
   where
+    -- TODO: make this dynamic
+    requestPublicRootPeers _n = do
+      let ttl :: Num n => n
+          ttl = 60
+      _ <- async $ do
+        threadDelay ttl
+        traceWith tracer TraceEnvPublicRootTTL
+      return (publicRootPeers, ttl)
+
     requestPeerGossip addr = do
+      _ <- async $ do
+        threadDelay policyGossipRetryTime
+        traceWith tracer (TraceEnvGossipTTL addr)
       let Just (gossipScript, _) = Map.lookup addr scripts
       mgossip <- stepScript gossipScript
       case mgossip of
@@ -286,6 +318,7 @@ mockPeerSelectionActions' tracer
                     threadDelay (interpretScriptDelay delay)
                     atomically $  writeTVar v PeerCold
                                $> True
+              traceWith tracer (TraceEnvPeersDemote demotion peeraddr)
 
               if done
                 then return ()

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -205,8 +205,11 @@ instance Arbitrary GovernorScripts where
       | gossipScript' <- shrink gossipScript
       ]
       ++
-      [ GovernorScripts gossipScript (fixConnectionScript connectionScript')
-      | connectionScript' <- shrink connectionScript
+      [ GovernorScripts gossipScript connectionScript'
+      | connectionScript' <- map fixConnectionScript (shrink connectionScript)
+        -- fixConnectionScript can result in re-creating the same script
+        -- which would cause shrinking to loop. Filter out such cases.
+      , connectionScript' /= connectionScript
       ]
 
 -- | We ensure that eventually the connection script will allow to connect to

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -14,7 +14,7 @@ module Test.Ouroboros.Network.PeerSelection.PeerGraph (
     GossipScript,
     ConnectionScript,
     AsyncDemotion(..),
-    GossipTime,
+    GossipTime(..),
     interpretGossipTime,
 
     prop_shrink_GovernorScripts,
@@ -25,7 +25,6 @@ module Test.Ouroboros.Network.PeerSelection.PeerGraph (
 
 import           Data.Graph (Graph)
 import qualified Data.Graph as Graph
-import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -17,6 +17,7 @@ module Test.Ouroboros.Network.PeerSelection.PeerGraph (
     GossipTime,
     interpretGossipTime,
 
+    prop_shrink_GovernorScripts,
     prop_arbitrary_PeerGraph,
     prop_shrink_PeerGraph,
 
@@ -313,6 +314,10 @@ instance Arbitrary GossipTime where
 -- Tests for the QC Arbitrary instances
 --
 
+prop_shrink_GovernorScripts :: Fixed GovernorScripts -> Property
+prop_shrink_GovernorScripts =
+    prop_shrink_nonequal
+
 prop_arbitrary_PeerGraph :: PeerGraph -> Property
 prop_arbitrary_PeerGraph pg =
     -- We are interested in the distribution of the graph size (in nodes)
@@ -341,7 +346,8 @@ peerGraphNumStronglyConnectedComponents pg =
   where
     (g,_,_) = peerGraphAsGraph pg
 
-prop_shrink_PeerGraph :: PeerGraph -> Bool
-prop_shrink_PeerGraph =
-    all validPeerGraph . shrink
+prop_shrink_PeerGraph :: Fixed PeerGraph -> Property
+prop_shrink_PeerGraph x =
+      prop_shrink_valid validPeerGraph x
+ .&&. prop_shrink_nonequal x
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -37,6 +37,7 @@ import           Test.Ouroboros.Network.PeerSelection.Instances
 import           Test.Ouroboros.Network.PeerSelection.Script
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Utils
 
 
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -255,7 +255,8 @@ instance Arbitrary PeerGraph where
 
 arbitraryGossipScript :: [PeerAddr] -> Gen GossipScript
 arbitraryGossipScript peers =
-    arbitraryShortScriptOf gossipResult
+    sized $ \sz ->
+      arbitraryScriptOf (isqrt sz) gossipResult
   where
     gossipResult :: Gen (Maybe ([PeerAddr], GossipTime))
     gossipResult =
@@ -267,6 +268,9 @@ arbitraryGossipScript peers =
     selectHalfRandomly xs = do
         picked <- vectorOf (length xs) arbitrary
         return [ x | (x, True) <- zip xs picked ]
+
+isqrt :: Int -> Int
+isqrt = floor . sqrt . (fromIntegral :: Int -> Double)
 
 -- | Remove dangling graph edges and gossip results.
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
@@ -112,6 +112,7 @@ playTimedScript :: (MonadAsync m, MonadTimer m)
                 => Tracer m a -> TimedScript a -> m (TVar m a)
 playTimedScript tracer (Script ((x0,d0) :| script)) = do
     v <- newTVarIO x0
+    traceWith tracer x0
     _ <- async $ do
            threadDelay (interpretScriptDelay d0)
            sequence_ [ do atomically (writeTVar v x)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
@@ -11,6 +11,7 @@ module Test.Ouroboros.Network.PeerSelection.Script (
     stepScript,
     stepScriptSTM,
     arbitraryScriptOf,
+    prop_shrink_Script,
 
     -- * Timed scripts
     ScriptDelay(..),
@@ -189,4 +190,12 @@ interpretPickMembers (PickSome as) ps n
   | otherwise    = Set.take n ps'
   where
     ps' = Set.intersection ps as
+
+
+--
+-- Tests for the QC Arbitrary instances
+--
+
+prop_shrink_Script :: Fixed (Script Int) -> Property
+prop_shrink_Script = prop_shrink_nonequal
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
@@ -176,9 +176,6 @@ interpretPickScript scriptVar available pickNum
   | pickNum <= 0
   = error "interpretPickScript: given invalid pickNum"
 
-  | Set.size available <= pickNum
-  = return available
-
   | otherwise
   = do pickmembers <- stepScriptSTM scriptVar
        return (interpretPickMembers pickmembers available pickNum)

--- a/ouroboros-network/test/Test/QuickCheck/Signal.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Signal.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.QuickCheck.Signal where
+
+import qualified Deque.Lazy as Deque
+import           Deque.Lazy (Deque)
+import qualified Data.Foldable as Deque (toList)
+import qualified Data.Signal as Signal
+import           Data.Signal (Signal)
+
+import           Control.Monad.Class.MonadTime (Time)
+
+import           Test.QuickCheck
+
+
+-- | Check a property over a 'Signal'. The property should be true at all times.
+--
+-- On failure it shows the @n@ most recent signal values.
+--
+signalProperty :: forall a. Int -> (a -> String)
+               -> (a -> Bool) -> Signal a -> Property
+signalProperty atMost showSignalValue p =
+    go 0 mempty . Signal.eventsToList . Signal.toChangeEvents
+  where
+    go :: Int -> Deque (Time, a) -> [(Time, a)] -> Property
+    go !_ !_ []                   = property True
+    go !n !q ((t, x) : txs) | p x = next
+      where
+        next
+          | n < atMost = go (n+1) (              Deque.snoc (t,x)  q) txs
+          | otherwise  = go n     ((Deque.tail . Deque.snoc (t,x)) q) txs
+
+    go !_ !recent ((t, x) : _) = counterexample details (property False)
+      where
+        details =
+          unlines [ "Last " ++ show atMost ++ " signal values:"
+                  , unlines [ show t' ++ "\t: " ++ showSignalValue x'
+                            | (t',x') <- Deque.toList recent ]
+                  , "Property violated at: " ++ show t
+                  , "Invalid signal value:"
+                  , showSignalValue x
+                  ]

--- a/ouroboros-network/test/Test/QuickCheck/Utils.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Utils.hs
@@ -1,0 +1,18 @@
+
+-- | QuickCheck utils
+--
+module Test.QuickCheck.Utils (
+
+    -- * Reporting utils
+    renderRanges,
+
+  ) where
+
+
+-- | Use in 'tabulate' to help summarise data into buckets.
+--
+renderRanges :: Int -> Int -> String
+renderRanges r n = show lower ++ " -- " ++ show upper
+  where
+    lower = n - n `mod` r
+    upper = lower + (r-1)

--- a/ouroboros-network/test/Test/QuickCheck/Utils.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Utils.hs
@@ -4,12 +4,31 @@
 module Test.QuickCheck.Utils (
 
     -- * Generator and shrinker utils
+    arbitrarySubset,
     shrinkListElems,
 
     -- * Reporting utils
     renderRanges,
 
   ) where
+
+import           Data.Set (Set)
+import qualified Data.Set as Set
+
+import           Test.QuickCheck
+
+-- | Pick a subset of a set, using a 50:50 chance for each set element.
+--
+arbitrarySubset :: Ord a => Set a -> Gen (Set a)
+arbitrarySubset s = do
+    picks <- vectorOf (Set.size s) (arbitrary :: Gen Bool)
+    let s' = Set.fromList
+           . map snd
+           . filter fst
+           . zip picks
+           . Set.toList
+           $ s
+    return s'
 
 
 -- | Like 'shrinkList' but only shrink the elems, don't drop elements.

--- a/ouroboros-network/test/Test/QuickCheck/Utils.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Utils.hs
@@ -3,10 +3,23 @@
 --
 module Test.QuickCheck.Utils (
 
+    -- * Generator and shrinker utils
+    shrinkListElems,
+
     -- * Reporting utils
     renderRanges,
 
   ) where
+
+
+-- | Like 'shrinkList' but only shrink the elems, don't drop elements.
+--
+-- Useful when you want a custom strategy for dropping elements.
+--
+shrinkListElems :: (a -> [a]) -> [a] -> [[a]]
+shrinkListElems _   []     = []
+shrinkListElems shr (x:xs) = [ x':xs | x'  <- shr x ]
+                          ++ [ x:xs' | xs' <- shrinkListElems shr xs ]
 
 
 -- | Use in 'tabulate' to help summarise data into buckets.


### PR DESCRIPTION
Various improvements to the QC tests for the p2p governor:

* Fix a bug in the shrinker for the governor mock environment. This was causing the shrinking of test cases to fail to terminate.
* Add simple shrinker tests to catch (most instances of) this class of shrinker bug.
* Improve the shrinker for scripts. This makes shrinking typically take fewer steps, and is hence typically quicker.
* Tweak the script generator so we get a wider range of script lengths.
* Change the strategy for the "pick scripts" to pick elements, not offsets, for better shrinker behaviour
* Restructure the main governor tests.
* Misc minor simplifications, and code clean-ups
* A new (hopefully improved) livelock property test. In fact we split it into two: a basic no-livelock test, and a more sophisticated "no excessive busyness" test.