### PR TITLE
Make stake distribution vary through the MockPraos tests.

### DIFF
--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
@@ -19,10 +19,10 @@ import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node ()
 import           Ouroboros.Consensus.Mock.Node.PraosRule
+import           Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
-import           Ouroboros.Consensus.Protocol.LeaderSchedule
 
 import           Test.ThreadNet.General
 import           Test.ThreadNet.TxGen.Mock ()

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
@@ -130,6 +130,7 @@ prop_simple_leader_schedule_convergence TestSetup
                   }
                   (HardFork.defaultEraParams k slotLength)
                   schedule
+                  emptyPraosEvolvingStake
             , mkRekeyM = Nothing
             }
 

--- a/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -44,6 +44,7 @@ library
                        Ouroboros.Consensus.Mock.Node.Praos
                        Ouroboros.Consensus.Mock.Node.PraosRule
                        Ouroboros.Consensus.Mock.Node.Serialisation
+                       Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
                        Ouroboros.Consensus.Mock.Protocol.Praos
 
   build-depends:       base              >=4.9   && <4.15

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -187,6 +187,8 @@ instance Serialise SimpleBody where
   Working with 'SimpleBlock'
 -------------------------------------------------------------------------------}
 
+-- | Create a header by hashing the header without hash and adding to the
+-- resulting value.
 mkSimpleHeader :: SimpleCrypto c
                => (ext' -> CBOR.Encoding)
                -> SimpleStdHeader c ext

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -38,7 +38,6 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Ledger.Forge
-import           Ouroboros.Consensus.Mock.Ledger.Stake
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.Protocol.Signed
@@ -120,24 +119,10 @@ instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
-  protocolLedgerView   cfg _  = pretendTicked $ stakeDist cfg
-  ledgerViewForecastAt cfg st = constantForecastOf
-                                 (pretendTicked $ stakeDist cfg)
+  protocolLedgerView   _ _  = TickedTrivial
+  ledgerViewForecastAt _ st = constantForecastOf
+                                 TickedTrivial
                                  (getTipSlot st)
-
--- | Praos needs a ledger that can give it the "active stake distribution"
---
--- TODO: Currently our mock ledger does not do this, and just assumes that all
--- the leaders have equal stake at all times. In a way this is not wrong: it
--- is just a different instantiation of the same consensus algorithm (see
--- documentation of 'LedgerView'). Ideally we'd change this however, but it
--- may not be worth it; it would be a bit of work, and after we have integrated
--- the Shelley rules, we'll have a proper instance anyway.
-stakeDist :: LedgerConfig (SimplePraosBlock c c') -> StakeDist
-stakeDist = equalStakeDist . simpleMockLedgerConfig
-
-pretendTicked :: StakeDist -> Ticked StakeDist
-pretendTicked (StakeDist sd) = TickedStakeDist sd
 
 {-------------------------------------------------------------------------------
   Forging

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -35,9 +35,9 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Ledger.Forge
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
-import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Util.Condense
 
 import           Ouroboros.Consensus.Storage.Serialisation

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Stake.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Stake.hs
@@ -50,11 +50,6 @@ data StakeHolder =
 newtype StakeDist = StakeDist { stakeDistToMap :: Map CoreNodeId Rational }
   deriving (Show, Eq, Serialise, NoThunks)
 
--- | Ticked stake distribution
-newtype instance Ticked StakeDist = TickedStakeDist {
-      tickedStakeDistToMap :: Map CoreNodeId Rational
-    }
-
 stakeWithDefault :: Rational -> CoreNodeId -> StakeDist -> Rational
 stakeWithDefault d n = Map.findWithDefault d n . stakeDistToMap
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
@@ -134,9 +134,13 @@ txOuts = Map.unions . map each . getMockTxs
         aux :: Ix -> TxOut -> (TxIn, TxOut)
         aux ix out = ((hashWithSerialiser toCBOR tx, ix), out)
 
+-- | @confirmed@ stands for all the transaction hashes present in the given
+-- collection.
 confirmed :: HasMockTxs a => a -> Set TxId
 confirmed = Set.fromList . map (hashWithSerialiser toCBOR) . getMockTxs
 
+-- |Update the Utxo with the transactions from the given @a@, by removing the
+-- inputs and adding the outputs.
 updateUtxo :: HasMockTxs a => a -> Utxo -> Except UtxoError Utxo
 updateUtxo = repeatedlyM each . getMockTxs
   where

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -36,16 +36,18 @@ protocolInfoPraos :: IOLike m
                   -> PraosParams
                   -> HardFork.EraParams
                   -> Natural
+                  -> PraosEvolvingStake
                   -> ProtocolInfo m MockPraosBlock
-protocolInfoPraos numCoreNodes nid params eraParams eta0 =
+protocolInfoPraos numCoreNodes nid params eraParams eta0 evolvingStakeDist =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
             topLevelConfigProtocol = PraosConfig {
-                praosParams       = params
-              , praosSignKeyVRF   = signKeyVRF nid
-              , praosInitialEta   = eta0
-              , praosInitialStake = genesisStakeDist addrDist
-              , praosVerKeys      = verKeys
+                praosParams        = params
+              , praosSignKeyVRF    = signKeyVRF nid
+              , praosInitialEta    = eta0
+              , praosInitialStake  = genesisStakeDist addrDist
+              , praosEvolvingStake = evolvingStakeDist
+              , praosVerKeys       = verKeys
               }
           , topLevelConfigLedger  = SimpleLedgerConfig addrDist eraParams
           , topLevelConfigBlock   = SimpleBlockConfig

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -16,10 +16,10 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node
+import           Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
-import           Ouroboros.Consensus.Protocol.LeaderSchedule
 
 type MockPraosRuleBlock = SimplePraosRuleBlock SimpleMockCrypto
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -29,22 +29,25 @@ protocolInfoPraosRule :: Monad m
                       -> PraosParams
                       -> HardFork.EraParams
                       -> LeaderSchedule
+                      -> PraosEvolvingStake
                       -> ProtocolInfo m MockPraosRuleBlock
 protocolInfoPraosRule numCoreNodes
                       nid
                       params
                       eraParams
-                      schedule =
+                      schedule
+                      evolvingStake =
     ProtocolInfo {
       pInfoConfig = TopLevelConfig {
           topLevelConfigProtocol = WLSConfig {
               wlsConfigSchedule = schedule
             , wlsConfigP        = PraosConfig
-                { praosParams       = params
-                , praosSignKeyVRF   = NeverUsedSignKeyVRF
-                , praosInitialEta   = 0
-                , praosInitialStake = genesisStakeDist addrDist
-                , praosVerKeys      = verKeys
+                { praosParams        = params
+                , praosSignKeyVRF    = NeverUsedSignKeyVRF
+                , praosInitialEta    = 0
+                , praosInitialStake  = genesisStakeDist addrDist
+                , praosEvolvingStake = evolvingStake
+                , praosVerKeys       = verKeys
                 }
             , wlsConfigNodeId   = nid
             }

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module Ouroboros.Consensus.Mock.Protocol.LeaderSchedule (
+    ConsensusConfig (..)
+  , LeaderSchedule (..)
+  , WithLeaderSchedule
+  , leaderScheduleFor
+  ) where
+
+import qualified Data.Map.Strict as Map
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.LeaderSchedule
+import           Ouroboros.Consensus.Ticked
+
+{-------------------------------------------------------------------------------
+  ConsensusProtocol instance that overrides leader selection
+
+  Using a provided LeaderSchedule, this instance will override the computation
+  for checking leadership and just take the leader from the provided schedule.
+-------------------------------------------------------------------------------}
+
+-- | Extension of protocol @p@ by a static leader schedule.
+data WithLeaderSchedule p
+
+data instance ConsensusConfig (WithLeaderSchedule p) = WLSConfig {
+      wlsConfigSchedule :: !LeaderSchedule
+    , wlsConfigP        :: !(ConsensusConfig p)
+    , wlsConfigNodeId   :: !CoreNodeId
+    }
+  deriving (Generic)
+
+instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
+  type SelectView    (WithLeaderSchedule p) = SelectView p
+
+  type ChainDepState (WithLeaderSchedule p) = ()
+  type LedgerView    (WithLeaderSchedule p) = ()
+  type ValidationErr (WithLeaderSchedule p) = ()
+  type IsLeader      (WithLeaderSchedule p) = ()
+  type ValidateView  (WithLeaderSchedule p) = ()
+  type CanBeLeader   (WithLeaderSchedule p) = ()
+
+  protocolSecurityParam = protocolSecurityParam . wlsConfigP
+
+  checkIsLeader WLSConfig{..} () slot _ =
+    case Map.lookup slot $ getLeaderSchedule wlsConfigSchedule of
+        Nothing -> error $ "WithLeaderSchedule: missing slot " ++ show slot
+        Just nids
+            | wlsConfigNodeId `elem` nids -> Just ()
+            | otherwise                   -> Nothing
+
+  tickChainDepState     _ _ _ _ = TickedTrivial
+  updateChainDepState   _ _ _ _ = return ()
+  reupdateChainDepState _ _ _ _ = ()
+
+instance ConsensusProtocol p
+      => NoThunks (ConsensusConfig (WithLeaderSchedule p))

--- a/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
@@ -57,7 +57,6 @@ import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract (LedgerView)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
-                     (LeaderSchedule (..))
 import           Ouroboros.Consensus.TypeFamilyWrappers
 
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
@@ -41,7 +41,6 @@ import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
-                     (LeaderSchedule (..))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
@@ -13,7 +13,6 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
-                     (LeaderSchedule (..))
 
 import           Test.ThreadNet.Util.NodeJoinPlan
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -6,9 +6,7 @@
 {-# LANGUAGE TypeFamilies       #-}
 
 module Ouroboros.Consensus.Protocol.LeaderSchedule (
-    ConsensusConfig (..)
-  , LeaderSchedule (..)
-  , WithLeaderSchedule
+    LeaderSchedule (..)
   , leaderScheduleFor
   ) where
 
@@ -20,8 +18,6 @@ import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), fromCoreNodeId)
-import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 {-------------------------------------------------------------------------------
@@ -57,43 +53,3 @@ instance Condense LeaderSchedule where
     condense (LeaderSchedule m) = condense
                                 $ map (\(s, ls) -> (s, map fromCoreNodeId ls))
                                 $ Map.toList m
-
-{-------------------------------------------------------------------------------
-  ConsensusProtocol instance
--------------------------------------------------------------------------------}
-
--- | Extension of protocol @p@ by a static leader schedule.
-data WithLeaderSchedule p
-
-data instance ConsensusConfig (WithLeaderSchedule p) = WLSConfig {
-      wlsConfigSchedule :: !LeaderSchedule
-    , wlsConfigP        :: !(ConsensusConfig p)
-    , wlsConfigNodeId   :: !CoreNodeId
-    }
-  deriving (Generic)
-
-instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
-  type SelectView    (WithLeaderSchedule p) = SelectView p
-
-  type ChainDepState (WithLeaderSchedule p) = ()
-  type LedgerView    (WithLeaderSchedule p) = ()
-  type ValidationErr (WithLeaderSchedule p) = ()
-  type IsLeader      (WithLeaderSchedule p) = ()
-  type ValidateView  (WithLeaderSchedule p) = ()
-  type CanBeLeader   (WithLeaderSchedule p) = ()
-
-  protocolSecurityParam = protocolSecurityParam . wlsConfigP
-
-  checkIsLeader WLSConfig{..} () slot _ =
-    case Map.lookup slot $ getLeaderSchedule wlsConfigSchedule of
-        Nothing -> error $ "WithLeaderSchedule: missing slot " ++ show slot
-        Just nids
-            | wlsConfigNodeId `elem` nids -> Just ()
-            | otherwise                   -> Nothing
-
-  tickChainDepState     _ _ _ _ = TickedTrivial
-  updateChainDepState   _ _ _ _ = return ()
-  reupdateChainDepState _ _ _ _ = ()
-
-instance ConsensusProtocol p
-      => NoThunks (ConsensusConfig (WithLeaderSchedule p))

--- a/shell.nix
+++ b/shell.nix
@@ -57,6 +57,9 @@ let
     tools = {
       ghcid = "0.8.7";
       cabal = "3.2.0.0";
+      hasktags = "0.71.2";
+      # https://hackage.haskell.org/package/graphmod
+      graphmod = "1.4.4";
       # todo: add back the build tools which are actually necessary
       # ghcide = "0.2.0";
       # hlint = "...";


### PR DESCRIPTION
Closes #2850.

Previously, the stake distribution was static, it was stored in every block with
the same value and although it retrieved it from the last block of 2 epochs ago,
the value was the same. In this scenario, all the probabilities of forging were
fixed.

Now, a new parameter `praosEvolvingStake` was added to the `PraosConfig` (only
used in MockPraos), which will be used when determining the stake distribution at
a given slot.

Side changes can be seen in individual commits:
- Documentation
- Moving `Ouroboros.Consensus.Protocol.LeaderSchedule` to `ouroboros-consensus-mock`.
- Added hasktags and graphmod to shell.nix.