### PR TITLE
New KeepAlive codec

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -1055,6 +1055,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
 
     customNodeToNodeCodecs
       :: TopLevelConfig blk
+      -> NodeToNodeVersion
       -> NTN.Codecs blk CodecError m
            Lazy.ByteString
            Lazy.ByteString
@@ -1063,7 +1064,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
            (AnyMessage (TxSubmission (GenTxId blk) (GenTx blk)))
            (AnyMessage (TxSubmission2 (GenTxId blk) (GenTx blk)))
            (AnyMessage KeepAlive)
-    customNodeToNodeCodecs cfg = NTN.Codecs
+    customNodeToNodeCodecs cfg ntnVersion = NTN.Codecs
         { cChainSyncCodec =
             mapFailureCodec (CodecBytesFailure "ChainSync") $
               NTN.cChainSyncCodec binaryProtocolCodecs
@@ -1087,7 +1088,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
               NTN.cKeepAliveCodec NTN.identityCodecs
         }
       where
-        binaryProtocolCodecs = NTN.defaultCodecs (configCodec cfg) blockVersion
+        binaryProtocolCodecs = NTN.defaultCodecs (configCodec cfg) blockVersion ntnVersion
 
 -- | Sum of 'CodecFailure' (from @identityCodecs@) and 'DeserialiseFailure'
 -- (from @defaultCodecs@).
@@ -1323,7 +1324,7 @@ directedEdgeInner registry clock (version, blockVersion) (cfg, calcMessageDelay)
           _ -> pure ()
       where
         codec =
-            NTN.cChainSyncCodec $ NTN.defaultCodecs cfg blockVersion
+            NTN.cChainSyncCodec $ NTN.defaultCodecs cfg blockVersion version
 
 -- | Variant of 'createConnectChannels' with intermediate queues for
 -- delayed-but-in-order messages

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -244,6 +244,7 @@ library ouroboros-protocol-tests
                        io-sim-classes,
                        ouroboros-network,
                        ouroboros-network-framework,
+                       ouroboros-network-testing,
                        typed-protocols
 
   ghc-options:         -Wall

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -50,34 +50,36 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =
-  testGroup "Ouroboros.Network.Protocol.BlockFetch"
-  [ testProperty "direct"              prop_direct
-  , testProperty "directPipelined 1"   prop_directPipelined1
-  , testProperty "directPipelined 2"   prop_directPipelined2
-  , testProperty "connect"             prop_connect
-  , testProperty "connect_pipelined 1" prop_connect_pipelined1
-  , testProperty "connect_pipelined 2" prop_connect_pipelined2
-  , testProperty "connect_pipelined 3" prop_connect_pipelined3
-  , testProperty "connect_pipelined 4" prop_connect_pipelined4
-  , testProperty "connect_pipelined 5" prop_connect_pipelined5
-  , testProperty "channel ST"          prop_channel_ST
-  , testProperty "channel IO"          prop_channel_IO
-  , testProperty "pipe IO"             prop_pipe_IO
-  , testProperty "codec"               prop_codec_BlockFetch
-  , testProperty "codec 2-splits"      prop_codec_splits2_BlockFetch
-  , testProperty "codec 3-splits"    $ withMaxSuccess 30
-                                       prop_codec_splits3_BlockFetch
-  , testProperty "codec cbor"          prop_codec_cbor_BlockFetch
-  , testProperty "codec valid cbor"    prop_codec_valid_cbor_BlockFetch
+  testGroup "Ouroboros.Network.Protocol"
+    [ testGroup "BlockFetch"
+        [ testProperty "direct"              prop_direct
+        , testProperty "directPipelined 1"   prop_directPipelined1
+        , testProperty "directPipelined 2"   prop_directPipelined2
+        , testProperty "connect"             prop_connect
+        , testProperty "connect_pipelined 1" prop_connect_pipelined1
+        , testProperty "connect_pipelined 2" prop_connect_pipelined2
+        , testProperty "connect_pipelined 3" prop_connect_pipelined3
+        , testProperty "connect_pipelined 4" prop_connect_pipelined4
+        , testProperty "connect_pipelined 5" prop_connect_pipelined5
+        , testProperty "channel ST"          prop_channel_ST
+        , testProperty "channel IO"          prop_channel_IO
+        , testProperty "pipe IO"             prop_pipe_IO
+        , testProperty "codec"               prop_codec_BlockFetch
+        , testProperty "codec 2-splits"      prop_codec_splits2_BlockFetch
+        , testProperty "codec 3-splits"    $ withMaxSuccess 30
+                                             prop_codec_splits3_BlockFetch
+        , testProperty "codec cbor"          prop_codec_cbor_BlockFetch
+        , testProperty "codec valid cbor"    prop_codec_valid_cbor_BlockFetch
 
-  , testProperty "codecSerialised"                   prop_codec_BlockFetchSerialised
-  , testProperty "codecSerialised 2-splits"          prop_codec_splits2_BlockFetchSerialised
-  , testProperty "codecSerialised 3-splits"        $ withMaxSuccess 30
-                                                     prop_codec_splits3_BlockFetchSerialised
-  , testProperty "codecSerialised cbor"              prop_codec_cbor_BlockFetchSerialised
-  , testProperty "codec/codecSerialised bin compat"  prop_codec_binary_compat_BlockFetch_BlockFetchSerialised
-  , testProperty "codecSerialised/codec bin compat"  prop_codec_binary_compat_BlockFetchSerialised_BlockFetch
-  ]
+        , testProperty "codecSerialised"                   prop_codec_BlockFetchSerialised
+        , testProperty "codecSerialised 2-splits"          prop_codec_splits2_BlockFetchSerialised
+        , testProperty "codecSerialised 3-splits"        $ withMaxSuccess 30
+                                                           prop_codec_splits3_BlockFetchSerialised
+        , testProperty "codecSerialised cbor"              prop_codec_cbor_BlockFetchSerialised
+        , testProperty "codec/codecSerialised bin compat"  prop_codec_binary_compat_BlockFetch_BlockFetchSerialised
+        , testProperty "codecSerialised/codec bin compat"  prop_codec_binary_compat_BlockFetchSerialised_BlockFetch
+        ]
+    ]
 
 
 --

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -41,7 +41,7 @@ import           Ouroboros.Network.Protocol.BlockFetch.Type
 
 import           Test.ChainGenerators (TestChainAndPoints (..))
 import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
