### PR TITLE
Replace cabal with iohk-nix's cabalWrapped

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -147,6 +147,12 @@ allow-newer:
   monoidal-containers:aeson,
   size-based:template-haskell
 
+
+-- ---------------------------------------------------------
+-- cabalWrapped - TODO: comment this
+-- --------------------------- 8< --------------------------
+-- Please do not put any `source-repository-package` clause above this line.
+
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/Win32-network

--- a/cabal.project
+++ b/cabal.project
@@ -143,6 +143,10 @@ package plutus-tx
 package prettyprinter-configurable
   tests: False
 
+allow-newer:
+  monoidal-containers:aeson,
+  size-based:template-haskell
+
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/Win32-network
@@ -223,7 +227,3 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-crypto
   tag: f73079303f663e028288f9f4a9e08bcca39a923e
   --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
-
-allow-newer:
-  monoidal-containers:aeson,
-  size-based:template-haskell

--- a/cabal.project
+++ b/cabal.project
@@ -149,7 +149,8 @@ allow-newer:
 
 
 -- ---------------------------------------------------------
--- cabalWrapped - TODO: comment this
+-- The "cabal" wrapper script provided by nix-shell will cut off / restore the remainder of this file
+-- in order to force usage of nix provided dependencies for `source-repository-package`s.
 -- --------------------------- 8< --------------------------
 -- Please do not put any `source-repository-package` clause above this line.
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -29,6 +29,7 @@ let
     ++ iohkNixMain.overlays.crypto
     # iohkNix: nix utilities and niv:
     ++ iohkNixMain.overlays.iohkNix
+    ++ iohkNixMain.overlays.utils
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -17,4 +17,6 @@ pkgs: _: with pkgs; {
     version = "latest";
     inherit (ouroborosNetworkHaskellPackages) index-state;
   };
+
+  trace = builtins.trace;
 }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -12,4 +12,9 @@ pkgs: _: with pkgs; {
 
   network-docs = callPackage ./network-docs.nix { };
   consensus-docs = callPackage ./consensus-docs.nix { };
+
+  cabal = haskell-nix.tool localConfig.ghcVersion "cabal" {
+    version = "latest";
+    inherit (ouroborosNetworkHaskellPackages) index-state;
+  };
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -30,10 +30,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "60fe72cf807a4ec4409a53883d5c3af77f60f721",
-        "sha256": "0hpn4fsmnrrqzpj7j3fcmrjm5d3fb15vvbhjn825ipknjjvz6zwd",
+        "rev": "0ce3abcfed803ed77472488f30b299fda9d941b1",
+        "sha256": "1bwwjh7cixyvl6pyisw109q9j3w5j5v1py8b0laaz3bpgg1bjar4",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/60fe72cf807a4ec4409a53883d5c3af77f60f721.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/0ce3abcfed803ed77472488f30b299fda9d941b1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/shell.nix
+++ b/shell.nix
@@ -43,6 +43,7 @@ let
 
     # These programs will be available inside the nix-shell.
     buildInputs = [
+      cabalWrapped
       niv
       pkgconfig
       nixpkgs-fmt
@@ -54,18 +55,12 @@ let
 
     tools = {
       ghcid = "0.8.7";
-      cabal = "3.2.0.0";
       hasktags = "0.71.2";
       # https://hackage.haskell.org/package/graphmod
       graphmod = "1.4.4";
       # todo: add back the build tools which are actually necessary
-      # ghcide = "0.2.0";
       # hlint = "...";
     };
-
-    # Prevents cabal from choosing alternate plans, so that
-    # *all* dependencies are provided by Nix.
-    exactDeps = true;
 
     inherit withHoogle;
   };


### PR DESCRIPTION
This addresses issue #3145. In a nutshell, cabalWrapped will remove
source-repository-package stanzas while invoking cabal - this avoids
unnecessary rebuilds of dependencies that were already built by nix.

Fixes almost all issue from #3145 except for HLS