### PR TITLE
Fix Windows build in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install pkgconfiglite
       if: matrix.os == 'windows-latest'
-      run: choco install -y pkgconfiglite
+      run: choco install -y pkgconfiglite --allow-empty-checksums
 
     - name: Install libsodium (Windows)
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install pkgconfiglite
       if: matrix.os == 'windows-latest'
-      run: choco install -y pkgconfiglite
+      run: choco install -y pkgconfiglite --allow-empty-checksums
 
     - name: Install libsodium
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Adds `--allow-empty-checksums` to fix this error:

```
WARNING: Missing package checksums are not allowed (by default for HTTP/FTP, 
 HTTPS when feature 'allowEmptyChecksumsSecure' is disabled) for 
 safety and security reasons. Although we strongly advise against it, 
 if you need this functionality, please set the feature 
 'allowEmptyChecksums' ('choco feature enable -n 
 allowEmptyChecksums') 
 or pass in the option '--allow-empty-checksums'. You can also pass 
 checksums at runtime (recommended). See choco install -? for details.
The integrity of the file 'pkg-config-lite-0.28-1_bin-win32.zip' from 'http://downloads.sourceforge.net/project/pkgconfiglite/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip' has not been verified by a checksum in the package scripts.
Do you wish to allow the install to continue (not recommended)?
[Y] Yes [N] No (default is "N")
  Confirmation (`-y`) is set.
  Respond within 30 seconds or the default selection will be chosen.
ERROR: Empty checksums are no longer allowed by default for non-secure sources. Please ask the maintainer to add checksums to this package. In the meantime if you need this package to work correctly, please enable the feature allowEmptyChecksums, provide the runtime switch '--allow-empty-checksums', or pass in checksums at runtime (recommended - see 'choco install -?' / 'choco upgrade -?' for details). It is strongly advised against allowing empty checksums for non-internal HTTP/FTP sources.
The install of pkgconfiglite was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\pkgconfiglite\tools\chocolateyInstall.ps1'.
 See log for details.
```