### PR TITLE
Set the peer as warm before monitoring

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -15,10 +15,12 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTime
 import           Control.Concurrent.JobPool (Job(..))
 import           Control.Exception (SomeException, assert)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
+import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
 import           Ouroboros.Network.PeerSelection.Governor.Types
 
@@ -207,31 +209,52 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                    peeraddr peerconn =
     Job job handler "promoteWarmPeer"
   where
+    -- TODO: The delay should be randomly picked from an interval.
+    reconnectDelay :: DiffTime
+    reconnectDelay = 10
+
     handler :: SomeException -> Completion m peeraddr peerconn
     handler e =
-      --TODO: decide what happens if promotion fails, do we stay warm or go to
-      -- cold? Will this be reported asynchronously via the state monitoring?
+      -- When promotion fails we set the peer as cold.
       Completion $ \st@PeerSelectionState {
                                activePeers,
+                               establishedPeers,
+                               knownPeers,
                                targets = PeerSelectionTargets {
                                            targetNumberOfActivePeers
                                          }
                              }
-                    _now -> Decision {
+                    now ->
+        let establishedPeers' = EstablishedPeers.delete peeraddr
+                                  establishedPeers
+            knownPeers'       = if peeraddr `KnownPeers.member` knownPeers
+                                   then KnownPeers.setConnectTime
+                                          (Set.singleton peeraddr)
+                                          (reconnectDelay `addTime` now)
+                                        $ snd $ KnownPeers.incrementFailCount
+                                          peeraddr
+                                          knownPeers
+                                   else
+                                     -- Apparently the governor can remove
+                                     -- the peer we failed to promote from the
+                                     -- set of known peers before we can process
+                                     -- the failure.
+                                     knownPeers in
+        Decision {
         decisionTrace = TracePromoteWarmFailed targetNumberOfActivePeers
-                                               (Set.size activePeers) 
+                                               (Set.size activePeers)
                                                peeraddr e,
         decisionState = st {
                           inProgressPromoteWarm = Set.delete peeraddr
-                                                    (inProgressPromoteWarm st)
+                                                    (inProgressPromoteWarm st),
+                          knownPeers            = knownPeers',
+                          establishedPeers      = establishedPeers'
                         },
         decisionJobs  = []
       }
 
     job :: m (Completion m peeraddr peerconn)
     job = do
-      --TODO: decide if we should do timeouts here or if we should make that
-      -- the responsibility of activatePeerConnection
       activatePeerConnection peerconn
       return $ Completion $ \st@PeerSelectionState {
                                activePeers,
@@ -241,6 +264,7 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                              }
                            _now ->
         assert (peeraddr `EstablishedPeers.member` establishedPeers st) $
+        assert (peeraddr `KnownPeers.member` knownPeers st) $
         let activePeers' = Set.insert peeraddr activePeers in
         Decision {
           decisionTrace = TracePromoteWarmDone targetNumberOfActivePeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
@@ -14,6 +14,7 @@ module Ouroboros.Network.PeerSelection.KnownPeers (
     insert,
     delete,
     toSet,
+    member,
 
     -- * Special operations
     setCurrentTime,
@@ -147,6 +148,13 @@ size = Map.size . allPeers
 -- | /O(n)/
 toSet :: KnownPeers peeraddr -> Set peeraddr
 toSet = Map.keysSet . allPeers
+
+member :: Ord peeraddr
+       => peeraddr
+       -> KnownPeers peeraddr
+       -> Bool
+member peeraddr KnownPeers {allPeers} =
+    peeraddr `Map.member` allPeers
 
 insert :: Ord peeraddr
        => Set peeraddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -673,6 +673,14 @@ withPeerStateActions timeout
                                             awaitVarBundle
                       }
 
+              startProtocols TokWarm connHandle
+              startProtocols TokEstablished connHandle
+              atomically $ writeTVar peerStateVar (PeerStatus PeerWarm)
+              traceWith spsTracer (PeerStatusChanged
+                                    (ColdToWarm
+                                      (Just localAddress)
+                                      remoteAddress))
+
               JobPool.forkJob jobPool
                               (Job (handleJust
                                      (\e -> case fromException e of
@@ -684,13 +692,6 @@ withPeerStateActions timeout
                                      (peerMonitoringLoop connHandle $> Nothing))
                                    Just
                                    ("peerMonitoringLoop " ++ show remoteAddress))
-              startProtocols TokWarm connHandle
-              startProtocols TokEstablished connHandle
-              atomically $ writeTVar peerStateVar (PeerStatus PeerWarm)
-              traceWith spsTracer (PeerStatusChanged
-                                    (ColdToWarm
-                                      (Just localAddress)
-                                      remoteAddress))
               pure connHandle
 
             Disconnected _ Nothing ->

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -29,6 +29,7 @@ module Ouroboros.Network.PeerSelection.PeerStateActions
   ) where
 
 import           Control.Exception (SomeAsyncException (..))
+import           Control.Monad (when)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime (DiffTime)
@@ -496,6 +497,19 @@ instance ( Show peerAddr
     toException   = peerSelectionActionExceptionToException
     fromException = peerSelectionActionExceptionFromException
 
+
+data ColdActionException peerAddr
+    = ColdActivationException   !(ConnectionId peerAddr)
+    | ColdDeactivationException !(ConnectionId peerAddr)
+  deriving Show
+
+instance ( Show peerAddr
+         , Typeable peerAddr
+         ) => Exception (ColdActionException peerAddr) where
+    toException   = peerSelectionActionExceptionToException
+    fromException = peerSelectionActionExceptionFromException
+
+
 --
 -- 'PeerStateActionsArguments' and 'peerStateActions'
 --
@@ -561,6 +575,17 @@ withPeerStateActions timeout
         }
 
   where
+
+    -- Update PeerState with the new state only if the current state isn't
+    -- cold. Returns True if the state wasn't PeerCold
+    updateUnlessCold :: StrictTVar m PeerState -> PeerState -> STM m Bool
+    updateUnlessCold stateVar newState = do
+      status <- getCurrentState <$> readTVar stateVar
+      if status == PeerCold
+         then return False
+         else writeTVar stateVar newState >> return True
+
+
     peerMonitoringLoop
       :: PeerConnectionHandle muxMode peerAddr ByteString m a b
       -> m ()
@@ -750,6 +775,9 @@ withPeerStateActions timeout
 
 
     -- Take a warm peer and promote it to a hot one.
+    -- NB when adding any operations that can block for an extended period of
+    -- of time timeouts should be implemented here in the same way it is in
+    -- establishPeerConnection and deactivatePeerConnection.
     activatePeerConnection :: PeerConnectionHandle muxMode peerAddr ByteString m a b
                            -> m ()
     activatePeerConnection
@@ -758,15 +786,32 @@ withPeerStateActions timeout
             pchPeerState,
             pchAppHandles } = do
       -- quiesce warm peer protocols and set hot ones in 'Continue' mode.
-      atomically $ do
-        writeTVar pchPeerState PromotingToHot
-        writeTVar (getControlVar TokHot pchAppHandles) Continue
-        writeTVar (getControlVar TokWarm pchAppHandles) Quiesce
+      wasWarm <- atomically $ do
+        -- if the peer is cold we can't activate it.
+        notCold <- updateUnlessCold pchPeerState PromotingToHot
+        when notCold $ do
+          writeTVar (getControlVar TokHot pchAppHandles) Continue
+          writeTVar (getControlVar TokWarm pchAppHandles) Quiesce
+        return notCold
+      when (not wasWarm) $ do
+        traceWith spsTracer (PeerStatusChangeFailure
+                              (WarmToHot pchConnectionId)
+                              ActiveCold)
+        throwIO $ ColdActivationException pchConnectionId
 
       -- start hot peer protocols
       startProtocols TokHot connHandle
-      atomically $ writeTVar pchPeerState (PeerStatus PeerHot)
-      traceWith spsTracer (PeerStatusChanged (WarmToHot pchConnectionId))
+
+      -- Only set the status to PeerHot if the peer isn't PeerCold.
+      -- This can happen asynchronously between the check above and now.
+      wasWarm' <- atomically $ updateUnlessCold pchPeerState (PeerStatus PeerHot)
+      if wasWarm'
+         then traceWith spsTracer (PeerStatusChanged (WarmToHot pchConnectionId))
+         else do
+           traceWith spsTracer (PeerStatusChangeFailure
+                                 (WarmToHot pchConnectionId)
+                                 ActiveCold)
+           throwIO $ ColdActivationException pchConnectionId
 
 
     -- Take a hot peer and demote it to a warm one.
@@ -778,10 +823,19 @@ withPeerStateActions timeout
             pchMux,
             pchAppHandles
           } = do