-                     splits2, splits3)
+                     prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
@@ -68,6 +68,7 @@ tests =
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3_BlockFetch
   , testProperty "codec cbor"          prop_codec_cbor_BlockFetch
+  , testProperty "codec valid cbor"    prop_codec_valid_cbor_BlockFetch
 
   , testProperty "codecSerialised"                   prop_codec_BlockFetchSerialised
   , testProperty "codecSerialised 2-splits"          prop_codec_splits2_BlockFetchSerialised
@@ -396,6 +397,11 @@ prop_codec_cbor_BlockFetch
   -> Bool
 prop_codec_cbor_BlockFetch msg =
   runST (prop_codec_cborM codec msg)
+
+prop_codec_valid_cbor_BlockFetch
+  :: AnyMessageAndAgency (BlockFetch Block (Point Block))
+  -> Property
+prop_codec_valid_cbor_BlockFetch = prop_codec_valid_cbor_encoding codec
 
 prop_codec_BlockFetchSerialised
   :: AnyMessageAndAgency (BlockFetch (Serialised Block) (Point Block))

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -54,7 +54,7 @@ import           Ouroboros.Network.Testing.ConcreteBlock (Block (..),
 import           Test.ChainGenerators ()
 import           Test.ChainProducerState (ChainProducerStateForkTest (..))
 import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
-                     splits2, splits3)
+                     prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import           Test.QuickCheck hiding (Result)
 import           Test.Tasty (TestTree, testGroup)
@@ -74,10 +74,11 @@ tests = testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
   , testProperty "connectPipelinedMin ST" propChainSyncPipelinedMinConnectST
   , testProperty "connectPipelinedMax IO" propChainSyncPipelinedMaxConnectIO
   , testProperty "connectPipelinedMin IO" propChainSyncPipelinedMinConnectIO
-  , testProperty "codec"          prop_codec_ChainSync
-  , testProperty "codec 2-splits" prop_codec_splits2_ChainSync
-  , testProperty "codec 3-splits" $ withMaxSuccess 30 prop_codec_splits3_ChainSync
-  , testProperty "codec cbor"     prop_codec_cbor
+  , testProperty "codec"            prop_codec_ChainSync
+  , testProperty "codec 2-splits"   prop_codec_splits2_ChainSync
+  , testProperty "codec 3-splits"   $ withMaxSuccess 30 prop_codec_splits3_ChainSync
+  , testProperty "codec cbor"       prop_codec_cbor
+  , testProperty "codec valid cbor" prop_codec_valid_cbor
   , testProperty "codecSerialised"            prop_codec_ChainSyncSerialised
   , testProperty "codecSerialised 2-splits"   prop_codec_splits2_ChainSyncSerialised
   , testProperty "codecSerialised 3-splits" $ withMaxSuccess 30
@@ -450,11 +451,17 @@ prop_codec_splits3_ChainSync msg =
       splits3
       codec
       msg
+
 prop_codec_cbor
   :: AnyMessageAndAgency ChainSync_BlockHeader
   -> Bool
 prop_codec_cbor msg =
     ST.runST (prop_codec_cborM codec msg)
