### PR TITLE
Update to the latest ledger-specs (and associated plutus)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,3 +8,9 @@ steps:
     command: 'nix-shell --run scripts/buildkite/check-nixpkgs-fmt.sh'
     agents:
       system: x86_64-linux
+
+  - label: 'Check dependency tags in cabal.project are present on master branches'
+    commands:
+      - "nix build -f ./nix iohkNix.checkRepoTagsOnMasterBranches --arg src ./. --show-trace"
+    agents:
+      system: x86_64-linux

--- a/cabal.project
+++ b/cabal.project
@@ -181,8 +181,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 7540043e0c565896be4eb8b278587e95eefa8a95
-  --sha256: 1b9c9d95sl3wnmjrly78i59f9k2zngvdr3cpnwbpn5scnkwkijm4
+  tag: 6fb462cb5d5de74f45a1eb6eca6b07ef94daf10f
+  --sha256: 1pl3mp6idl4z0im9hilbpciar38rwpbh0bq7lqkaf89w05kzya8n
   subdir:
     alonzo/impl
     alonzo/test
@@ -204,8 +204,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 530d3f7940319788a49c7ecb017f8366994990b0
-  --sha256: 01jzrl04zyp63c9sxd1qgdy4nxbnaz7n2g1pw4x2d5y9562mrq6v
+  tag: 0b23a51891a83690222888e891c0b0a6d80501d2
+  --sha256: 188s6fmib0zpzr9wxsa0qvdk2k8scld0lsvzpfrsnir4s5ixjjrn
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/cabal.project
+++ b/cabal.project
@@ -181,8 +181,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6fb462cb5d5de74f45a1eb6eca6b07ef94daf10f
-  --sha256: 1pl3mp6idl4z0im9hilbpciar38rwpbh0bq7lqkaf89w05kzya8n
+  tag: 2d8560792d5306627a5add27d76fc2a26feea669
+  --sha256: 09wqfcbmzmrm73ik91ld2b46pv537w9y0i8y3alvlx1hinids10l
   subdir:
     alonzo/impl
     alonzo/test

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
@@ -40,7 +40,7 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
 
-import           Cardano.Ledger.Alonzo.Translation (AlonzoGenesis)
+import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import qualified Shelley.Spec.Ledger.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -73,7 +73,7 @@ import           Ouroboros.Consensus.Shelley.Protocol
 import           Ouroboros.Consensus.Shelley.ShelleyHFC
 
 import           Cardano.Ledger.Allegra.Translation ()
-import qualified Cardano.Ledger.Alonzo.Translation as Alonzo
+import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import           Cardano.Ledger.Crypto (ADDRHASH, DSIGN, HASH)
 import qualified Cardano.Ledger.Era as SL
 import           Cardano.Ledger.Mary.Translation ()

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -10,7 +10,11 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans
+                -Wno-incomplete-patterns
+                -Wno-incomplete-uni-patterns
+                -Wno-incomplete-record-updates
+                -Wno-overlapping-patterns #-}
 module Ouroboros.Consensus.Cardano.Node (
     CardanoHardForkConstraints
   , MaxMajorProtVer (..)

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -26,7 +26,7 @@ import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock (..),
                      OneEraBlock (..), OneEraHash (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo
 
-import qualified Cardano.Ledger.Alonzo.Translation as SL (AlonzoGenesis)
+import qualified Cardano.Ledger.Alonzo.Genesis as SL (AlonzoGenesis)
 
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto
 

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
@@ -2,8 +2,8 @@ module Test.ThreadNet.Infra.Alonzo (degenerateAlonzoGenesis) where
 
 import qualified Data.Map as Map
 
+import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import           Cardano.Ledger.Alonzo.Scripts (Prices (..))
-import           Cardano.Ledger.Alonzo.Translation (AlonzoGenesis (..))
 import           Shelley.Spec.Ledger.API (Coin (..))
 
 degenerateAlonzoGenesis :: AlonzoGenesis

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
@@ -122,8 +122,7 @@ class ( SL.ShelleyBasedEra era
       , HasField "_protocolVersion" (Core.PParamsDelta era) (SL.StrictMaybe SL.ProtVer)
       , FromCBOR (Core.PParamsDelta era)
 
-      , SL.AdditionalGenesisConfig era ~ ()
-
+      , SL.AdditionalGenesisConfig era ~ Core.TranslationContext era
       , SL.ToCBORGroup (TxSeq era)
 
       , Eq (Core.TxInBlock era)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -286,6 +286,19 @@ protocolInfoShelleyBased ProtocolParamsShelleyBased {
           traverse (shelleyBlockForging tpraosParams) credentialss
       }
   where
+
+    -- | Currently for all existing eras in ledger-specs (Shelley, Allegra, Mary
+    -- and Alonzo) it happens to be the case that AdditionalGenesisConfig and
+    -- TranslationContext are instantiated to the same type.
+    -- We take advantage of this fact below to simplify our code, but we are
+    -- aware that this might change in future (for new eras), breaking this
+    -- code.
+    --
+    -- see type equality constraint in
+    -- Ouroboros.Consensus.Shelley.Eras.ShelleyBasedEra
+    additionalGenesisConfig :: SL.AdditionalGenesisConfig era
+    additionalGenesisConfig = transCtxt
+
     maxMajorProtVer :: MaxMajorProtVer
     maxMajorProtVer = MaxMajorProtVer $ SL.pvMajor protVer
 
@@ -334,7 +347,7 @@ protocolInfoShelleyBased ProtocolParamsShelleyBased {
         shelleyLedgerTip        = Origin
       , shelleyLedgerState      =
           registerGenesisStaking (SL.sgStaking genesis) $
-            SL.initialState genesis ()
+            SL.initialState genesis additionalGenesisConfig
       , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
       }
 


### PR DESCRIPTION
Also bring back the dependency check on buildkite, which was removed
previously when we were using plutus that was not on master

Fixes https://github.com/input-output-hk/ouroboros-network/issues/3156

Co-authored-by: Javier Sagredo <javier.sagredo@iohk.io>