-      atomically $ do
-        writeTVar pchPeerState DemotingToWarm
-        writeTVar (getControlVar TokHot pchAppHandles) Terminate
-        writeTVar (getControlVar TokWarm pchAppHandles) Continue
+      wasWarm <- atomically $ do
+        notCold <- updateUnlessCold pchPeerState DemotingToWarm
+        when notCold $ do
+          writeTVar (getControlVar TokHot pchAppHandles) Terminate
+          writeTVar (getControlVar TokWarm pchAppHandles) Continue
+        return notCold
+      when (not wasWarm) $ do
+        -- The governor attempted to demote an already cold peer.
+        traceWith spsTracer (PeerStatusChangeFailure
+                             (HotToWarm pchConnectionId)
+                             ActiveCold)
+        throwIO $ ColdDeactivationException pchConnectionId
+
 
       -- Hot protocols should stop within 'spsDeactivateTimeout'.
       res <-
@@ -804,15 +858,26 @@ withPeerStateActions timeout
           throwIO (MiniProtocolExceptions errs)
 
         Just AllSucceeded -> do
-          atomically $ do
-            writeTVar pchPeerState (PeerStatus PeerWarm)
-            -- We need to update hot protocols to indicate that they are not
-            -- running.
-            stateTVar (getMiniProtocolsVar TokHot pchAppHandles)
-                      (\a -> ( Map.map (const (pure NotRunning)) a
-                             , ()
-                             ))
-          traceWith spsTracer (PeerStatusChanged (HotToWarm pchConnectionId))
+          wasWarm' <- atomically $ do
+            -- Only set the status to PeerWarm if the peer isn't PeerCold
+            -- (can happen asynchronously).
+            notCold <- updateUnlessCold pchPeerState (PeerStatus PeerWarm)
+            when notCold $ do
+              -- We need to update hot protocols to indicate that they are not
+              -- running.
+              stateTVar (getMiniProtocolsVar TokHot pchAppHandles)
+                        (\a -> ( Map.map (const (pure NotRunning)) a
+                               , ()
+                               ))
+            return notCold
+
+          if wasWarm'
+             then traceWith spsTracer (PeerStatusChanged (HotToWarm pchConnectionId))
+             else do
+                 traceWith spsTracer (PeerStatusChangeFailure
+                                      (WarmToHot pchConnectionId)
+                                      ActiveCold)
+                 throwIO $ ColdDeactivationException pchConnectionId
 
 
     closePeerConnection :: PeerConnectionHandle muxMode peerAddr ByteString m a b
