### PR TITLE
Add Haskell-Language-Server as a build input to the shell environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ launch-*
 # Local development
 stack.yaml.local.lock
 stack.yaml.local
+.envrc
 
 # latex files
 doc/*.fdb_latexmk

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,7 @@
 , sourcesOverride ? { }
 }:
 let
-  sources = import ./sources.nix { pkgs = import iohkNixMain.nixpkgs { }; }
+  sources = import ./sources.nix { pkgs = import nixpkgs { }; }
     // sourcesOverride;
   iohkNixMain = import sources.iohk-nix { };
   haskellNix = import sources."haskell.nix" { inherit system sourcesOverride; };

--- a/nix/hls.nix
+++ b/nix/hls.nix
@@ -1,0 +1,25 @@
+################################################
+# Prepare Haskell-language-server to be added as a buildInput
+################################################
+{ pkgs
+, ghcVersion
+}:
+let
+  inherit (pkgs.commonLib) sources;
+
+  planConfig = {
+    compiler-nix-name = ghcVersion;
+    # get the sources from niv
+    src = sources.hls-released;
+    configureArgs = "--disable-benchmarks";
+    modules = [{ enableSeparateDataOutput = true; }];
+  };
+
+  # bring all exes into scope
+  hlsExes = (pkgs.haskell-nix.cabalProject planConfig).haskell-language-server.components.exes;
+in
+{
+  hls = hlsExes.haskell-language-server;
+  hls-wrapper = hlsExes.haskell-language-server-wrapper;
+  implicit-hie = pkgs.haskellPackages.implicit-hie;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,19 @@
         "url": "https://github.com/input-output-hk/haskell.nix/archive/1b9b05beed75a1be98405501fbb33ac1f080069e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "hls-released": {
+        "branch": "1.1.0",
+        "description": "Successor of ghcide & haskell-ide-engine. One IDE to rule them all.",
+        "homepage": "",
+        "builtin": false,
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "f1c096927186a93d8e3ccd4fe8385cc1b070350b",
+        "sha256": "0kviq3kinm3i0qm4r26rdnlkwbs1s3r1rqiqdry517rgkgnjpcp5",
+        "type": "tarball",
+        "url": "https://github.com/haskell/haskell-language-server/archive/f1c096927186a93d8e3ccd4fe8385cc1b070350b.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "iohk-nix": {
         "branch": "master",
         "description": "nix scripts shared across projects",
@@ -33,6 +46,19 @@
         "sha256": "0jn88ahv6mycxdkzihy1v0dz2110q0d42q4ggyj68l2lyba6y0yy",
         "type": "tarball",
         "url": "https://github.com/input-output-hk/niv/archive/89da7b2e7ae0779fd351618fc74df1b1da5e6214.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "stylish-haskell": {
+        "branch": "main",
+        "description": "Haskell code prettifier",
+        "homepage": "",
+        "builtin": false,
+        "owner": "haskell",
+        "repo": "stylish-haskell",
+        "rev": "3d5348041e2efbcae95f1c62ace5ac0ffd9629d2",
+        "sha256": "1rms68fll6w1rzdg9ppjs9g246mbgxi5589vxb8r8pcn5v1ncfj2",
+        "type": "tarball",
+        "url": "https://github.com/haskell/stylish-haskell/archive/3d5348041e2efbcae95f1c62ace5ac0ffd9629d2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -26,27 +26,15 @@ let
   fetch_git = spec:
     builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
 
-  fetch_builtin-tarball = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-tarball" will soon be deprecated. You should
-          instead use `builtin = true`.
+  fetch_local = spec: spec.path;
 
-          $ niv modify <package> -a type=tarball -a builtin=true
-      ''
-      builtins_fetchTarball { inherit (spec) url sha256; };
+  fetch_builtin-tarball = name: throw
+    ''[${name}] The niv type "builtin-tarball" is deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=tarball -a builtin=true'';
 
-  fetch_builtin-url = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-url" will soon be deprecated. You should
-          instead use `builtin = true`.
-
-          $ niv modify <package> -a type=file -a builtin=true
-      ''
-      (builtins_fetchurl { inherit (spec) url sha256; });
+  fetch_builtin-url = name: throw
+    ''[${name}] The niv type "builtin-url" will soon be deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=file -a builtin=true'';
 
   #
   # Various helpers
@@ -79,10 +67,20 @@ let
     else if spec.type == "file" then fetch_file pkgs spec
     else if spec.type == "tarball" then fetch_tarball pkgs name spec
     else if spec.type == "git" then fetch_git spec
+    else if spec.type == "local" then fetch_local spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
     else if spec.type == "builtin-url" then fetch_builtin-url name
     else
       abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  # If the environment variable NIV_OVERRIDE_${name} is set, then use
+  # the path directly as opposed to the fetched source.
+  replace = name: drv:
+    let
+      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
+    in
+      if ersatz == "" then drv else ersatz;
 
   # Ports of functions for older nix versions
 
@@ -130,13 +128,13 @@ let
         then abort
           "The values in sources.json should not have an 'outPath' attribute"
         else
-          spec // { outPath = fetch config.pkgs name spec; }
+          spec // { outPath = replace name (fetch config.pkgs name spec); }
     ) config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
-    , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
     , pkgs ? mkPkgs sources
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
@@ -145,5 +143,6 @@ let
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       inherit pkgs;
     };
+
 in
 mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/nix/stylish-haskell.nix
+++ b/nix/stylish-haskell.nix
@@ -1,17 +1,18 @@
+################################################
+# Prepare stylish-haskell to be added as a buildInput
+################################################
 { pkgs
+, ghcVersion
 }:
 let
-  hsPkgs = pkgs.haskell-nix.stackProject {
-    compiler-nix-name = "ghc8104";
+  inherit (pkgs.commonLib) sources;
+
+  planConfig = {
+    compiler-nix-name = ghcVersion;
+    # get the sources from niv
+    src = sources.stylish-haskell;
     modules = [ ];
-    src = pkgs.fetchFromGitHub {
-      owner = "jaspervdj";
-      repo = "stylish-haskell";
-      # 0.12.2.0 with custom feature that will be added to 0.12.3.0 release
-      # see https://github.com/jaspervdj/stylish-haskell/commit/3d5348041e2efbcae95f1c62ace5ac0ffd9629d2
-      rev = "3d5348041e2efbcae95f1c62ace5ac0ffd9629d2";
-      sha256 = "1rms68fll6w1rzdg9ppjs9g246mbgxi5589vxb8r8pcn5v1ncfj2";
-    };
   };
+
 in
-hsPkgs.stylish-haskell.components.exes.stylish-haskell
+(pkgs.haskell-nix.stackProject planConfig).stylish-haskell.components.exes.stylish-haskell

--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,29 @@
 }:
 with pkgs;
 let
-  # This is temporally till we get a stylish 0.12.3.0 release available in hackage
-  stylish-haskell = import ./nix/stylish-haskell.nix { inherit pkgs; };
+  ghcVersion = "ghc8104";
+
+  # Both stylish-haskell and Haskell-language-server are pulled in with niv
+  # directly from their repositories at specific commits because the versions we
+  # want are not yet in Hackage. Right now we are using stylish-haskell at
+  # version 0.12.2.0 with some features that are not yet released in hackage,
+  # and hls at version 1.1.0 which is also not released in hackage. Once one of
+  # those arrives we can pull it in specifying a version on the tools attribute
+  # set, something like:
+  #
+  # > tools = {
+  # >   ...
+  # >   haskell-language-server = "1.1.0";
+  # >   stylish-haskell = "0.12.3.0";
+  #
+  # Note that the tools attribute comes from haskell-nix when defining the
+  # shellFor function. At the same time, the niv depencency will not be needed
+  # and it can be removed with `niv drop hls-released` or `niv drop
+  # stylish-haskell` (or manually removing the relevant entries from
+  # `sources.json`).
+  stylish-haskell = import ./nix/stylish-haskell.nix { inherit pkgs ghcVersion; };
+  hls = import ./nix/hls.nix { inherit pkgs ghcVersion; };
+
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
   # NOTE: due to some cabal limitation,
@@ -28,6 +49,9 @@ let
       pkgconfig
       nixpkgs-fmt
       stylish-haskell
+      hls.hls
+      hls.hls-wrapper
+      hls.implicit-hie
     ];
 
     tools = {


### PR DESCRIPTION
Adds the Haskell-Language-Server currently at version 1.1.0 (not yet released
in Hackage) through a niv dependency.

For a final user, adding this is fine because it is cached by Hydra so it will 
just download the whole shell.

Incidentally:
- Using the same set of nixpkgs as for the rest of the build when providing
  it to Niv for non-builtin fetchers.
- Replaced the sources.nix file with a newer generated version (probably this
  should actually be updated each time we update the niv version).
- Also rephrase how stylish-haskell was being built as we can just point
  to the repository at a specific branch with niv.
- Adding .envrc to .gitignore as not everybody uses lorri.

Co-authored-by: Pawel Szulc <paul.szulc@gmail.com>