### PR TITLE
Add some randomness to the reconnection delay

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -664,7 +664,8 @@ runDataDiffusion tracers
     -- demoting/promoting peers.
     rng <- newStdGen
     let (ledgerPeersRng, rng') = split rng
-        (policyRng, churnRng)  = split rng'
+        (policyRng, rng'')  = split rng'
+        (churnRng, fuzzRng) = split rng''
     policyRngVar <- newTVarIO policyRng
 
     -- Request interface, supply the number of peers desired.
@@ -887,6 +888,7 @@ runDataDiffusion tracers
                             dtTracePeerSelectionTracer
                             dtDebugPeerSelectionInitiatorTracer
                             dtTracePeerSelectionCounters
+                            fuzzRng
                             peerSelectionActions
                             (Diffusion.Policies.simplePeerSelectionPolicy policyRngVar))
                           $ \governorThread ->
@@ -1008,6 +1010,7 @@ runDataDiffusion tracers
                           dtTracePeerSelectionTracer
                           dtDebugPeerSelectionInitiatorResponderTracer
                           dtTracePeerSelectionCounters
+                          fuzzRng
                           peerSelectionActions
                           (Diffusion.Policies.simplePeerSelectionPolicy policyRngVar))
                         $ \governorThread -> do

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -438,16 +438,17 @@ peerSelectionGovernor :: (MonadAsync m, MonadMask m, MonadTime m, MonadTimer m,
                       => Tracer m (TracePeerSelection peeraddr)
                       -> Tracer m (DebugPeerSelection peeraddr peerconn)
                       -> Tracer m PeerSelectionCounters
+                      -> StdGen
                       -> PeerSelectionActions peeraddr peerconn m
                       -> PeerSelectionPolicy  peeraddr m
                       -> m Void
-peerSelectionGovernor tracer debugTracer countersTracer actions policy =
+peerSelectionGovernor tracer debugTracer countersTracer fuzzRng actions policy =
     JobPool.withJobPool $ \jobPool ->
       peerSelectionGovernorLoop
         tracer (debugTracer <> contramap transform countersTracer)
         actions policy
         jobPool
-        emptyPeerSelectionState
+        (emptyPeerSelectionState fuzzRng)
   where
     transform :: Ord peeraddr => DebugPeerSelection peeraddr peerconn -> PeerSelectionCounters
     transform (TraceGovernorState _ _ st) = peerStateToCounters st

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -18,6 +18,7 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Concurrent.JobPool (Job(..))
 import           Control.Exception (SomeException, assert)
+import           System.Random (randomR)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
@@ -209,9 +210,8 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                    peeraddr peerconn =
     Job job handler "promoteWarmPeer"
   where
-    -- TODO: The delay should be randomly picked from an interval.
-    reconnectDelay :: DiffTime
-    reconnectDelay = 10
+    baseReconnectDelay :: Double
+    baseReconnectDelay = 10
 
     handler :: SomeException -> Completion m peeraddr peerconn
     handler e =
@@ -220,6 +220,7 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                                activePeers,
                                establishedPeers,
                                knownPeers,
+                               fuzzRng,
                                targets = PeerSelectionTargets {
                                            targetNumberOfActivePeers
                                          }
@@ -227,10 +228,12 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                     now ->
         let establishedPeers' = EstablishedPeers.delete peeraddr
                                   establishedPeers
+            (fuzz, fuzzRng')  = randomR (-2, 2 :: Double) fuzzRng
+            delay             = realToFrac $ fuzz + baseReconnectDelay
             knownPeers'       = if peeraddr `KnownPeers.member` knownPeers
                                    then KnownPeers.setConnectTime
                                           (Set.singleton peeraddr)
-                                          (reconnectDelay `addTime` now)
+                                          (delay `addTime` now)
                                         $ snd $ KnownPeers.incrementFailCount
                                           peeraddr
                                           knownPeers
@@ -248,7 +251,8 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                           inProgressPromoteWarm = Set.delete peeraddr
                                                     (inProgressPromoteWarm st),
                           knownPeers            = knownPeers',
-                          establishedPeers      = establishedPeers'
+                          establishedPeers      = establishedPeers',
+                          fuzzRng               = fuzzRng'
                         },
         decisionJobs  = []
       }

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -16,6 +16,7 @@ import           Control.Concurrent.JobPool (Job(..))
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Exception (SomeException)
+import           System.Random (randomR)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
@@ -239,6 +240,7 @@ jobPromoteColdPeer PeerSelectionActions {
     handler e =
       Completion $ \st@PeerSelectionState {
                       establishedPeers,
+                      fuzzRng,
                       targets = PeerSelectionTargets {
                                   targetNumberOfEstablishedPeers
                                 }
@@ -247,12 +249,14 @@ jobPromoteColdPeer PeerSelectionActions {
         let (failCount, knownPeers') = KnownPeers.incrementFailCount
                                          peeraddr
                                          (knownPeers st)
+            (fuzz, fuzzRng') = randomR (-2, 2 :: Double) fuzzRng
 
             -- exponential backoff: 5s, 10s, 20s, 40s, 80s, 160s.
-            delay :: DiffTime
-            delay = fromIntegral $
-                baseColdPeerRetryDiffTime
-              * 2 ^ (pred failCount `min` maxColdPeerRetryBackoff)
+            delay = realToFrac fuzz
+                  + fromIntegral
+                      ( baseColdPeerRetryDiffTime
+                      * 2 ^ (pred failCount `min` maxColdPeerRetryBackoff)
+                      )
         in
           Decision {
             decisionTrace = TracePromoteColdFailed targetNumberOfEstablishedPeers
@@ -264,7 +268,8 @@ jobPromoteColdPeer PeerSelectionActions {
                                                         (delay `addTime` now)
                                                         knownPeers',
                               inProgressPromoteCold = Set.delete peeraddr
-                                                        (inProgressPromoteCold st)
+                                                        (inProgressPromoteCold st),
+                              fuzzRng = fuzzRng'
                             },
             decisionJobs  = []
           }

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -28,6 +28,7 @@ import           Data.Void (Void)
 import qualified Data.Signal as Signal
 import           Data.Signal (Signal, Events, E(E), TS(TS))
 import qualified Data.OrdPSQ as PSQ
+import           System.Random (mkStdGen)
 
 import           Control.Monad.Class.MonadSTM.Strict (STM)
 import           Control.Monad.Class.MonadTime
@@ -1867,7 +1868,8 @@ selectGovState :: Eq a
 selectGovState f =
     Signal.nub
   . fmap f
-  . Signal.fromChangeEvents Governor.emptyPeerSelectionState
+  -- TODO: #3182 Rng seed should come from quickcheck.
+  . Signal.fromChangeEvents (Governor.emptyPeerSelectionState $ mkStdGen 42)
   . Signal.selectEvents
       (\case GovernorDebug (TraceGovernorState _ _ st) -> Just st
              _                                         -> Nothing)
@@ -1907,6 +1909,8 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains =
 
         peerSelectionGovernor
           tracer tracer tracer
+          -- TODO: #3182 Rng seed should come from quickcheck.
+          (mkStdGen 42)
           actions { requestPublicRootPeers }
           policy
   where

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -35,6 +35,7 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
+import           System.Random (mkStdGen)
 
 import           Control.Exception (throw)
 import           Control.Monad (forM_)
@@ -168,6 +169,7 @@ runGovernorInMockEnvironment mockEnv =
         tracerTracePeerSelection
         tracerDebugPeerSelection
         tracerTracePeerSelectionCounters
+        (mkStdGen 42)
         actions
         policy
 


### PR DESCRIPTION
Add randomness to the time a peer waits before attempting to reconnect/reactive a peer. This avoids synchronization between peers who otherwise would attempt to reestablish the connection at exactly the same time.