@@ -960,6 +1025,7 @@ data FailureType =
     | HandleFailure !SomeException
     | MuxStoppedFailure
     | TimeoutError
+    | ActiveCold
     | ApplicationFailure ![MiniProtocolException]
   deriving Show
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1365,6 +1365,8 @@ prop_governor_target_established_below env =
                        | otherwise         -> Just failures
                        where
                          failures = Map.keysSet (Map.filter (==PeerCold) status)
+                     TracePromoteWarmFailed _ _ peer _ ->
+                       Just (Set.singleton peer)
                      _ -> Nothing
               )
           . selectGovEvents
@@ -1664,6 +1666,8 @@ prop_governor_target_established_local env =
                        | otherwise         -> Just failures
                        where
                          failures = Map.keysSet (Map.filter (==PeerCold) status)
+                     TracePromoteWarmFailed _ _ peer _ ->
+                       Just (Set.singleton peer)
                      _ -> Nothing
               )
           . selectGovEvents


### PR DESCRIPTION
The peer status must be set to PeerWarm before we start the monitoring
thread.

Previously we started the monitoring thread first which meant that it
was possible for the monitor thread to notice an error and set the peer
status to PeerCold only to have it overwritten with PeerWarm. This
caused peers to get stuck in warm/hot without a corresponding
connection.