### PR TITLE
Trace peer for chainsync clients

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -56,7 +56,8 @@ import           GHC.Stack
 import           System.Random (mkStdGen)
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
+import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
+                     TraceLabelPeer (..))
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec (AnyMessage (..), CodecFailure,
                      mapFailureCodec)
@@ -912,7 +913,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       let -- prop_general relies on these tracers
           instrumentationTracers = nullTracers
                 { chainSyncClientTracer = Tracer $ \case
-                    CSClient.TraceDownloadedHeader hdr
+                    TraceLabelPeer _ (CSClient.TraceDownloadedHeader hdr)
                       -> case blockPoint hdr of
                             GenesisPoint   -> pure ()
                             BlockPoint s h ->

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -49,7 +49,7 @@ import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
 -------------------------------------------------------------------------------}
 
 data Tracers' remotePeer localPeer blk f = Tracers
-  { chainSyncClientTracer         :: f (TraceChainSyncClientEvent blk)
+  { chainSyncClientTracer         :: f (TraceLabelPeer remotePeer (TraceChainSyncClientEvent blk))
   , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent blk)
   , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk)
   , blockFetchDecisionTracer      :: f [TraceLabelPeer remotePeer (FetchDecision [Point (Header blk)])]


### PR DESCRIPTION
This makes it possible to track which peer presented us which header at what time. Useful for debugging/performance analysis. 