### PR TITLE
Wrap all Node-To-Client queries in a top level query type

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -163,11 +163,11 @@ instance SerialiseNodeToClient DualByronBlock (DualGenTxErr ByronBlock ByronSpec
   encodeNodeToClient _ _ = encodeDualGenTxErr encodeByronApplyTxError
   decodeNodeToClient _ _ = decodeDualGenTxErr decodeByronApplyTxError
 
-instance SerialiseNodeToClient DualByronBlock (SomeSecond Query DualByronBlock) where
+instance SerialiseNodeToClient DualByronBlock (SomeSecond BlockQuery DualByronBlock) where
   encodeNodeToClient _ _ = \case {}
   decodeNodeToClient _ _ = error "DualByron: no query to decode"
 
-instance SerialiseResult DualByronBlock (Query DualByronBlock) where
+instance SerialiseResult DualByronBlock (BlockQuery DualByronBlock) where
   encodeResult _ _ = \case {}
   decodeResult _ _ = \case {}
 

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -313,14 +313,3 @@ instance Arbitrary (WithVersion ByronNodeToNodeVersion (SomeSecond (NestedCtxt H
                    , SomeSecond . NestedCtxt $ CtxtByronBoundary size
                    ]
       return (WithVersion version ctxt)
-
--- | All other types are unaffected by the versioning for
--- 'ByronNodeToNodeVersion'.
-instance {-# OVERLAPPABLE #-} Arbitrary a
-      => Arbitrary (WithVersion ByronNodeToNodeVersion a) where
-  arbitrary = WithVersion <$> arbitrary <*> arbitrary
-
--- | No types are affected by the versioning for
--- 'ByronNodeToClientVersion'.
-instance Arbitrary a => Arbitrary (WithVersion ByronNodeToClientVersion a) where
-  arbitrary = WithVersion <$> arbitrary <*> arbitrary

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -159,7 +159,7 @@ instance Arbitrary API.ApplyMempoolPayloadErr where
     -- , MempoolUpdateVoteErr     <$> arbitrary
     ]
 
-instance Arbitrary (SomeSecond Query ByronBlock) where
+instance Arbitrary (SomeSecond BlockQuery ByronBlock) where
   arbitrary = pure $ SomeSecond GetUpdateInterfaceState
 
 instance Arbitrary EpochNumber where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -35,7 +35,7 @@ module Ouroboros.Consensus.Byron.Ledger.Ledger (
   , encodeByronResult
     -- * Type family instances
   , LedgerState (..)
-  , Query (..)
+  , BlockQuery (..)
   , Ticked (..)
     -- * Auxiliary
   , validationErrorImpossible
@@ -195,23 +195,23 @@ instance ApplyBlock (LedgerState ByronBlock) ByronBlock where
     where
       validationMode = CC.fromBlockValidationMode CC.NoBlockValidation
 
-data instance Query ByronBlock :: Type -> Type where
-  GetUpdateInterfaceState :: Query ByronBlock UPI.State
+data instance BlockQuery ByronBlock :: Type -> Type where
+  GetUpdateInterfaceState :: BlockQuery ByronBlock UPI.State
 
 instance QueryLedger ByronBlock where
   answerQuery _cfg GetUpdateInterfaceState (ExtLedgerState ledgerState _) =
     CC.cvsUpdateState (byronLedgerState ledgerState)
 
-instance SameDepIndex (Query ByronBlock) where
+instance SameDepIndex (BlockQuery ByronBlock) where
   sameDepIndex GetUpdateInterfaceState GetUpdateInterfaceState = Just Refl
 
-deriving instance Eq (Query ByronBlock result)
-deriving instance Show (Query ByronBlock result)
+deriving instance Eq (BlockQuery ByronBlock result)
+deriving instance Show (BlockQuery ByronBlock result)
 
-instance ShowQuery (Query ByronBlock) where
+instance ShowQuery (BlockQuery ByronBlock) where
   showResult GetUpdateInterfaceState = show
 
-instance ShowProxy (Query ByronBlock) where
+instance ShowProxy (BlockQuery ByronBlock) where
 
 instance LedgerSupportsPeerSelection ByronBlock where
   getPeers = const []
@@ -480,22 +480,22 @@ decodeByronLedgerState = do
       <*> decode
       <*> decodeByronTransition
 
-encodeByronQuery :: Query ByronBlock result -> Encoding
+encodeByronQuery :: BlockQuery ByronBlock result -> Encoding
 encodeByronQuery query = case query of
     GetUpdateInterfaceState -> CBOR.encodeWord8 0
 
-decodeByronQuery :: Decoder s (SomeSecond Query ByronBlock)
+decodeByronQuery :: Decoder s (SomeSecond BlockQuery ByronBlock)
 decodeByronQuery = do
     tag <- CBOR.decodeWord8
     case tag of
       0 -> return $ SomeSecond GetUpdateInterfaceState
       _ -> fail $ "decodeByronQuery: invalid tag " <> show tag
 
-encodeByronResult :: Query ByronBlock result -> result -> Encoding
+encodeByronResult :: BlockQuery ByronBlock result -> result -> Encoding
 encodeByronResult query = case query of
     GetUpdateInterfaceState -> toCBOR
 
-decodeByronResult :: Query ByronBlock result
+decodeByronResult :: BlockQuery ByronBlock result
                   -> forall s. Decoder s result
 decodeByronResult query = case query of
     GetUpdateInterfaceState -> fromCBOR

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -34,8 +34,8 @@ module Ouroboros.Consensus.Byron.Ledger.Ledger (
   , encodeByronQuery
   , encodeByronResult
     -- * Type family instances
-  , LedgerState (..)
   , BlockQuery (..)
+  , LedgerState (..)
   , Ticked (..)
     -- * Auxiliary
   , validationErrorImpossible
@@ -199,7 +199,7 @@ data instance BlockQuery ByronBlock :: Type -> Type where
   GetUpdateInterfaceState :: BlockQuery ByronBlock UPI.State
 
 instance QueryLedger ByronBlock where
-  answerQuery _cfg GetUpdateInterfaceState (ExtLedgerState ledgerState _) =
+  answerBlockQuery _cfg GetUpdateInterfaceState (ExtLedgerState ledgerState _) =
     CC.cvsUpdateState (byronLedgerState ledgerState)
 
 instance SameDepIndex (BlockQuery ByronBlock) where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -173,11 +173,11 @@ instance SerialiseNodeToClient ByronBlock CC.ApplyMempoolPayloadErr where
   encodeNodeToClient _ _ = encodeByronApplyTxError
   decodeNodeToClient _ _ = decodeByronApplyTxError
 
-instance SerialiseNodeToClient ByronBlock (SomeSecond Query ByronBlock) where
+instance SerialiseNodeToClient ByronBlock (SomeSecond BlockQuery ByronBlock) where
   encodeNodeToClient _ _ (SomeSecond q) = encodeByronQuery q
   decodeNodeToClient _ _               = decodeByronQuery
 
-instance SerialiseResult ByronBlock (Query ByronBlock) where
+instance SerialiseResult ByronBlock (BlockQuery ByronBlock) where
   encodeResult _ _ = encodeByronResult
   decodeResult _ _ = decodeByronResult
 

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -108,20 +108,20 @@ instance Inject SomeResult where
 
 instance Inject Examples where
   inject startBounds (idx :: Index xs x) Golden.Examples {..} = Golden.Examples {
-        exampleBlock            = inj (Proxy @I)                  exampleBlock
-      , exampleSerialisedBlock  = inj (Proxy @Serialised)         exampleSerialisedBlock
-      , exampleHeader           = inj (Proxy @Header)             exampleHeader
-      , exampleSerialisedHeader = inj (Proxy @SerialisedHeader)   exampleSerialisedHeader
-      , exampleHeaderHash       = inj (Proxy @WrapHeaderHash)     exampleHeaderHash
-      , exampleGenTx            = inj (Proxy @GenTx)              exampleGenTx
-      , exampleGenTxId          = inj (Proxy @WrapGenTxId)        exampleGenTxId
-      , exampleApplyTxErr       = inj (Proxy @WrapApplyTxErr)     exampleApplyTxErr
-      , exampleQuery            = inj (Proxy @(SomeSecond Query)) exampleQuery
-      , exampleResult           = inj (Proxy @SomeResult)         exampleResult
-      , exampleAnnTip           = inj (Proxy @AnnTip)             exampleAnnTip
-      , exampleLedgerState      = inj (Proxy @LedgerState)        exampleLedgerState
-      , exampleChainDepState    = inj (Proxy @WrapChainDepState)  exampleChainDepState
-      , exampleExtLedgerState   = inj (Proxy @ExtLedgerState)     exampleExtLedgerState
+        exampleBlock            = inj (Proxy @I)                       exampleBlock
+      , exampleSerialisedBlock  = inj (Proxy @Serialised)              exampleSerialisedBlock
+      , exampleHeader           = inj (Proxy @Header)                  exampleHeader
+      , exampleSerialisedHeader = inj (Proxy @SerialisedHeader)        exampleSerialisedHeader
+      , exampleHeaderHash       = inj (Proxy @WrapHeaderHash)          exampleHeaderHash
+      , exampleGenTx            = inj (Proxy @GenTx)                   exampleGenTx
+      , exampleGenTxId          = inj (Proxy @WrapGenTxId)             exampleGenTxId
+      , exampleApplyTxErr       = inj (Proxy @WrapApplyTxErr)          exampleApplyTxErr
+      , exampleQuery            = inj (Proxy @(SomeSecond BlockQuery)) exampleQuery
+      , exampleResult           = inj (Proxy @SomeResult)              exampleResult
+      , exampleAnnTip           = inj (Proxy @AnnTip)                  exampleAnnTip
+      , exampleLedgerState      = inj (Proxy @LedgerState)             exampleLedgerState
+      , exampleChainDepState    = inj (Proxy @WrapChainDepState)       exampleChainDepState
+      , exampleExtLedgerState   = inj (Proxy @ExtLedgerState)          exampleExtLedgerState
       }
     where
       inj ::
@@ -277,23 +277,23 @@ exampleApplyTxErrWrongEraShelley :: ApplyTxErr (CardanoBlock Crypto)
 exampleApplyTxErrWrongEraShelley =
       HardForkApplyTxErrWrongEra exampleEraMismatchShelley
 
-exampleQueryEraMismatchByron :: SomeSecond Query (CardanoBlock Crypto)
+exampleQueryEraMismatchByron :: SomeSecond BlockQuery (CardanoBlock Crypto)
 exampleQueryEraMismatchByron =
     SomeSecond (QueryIfCurrentShelley Shelley.GetLedgerTip)
 
-exampleQueryEraMismatchShelley :: SomeSecond Query (CardanoBlock Crypto)
+exampleQueryEraMismatchShelley :: SomeSecond BlockQuery (CardanoBlock Crypto)
 exampleQueryEraMismatchShelley =
     SomeSecond (QueryIfCurrentByron Byron.GetUpdateInterfaceState)
 
-exampleQueryAnytimeByron :: SomeSecond Query (CardanoBlock Crypto)
+exampleQueryAnytimeByron :: SomeSecond BlockQuery (CardanoBlock Crypto)
 exampleQueryAnytimeByron =
     SomeSecond (QueryAnytimeByron GetEraStart)
 
-exampleQueryAnytimeShelley :: SomeSecond Query (CardanoBlock Crypto)
+exampleQueryAnytimeShelley :: SomeSecond BlockQuery (CardanoBlock Crypto)
 exampleQueryAnytimeShelley =
     SomeSecond (QueryAnytimeShelley GetEraStart)
 
-exampleQueryHardFork :: SomeSecond Query (CardanoBlock Crypto)
+exampleQueryHardFork :: SomeSecond BlockQuery (CardanoBlock Crypto)
 exampleQueryHardFork =
     SomeSecond (QueryHardFork GetInterpreter)
 

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
@@ -378,7 +378,7 @@ instance CardanoHardForkConstraints c
 
 instance c ~ MockCryptoCompatByron
       => Arbitrary (WithVersion (HardForkNodeToClientVersion (CardanoEras c))
-                                (SomeSecond Query (CardanoBlock c))) where
+                                (SomeSecond BlockQuery (CardanoBlock c))) where
   arbitrary = frequency
       [ (1, arbitraryNodeToClient injByron injShelley injAllegra injMary)
       , (1, WithVersion

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
@@ -105,9 +105,9 @@ instance Arbitrary (BlockNodeToNodeVersion blk)
 
 arbitraryNodeToNode
   :: ( Arbitrary (WithVersion ByronNodeToNodeVersion byron)
-     , Arbitrary shelley
-     , Arbitrary allegra
-     , Arbitrary mary
+     , Arbitrary (WithVersion ShelleyNodeToNodeVersion shelley)
+     , Arbitrary (WithVersion ShelleyNodeToNodeVersion allegra)
+     , Arbitrary (WithVersion ShelleyNodeToNodeVersion mary)
      )
   => (byron   -> cardano)
   -> (shelley -> cardano)

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/ByronCompatibility.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/ByronCompatibility.hs
@@ -136,11 +136,11 @@ toCardanoCodecConfig codecConfigByron =
 --
 -- Note that ledger state and all other types stored as part of the ledger
 -- snapshot are __not__ forwards compatible.
-newtype ByronToCardano                       = B2C        { unB2C        ::         ByronBlock   } deriving (Eq, Show)
-newtype instance Header ByronToCardano       = HeaderB2C  { unHeaderB2C  :: Header  ByronBlock   } deriving (Eq, Show)
-newtype instance GenTx ByronToCardano        = GenTxB2C   { unGenTxB2C   :: GenTx   ByronBlock   } deriving (Eq, Show)
-newtype instance TxId (GenTx ByronToCardano) = GenTxIdB2C { unGenTxIdB2C :: GenTxId ByronBlock   } deriving (Eq, Show)
-newtype instance Query ByronToCardano a      = QueryB2C   { unQueryB2C   :: Query   ByronBlock a } deriving (Eq, Show)
+newtype ByronToCardano                       = B2C        { unB2C        ::            ByronBlock   } deriving (Eq, Show)
+newtype instance Header ByronToCardano       = HeaderB2C  { unHeaderB2C  :: Header     ByronBlock   } deriving (Eq, Show)
+newtype instance GenTx ByronToCardano        = GenTxB2C   { unGenTxB2C   :: GenTx      ByronBlock   } deriving (Eq, Show)
+newtype instance TxId (GenTx ByronToCardano) = GenTxIdB2C { unGenTxIdB2C :: GenTxId    ByronBlock   } deriving (Eq, Show)
+newtype instance BlockQuery ByronToCardano a = QueryB2C   { unQueryB2C   :: BlockQuery ByronBlock a } deriving (Eq, Show)
 
 newtype instance NestedCtxt_ ByronToCardano f a where
   NestedCtxt_B2C :: NestedCtxt_ ByronBlock     f a
@@ -173,10 +173,10 @@ instance HasNestedContent Header ByronToCardano where
   nest (DepPair ctxt a) =
       HeaderB2C $ nest (DepPair (mapNestedCtxt unNestedCtxt_B2C ctxt) a)
 
-instance ShowQuery (Query ByronToCardano) where
+instance ShowQuery (BlockQuery ByronToCardano) where
   showResult (QueryB2C query) = showResult query
 
-instance SameDepIndex (Query ByronToCardano) where
+instance SameDepIndex (BlockQuery ByronToCardano) where
   sameDepIndex (QueryB2C q1) (QueryB2C q2) = sameDepIndex q1 q2
 
 {------------------------------------------------------------------------------
@@ -354,18 +354,18 @@ instance SerialiseNodeToClient ByronToCardano CC.ApplyMempoolPayloadErr where
   encodeNodeToClient = encodeNodeToClientB2C (Proxy @WrapApplyTxErr) id
   decodeNodeToClient = decodeNodeToClientB2C (Proxy @WrapApplyTxErr) (\(ApplyTxErrByron err) -> err)
 
-instance SerialiseNodeToClient ByronToCardano (SomeSecond Query ByronToCardano) where
+instance SerialiseNodeToClient ByronToCardano (SomeSecond BlockQuery ByronToCardano) where
   encodeNodeToClient = encodeNodeToClientB2C
-                         (Proxy @(SomeSecond Query))
+                         (Proxy @(SomeSecond BlockQuery))
                          (\(SomeSecond q) -> SomeSecond (unQueryB2C q))
   decodeNodeToClient = decodeNodeToClientB2C
-                         (Proxy @(SomeSecond Query))
+                         (Proxy @(SomeSecond BlockQuery))
                          (\(SomeSecond (QueryIfCurrentByron q)) -> SomeSecond (QueryB2C q))
 
-instance SerialiseResult ByronToCardano (Query ByronToCardano) where
+instance SerialiseResult ByronToCardano (BlockQuery ByronToCardano) where
   encodeResult (CodecConfigB2C ccfg) () (QueryB2C q) r =
       encodeResult ccfg byronNodeToClientVersion q r
-  decodeResult (CodecConfigB2C ccfg) () (QueryB2C (q :: Query ByronBlock result)) =
+  decodeResult (CodecConfigB2C ccfg) () (QueryB2C (q :: BlockQuery ByronBlock result)) =
       (\(QueryResultSuccess r) -> r) <$>
         decodeResult
           (toCardanoCodecConfig ccfg)
@@ -399,7 +399,7 @@ instance Arbitrary (GenTx ByronToCardano) where
 instance Arbitrary (GenTxId ByronToCardano) where
   arbitrary = GenTxIdB2C <$> arbitrary
 
-instance Arbitrary (SomeSecond Query ByronToCardano) where
+instance Arbitrary (SomeSecond BlockQuery ByronToCardano) where
   arbitrary = (\(SomeSecond q) -> SomeSecond (QueryB2C q)) <$> arbitrary
 
 instance Arbitrary (SomeResult ByronToCardano) where
@@ -417,11 +417,11 @@ instance Arbitrary (SomeResult ByronToCardano) where
 --
 -- Note that ledger state and all other types stored as part of the ledger
 -- snapshot are __not__ forwards compatible.
-newtype CardanoToByron                       = C2B        { unC2B        ::         ByronBlock   } deriving (Eq, Show)
-newtype instance Header CardanoToByron       = HeaderC2B  { unHeaderC2B  :: Header  ByronBlock   } deriving (Eq, Show)
-newtype instance GenTx CardanoToByron        = GenTxC2B   { unGenTxC2B   :: GenTx   ByronBlock   } deriving (Eq, Show)
-newtype instance TxId (GenTx CardanoToByron) = GenTxIdC2B { unGenTxIdC2B :: GenTxId ByronBlock   } deriving (Eq, Show)
-newtype instance Query CardanoToByron a      = QueryC2B   { unQueryC2B   :: Query   ByronBlock a } deriving (Eq, Show)
+newtype CardanoToByron                       = C2B        { unC2B        ::            ByronBlock   } deriving (Eq, Show)
+newtype instance Header CardanoToByron       = HeaderC2B  { unHeaderC2B  :: Header     ByronBlock   } deriving (Eq, Show)
+newtype instance GenTx CardanoToByron        = GenTxC2B   { unGenTxC2B   :: GenTx      ByronBlock   } deriving (Eq, Show)
+newtype instance TxId (GenTx CardanoToByron) = GenTxIdC2B { unGenTxIdC2B :: GenTxId    ByronBlock   } deriving (Eq, Show)
+newtype instance BlockQuery CardanoToByron a = QueryC2B   { unQueryC2B   :: BlockQuery ByronBlock a } deriving (Eq, Show)
 
 newtype instance NestedCtxt_ CardanoToByron f a where
   NestedCtxt_C2B :: NestedCtxt_ ByronBlock     f a
@@ -454,10 +454,10 @@ instance HasNestedContent Header CardanoToByron where
   nest (DepPair ctxt a) =
       HeaderC2B $ nest (DepPair (mapNestedCtxt unNestedCtxt_C2B ctxt) a)
 
-instance ShowQuery (Query CardanoToByron) where
+instance ShowQuery (BlockQuery CardanoToByron) where
   showResult (QueryC2B query) = showResult query
 
-instance SameDepIndex (Query CardanoToByron) where
+instance SameDepIndex (BlockQuery CardanoToByron) where
   sameDepIndex (QueryC2B q1) (QueryC2B q2) = sameDepIndex q1 q2
 
 {------------------------------------------------------------------------------
@@ -637,17 +637,17 @@ instance SerialiseNodeToClient CardanoToByron CC.ApplyMempoolPayloadErr where
   encodeNodeToClient = encodeNodeToClientC2B (Proxy @WrapApplyTxErr) ApplyTxErrByron
   decodeNodeToClient = decodeNodeToClientC2B (Proxy @WrapApplyTxErr) id
 
-instance SerialiseNodeToClient CardanoToByron (SomeSecond Query CardanoToByron) where
+instance SerialiseNodeToClient CardanoToByron (SomeSecond BlockQuery CardanoToByron) where
   encodeNodeToClient =
       encodeNodeToClientC2B
-        (Proxy @(SomeSecond Query))
+        (Proxy @(SomeSecond BlockQuery))
         (\(SomeSecond q) -> SomeSecond (QueryIfCurrentByron (unQueryC2B q)))
   decodeNodeToClient =
       decodeNodeToClientC2B
-        (Proxy @(SomeSecond Query))
+        (Proxy @(SomeSecond BlockQuery))
         (\(SomeSecond q) -> SomeSecond (QueryC2B q))
 
-instance SerialiseResult CardanoToByron (Query CardanoToByron) where
+instance SerialiseResult CardanoToByron (BlockQuery CardanoToByron) where
   encodeResult (CodecConfigC2B ccfg) () (QueryC2B q) (r :: result) =
       encodeResult
         (toCardanoCodecConfig ccfg)
@@ -682,7 +682,7 @@ instance Arbitrary (GenTx CardanoToByron) where
 instance Arbitrary (GenTxId CardanoToByron) where
   arbitrary = GenTxIdC2B <$> arbitrary
 
-instance Arbitrary (SomeSecond Query CardanoToByron) where
+instance Arbitrary (SomeSecond BlockQuery CardanoToByron) where
   arbitrary = (\(SomeSecond q) -> SomeSecond (QueryC2B q)) <$> arbitrary
 
 instance Arbitrary (SomeResult CardanoToByron) where

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -37,10 +37,10 @@ module Ouroboros.Consensus.Cardano.Block (
   , CardanoTipInfo
   , OneEraTipInfo (TipInfoByron, TipInfoShelley, TipInfoAllegra, TipInfoMary)
     -- * Query
+  , BlockQuery (QueryIfCurrentByron, QueryIfCurrentShelley, QueryIfCurrentAllegra, QueryIfCurrentMary, QueryAnytimeByron, QueryAnytimeShelley, QueryAnytimeAllegra, QueryAnytimeMary, QueryHardFork)
   , CardanoQuery
   , CardanoQueryResult
   , Either (QueryResultSuccess, QueryResultEraMismatch)
-  , BlockQuery (QueryIfCurrentByron, QueryIfCurrentShelley, QueryIfCurrentAllegra, QueryIfCurrentMary, QueryAnytimeByron, QueryAnytimeShelley, QueryAnytimeAllegra, QueryAnytimeMary, QueryHardFork)
     -- * CodecConfig
   , CardanoCodecConfig
   , CodecConfig (CardanoCodecConfig)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -40,7 +40,7 @@ module Ouroboros.Consensus.Cardano.Block (
   , CardanoQuery
   , CardanoQueryResult
   , Either (QueryResultSuccess, QueryResultEraMismatch)
-  , Query (QueryIfCurrentByron, QueryIfCurrentShelley, QueryIfCurrentAllegra, QueryIfCurrentMary, QueryAnytimeByron, QueryAnytimeShelley, QueryAnytimeAllegra, QueryAnytimeMary, QueryHardFork)
+  , BlockQuery (QueryIfCurrentByron, QueryIfCurrentShelley, QueryIfCurrentAllegra, QueryIfCurrentMary, QueryAnytimeByron, QueryAnytimeShelley, QueryAnytimeAllegra, QueryAnytimeMary, QueryHardFork)
     -- * CodecConfig
   , CardanoCodecConfig
   , CodecConfig (CardanoCodecConfig)
@@ -394,14 +394,14 @@ pattern TipInfoMary ti = OneEraTipInfo (S (S (S (Z (WrapTipInfo ti)))))
 -------------------------------------------------------------------------------}
 
 -- | The 'Query' of Cardano chain.
-type CardanoQuery c = Query (CardanoBlock c)
+type CardanoQuery c = BlockQuery (CardanoBlock c)
 
 -- | Byron-specific query that can only be answered when the ledger is in the
 -- Byron era.
 pattern QueryIfCurrentByron
   :: ()
   => CardanoQueryResult c result ~ a
-  => Query ByronBlock result
+  => BlockQuery ByronBlock result
   -> CardanoQuery c a
 pattern QueryIfCurrentByron q = QueryIfCurrent (QZ q)
 
@@ -410,7 +410,7 @@ pattern QueryIfCurrentByron q = QueryIfCurrent (QZ q)
 pattern QueryIfCurrentShelley
   :: ()
   => CardanoQueryResult c result ~ a
-  => Query (ShelleyBlock (ShelleyEra c)) result
+  => BlockQuery (ShelleyBlock (ShelleyEra c)) result
   -> CardanoQuery c a
 pattern QueryIfCurrentShelley q = QueryIfCurrent (QS (QZ q))
 
@@ -419,7 +419,7 @@ pattern QueryIfCurrentShelley q = QueryIfCurrent (QS (QZ q))
 pattern QueryIfCurrentAllegra
   :: ()
   => CardanoQueryResult c result ~ a
-  => Query (ShelleyBlock (AllegraEra c)) result
+  => BlockQuery (ShelleyBlock (AllegraEra c)) result
   -> CardanoQuery c a
 pattern QueryIfCurrentAllegra q = QueryIfCurrent (QS (QS (QZ q)))
 
@@ -428,7 +428,7 @@ pattern QueryIfCurrentAllegra q = QueryIfCurrent (QS (QS (QZ q)))
 pattern QueryIfCurrentMary
   :: ()
   => CardanoQueryResult c result ~ a
-  => Query (ShelleyBlock (MaryEra c)) result
+  => BlockQuery (ShelleyBlock (MaryEra c)) result
   -> CardanoQuery c a
 pattern QueryIfCurrentMary q = QueryIfCurrent (QS (QS (QS (QZ q))))
 

--- a/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
@@ -97,7 +97,7 @@ instance Arbitrary SimpleBody where
 instance Arbitrary (SomeSecond (NestedCtxt Header) (SimpleBlock c ext)) where
   arbitrary = return $ SomeSecond indexIsTrivial
 
-instance Arbitrary (SomeSecond Query (SimpleBlock c ext)) where
+instance Arbitrary (SomeSecond BlockQuery (SimpleBlock c ext)) where
   arbitrary = return $ SomeSecond QueryLedgerTip
 
 instance (SimpleCrypto c, Typeable ext) => Arbitrary (SomeResult (SimpleBlock c ext)) where

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -24,8 +24,8 @@
 -- None of the definitions in this module depend on, or even refer to, any
 -- specific consensus protocols.
 module Ouroboros.Consensus.Mock.Ledger.Block (
-    Header (..)
-  , BlockQuery (..)
+    BlockQuery (..)
+  , Header (..)
   , SimpleBlock
   , SimpleBlock' (..)
   , SimpleBody (..)
@@ -494,7 +494,7 @@ data instance BlockQuery (SimpleBlock c ext) result where
     QueryLedgerTip :: BlockQuery (SimpleBlock c ext) (Point (SimpleBlock c ext))
 
 instance MockProtocolSpecific c ext => QueryLedger (SimpleBlock c ext) where
-  answerQuery _cfg QueryLedgerTip =
+  answerBlockQuery _cfg QueryLedgerTip =
         castPoint
       . ledgerTipPoint (Proxy @(SimpleBlock c ext))
       . ledgerState

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -25,7 +25,7 @@
 -- specific consensus protocols.
 module Ouroboros.Consensus.Mock.Ledger.Block (
     Header (..)
-  , Query (..)
+  , BlockQuery (..)
   , SimpleBlock
   , SimpleBlock' (..)
   , SimpleBody (..)
@@ -490,8 +490,8 @@ txSize = fromIntegral . Lazy.length . serialise
   Support for QueryLedger
 -------------------------------------------------------------------------------}
 
-data instance Query (SimpleBlock c ext) result where
-    QueryLedgerTip :: Query (SimpleBlock c ext) (Point (SimpleBlock c ext))
+data instance BlockQuery (SimpleBlock c ext) result where
+    QueryLedgerTip :: BlockQuery (SimpleBlock c ext) (Point (SimpleBlock c ext))
 
 instance MockProtocolSpecific c ext => QueryLedger (SimpleBlock c ext) where
   answerQuery _cfg QueryLedgerTip =
@@ -499,16 +499,16 @@ instance MockProtocolSpecific c ext => QueryLedger (SimpleBlock c ext) where
       . ledgerTipPoint (Proxy @(SimpleBlock c ext))
       . ledgerState
 
-instance SameDepIndex (Query (SimpleBlock c ext)) where
+instance SameDepIndex (BlockQuery (SimpleBlock c ext)) where
   sameDepIndex QueryLedgerTip QueryLedgerTip = Just Refl
 
-deriving instance Show (Query (SimpleBlock c ext) result)
+deriving instance Show (BlockQuery (SimpleBlock c ext) result)
 
 instance (Typeable c, Typeable ext)
-    => ShowProxy (Query (SimpleBlock c ext)) where
+    => ShowProxy (BlockQuery (SimpleBlock c ext)) where
 
 instance (SimpleCrypto c, Typeable ext)
-      => ShowQuery (Query (SimpleBlock c ext)) where
+      => ShowQuery (BlockQuery (SimpleBlock c ext)) where
   showResult QueryLedgerTip = show
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -109,11 +109,11 @@ instance SerialiseNodeToClient (MockBlock ext) (Serialised (MockBlock ext))
 instance SerialiseNodeToClient (MockBlock ext) (GenTx (MockBlock ext))
 instance SerialiseNodeToClient (MockBlock ext) (MockError (MockBlock ext))
 
-instance SerialiseNodeToClient (MockBlock ext) (SomeSecond Query (MockBlock ext)) where
+instance SerialiseNodeToClient (MockBlock ext) (SomeSecond BlockQuery (MockBlock ext)) where
   encodeNodeToClient _ _ (SomeSecond QueryLedgerTip) = encode ()
   decodeNodeToClient _ _ = (\() -> SomeSecond QueryLedgerTip) <$> decode
 
-instance SerialiseResult (MockBlock ext) (Query (MockBlock ext)) where
+instance SerialiseResult (MockBlock ext) (BlockQuery (MockBlock ext)) where
   encodeResult _ _ QueryLedgerTip = encode
   decodeResult _ _ QueryLedgerTip = decode
 

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -19,6 +19,7 @@ import           Ouroboros.Network.Block (mkSerialised)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 
 import qualified Shelley.Spec.Ledger.API as SL
@@ -157,19 +158,6 @@ instance PraosCrypto c => Arbitrary (SL.ChainDepState c) where
 {-------------------------------------------------------------------------------
   Versioned generators for serialisation
 -------------------------------------------------------------------------------}
-
--- | We only have single version, so no special casing required.
---
--- This blanket orphan instance will have to be replaced with more specific
--- ones, once we introduce a different Shelley version.
-instance Arbitrary a => Arbitrary (WithVersion ShelleyNodeToNodeVersion a) where
-  arbitrary = WithVersion <$> arbitrary <*> arbitrary
-
--- | This is @OVERLAPPABLE@ because we have to override the default behaviour
--- for 'Query's.
-instance {-# OVERLAPPABLE #-} Arbitrary a
-      => Arbitrary (WithVersion ShelleyNodeToClientVersion a) where
-  arbitrary = WithVersion <$> arbitrary <*> arbitrary
 
 -- | Some 'Query's are only supported by 'ShelleyNodeToClientVersion2', so we
 -- make sure to not generate those queries in combination with

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -65,7 +65,7 @@ instance CanMock era => Arbitrary (GenTx (ShelleyBlock era)) where
 instance CanMock era => Arbitrary (GenTxId (ShelleyBlock era)) where
   arbitrary = ShelleyTxId <$> arbitrary
 
-instance CanMock era => Arbitrary (SomeSecond Query (ShelleyBlock era)) where
+instance CanMock era => Arbitrary (SomeSecond BlockQuery (ShelleyBlock era)) where
   arbitrary = oneof
     [ pure $ SomeSecond GetLedgerTip
     , pure $ SomeSecond GetEpochNo
@@ -175,7 +175,7 @@ instance {-# OVERLAPPABLE #-} Arbitrary a
 -- make sure to not generate those queries in combination with
 -- 'ShelleyNodeToClientVersion1'.
 instance CanMock era
-      => Arbitrary (WithVersion ShelleyNodeToClientVersion (SomeSecond Query (ShelleyBlock era))) where
+      => Arbitrary (WithVersion ShelleyNodeToClientVersion (SomeSecond BlockQuery (ShelleyBlock era))) where
   arbitrary = do
       query@(SomeSecond q) <- arbitrary
       version <- arbitrary `suchThat` querySupportedVersion q

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -12,8 +12,8 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Ledger.Query (
-    NonMyopicMemberRewards (..)
-  , Query (..)
+    BlockQuery (..)
+  , NonMyopicMemberRewards (..)
   , querySupportedVersion
     -- * Serialisation
   , decodeShelleyQuery
@@ -79,18 +79,18 @@ instance SL.PraosCrypto c => Serialise (NonMyopicMemberRewards c) where
   encode = toCBOR . unNonMyopicMemberRewards
   decode = NonMyopicMemberRewards <$> fromCBOR
 
-data instance Query (ShelleyBlock era) :: Type -> Type where
-  GetLedgerTip :: Query (ShelleyBlock era) (Point (ShelleyBlock era))
-  GetEpochNo :: Query (ShelleyBlock era) EpochNo
+data instance BlockQuery (ShelleyBlock era) :: Type -> Type where
+  GetLedgerTip :: BlockQuery (ShelleyBlock era) (Point (ShelleyBlock era))
+  GetEpochNo :: BlockQuery (ShelleyBlock era) EpochNo
   -- | Calculate the Non-Myopic Pool Member Rewards for a set of
   -- credentials. See 'SL.getNonMyopicMemberRewards'
   GetNonMyopicMemberRewards
     :: Set (Either SL.Coin (SL.Credential 'SL.Staking (EraCrypto era)))
-    -> Query (ShelleyBlock era) (NonMyopicMemberRewards (EraCrypto era))
+    -> BlockQuery (ShelleyBlock era) (NonMyopicMemberRewards (EraCrypto era))
   GetCurrentPParams
-    :: Query (ShelleyBlock era) (LC.PParams era)
+    :: BlockQuery (ShelleyBlock era) (LC.PParams era)
   GetProposedPParamsUpdates
-    :: Query (ShelleyBlock era) (SL.ProposedPPUpdates era)
+    :: BlockQuery (ShelleyBlock era) (SL.ProposedPPUpdates era)
   -- | This gets the stake distribution, but not in terms of _active_ stake
   -- (which we need for the leader schedule), but rather in terms of _total_
   -- stake, which is relevant for rewards. It is used by the wallet to show
@@ -98,17 +98,17 @@ data instance Query (ShelleyBlock era) :: Type -> Type where
   -- an endpoint that provides all the information that the wallet wants about
   -- pools, in an extensible fashion.
   GetStakeDistribution
-    :: Query (ShelleyBlock era) (SL.PoolDistr (EraCrypto era))
+    :: BlockQuery (ShelleyBlock era) (SL.PoolDistr (EraCrypto era))
   GetFilteredUTxO
     :: Set (SL.Addr (EraCrypto era))
-    -> Query (ShelleyBlock era) (SL.UTxO era)
+    -> BlockQuery (ShelleyBlock era) (SL.UTxO era)
   GetUTxO
-    :: Query (ShelleyBlock era) (SL.UTxO era)
+    :: BlockQuery (ShelleyBlock era) (SL.UTxO era)
 
   -- | Only for debugging purposes, we make no effort to ensure binary
   -- compatibility (cf the comment on 'GetCBOR'). Moreover, it is huge.
   DebugEpochState
-    :: Query (ShelleyBlock era) (SL.EpochState era)
+    :: BlockQuery (ShelleyBlock era) (SL.EpochState era)
 
   -- | Wrap the result of the query using CBOR-in-CBOR.
   --
@@ -124,29 +124,29 @@ data instance Query (ShelleyBlock era) :: Type -> Type where
   -- decode it, the client can fall back to pretty printing the actual CBOR,
   -- which is better than no output at all.
   GetCBOR
-    :: Query (ShelleyBlock era) result
-    -> Query (ShelleyBlock era) (Serialised result)
+    :: BlockQuery (ShelleyBlock era) result
+    -> BlockQuery (ShelleyBlock era) (Serialised result)
 
   GetFilteredDelegationsAndRewardAccounts
     :: Set (SL.Credential 'SL.Staking (EraCrypto era))
-    -> Query (ShelleyBlock era)
+    -> BlockQuery (ShelleyBlock era)
              (Delegations (EraCrypto era), SL.RewardAccounts (EraCrypto era))
 
   GetGenesisConfig
-    :: Query (ShelleyBlock era) (CompactGenesis era)
+    :: BlockQuery (ShelleyBlock era) (CompactGenesis era)
 
   -- | Only for debugging purposes, we make no effort to ensure binary
   -- compatibility (cf the comment on 'GetCBOR'). Moreover, it is huge.
   DebugNewEpochState
-    :: Query (ShelleyBlock era) (SL.NewEpochState era)
+    :: BlockQuery (ShelleyBlock era) (SL.NewEpochState era)
 
   -- | Only for debugging purposes, we make no effort to ensure binary
   -- compatibility (cf the comment on 'GetCBOR').
   DebugChainDepState
-    :: Query (ShelleyBlock era) (SL.ChainDepState (EraCrypto era))
+    :: BlockQuery (ShelleyBlock era) (SL.ChainDepState (EraCrypto era))
 
   GetRewardProvenance
-    :: Query (ShelleyBlock era) (SL.RewardProvenance (EraCrypto era))
+    :: BlockQuery (ShelleyBlock era) (SL.RewardProvenance (EraCrypto era))
 
   -- WARNING: please add new queries to the end of the list and stick to this
   -- order in all other pattern matches on queries. This helps in particular
@@ -162,7 +162,7 @@ data instance Query (ShelleyBlock era) :: Type -> Type where
   -- longer used (because mainnet has hard-forked to a newer version), it can be
   -- removed.
 
-instance Typeable era => ShowProxy (Query (ShelleyBlock era)) where
+instance Typeable era => ShowProxy (BlockQuery (ShelleyBlock era)) where
 
 instance ShelleyBasedEra era => QueryLedger (ShelleyBlock era) where
   answerQuery cfg query ext =
@@ -213,7 +213,7 @@ instance ShelleyBasedEra era => QueryLedger (ShelleyBlock era) where
       hst = headerState ext
       st  = shelleyLedgerState lst
 
-instance SameDepIndex (Query (ShelleyBlock era)) where
+instance SameDepIndex (BlockQuery (ShelleyBlock era)) where
   sameDepIndex GetLedgerTip GetLedgerTip
     = Just Refl
   sameDepIndex GetLedgerTip _
@@ -285,10 +285,10 @@ instance SameDepIndex (Query (ShelleyBlock era)) where
   sameDepIndex GetRewardProvenance _
     = Nothing
 
-deriving instance Eq   (Query (ShelleyBlock era) result)
-deriving instance Show (Query (ShelleyBlock era) result)
+deriving instance Eq   (BlockQuery (ShelleyBlock era) result)
+deriving instance Show (BlockQuery (ShelleyBlock era) result)
 
-instance ShelleyBasedEra era => ShowQuery (Query (ShelleyBlock era)) where
+instance ShelleyBasedEra era => ShowQuery (BlockQuery (ShelleyBlock era)) where
   showResult = \case
       GetLedgerTip                               -> show
       GetEpochNo                                 -> show
@@ -307,7 +307,7 @@ instance ShelleyBasedEra era => ShowQuery (Query (ShelleyBlock era)) where
       GetRewardProvenance                        -> show
 
 -- | Is the given query supported by the given 'ShelleyNodeToClientVersion'?
-querySupportedVersion :: Query (ShelleyBlock era) result -> ShelleyNodeToClientVersion -> Bool
+querySupportedVersion :: BlockQuery (ShelleyBlock era) result -> ShelleyNodeToClientVersion -> Bool
 querySupportedVersion = \case
     GetLedgerTip                               -> (>= v1)
     GetEpochNo                                 -> (>= v1)
@@ -365,7 +365,7 @@ getFilteredDelegationsAndRewardAccounts ss creds =
 
 encodeShelleyQuery ::
      ShelleyBasedEra era
-  => Query (ShelleyBlock era) result -> Encoding
+  => BlockQuery (ShelleyBlock era) result -> Encoding
 encodeShelleyQuery query = case query of
     GetLedgerTip ->
       CBOR.encodeListLen 1 <> CBOR.encodeWord8 0
@@ -400,7 +400,7 @@ encodeShelleyQuery query = case query of
 
 decodeShelleyQuery ::
      ShelleyBasedEra era
-  => Decoder s (SomeSecond Query (ShelleyBlock era))
+  => Decoder s (SomeSecond BlockQuery (ShelleyBlock era))
 decodeShelleyQuery = do
     len <- CBOR.decodeListLen
     tag <- CBOR.decodeWord8
@@ -426,7 +426,7 @@ decodeShelleyQuery = do
 
 encodeShelleyResult ::
      ShelleyBasedEra era
-  => Query (ShelleyBlock era) result -> result -> Encoding
+  => BlockQuery (ShelleyBlock era) result -> result -> Encoding
 encodeShelleyResult query = case query of
     GetLedgerTip                               -> encodePoint encode
     GetEpochNo                                 -> encode
@@ -446,7 +446,7 @@ encodeShelleyResult query = case query of
 
 decodeShelleyResult ::
      ShelleyBasedEra era
-  => Query (ShelleyBlock era) result
+  => BlockQuery (ShelleyBlock era) result
   -> forall s. Decoder s result
 decodeShelleyResult query = case query of
     GetLedgerTip                               -> decodePoint decode

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -165,7 +165,7 @@ data instance BlockQuery (ShelleyBlock era) :: Type -> Type where
 instance Typeable era => ShowProxy (BlockQuery (ShelleyBlock era)) where
 
 instance ShelleyBasedEra era => QueryLedger (ShelleyBlock era) where
-  answerQuery cfg query ext =
+  answerBlockQuery cfg query ext =
       case query of
         GetLedgerTip ->
           shelleyLedgerTipPoint lst
@@ -188,7 +188,7 @@ instance ShelleyBasedEra era => QueryLedger (ShelleyBlock era) where
           getEpochState st
         GetCBOR query' ->
           mkSerialised (encodeShelleyResult query') $
-            answerQuery cfg query' ext
+            answerBlockQuery cfg query' ext
         GetFilteredDelegationsAndRewardAccounts creds ->
           getFilteredDelegationsAndRewardAccounts st creds
         GetGenesisConfig ->

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -122,7 +122,7 @@ data ShelleyEncoderException era =
     -- | A query was submitted that is not supported by the given
     -- 'ShelleyNodeToClientVersion'.
     ShelleyEncoderUnsupportedQuery
-         (SomeSecond Query (ShelleyBlock era))
+         (SomeSecond BlockQuery (ShelleyBlock era))
          ShelleyNodeToClientVersion
   deriving (Show)
 
@@ -151,7 +151,7 @@ instance ShelleyBasedEra era => SerialiseNodeToClient (ShelleyBlock era) (SL.App
   decodeNodeToClient _ _ = fromCBOR
 
 instance ShelleyBasedEra era
-      => SerialiseNodeToClient (ShelleyBlock era) (SomeSecond Query (ShelleyBlock era)) where
+      => SerialiseNodeToClient (ShelleyBlock era) (SomeSecond BlockQuery (ShelleyBlock era)) where
   encodeNodeToClient _ version (SomeSecond q)
     | querySupportedVersion q version
     = encodeShelleyQuery q
@@ -159,7 +159,7 @@ instance ShelleyBasedEra era
     = throw $ ShelleyEncoderUnsupportedQuery (SomeSecond q) version
   decodeNodeToClient _ _ = decodeShelleyQuery
 
-instance ShelleyBasedEra era => SerialiseResult (ShelleyBlock era) (Query (ShelleyBlock era)) where
+instance ShelleyBasedEra era => SerialiseResult (ShelleyBlock era) (BlockQuery (ShelleyBlock era)) where
   encodeResult _ _ = encodeShelleyResult
   decodeResult _ _ = decodeShelleyResult
 

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
@@ -55,7 +55,7 @@ import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState,
                      encodeExtLedgerState)
-import           Ouroboros.Consensus.Ledger.Query (Query)
+import           Ouroboros.Consensus.Ledger.Query (BlockQuery)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx,
                      GenTxId)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -213,7 +213,7 @@ data Examples blk = Examples {
     , exampleGenTx            :: Labelled (GenTx blk)
     , exampleGenTxId          :: Labelled (GenTxId blk)
     , exampleApplyTxErr       :: Labelled (ApplyTxErr blk)
-    , exampleQuery            :: Labelled (SomeSecond Query blk)
+    , exampleQuery            :: Labelled (SomeSecond BlockQuery blk)
     , exampleResult           :: Labelled (SomeResult blk)
     , exampleAnnTip           :: Labelled (AnnTip blk)
     , exampleLedgerState      :: Labelled (LedgerState blk)

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -43,7 +43,7 @@ import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
-import           Ouroboros.Consensus.Ledger.Query (Query)
+import           Ouroboros.Consensus.Ledger.Query (BlockQuery)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx,
                      GenTxId)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -133,7 +133,7 @@ roundtrip_all
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) blk
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (GenTx blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (ApplyTxErr blk)
-     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond Query blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond BlockQuery blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeResult blk)
      )
   => CodecConfig blk
@@ -313,7 +313,7 @@ roundtrip_SerialiseNodeToClient
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) blk
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (GenTx blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (ApplyTxErr blk)
-     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond Query blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond BlockQuery blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeResult blk)
 
        -- Needed for testing the @Serialised blk@
@@ -323,10 +323,10 @@ roundtrip_SerialiseNodeToClient
   => CodecConfig blk
   -> [TestTree]
 roundtrip_SerialiseNodeToClient ccfg =
-    [ rt (Proxy @blk)                    "blk"
-    , rt (Proxy @(GenTx blk))            "GenTx"
-    , rt (Proxy @(ApplyTxErr blk))       "ApplyTxErr"
-    , rt (Proxy @(SomeSecond Query blk)) "Query"
+    [ rt (Proxy @blk)                         "blk"
+    , rt (Proxy @(GenTx blk))                 "GenTx"
+    , rt (Proxy @(ApplyTxErr blk))            "ApplyTxErr"
+    , rt (Proxy @(SomeSecond BlockQuery blk)) "BlockQuery"
       -- See roundtrip_SerialiseNodeToNode for more info
     , testProperty "roundtrip Serialised blk" $
         \(WithVersion version blk) ->
@@ -507,7 +507,7 @@ decodeThroughSerialised dec decSerialised = do
 -- need them in the tests.
 data SomeResult blk where
   SomeResult :: (Eq result, Show result, Typeable result)
-             => Query blk result -> result -> SomeResult blk
+             => BlockQuery blk result -> result -> SomeResult blk
 
 instance Show (SomeResult blk) where
   show (SomeResult _ result) = show result

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -43,7 +43,7 @@ import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
-import           Ouroboros.Consensus.Ledger.Query (BlockQuery)
+import           Ouroboros.Consensus.Ledger.Query (BlockQuery, Query)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx,
                      GenTxId)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -133,6 +133,7 @@ roundtrip_all
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) blk
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (GenTx blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (ApplyTxErr blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond Query blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond BlockQuery blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeResult blk)
      )
@@ -200,9 +201,6 @@ roundtrip_SerialiseDisk ccfg dictNestedHdr =
 -- and can thus not be generated for any prior versions.
 data WithVersion v a = WithVersion v a
   deriving (Eq, Show, Functor, Foldable, Traversable)
-
-instance Arbitrary a => Arbitrary (WithVersion () a) where
-  arbitrary = WithVersion () <$> arbitrary
 
 -- | Similar to @Arbitrary'@, but with an 'Arbitrary' instasnce for
 -- @('WithVersion' v a)@.
@@ -313,6 +311,7 @@ roundtrip_SerialiseNodeToClient
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) blk
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (GenTx blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (ApplyTxErr blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond Query blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeSecond BlockQuery blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeResult blk)
 
@@ -327,6 +326,7 @@ roundtrip_SerialiseNodeToClient ccfg =
     , rt (Proxy @(GenTx blk))                 "GenTx"
     , rt (Proxy @(ApplyTxErr blk))            "ApplyTxErr"
     , rt (Proxy @(SomeSecond BlockQuery blk)) "BlockQuery"
+    , rt (Proxy @(SomeSecond Query blk))      "Query"
       -- See roundtrip_SerialiseNodeToNode for more info
     , testProperty "roundtrip Serialised blk" $
         \(WithVersion version blk) ->

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -21,9 +21,9 @@
 module Test.Util.TestBlock (
     -- * Blocks
     BlockConfig (..)
+  , BlockQuery (..)
   , CodecConfig (..)
   , Header (..)
-  , BlockQuery (..)
   , StorageConfig (..)
   , TestBlock (..)
   , TestBlockError (..)
@@ -379,7 +379,7 @@ data instance BlockQuery TestBlock result where
   QueryLedgerTip :: BlockQuery TestBlock (Point TestBlock)
 
 instance QueryLedger TestBlock where
-  answerQuery _cfg QueryLedgerTip (ExtLedgerState TestLedger { lastAppliedPoint } _) =
+  answerBlockQuery _cfg QueryLedgerTip (ExtLedgerState TestLedger { lastAppliedPoint } _) =
     lastAppliedPoint
 
 instance SameDepIndex (BlockQuery TestBlock) where

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -23,7 +23,7 @@ module Test.Util.TestBlock (
     BlockConfig (..)
   , CodecConfig (..)
   , Header (..)
-  , Query (..)
+  , BlockQuery (..)
   , StorageConfig (..)
   , TestBlock (..)
   , TestBlockError (..)
@@ -375,20 +375,20 @@ instance HasHardForkHistory TestBlock where
   type HardForkIndices TestBlock = '[TestBlock]
   hardForkSummary = neverForksHardForkSummary id
 
-data instance Query TestBlock result where
-  QueryLedgerTip :: Query TestBlock (Point TestBlock)
+data instance BlockQuery TestBlock result where
+  QueryLedgerTip :: BlockQuery TestBlock (Point TestBlock)
 
 instance QueryLedger TestBlock where
   answerQuery _cfg QueryLedgerTip (ExtLedgerState TestLedger { lastAppliedPoint } _) =
     lastAppliedPoint
 
-instance SameDepIndex (Query TestBlock) where
+instance SameDepIndex (BlockQuery TestBlock) where
   sameDepIndex QueryLedgerTip QueryLedgerTip = Just Refl
 
-deriving instance Eq (Query TestBlock result)
-deriving instance Show (Query TestBlock result)
+deriving instance Eq (BlockQuery TestBlock result)
+deriving instance Show (BlockQuery TestBlock result)
 
-instance ShowQuery (Query TestBlock) where
+instance ShowQuery (BlockQuery TestBlock) where
   showResult QueryLedgerTip = show
 
 testInitLedger :: LedgerState TestBlock

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -332,16 +332,16 @@ newtype instance TxId (GenTx BlockA) = TxIdA Int
 instance HasTxId (GenTx BlockA) where
   txId = txA_id
 
-instance ShowQuery (Query BlockA) where
+instance ShowQuery (BlockQuery BlockA) where
   showResult qry = case qry of {}
 
-data instance Query BlockA result
+data instance BlockQuery BlockA result
   deriving (Show)
 
 instance QueryLedger BlockA where
   answerQuery _ qry = case qry of {}
 
-instance SameDepIndex (Query BlockA) where
+instance SameDepIndex (BlockQuery BlockA) where
   sameDepIndex qry _qry' = case qry of {}
 
 instance ConvertRawHash BlockA where
@@ -565,10 +565,10 @@ instance SerialiseNodeToClient BlockA Void where
   encodeNodeToClient _ _ = absurd
   decodeNodeToClient _ _ = fail "no ApplyTxErr to be decoded"
 
-instance SerialiseNodeToClient BlockA (SomeSecond Query BlockA) where
+instance SerialiseNodeToClient BlockA (SomeSecond BlockQuery BlockA) where
   encodeNodeToClient _ _ = \case {}
   decodeNodeToClient _ _ = fail "there are no queries to be decoded"
 
-instance SerialiseResult BlockA (Query BlockA) where
+instance SerialiseResult BlockA (BlockQuery BlockA) where
   encodeResult _ _ = \case {}
   decodeResult _ _ = \case {}

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -339,7 +339,7 @@ data instance BlockQuery BlockA result
   deriving (Show)
 
 instance QueryLedger BlockA where
-  answerQuery _ qry = case qry of {}
+  answerBlockQuery _ qry = case qry of {}
 
 instance SameDepIndex (BlockQuery BlockA) where
   sameDepIndex qry _qry' = case qry of {}

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -279,7 +279,7 @@ data instance BlockQuery BlockB result
   deriving (Show)
 
 instance QueryLedger BlockB where
-  answerQuery _ qry = case qry of {}
+  answerBlockQuery _ qry = case qry of {}
 
 instance SameDepIndex (BlockQuery BlockB) where
   sameDepIndex qry _qry' = case qry of {}

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -272,16 +272,16 @@ data instance TxId (GenTx BlockB)
 instance HasTxId (GenTx BlockB) where
   txId tx = case tx of {}
 
-instance ShowQuery (Query BlockB) where
+instance ShowQuery (BlockQuery BlockB) where
   showResult qry = case qry of {}
 
-data instance Query BlockB result
+data instance BlockQuery BlockB result
   deriving (Show)
 
 instance QueryLedger BlockB where
   answerQuery _ qry = case qry of {}
 
-instance SameDepIndex (Query BlockB) where
+instance SameDepIndex (BlockQuery BlockB) where
   sameDepIndex qry _qry' = case qry of {}
 
 instance ConvertRawHash BlockB where
@@ -426,10 +426,10 @@ instance SerialiseNodeToClient BlockB Void where
   encodeNodeToClient _ _ = absurd
   decodeNodeToClient _ _ = fail "no ApplyTxErr to be decoded"
 
-instance SerialiseNodeToClient BlockB (SomeSecond Query BlockB) where
+instance SerialiseNodeToClient BlockB (SomeSecond BlockQuery BlockB) where
   encodeNodeToClient _ _ = \case {}
   decodeNodeToClient _ _ = fail "there are no queries to be decoded"
 
-instance SerialiseResult BlockB (Query BlockB) where
+instance SerialiseResult BlockB (BlockQuery BlockB) where
   encodeResult _ _ = \case {}
   decodeResult _ _ = \case {}

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -153,7 +153,7 @@ mkClient
   -> LocalStateQueryClient
        TestBlock
        (Point TestBlock)
-       (Query TestBlock)
+       (BlockQuery TestBlock)
        m
        [(Maybe (Point TestBlock), Either AcquireFailure (Point TestBlock))]
 mkClient points = localStateQueryClient [(pt, QueryLedgerTip) | pt <- points]
@@ -162,7 +162,7 @@ mkServer
   :: IOLike m
   => SecurityParam
   -> Chain TestBlock
-  -> m (LocalStateQueryServer TestBlock (Point TestBlock) (Query TestBlock) m ())
+  -> m (LocalStateQueryServer TestBlock (Point TestBlock) (BlockQuery TestBlock) m ())
 mkServer k chain = do
     lgrDB <- initLgrDB k chain
     return $

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -28,6 +28,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Query (Query (..))
 import           Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId
@@ -153,16 +154,16 @@ mkClient
   -> LocalStateQueryClient
        TestBlock
        (Point TestBlock)
-       (BlockQuery TestBlock)
+       (Query TestBlock)
        m
        [(Maybe (Point TestBlock), Either AcquireFailure (Point TestBlock))]
-mkClient points = localStateQueryClient [(pt, QueryLedgerTip) | pt <- points]
+mkClient points = localStateQueryClient [(pt, BlockQuery QueryLedgerTip) | pt <- points]
 
 mkServer
   :: IOLike m
   => SecurityParam
   -> Chain TestBlock
-  -> m (LocalStateQueryServer TestBlock (Point TestBlock) (BlockQuery TestBlock) m ())
+  -> m (LocalStateQueryServer TestBlock (Point TestBlock) (Query TestBlock) m ())
 mkServer k chain = do
     lgrDB <- initLgrDB k chain
     return $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Compat.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Compat.hs
@@ -40,7 +40,7 @@ import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 -- at least two eras
 data HardForkCompatQuery blk :: Type -> Type where
   CompatIfCurrent ::
-       Query blk result
+       BlockQuery blk result
     -> HardForkCompatQuery blk result
 
   CompatAnytime ::
@@ -58,7 +58,7 @@ data HardForkCompatQuery blk :: Type -> Type where
 
 -- | Submit query to underlying ledger
 compatIfCurrent ::
-     Query blk result
+     BlockQuery blk result
   -> HardForkCompatQuery blk result
 compatIfCurrent = CompatIfCurrent
 
@@ -83,7 +83,7 @@ compatGetInterpreter = CompatHardFork GetInterpreter
 -- at least two eras
 forwardCompatQuery ::
        forall m x xs. IsNonEmpty xs
-    => (forall result. Query (HardForkBlock (x ': xs)) result -> m result)
+    => (forall result. BlockQuery (HardForkBlock (x ': xs)) result -> m result)
     -- ^ Submit a query through the LocalStateQuery protocol.
     -> (forall result. HardForkCompatQuery (HardForkBlock (x ': xs)) result -> m result)
 forwardCompatQuery f = go
@@ -99,7 +99,7 @@ singleEraCompatQuery ::
        forall m blk era. (Monad m, HardForkIndices blk ~ '[era])
     => EpochSize
     -> SlotLength
-    -> (forall result. Query blk result -> m result)
+    -> (forall result. BlockQuery blk result -> m result)
     -- ^ Submit a query through the LocalStateQuery protocol.
     -> (forall result. HardForkCompatQuery blk result -> m result)
 singleEraCompatQuery epochSize slotLen f = go

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -13,6 +13,7 @@
 module Ouroboros.Consensus.HardFork.Combinator.Degenerate (
     -- * Pattern synonyms
     BlockConfig (DegenBlockConfig)
+  , BlockQuery (DegenQuery)
   , CodecConfig (DegenCodecConfig)
   , ConsensusConfig (DegenConsensusConfig)
   , Either (DegenQueryResult)
@@ -25,7 +26,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Degenerate (
   , Header (DegenHeader)
   , LedgerState (DegenLedgerState)
   , OneEraTipInfo (DegenTipInfo)
-  , Query (DegenQuery)
   , TopLevelConfig (DegenTopLevelConfig)
   , TxId (DegenGenTxId)
   ) where
@@ -138,8 +138,8 @@ pattern DegenTipInfo x <- (project' (Proxy @(WrapTipInfo b)) -> x)
 pattern DegenQuery ::
      ()
   => HardForkQueryResult '[b] result ~ a
-  => Query b result
-  -> Query (HardForkBlock '[b]) a
+  => BlockQuery b result
+  -> BlockQuery (HardForkBlock '[b]) a
 pattern DegenQuery x <- (projQuery' -> ProjHardForkQuery x)
   where
     DegenQuery x = injQuery x

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -79,7 +79,7 @@ injectNestedCtxt_ idx nc = case idx of
 injectQuery ::
      forall x xs result.
      Index xs x
-  -> Query x result
+  -> BlockQuery x result
   -> QueryIfCurrent xs result
 injectQuery idx q = case idx of
     IZ      -> QZ q
@@ -142,7 +142,7 @@ instance Inject WrapApplyTxErr where
       (WrapApplyTxErr . HardForkApplyTxErrFromEra)
         .: injectNS' (Proxy @WrapApplyTxErr)
 
-instance Inject (SomeSecond Query) where
+instance Inject (SomeSecond BlockQuery) where
   inject _ idx (SomeSecond q) = SomeSecond (QueryIfCurrent (injectQuery idx q))
 
 instance Inject AnnTip where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -614,13 +614,13 @@ instance Isomorphic SerialisedHeader where
   TODO: Class?
 -------------------------------------------------------------------------------}
 
--- | Project 'Query'
+-- | Project 'BlockQuery'
 --
 -- Not an instance of 'Isomorphic' because the types change.
-projQuery :: Query (HardForkBlock '[b]) result
+projQuery :: BlockQuery (HardForkBlock '[b]) result
           -> (forall result'.
                   (result :~: HardForkQueryResult '[b] result')
-               -> Query b result'
+               -> BlockQuery b result'
                -> a)
           -> a
 projQuery qry k =
@@ -630,24 +630,24 @@ projQuery qry k =
       (\Refl prfNonEmpty _ _ -> case prfNonEmpty of {})
       (\Refl prfNonEmpty _   -> case prfNonEmpty of {})
   where
-    aux :: QueryIfCurrent '[b] result -> Query b result
+    aux :: QueryIfCurrent '[b] result -> BlockQuery b result
     aux (QZ q) = q
     aux (QS q) = case q of {}
 
-projQuery' :: Query (HardForkBlock '[b]) result
+projQuery' :: BlockQuery (HardForkBlock '[b]) result
            -> ProjHardForkQuery b result
 projQuery' qry = projQuery qry $ \Refl -> ProjHardForkQuery
 
 data ProjHardForkQuery b :: Type -> Type where
   ProjHardForkQuery ::
-       Query b result'
+       BlockQuery b result'
     -> ProjHardForkQuery b (HardForkQueryResult '[b] result')
 
--- | Inject 'Query'
+-- | Inject 'BlockQuery'
 --
 -- Not an instance of 'Isomorphic' because the types change.
-injQuery :: Query b result
-         -> Query (HardForkBlock '[b]) (HardForkQueryResult '[b] result)
+injQuery :: BlockQuery b result
+         -> BlockQuery (HardForkBlock '[b]) (HardForkQueryResult '[b] result)
 injQuery = QueryIfCurrent . QZ
 
 projQueryResult :: HardForkQueryResult '[b] result -> result

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -113,7 +113,7 @@ data instance BlockQuery (HardForkBlock xs) :: Type -> Type where
     -> BlockQuery (HardForkBlock (x ': xs)) result
 
 instance All SingleEraBlock xs => QueryLedger (HardForkBlock xs) where
-  answerQuery (ExtLedgerCfg cfg)
+  answerBlockQuery (ExtLedgerCfg cfg)
               query
               ext@(ExtLedgerState st@(HardForkLedgerState hardForkState) _) =
       case query of
@@ -240,7 +240,7 @@ interpretQueryIfCurrent = go
        -> NS ExtLedgerState xs'
        -> HardForkQueryResult xs' result
     go (c :* _)  (QZ qry) (Z st) =
-        Right $ answerQuery c qry st
+        Right $ answerBlockQuery c qry st
     go (_ :* cs) (QS qry) (S st) =
         first shiftMismatch $ go cs qry st
     go _         (QZ qry) (S st) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -113,9 +113,10 @@ data instance BlockQuery (HardForkBlock xs) :: Type -> Type where
     -> BlockQuery (HardForkBlock (x ': xs)) result
 
 instance All SingleEraBlock xs => QueryLedger (HardForkBlock xs) where
-  answerBlockQuery (ExtLedgerCfg cfg)
-              query
-              ext@(ExtLedgerState st@(HardForkLedgerState hardForkState) _) =
+  answerBlockQuery
+    (ExtLedgerCfg cfg)
+    query
+    ext@(ExtLedgerState st@(HardForkLedgerState hardForkState) _) =
       case query of
         QueryIfCurrent queryIfCurrent ->
           interpretQueryIfCurrent

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -646,19 +646,19 @@ undistribSerialisedHeader =
 
 distribQueryIfCurrent ::
      Some (QueryIfCurrent xs)
-  -> NS (SomeSecond Query) xs
+  -> NS (SomeSecond BlockQuery) xs
 distribQueryIfCurrent = \(Some qry) -> go qry
   where
-    go :: QueryIfCurrent xs result -> NS (SomeSecond Query) xs
+    go :: QueryIfCurrent xs result -> NS (SomeSecond BlockQuery) xs
     go (QZ qry) = Z (SomeSecond qry)
     go (QS qry) = S (go qry)
 
 undistribQueryIfCurrent ::
-     NS (SomeSecond Query) xs
+     NS (SomeSecond BlockQuery) xs
   -> Some (QueryIfCurrent xs)
 undistribQueryIfCurrent = go
   where
-    go :: NS (SomeSecond Query) xs -> Some (QueryIfCurrent xs)
+    go :: NS (SomeSecond BlockQuery) xs -> Some (QueryIfCurrent xs)
     go (Z qry) = case qry of
                    SomeSecond qry' ->
                      Some (QZ qry')

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
@@ -198,7 +198,7 @@ decodeQueryHardFork = do
       _ -> fail $ "QueryHardFork: invalid tag " ++ show tag
 
 instance SerialiseHFC xs
-      => SerialiseNodeToClient (HardForkBlock xs) (SomeSecond Query (HardForkBlock xs)) where
+      => SerialiseNodeToClient (HardForkBlock xs) (SomeSecond BlockQuery (HardForkBlock xs)) where
   encodeNodeToClient ccfg version (SomeSecond q) = case version of
       HardForkNodeToClientDisabled v0 -> case q of
         QueryIfCurrent qry ->
@@ -260,8 +260,8 @@ instance SerialiseHFC xs
     where
       ccfgs = getPerEraCodecConfig $ hardForkCodecConfigPerEra ccfg
 
-      injQueryIfCurrent :: NS (SomeSecond Query) xs
-                        -> SomeSecond Query (HardForkBlock xs)
+      injQueryIfCurrent :: NS (SomeSecond BlockQuery) xs
+                        -> SomeSecond BlockQuery (HardForkBlock xs)
       injQueryIfCurrent ns =
           case undistribQueryIfCurrent ns of
             Some q -> SomeSecond (QueryIfCurrent q)
@@ -271,7 +271,7 @@ instance SerialiseHFC xs
 -------------------------------------------------------------------------------}
 
 instance SerialiseHFC xs
-      => SerialiseResult (HardForkBlock xs) (Query (HardForkBlock xs)) where
+      => SerialiseResult (HardForkBlock xs) (BlockQuery (HardForkBlock xs)) where
   encodeResult ccfg version (QueryIfCurrent qry) =
       case isNonEmpty (Proxy @xs) of
         ProofNonEmpty {} ->
@@ -318,7 +318,7 @@ encodeQueryIfCurrentResult (_ :* _) (EraNodeToClientDisabled :* _) (QZ qry) =
     qryDisabledEra qry
   where
     qryDisabledEra :: forall blk result. SingleEraBlock blk
-                   => Query blk result -> result -> Encoding
+                   => BlockQuery blk result -> result -> Encoding
     qryDisabledEra _ _ = throw $ disabledEraException (Proxy @blk)
 encodeQueryIfCurrentResult (_ :* cs) (_ :* vs) (QS qry) =
     encodeQueryIfCurrentResult cs vs qry
@@ -337,7 +337,7 @@ decodeQueryIfCurrentResult (_ :* _) (EraNodeToClientDisabled :* _) (QZ qry) =
     qryDisabledEra qry
   where
     qryDisabledEra :: forall blk result. SingleEraBlock blk
-                   => Query blk result -> forall s. Decoder s result
+                   => BlockQuery blk result -> forall s. Decoder s result
     qryDisabledEra _ = fail . show $ disabledEraException (Proxy @blk)
 decodeQueryIfCurrentResult (_ :* cs) (_ :* vs) (QS qry) =
     decodeQueryIfCurrentResult cs vs qry

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -494,7 +494,7 @@ instance (Typeable m, Typeable a)
 
 -- | Not used in the tests: no constructors
 instance Bridge m a => QueryLedger (DualBlock m a) where
-  answerQuery _ = \case {}
+  answerBlockQuery _ = \case {}
 
 instance SameDepIndex (BlockQuery (DualBlock m a)) where
   sameDepIndex = \case {}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -486,20 +486,20 @@ instance Bridge m a => HasHardForkHistory (DualBlock m a) where
   Querying the ledger
 -------------------------------------------------------------------------------}
 
-data instance Query (DualBlock m a) result
+data instance BlockQuery (DualBlock m a) result
   deriving (Show)
 
 instance (Typeable m, Typeable a)
-    => ShowProxy (Query (DualBlock m a)) where
+    => ShowProxy (BlockQuery (DualBlock m a)) where
 
 -- | Not used in the tests: no constructors
 instance Bridge m a => QueryLedger (DualBlock m a) where
   answerQuery _ = \case {}
 
-instance SameDepIndex (Query (DualBlock m a)) where
+instance SameDepIndex (BlockQuery (DualBlock m a)) where
   sameDepIndex = \case {}
 
-instance ShowQuery (Query (DualBlock m a)) where
+instance ShowQuery (BlockQuery (DualBlock m a)) where
   showResult = \case {}
 
 -- | Forward to the main ledger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 module Ouroboros.Consensus.Ledger.Query (
-    Query
+    BlockQuery
   , QueryLedger (..)
   , ShowQuery (..)
   ) where
@@ -25,18 +25,18 @@ import           Ouroboros.Consensus.Util.DepPair
 -------------------------------------------------------------------------------}
 
 -- | Different queries supported by the ledger, indexed by the result type.
-data family Query blk :: Type -> Type
+data family BlockQuery blk :: Type -> Type
 
 -- | Query the ledger extended state.
 --
 -- Used by the LocalStateQuery protocol to allow clients to query the extended
 -- ledger state.
-class (ShowQuery (Query blk), SameDepIndex (Query blk)) => QueryLedger blk where
+class (ShowQuery (BlockQuery blk), SameDepIndex (BlockQuery blk)) => QueryLedger blk where
 
   -- | Answer the given query about the extended ledger state.
-  answerQuery :: ExtLedgerCfg blk -> Query blk result -> ExtLedgerState blk -> result
+  answerQuery :: ExtLedgerCfg blk -> BlockQuery blk result -> ExtLedgerState blk -> result
 
-instance SameDepIndex (Query blk) => Eq (SomeSecond Query blk) where
+instance SameDepIndex (BlockQuery blk) => Eq (SomeSecond BlockQuery blk) where
   SomeSecond qry == SomeSecond qry' = isJust (sameDepIndex qry qry')
 
-deriving instance (forall result. Show (Query blk result)) => Show (SomeSecond Query blk)
+deriving instance (forall result. Show (BlockQuery blk result)) => Show (SomeSecond BlockQuery blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -34,7 +34,7 @@ data family BlockQuery blk :: Type -> Type
 class (ShowQuery (BlockQuery blk), SameDepIndex (BlockQuery blk)) => QueryLedger blk where
 
   -- | Answer the given query about the extended ledger state.
-  answerQuery :: ExtLedgerCfg blk -> BlockQuery blk result -> ExtLedgerState blk -> result
+  answerBlockQuery :: ExtLedgerCfg blk -> BlockQuery blk result -> ExtLedgerState blk -> result
 
 instance SameDepIndex (BlockQuery blk) => Eq (SomeSecond BlockQuery blk) where
   SomeSecond qry == SomeSecond qry' = isJust (sameDepIndex qry qry')

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -6,8 +6,10 @@
 {-# LANGUAGE UndecidableInstances  #-}
 module Ouroboros.Consensus.Ledger.Query (
     BlockQuery
+  , Query (..)
   , QueryLedger (..)
   , ShowQuery (..)
+  , answerQuery
   ) where
 
 import           Data.Kind (Type)
@@ -23,6 +25,17 @@ import           Ouroboros.Consensus.Util.DepPair
 {-------------------------------------------------------------------------------
   Queries
 -------------------------------------------------------------------------------}
+
+-- | Different queries supported by the ledger for all block types, indexed
+-- by the result type.
+data Query blk result = BlockQuery (BlockQuery blk result)
+
+deriving instance Show (BlockQuery blk result) => Show (Query blk result)
+
+-- | Answer the given query about the extended ledger state.
+answerQuery :: QueryLedger blk => ExtLedgerCfg blk -> Query blk result -> ExtLedgerState blk -> result
+answerQuery cfg query st = case query of
+  BlockQuery blockQuery -> answerBlockQuery cfg blockQuery st
 
 -- | Different queries supported by the ledger, indexed by the result type.
 data family BlockQuery blk :: Type -> Type

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -61,5 +61,5 @@ localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
       -> m (ServerStQuerying blk (Point blk) (BlockQuery blk) m () result)
     handleQuery ledgerState query = return $
         SendMsgResult
-          (answerQuery cfg query ledgerState)
+          (answerBlockQuery cfg query ledgerState)
           (acquired ledgerState)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -21,18 +21,18 @@ localStateQueryServer ::
      -- ^ Get a past ledger
   -> STM m (Point blk)
      -- ^ Get the immutable point
-  -> LocalStateQueryServer blk (Point blk) (Query blk) m ()
+  -> LocalStateQueryServer blk (Point blk) (BlockQuery blk) m ()
 localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
     LocalStateQueryServer $ return idle
   where
-    idle :: ServerStIdle blk (Point blk) (Query blk) m ()
+    idle :: ServerStIdle blk (Point blk) (BlockQuery blk) m ()
     idle = ServerStIdle {
           recvMsgAcquire = handleAcquire
         , recvMsgDone    = return ()
         }
 
     handleAcquire :: Maybe (Point blk)
-                  -> m (ServerStAcquiring blk (Point blk) (Query blk) m ())
+                  -> m (ServerStAcquiring blk (Point blk) (BlockQuery blk) m ())
     handleAcquire mpt = do
         (pt, mPastLedger, immutablePoint) <- atomically $ do
           pt <- maybe getTipPoint pure mpt
@@ -48,7 +48,7 @@ localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
             -> SendMsgFailure AcquireFailurePointNotOnChain idle
 
     acquired :: ExtLedgerState blk
-             -> ServerStAcquired blk (Point blk) (Query blk) m ()
+             -> ServerStAcquired blk (Point blk) (BlockQuery blk) m ()
     acquired ledgerState = ServerStAcquired {
           recvMsgQuery     = handleQuery ledgerState
         , recvMsgReAcquire = handleAcquire
@@ -57,8 +57,8 @@ localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
 
     handleQuery ::
          ExtLedgerState blk
-      -> Query blk result
-      -> m (ServerStQuerying blk (Point blk) (Query blk) m () result)
+      -> BlockQuery blk result
+      -> m (ServerStQuerying blk (Point blk) (BlockQuery blk) m () result)
     handleQuery ledgerState query = return $
         SendMsgResult
           (answerQuery cfg query ledgerState)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -94,7 +94,7 @@ data Handlers m peer blk = Handlers {
         :: LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()
 
     , hStateQueryServer
-        :: LocalStateQueryServer blk (Point blk) (BlockQuery blk) m ()
+        :: LocalStateQueryServer blk (Point blk) (Query blk) m ()
     }
 
 mkHandlers
@@ -133,7 +133,7 @@ mkHandlers NodeKernelArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
 data Codecs' blk serialisedBlk e m bCS bTX bSQ = Codecs {
       cChainSyncCodec    :: Codec (ChainSync serialisedBlk (Point blk) (Tip blk))  e m bCS
     , cTxSubmissionCodec :: Codec (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)) e m bTX
-    , cStateQueryCodec   :: Codec (LocalStateQuery blk (Point blk) (BlockQuery blk))    e m bSQ
+    , cStateQueryCodec   :: Codec (LocalStateQuery blk (Point blk) (Query blk))    e m bSQ
     }
 
 type Codecs blk e m bCS bTX bSQ =
@@ -259,7 +259,7 @@ identityCodecs :: (Monad m, QueryLedger blk)
                => Codecs blk CodecFailure m
                     (AnyMessage (ChainSync (Serialised blk) (Point blk) (Tip blk)))
                     (AnyMessage (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)))
-                    (AnyMessage (LocalStateQuery blk (Point blk) (BlockQuery blk)))
+                    (AnyMessage (LocalStateQuery blk (Point blk) (Query blk)))
 identityCodecs = Codecs {
       cChainSyncCodec    = codecChainSyncId
     , cTxSubmissionCodec = codecLocalTxSubmissionId
@@ -277,7 +277,7 @@ type Tracers m peer blk e =
 data Tracers' peer blk e f = Tracers {
       tChainSyncTracer    :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Serialised blk) (Point blk) (Tip blk))))
     , tTxSubmissionTracer :: f (TraceLabelPeer peer (TraceSendRecv (LocalTxSubmission (GenTx blk) (ApplyTxErr blk))))
-    , tStateQueryTracer   :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Point blk) (BlockQuery blk))))
+    , tStateQueryTracer   :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Point blk) (Query blk))))
     }
 
 instance (forall a. Semigroup (f a)) => Semigroup (Tracers' peer blk e f) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -94,7 +94,7 @@ data Handlers m peer blk = Handlers {
         :: LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()
 
     , hStateQueryServer
-        :: LocalStateQueryServer blk (Point blk) (Query blk) m ()
+        :: LocalStateQueryServer blk (Point blk) (BlockQuery blk) m ()
     }
 
 mkHandlers
@@ -133,7 +133,7 @@ mkHandlers NodeKernelArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
 data Codecs' blk serialisedBlk e m bCS bTX bSQ = Codecs {
       cChainSyncCodec    :: Codec (ChainSync serialisedBlk (Point blk) (Tip blk))  e m bCS
     , cTxSubmissionCodec :: Codec (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)) e m bTX
-    , cStateQueryCodec   :: Codec (LocalStateQuery blk (Point blk) (Query blk))    e m bSQ
+    , cStateQueryCodec   :: Codec (LocalStateQuery blk (Point blk) (BlockQuery blk))    e m bSQ
     }
 
 type Codecs blk e m bCS bTX bSQ =
@@ -162,7 +162,7 @@ type ClientCodecs blk  m =
 defaultCodecs :: forall m blk.
                  ( MonadST m
                  , SerialiseNodeToClientConstraints blk
-                 , ShowQuery (Query blk)
+                 , ShowQuery (BlockQuery blk)
                  )
               => CodecConfig blk
               -> BlockNodeToClientVersion blk
@@ -211,7 +211,7 @@ defaultCodecs ccfg version networkVersion = Codecs {
 clientCodecs :: forall m blk.
                 ( MonadST m
                 , SerialiseNodeToClientConstraints blk
-                , ShowQuery (Query blk)
+                , ShowQuery (BlockQuery blk)
                 )
              => CodecConfig blk
              -> BlockNodeToClientVersion blk
@@ -259,7 +259,7 @@ identityCodecs :: (Monad m, QueryLedger blk)
                => Codecs blk CodecFailure m
                     (AnyMessage (ChainSync (Serialised blk) (Point blk) (Tip blk)))
                     (AnyMessage (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)))
-                    (AnyMessage (LocalStateQuery blk (Point blk) (Query blk)))
+                    (AnyMessage (LocalStateQuery blk (Point blk) (BlockQuery blk)))
 identityCodecs = Codecs {
       cChainSyncCodec    = codecChainSyncId
     , cTxSubmissionCodec = codecLocalTxSubmissionId
@@ -277,7 +277,7 @@ type Tracers m peer blk e =
 data Tracers' peer blk e f = Tracers {
       tChainSyncTracer    :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Serialised blk) (Point blk) (Tip blk))))
     , tTxSubmissionTracer :: f (TraceLabelPeer peer (TraceSendRecv (LocalTxSubmission (GenTx blk) (ApplyTxErr blk))))
-    , tStateQueryTracer   :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Point blk) (Query blk))))
+    , tStateQueryTracer   :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Point blk) (BlockQuery blk))))
     }
 
 instance (forall a. Semigroup (f a)) => Semigroup (Tracers' peer blk e f) where
@@ -303,7 +303,7 @@ nullTracers = Tracers {
 showTracers :: ( Show peer
                , Show (GenTx blk)
                , Show (ApplyTxErr blk)
-               , ShowQuery (Query blk)
+               , ShowQuery (BlockQuery blk)
                , HasHeader blk
                )
             => Tracer m String -> Tracers m peer blk e
@@ -341,9 +341,9 @@ mkApps
      , Exception e
      , ShowProxy blk
      , ShowProxy (ApplyTxErr blk)
-     , ShowProxy (Query blk)
+     , ShowProxy (BlockQuery blk)
      , ShowProxy (GenTx blk)
-     , ShowQuery (Query blk)
+     , ShowQuery (BlockQuery blk)
      )
   => NodeKernel m remotePeer localPeer blk
   -> Tracers m localPeer blk e

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -69,8 +69,8 @@ class ( ConvertRawHash blk
       , SerialiseNodeToClient blk (Serialised blk)
       , SerialiseNodeToClient blk (GenTx blk)
       , SerialiseNodeToClient blk (ApplyTxErr blk)
-      , SerialiseNodeToClient blk (SomeSecond Query blk)
-      , SerialiseResult       blk (Query blk)
+      , SerialiseNodeToClient blk (SomeSecond BlockQuery blk)
+      , SerialiseResult       blk (BlockQuery blk)
       ) => SerialiseNodeToClientConstraints blk
 
 class ( LedgerSupportsProtocol           blk
@@ -97,7 +97,7 @@ class ( LedgerSupportsProtocol           blk
       , ShowProxy            (ApplyTxErr blk)
       , ShowProxy                 (GenTx blk)
       , ShowProxy                (Header blk)
-      , ShowProxy                 (Query blk)
+      , ShowProxy            (BlockQuery blk)
       , ShowProxy           (TxId (GenTx blk))
       ) => RunNode blk
   -- This class is intentionally empty. It is not necessarily compositional - ie


### PR DESCRIPTION
This is just a refactoring in preparation for adding a new query: `GetPartialLedgerConfig :: Query blk (PartialLedgerConfig blk)` (I've got a WIP branch where I do that here: [davide/query-ledger-config](https://github.com/input-output-hk/ouroboros-network/tree/davide/query-ledger-config)). You may want to review this commit by commit. The first 2 commits are simple renamings