### PR TITLE
Define ShelleyLedgerExamples and rework the shelley examples around it.

### DIFF
--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -171,6 +171,33 @@ defaultShelleyLedgerExamples mkWitnesses mkValidatedTx value txBody auxiliaryDat
       , sreShelleyGenesis = testShelleyGenesis
       }
 
+ledgerExamplesShelley :: ShelleyLedgerExamples StandardShelley
+ledgerExamplesShelley =
+    defaultShelleyLedgerExamples
+      (mkWitnessesPreAlonzo (Proxy @StandardShelley))
+      id
+      exampleCoin
+      exampleTxBodyShelley
+      exampleAuxiliaryDataShelley
+
+ledgerExamplesAllegra :: ShelleyLedgerExamples StandardAllegra
+ledgerExamplesAllegra =
+    defaultShelleyLedgerExamples
+      (mkWitnessesPreAlonzo (Proxy @StandardAllegra))
+      id
+      exampleCoin
+      exampleTxBodyAllegra
+      exampleAuxiliaryDataMA
+
+ledgerExamplesMary :: ShelleyLedgerExamples StandardMary
+ledgerExamplesMary =
+    defaultShelleyLedgerExamples
+      (mkWitnessesPreAlonzo (Proxy @StandardMary))
+      id
+      exampleMultiAssetValue
+      exampleTxBodyMary
+      exampleAuxiliaryDataMA
+
 exampleShelleyLedgerBlock
   :: forall era. ShelleyBasedEra era
   => SL.TxInBlock era
@@ -576,7 +603,9 @@ keyToCredential = SL.KeyHashObj . SL.hashKey . SL.vKey
 codecConfig :: CodecConfig (ShelleyBlock StandardShelley)
 codecConfig = ShelleyCodecConfig
 
-fromShelleyLedgerExamples :: ShelleyBasedEra era => ShelleyLedgerExamples era -- ^
+fromShelleyLedgerExamples
+  :: ShelleyBasedEra era
+  => ShelleyLedgerExamples era -- ^
   -> Golden.Examples (ShelleyBlock era)
 fromShelleyLedgerExamples ShelleyLedgerExamples {
                             sleResultExamples = ShelleyResultExamples{..}
@@ -642,59 +671,17 @@ fromShelleyLedgerExamples ShelleyLedgerExamples {
                        ledgerState
                        (genesisHeaderState chainDepState)
 
-examples ::
-     forall era.
-     ( ShelleyBasedEra era
-     ,   SL.PredicateFailure (Core.EraRule "DELEGS" era)
-       ~ SL.DelegsPredicateFailure era
-     , Core.PParams era ~ SL.PParams era
-     , Core.PParamsDelta era ~ SL.PParams' StrictMaybe era
-     )
-  => (Core.TxBody era -> KeyPairWits era -> Core.Witnesses era)
-  -> (Core.Tx era -> SL.TxInBlock era)
-  -> Core.Value era
-  -> Core.TxBody era
-  -> Core.AuxiliaryData era
-  -> Golden.Examples (ShelleyBlock era)
-examples mkWitnesses mkValidatedTx value txBody auxiliaryData =
-  fromShelleyLedgerExamples shelleyLedgerExamples
-  where
-    shelleyLedgerExamples = defaultShelleyLedgerExamples
-                              mkWitnesses
-                              mkValidatedTx
-                              value
-                              txBody
-                              auxiliaryData
-
 examplesShelley :: Golden.Examples (ShelleyBlock StandardShelley)
-examplesShelley =
-    examples
-      (mkWitnessesPreAlonzo (Proxy @StandardShelley))
-      id
-      exampleCoin
-      exampleTxBodyShelley
-      exampleAuxiliaryDataShelley
+examplesShelley = fromShelleyLedgerExamples ledgerExamplesShelley
 
 examplesAllegra :: Golden.Examples (ShelleyBlock StandardAllegra)
-examplesAllegra =
-    examples
-      (mkWitnessesPreAlonzo (Proxy @StandardAllegra))
-      id
-      exampleCoin
-      exampleTxBodyAllegra
-      exampleAuxiliaryDataMA
+examplesAllegra = fromShelleyLedgerExamples ledgerExamplesAllegra
 
 examplesMary :: Golden.Examples (ShelleyBlock StandardMary)
-examplesMary =
-    examples
-      (mkWitnessesPreAlonzo (Proxy @StandardMary))
-      id
-      exampleMultiAssetValue
-      exampleTxBodyMary
-      exampleAuxiliaryDataMA
+examplesMary = fromShelleyLedgerExamples ledgerExamplesMary
 
 examplesAlonzo :: Golden.Examples (ShelleyBlock StandardAlonzo)
-examplesAlonzo = mempty   -- TODO
+examplesAlonzo = mempty -- TODO fromShelleyLedgerExamples ledgerExamplesAlonzo
 
 {-------------------------------------------------------------------------------
   Keys


### PR DESCRIPTION
`ShelleyLedgerExamples` contains examples of the types that come entirely from the
ledger side and are required to create `Examples` which we were using on our
side for the Golden tests.

The actual values that are tested are unchanged.

Addresses #3139.

We have `Examples` which we want to keep, but those are mainly generated from ledger
types. Eventhough this PR looks like it changes a lot things, it is mostly just moving code around.
Aside from moving things around, the changes are basically defining this new
datatype (`ShelleyLedgerExamples`) and grouping all the ledger-specific functions at 
the top of the module, sometimes adapting them (e.g. `exampleHashHeader -> exampleHeaderHash`).

In a follow up PR, the section between `-- To Ledger START` and `-- To Ledger END` will 
be moved to cardano-ledger-specs.

The main functions that will need to be provided by ledger in the end are now named 
`ledgerExamplesX` where `X ∈ {Shelley,Allegra,Mary,Alonzo}`.