+
+prop_codec_valid_cbor
+  :: AnyMessageAndAgency ChainSync_BlockHeader
+  -> Property
+prop_codec_valid_cbor = prop_codec_valid_cbor_encoding codec
 
 codecSerialised
   :: ( MonadST m

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -61,43 +61,45 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
-tests = testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
-  [ testProperty "direct ST" propChainSyncDirectST
-  , testProperty "direct IO" propChainSyncDirectIO
-  , testProperty "connect ST" propChainSyncConnectST
-  , testProperty "connect IO" propChainSyncConnectIO
-  , testProperty "directPipelinedMax ST" propChainSyncPipeliendMaxDirectST
-  , testProperty "directPipelinedMax IO" propChainSyncPipeliendMaxDirectIO
-  , testProperty "directPipelinedMin ST" propChainSyncPipeliendMinDirectST
-  , testProperty "directPipelinedMin IO" propChainSyncPipeliendMinDirectIO
-  , testProperty "connectPipelinedMax ST" propChainSyncPipelinedMaxConnectST
-  , testProperty "connectPipelinedMin ST" propChainSyncPipelinedMinConnectST
-  , testProperty "connectPipelinedMax IO" propChainSyncPipelinedMaxConnectIO
-  , testProperty "connectPipelinedMin IO" propChainSyncPipelinedMinConnectIO
-  , testProperty "codec"            prop_codec_ChainSync
-  , testProperty "codec 2-splits"   prop_codec_splits2_ChainSync
-  , testProperty "codec 3-splits"   $ withMaxSuccess 30 prop_codec_splits3_ChainSync
-  , testProperty "codec cbor"       prop_codec_cbor
-  , testProperty "codec valid cbor" prop_codec_valid_cbor
-  , testProperty "codecSerialised"            prop_codec_ChainSyncSerialised
-  , testProperty "codecSerialised 2-splits"   prop_codec_splits2_ChainSyncSerialised
-  , testProperty "codecSerialised 3-splits" $ withMaxSuccess 30
-                                              prop_codec_splits3_ChainSyncSerialised
-  , testProperty "codecSerialised cbor"       prop_codec_cbor_ChainSyncSerialised
-  , testProperty "codec/codecSerialised bin compat"  prop_codec_binary_compat_ChainSync_ChainSyncSerialised
-  , testProperty "codecSerialised/codec bin compat"  prop_codec_binary_compat_ChainSyncSerialised_ChainSync
-  , testProperty "demo ST" propChainSyncDemoST
-  , testProperty "demo IO" propChainSyncDemoIO
-  , testProperty "demoPipelinedMax ST"     propChainSyncDemoPipelinedMaxST
-  , testProperty "demoPipelinedMax IO"     propChainSyncDemoPipelinedMaxIO
-  , testProperty "demoPipelinedMin ST"     propChainSyncDemoPipelinedMinST
-  , testProperty "demoPipelinedMin IO"     propChainSyncDemoPipelinedMinIO
-  , testProperty "demoPipelinedLowHigh ST" propChainSyncDemoPipelinedLowHighST
-  , testProperty "demoPipelinedLowHigh IO" propChainSyncDemoPipelinedLowHighIO
-  , testProperty "demoPipelinedMin IO (buffered)"
-                                       propChainSyncDemoPipelinedMinBufferedIO
-  , testProperty "demo IO" propChainSyncDemoIO
-  , testProperty "pipe demo" propChainSyncPipe
+tests = testGroup "Ouroboros.Network.Protocol"
+  [ testGroup "ChainSync"
+    [ testProperty "direct ST" propChainSyncDirectST
+    , testProperty "direct IO" propChainSyncDirectIO
+    , testProperty "connect ST" propChainSyncConnectST
+    , testProperty "connect IO" propChainSyncConnectIO
+    , testProperty "directPipelinedMax ST" propChainSyncPipeliendMaxDirectST
+    , testProperty "directPipelinedMax IO" propChainSyncPipeliendMaxDirectIO
+    , testProperty "directPipelinedMin ST" propChainSyncPipeliendMinDirectST
+    , testProperty "directPipelinedMin IO" propChainSyncPipeliendMinDirectIO
+    , testProperty "connectPipelinedMax ST" propChainSyncPipelinedMaxConnectST
+    , testProperty "connectPipelinedMin ST" propChainSyncPipelinedMinConnectST
+    , testProperty "connectPipelinedMax IO" propChainSyncPipelinedMaxConnectIO
+    , testProperty "connectPipelinedMin IO" propChainSyncPipelinedMinConnectIO
+    , testProperty "codec"            prop_codec_ChainSync
+    , testProperty "codec 2-splits"   prop_codec_splits2_ChainSync
+    , testProperty "codec 3-splits"   $ withMaxSuccess 30 prop_codec_splits3_ChainSync
+    , testProperty "codec cbor"       prop_codec_cbor
+    , testProperty "codec valid cbor" prop_codec_valid_cbor
+    , testProperty "codecSerialised"            prop_codec_ChainSyncSerialised
+    , testProperty "codecSerialised 2-splits"   prop_codec_splits2_ChainSyncSerialised
+    , testProperty "codecSerialised 3-splits" $ withMaxSuccess 30
+                                                prop_codec_splits3_ChainSyncSerialised
+    , testProperty "codecSerialised cbor"       prop_codec_cbor_ChainSyncSerialised
+    , testProperty "codec/codecSerialised bin compat"  prop_codec_binary_compat_ChainSync_ChainSyncSerialised
+    , testProperty "codecSerialised/codec bin compat"  prop_codec_binary_compat_ChainSyncSerialised_ChainSync
+    , testProperty "demo ST" propChainSyncDemoST
+    , testProperty "demo IO" propChainSyncDemoIO
+    , testProperty "demoPipelinedMax ST"     propChainSyncDemoPipelinedMaxST
+    , testProperty "demoPipelinedMax IO"     propChainSyncDemoPipelinedMaxIO
+    , testProperty "demoPipelinedMin ST"     propChainSyncDemoPipelinedMinST
+    , testProperty "demoPipelinedMin IO"     propChainSyncDemoPipelinedMinIO
+    , testProperty "demoPipelinedLowHigh ST" propChainSyncDemoPipelinedLowHighST
+    , testProperty "demoPipelinedLowHigh IO" propChainSyncDemoPipelinedLowHighIO
+    , testProperty "demoPipelinedMin IO (buffered)"
+                                         propChainSyncDemoPipelinedMinBufferedIO
+    , testProperty "demo IO" propChainSyncDemoIO
+    , testProperty "pipe demo" propChainSyncPipe
+    ]
   ]
 
 -- | Testing @'Client'@ which stops at a given point.

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -54,30 +54,32 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =
-  testGroup "Ouroboros.Network.Protocol.Handshake"
-  [ testProperty "connect"               prop_connect
-  , testProperty "channel ST"            prop_channel_ST
-  , testProperty "channel IO"            prop_channel_IO
-  , testProperty "pipe IO"               prop_pipe_IO
-  , testProperty "channel asymmetric ST" prop_channel_asymmetric_ST
-  , testProperty "channel asymmetric IO" prop_channel_asymmetric_IO
-  , testProperty "pipe asymmetric IO"    prop_pipe_asymmetric_IO
-  , testProperty "codec RefuseReason"    prop_codec_RefuseReason
-  , testProperty "codec"                 prop_codec_Handshake
-  , testProperty "codec 2-splits"        prop_codec_splits2_Handshake
-  , testProperty "codec 3-splits"      $ withMaxSuccess 30
-                                         prop_codec_splits3_Handshake
-  , testProperty "codec cbor"            prop_codec_cbor
-  , testProperty "codec valid cbor"      prop_codec_valid_cbor
-  , testGroup "Generators"
-    [ testProperty "ArbitraryVersions" $
-        checkCoverage prop_arbitrary_ArbitraryVersions
-    , testProperty "arbitrary ArbitraryValidVersions"
-        prop_arbitrary_ArbitraryValidVersions
-    , testProperty "shrink ArbitraryValidVersions"
-        prop_shrink_ArbitraryValidVersions
+  testGroup "Ouroboros.Network.Protocol"
+    [ testGroup "Handshake"
+        [ testProperty "connect"               prop_connect
+        , testProperty "channel ST"            prop_channel_ST
+        , testProperty "channel IO"            prop_channel_IO
+        , testProperty "pipe IO"               prop_pipe_IO
+        , testProperty "channel asymmetric ST" prop_channel_asymmetric_ST
+        , testProperty "channel asymmetric IO" prop_channel_asymmetric_IO
+        , testProperty "pipe asymmetric IO"    prop_pipe_asymmetric_IO
+        , testProperty "codec RefuseReason"    prop_codec_RefuseReason
+        , testProperty "codec"                 prop_codec_Handshake
+        , testProperty "codec 2-splits"        prop_codec_splits2_Handshake
+        , testProperty "codec 3-splits"      $ withMaxSuccess 30
+                                               prop_codec_splits3_Handshake
+        , testProperty "codec cbor"            prop_codec_cbor
+        , testProperty "codec valid cbor"      prop_codec_valid_cbor
+        , testGroup "Generators"
+          [ testProperty "ArbitraryVersions" $
+              checkCoverage prop_arbitrary_ArbitraryVersions
+          , testProperty "arbitrary ArbitraryValidVersions"
+              prop_arbitrary_ArbitraryValidVersions
+          , testProperty "shrink ArbitraryValidVersions"
+              prop_shrink_ArbitraryValidVersions
+          ]
+        ]
     ]
-  ]
 
 --
 -- Test Versions

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Network.Protocol.Handshake.Test where
 
@@ -28,7 +29,8 @@ import           Control.Tracer (nullTracer)
 
 import           Network.TypedProtocol.Proofs
 
-import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+                     prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
@@ -66,6 +68,7 @@ tests =
   , testProperty "codec 3-splits"      $ withMaxSuccess 30
                                          prop_codec_splits3_Handshake
   , testProperty "codec cbor"            prop_codec_cbor
+  , testProperty "codec valid cbor"      prop_codec_valid_cbor
   , testGroup "Generators"
     [ testProperty "ArbitraryVersions" $
         checkCoverage prop_arbitrary_ArbitraryVersions
@@ -633,3 +636,10 @@ prop_codec_cbor
   -> Bool
 prop_codec_cbor msg =
   runSimOrThrow (prop_codec_cborM (codecHandshake versionNumberCodec) msg)
+
+-- | Check that the encoder produces a valid CBOR.
+--
+prop_codec_valid_cbor
+  :: AnyMessageAndAgency (Handshake VersionNumber CBOR.Term)
+  -> Property
+prop_codec_valid_cbor = prop_codec_valid_cbor_encoding (codecHandshake versionNumberCodec)

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/KeepAlive/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/KeepAlive/Test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE TypeApplications  #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -34,9 +35,11 @@ import           Ouroboros.Network.Protocol.KeepAlive.Examples
 import           Ouroboros.Network.Protocol.KeepAlive.Direct
 
 import Test.Ouroboros.Network.Testing.Utils
-        ( splits2
+        ( prop_codec_valid_cbor_encoding
+        , splits2
         , splits3
         )
+
 
 import Test.QuickCheck
 import Text.Show.Functions ()
@@ -50,17 +53,18 @@ import Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests = testGroup "Ouroboros.Network.Protocol.KeepAlive"
-  [ testProperty "direct"            prop_direct
-  , testProperty "connect"           prop_connect
-  , testProperty "channel ST"        prop_channel_ST
-  , testProperty "channel IO"        prop_channel_IO
-  , testProperty "codec"             prop_codec
-  , testProperty "codec 2-splits"    prop_codec_splits2
-  , testProperty "codec 3-splits"    (withMaxSuccess 33 prop_codec_splits3)
-  , testProperty "codec v2"          prop_codec_v2
-  , testProperty "codec v2 2-splits" prop_codec_v2_splits2
-  , testProperty "codec v2 3-splits" (withMaxSuccess 33 prop_codec_v2_splits3)
-  , testProperty "byteLimits"        prop_byteLimits
+  [ testProperty "direct"              prop_direct
+  , testProperty "connect"             prop_connect
+  , testProperty "channel ST"          prop_channel_ST
+  , testProperty "channel IO"          prop_channel_IO
+  , testProperty "codec"               prop_codec
+  , testProperty "codec 2-splits"      prop_codec_splits2
+  , testProperty "codec 3-splits"      (withMaxSuccess 33 prop_codec_splits3)
+  , testProperty "codec v2"            prop_codec_v2
+  , testProperty "codec v2 2-splits"   prop_codec_v2_splits2
+  , testProperty "codec v2 3-splits"   (withMaxSuccess 33 prop_codec_v2_splits3)
+  , testProperty "codec v2 valid CBOR" prop_codec_v2_valid_cbor
+  , testProperty "byteLimits"          prop_byteLimits
   ]
 
 --
@@ -170,6 +174,9 @@ prop_codec_v2_splits3 :: AnyMessageAndAgency KeepAlive -> Bool
 prop_codec_v2_splits3 msg =
     runST (prop_codec_splitsM splits3 codecKeepAlive_v2 msg)
 
+prop_codec_v2_valid_cbor :: AnyMessageAndAgency KeepAlive -> Property
+prop_codec_v2_valid_cbor msg =
+    prop_codec_valid_cbor_encoding codecKeepAlive_v2 msg
 
 prop_byteLimits :: AnyMessageAndAgency KeepAlive
                          -> Bool

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/KeepAlive/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/KeepAlive/Test.hs
@@ -50,14 +50,17 @@ import Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests = testGroup "Ouroboros.Network.Protocol.KeepAlive"
-  [ testProperty "direct"         prop_direct
-  , testProperty "connect"        prop_connect
-  , testProperty "channel ST"     prop_channel_ST
-  , testProperty "channel IO"     prop_channel_IO
-  , testProperty "codec"          prop_codec
-  , testProperty "codec 2-splits" prop_codec_splits2
-  , testProperty "codec 3-splits" (withMaxSuccess 33 prop_codec_splits3)
-  , testProperty "byteLimits"     prop_byteLimits
+  [ testProperty "direct"            prop_direct
+  , testProperty "connect"           prop_connect
+  , testProperty "channel ST"        prop_channel_ST
+  , testProperty "channel IO"        prop_channel_IO
+  , testProperty "codec"             prop_codec
+  , testProperty "codec 2-splits"    prop_codec_splits2
+  , testProperty "codec 3-splits"    (withMaxSuccess 33 prop_codec_splits3)
+  , testProperty "codec v2"          prop_codec_v2
+  , testProperty "codec v2 2-splits" prop_codec_v2_splits2
+  , testProperty "codec v2 3-splits" (withMaxSuccess 33 prop_codec_v2_splits3)
+  , testProperty "byteLimits"        prop_byteLimits
   ]
 
 --
@@ -154,6 +157,18 @@ prop_codec_splits2 msg =
 prop_codec_splits3 :: AnyMessageAndAgency KeepAlive -> Bool
 prop_codec_splits3 msg =
     runST (prop_codec_splitsM splits3 codecKeepAlive msg)
+
+prop_codec_v2 :: AnyMessageAndAgency KeepAlive -> Bool
+prop_codec_v2 msg =
+    runST (prop_codecM codecKeepAlive_v2 msg)
+
+prop_codec_v2_splits2 :: AnyMessageAndAgency KeepAlive -> Bool
+prop_codec_v2_splits2 msg =
+    runST (prop_codec_splitsM splits2 codecKeepAlive_v2 msg)
+
+prop_codec_v2_splits3 :: AnyMessageAndAgency KeepAlive -> Bool
+prop_codec_v2_splits3 msg =
+    runST (prop_codec_splitsM splits3 codecKeepAlive_v2 msg)
 
 
 prop_byteLimits :: AnyMessageAndAgency KeepAlive

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Network.Protocol.LocalStateQuery.Test (tests) where
@@ -43,7 +44,7 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 
 import           Test.ChainGenerators ()
 import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
-                     splits2, splits3)
+                     prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import           Test.QuickCheck as QC hiding (Result)
 import           Test.Tasty (TestTree, testGroup)
@@ -67,6 +68,7 @@ tests =
   , testProperty "codecs V7/V8 compatible"
                                        prop_codec_V7_compatible
   , testProperty "codec cbor"          prop_codec_cbor
+  , testProperty "codec valid cbor"    prop_codec_valid_cbor
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "pipe IO"             prop_pipe_IO
@@ -369,6 +371,13 @@ prop_codec_cbor
   -> Bool
 prop_codec_cbor msg =
   runST (prop_codec_cborM (codec True) msg)
+
+-- | Check that the encoder produces a valid CBOR.
+--
+prop_codec_valid_cbor
+  :: AnyMessageAndAgency (LocalStateQuery Block (Point Block) Query)
+  -> Property
+prop_codec_valid_cbor = prop_codec_valid_cbor_encoding (codec True)
 
 prop_codec_V7_compatible
   :: AnyMessageAndAgencyV7

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
@@ -58,21 +58,23 @@ import           Text.Show.Functions ()
 
 tests :: TestTree
 tests =
-  testGroup "Ouroboros.Network.Protocol.LocalStateQuery"
-  [ testProperty "direct"              prop_direct
-  , testProperty "connect"             prop_connect
-  , testProperty "codec"               prop_codec
-  , testProperty "codec 2-splits"      prop_codec_splits2
-  , testProperty "codec 3-splits"    $ withMaxSuccess 30
-                                       prop_codec_splits3
-  , testProperty "codecs V7/V8 compatible"
-                                       prop_codec_V7_compatible
-  , testProperty "codec cbor"          prop_codec_cbor
-  , testProperty "codec valid cbor"    prop_codec_valid_cbor
-  , testProperty "channel ST"          prop_channel_ST
-  , testProperty "channel IO"          prop_channel_IO
-  , testProperty "pipe IO"             prop_pipe_IO
-  ]
+  testGroup "Ouroboros.Network.Protocol"
+    [ testGroup "LocalStateQuery"
+        [ testProperty "direct"              prop_direct
+        , testProperty "connect"             prop_connect
+        , testProperty "codec"               prop_codec
+        , testProperty "codec 2-splits"      prop_codec_splits2
+        , testProperty "codec 3-splits"    $ withMaxSuccess 30
+                                             prop_codec_splits3
+        , testProperty "codecs V7/V8 compatible"
+                                             prop_codec_V7_compatible
+        , testProperty "codec cbor"          prop_codec_cbor
+        , testProperty "codec valid cbor"    prop_codec_valid_cbor
+        , testProperty "channel ST"          prop_channel_ST
+        , testProperty "channel IO"          prop_channel_IO
+        , testProperty "pipe IO"             prop_pipe_IO
+        ]
+    ]
 
 
 --

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -57,19 +57,21 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =
-  testGroup "Ouroboros.Network.Protocol.LocalTxSubmission"
-  [ testProperty "direct"              prop_direct
-  , testProperty "connect"             prop_connect
-  , testProperty "codec"               prop_codec
-  , testProperty "codec 2-splits"      prop_codec_splits2
-  , testProperty "codec 3-splits"    $ withMaxSuccess 30
-                                       prop_codec_splits3
-  , testProperty "codec cbor"          prop_codec_cbor
-  , testProperty "codec valid cbor"    prop_codec_valid_cbor
-  , testProperty "channel ST"          prop_channel_ST
-  , testProperty "channel IO"          prop_channel_IO
-  , testProperty "pipe IO"             prop_pipe_IO
-  ]
+  testGroup "Ouroboros.Network.Protocol"
+    [ testGroup "LocalTxSubmission"
+        [ testProperty "direct"              prop_direct
+        , testProperty "connect"             prop_connect
+        , testProperty "codec"               prop_codec
+        , testProperty "codec 2-splits"      prop_codec_splits2
+        , testProperty "codec 3-splits"    $ withMaxSuccess 30
+                                             prop_codec_splits3
+        , testProperty "codec cbor"          prop_codec_cbor
+        , testProperty "codec valid cbor"    prop_codec_valid_cbor
+        , testProperty "channel ST"          prop_channel_ST
+        , testProperty "channel IO"          prop_channel_IO
+        , testProperty "pipe IO"             prop_pipe_IO
+        ]
+    ]
 
 
 --

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -42,7 +42,8 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Examples
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 
-import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+                     prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import           Text.Show.Functions ()
 import           Test.QuickCheck as QC
@@ -64,6 +65,7 @@ tests =
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3
   , testProperty "codec cbor"          prop_codec_cbor
+  , testProperty "codec valid cbor"    prop_codec_valid_cbor
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "pipe IO"             prop_pipe_IO
@@ -254,3 +256,10 @@ prop_codec_cbor
   -> Bool
 prop_codec_cbor msg =
   runST (prop_codec_cborM codec msg)
+
+-- | Check that the encoder produces a valid CBOR.
+--
+prop_codec_valid_cbor
+  :: AnyMessageAndAgency (LocalTxSubmission Tx Reject)
+  -> Property
+prop_codec_valid_cbor = prop_codec_valid_cbor_encoding codec

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -68,20 +68,22 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =
-  testGroup "Ouroboros.Network.Protocol.TxSubmission"
-  [ testProperty "direct"              prop_direct
-  , testProperty "connect 1"           prop_connect1
-  , testProperty "connect 2"           prop_connect2
-  , testProperty "codec"               prop_codec
-  , testProperty "codec id"            prop_codec_id
-  , testProperty "codec 2-splits"      prop_codec_splits2
-  , testProperty "codec 3-splits"    $ withMaxSuccess 30
-                                       prop_codec_splits3
-  , testProperty "codec cbor"          prop_codec_cbor
-  , testProperty "codec valid cbor"    prop_codec_valid_cbor
-  , testProperty "channel ST"          prop_channel_ST
-  , testProperty "channel IO"          prop_channel_IO
-  , testProperty "pipe IO"             prop_pipe_IO
+  testGroup "Ouroboros.Network.Protocol"
+  [ testGroup "TxSubmission"
+      [ testProperty "direct"              prop_direct
+      , testProperty "connect 1"           prop_connect1
+      , testProperty "connect 2"           prop_connect2
+      , testProperty "codec"               prop_codec
+      , testProperty "codec id"            prop_codec_id
+      , testProperty "codec 2-splits"      prop_codec_splits2
+      , testProperty "codec 3-splits"    $ withMaxSuccess 30
+                                           prop_codec_splits3
+      , testProperty "codec cbor"          prop_codec_cbor
+      , testProperty "codec valid cbor"    prop_codec_valid_cbor
+      , testProperty "channel ST"          prop_channel_ST
+      , testProperty "channel IO"          prop_channel_IO
+      , testProperty "pipe IO"             prop_pipe_IO
+      ]
   ]
 
 

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE TypeApplications           #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- usage of `MsgKThxBye` is safe in this module.
@@ -53,7 +54,8 @@ import           Ouroboros.Network.Protocol.TxSubmission.Examples
 import           Ouroboros.Network.Protocol.TxSubmission.Server
 import           Ouroboros.Network.Protocol.TxSubmission.Type
 
-import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+                     prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import           Test.QuickCheck as QC
 import           Test.Tasty (TestTree, testGroup)
@@ -76,6 +78,7 @@ tests =
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3
   , testProperty "codec cbor"          prop_codec_cbor
+  , testProperty "codec valid cbor"    prop_codec_valid_cbor
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "pipe IO"             prop_pipe_IO
@@ -348,6 +351,13 @@ prop_codec_cbor
   -> Bool
 prop_codec_cbor msg =
   runST (prop_codec_cborM codec msg)
+
+-- | Check that the encoder produces a valid CBOR.
+--
+prop_codec_valid_cbor
+  :: AnyMessageAndAgency (TxSubmission TxId Tx)
+  -> Property
+prop_codec_valid_cbor = prop_codec_valid_cbor_encoding codec
 
 --
 -- Local generators

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
@@ -53,21 +53,23 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =
-  testGroup "Ouroboros.Network.Protocol.TxSubmission2"
-  [ testProperty "connect 1" prop_connect1
-  , testProperty "connect 2"           prop_connect2
-  , testProperty "codec"               prop_codec
-  , testProperty "codec id"            prop_codec_id
-  , testProperty "codec 2-splits"      prop_codec_splits2
-  , testProperty "codec 3-splits"    $ withMaxSuccess 30
-                                       prop_codec_splits3
-  , testProperty "codec cbor"          prop_codec_cbor
-  , testProperty "codec valid cbor"    prop_codec_valid_cbor
-  , testProperty "encodings agree"     prop_encodings_agree
-  , testProperty "channel ST"          prop_channel_ST
-  , testProperty "channel IO"          prop_channel_IO
-  , testProperty "pipe IO"             prop_pipe_IO
-  ]
+  testGroup "Ouroboros.Network.Protocol"
+    [ testGroup "TxSubmission2"
+        [ testProperty "connect 1" prop_connect1
+        , testProperty "connect 2"           prop_connect2
+        , testProperty "codec"               prop_codec
+        , testProperty "codec id"            prop_codec_id
+        , testProperty "codec 2-splits"      prop_codec_splits2
+        , testProperty "codec 3-splits"    $ withMaxSuccess 30
+                                             prop_codec_splits3
+        , testProperty "codec cbor"          prop_codec_cbor
+        , testProperty "codec valid cbor"    prop_codec_valid_cbor
+        , testProperty "encodings agree"     prop_encodings_agree
+        , testProperty "channel ST"          prop_channel_ST
+        , testProperty "channel IO"          prop_channel_IO
+        , testProperty "pipe IO"             prop_pipe_IO
+        ]
+    ]
 
 
 -- | Run a simple tx-submission client and server, going via the 'Peer'

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
@@ -38,7 +38,8 @@ import           Ouroboros.Network.Protocol.TxSubmission.Test hiding (tests)
 import           Ouroboros.Network.Protocol.TxSubmission2.Type
 import           Ouroboros.Network.Protocol.TxSubmission2.Codec
 
-import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+                     prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import           Test.QuickCheck as QC
 import           Test.Tasty (TestTree, testGroup)
@@ -61,6 +62,7 @@ tests =
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3
   , testProperty "codec cbor"          prop_codec_cbor
+  , testProperty "codec valid cbor"    prop_codec_valid_cbor
   , testProperty "encodings agree"     prop_encodings_agree
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
@@ -244,6 +246,13 @@ prop_codec_cbor
   -> Bool
 prop_codec_cbor msg =
   runST (prop_codec_cborM codec2 msg)
+
+-- | Check that the encoder produces a valid CBOR.
+--
+prop_codec_valid_cbor
+  :: AnyMessageAndAgency (TxSubmission2 TxId Tx)
+  -> Property
+prop_codec_valid_cbor = prop_codec_valid_cbor_encoding codec2
 
 -- | 'codecTxSubmission' and 'codecTxSubmission2' agree on the encoding.  This
 -- and 'prop_codec' ensures the 'codecTxSubmission2' is backward compatible with

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -49,6 +49,10 @@ data NodeToNodeVersion
     -- ^ Changes:
     --
     -- * Replace 'TxSubmision' with 'Txsubmission2' protocol.
+    | NodeToNodeV_7
+    -- ^ Changes:
+    --
+    -- * new 'KeepAlive' codec
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
@@ -60,6 +64,7 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     encodeTerm NodeToNodeV_4  = CBOR.TInt 4
     encodeTerm NodeToNodeV_5  = CBOR.TInt 5
     encodeTerm NodeToNodeV_6  = CBOR.TInt 6
+    encodeTerm NodeToNodeV_7  = CBOR.TInt 7
 
     decodeTerm (CBOR.TInt 1) = Right NodeToNodeV_1
     decodeTerm (CBOR.TInt 2) = Right NodeToNodeV_2
@@ -67,6 +72,7 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     decodeTerm (CBOR.TInt 4) = Right NodeToNodeV_4
     decodeTerm (CBOR.TInt 5) = Right NodeToNodeV_5
     decodeTerm (CBOR.TInt 6) = Right NodeToNodeV_6
+    decodeTerm (CBOR.TInt 7) = Right NodeToNodeV_7
     decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
                                         <> T.pack (show n)
                                     , Just n


### PR DESCRIPTION
The new keep alive codec produces valid CBOR encoding.  This PR provides:

- KeepAlive: codec with valid CBOR encoding
- ouroboros-network-testing: added prop_valid_cbor
- Test that mini-protocol codecs produce valid CBOR
- NodeToNodeV_7: use new KeepAlive codec
