### PR TITLE
Fix signature of `Control.Monad.Class.MonadSTM.Strict.stateTVar`

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
@@ -138,10 +138,10 @@ writeTVar StrictTVar { tvar, invariant } !a =
 modifyTVar :: MonadSTM m => StrictTVar m a -> (a -> a) -> STM m ()
 modifyTVar v f = readTVar v >>= writeTVar v . f
 
-stateTVar :: MonadSTM m => StrictTVar m a -> (a -> (a, b)) -> STM m b
+stateTVar :: MonadSTM m => StrictTVar m s -> (s -> (a, s)) -> STM m a
 stateTVar v f = do
     a <- readTVar v
-    let (a', b) = f a
+    let (b, a') = f a
     writeTVar v a'
     return b
 
@@ -152,7 +152,7 @@ swapTVar v a' = do
     return a
 
 
-updateTVar :: MonadSTM m => StrictTVar m a -> (a -> (a, b)) -> STM m b
+updateTVar :: MonadSTM m => StrictTVar m s -> (s -> (a, s)) -> STM m a
 updateTVar = stateTVar
 {-# DEPRECATED updateTVar "Use stateTVar" #-}
 

--- a/network-mux/src/Network/Mux/DeltaQ/TraceStats.hs
+++ b/network-mux/src/Network/Mux/DeltaQ/TraceStats.hs
@@ -23,7 +23,7 @@ step :: RemoteClockModel        -- ^ Remote clock timestamp
      -> Int                     -- ^ the number of octets in the
                                 --   observed outcome
      -> StatsA                  -- ^ accumulation state
-     -> (StatsA, Maybe OneWayDeltaQSample)
+     -> (Maybe OneWayDeltaQSample, StatsA)
 step remoteTS localTS obsSize s
  | isNothing (referenceTimePoint s) -- first observation this sample period
    = step remoteTS localTS obsSize
@@ -37,11 +37,11 @@ step remoteTS localTS obsSize s
           Just a  -> a
           Nothing -> error "step: missing referenceTimePoint"
         transitTime       = calcTransitTime refTimePoint remoteTS localTS
-    in (recordObservation s localTS obsSize transitTime, Nothing)
+    in (Nothing, recordObservation s localTS obsSize transitTime)
  | otherwise                    -- need to start next sample period
   = let sample  = constructSample s
-        (s', _) = step remoteTS localTS obsSize initialStatsA
-    in (s', Just sample)
+        (_, s') = step remoteTS localTS obsSize initialStatsA
+    in (Just sample, s')
 
 -- Calculate the transit time by transforming the remotely reported
 -- emit time into local clock domain then calculating differences.

--- a/network-mux/src/Network/Mux/DeltaQ/TraceTransformer.hs
+++ b/network-mux/src/Network/Mux/DeltaQ/TraceTransformer.hs
@@ -52,7 +52,7 @@ dqTracer sTvar tr = Tracer go
          >>= traceWith tr . formatSample
 
     processSample s
-      = (initialStatsA, constructSample s)
+      = (constructSample s, initialStatsA)
 
     formatSample (OneWaySample {..})
       = MuxTraceRecvDeltaQSample duration sumPackets sumTotalSDU

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -361,10 +361,10 @@ instance MonadDelay (OverrideDelay (IOSim s)) where
         Nothing -> return ()
         Just t  -> setCurrentTime t
     where
-      nextDelay :: Schedule -> (Schedule, Maybe UTCTime)
+      nextDelay :: Schedule -> (Maybe UTCTime, Schedule)
       nextDelay = \case
-          Schedule []     -> (Schedule [], Nothing)
-          Schedule (t:ts) -> (Schedule ts, Just $ offsetToTime t)
+          Schedule []     -> (Nothing, Schedule [])
+          Schedule (t:ts) -> (Just $ offsetToTime t, Schedule ts)
 
       offsetToTime :: Fixed E1 -> UTCTime
       offsetToTime t = Time.addUTCTime (realToFrac t) dawnOfTime

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -373,7 +373,7 @@ run env@ChainDBEnv { varDB, .. } cmd =
 
     giveWithEq :: a -> m (WithEq a)
     giveWithEq a =
-      fmap (`WithEq` a) $ atomically $ stateTVar varNextId $ \i -> (succ i, i)
+      fmap (`WithEq` a) $ atomically $ stateTVar varNextId $ \i -> (i, succ i)
 
 runBgTasks :: IOLike m => ChainDB.Internal m blk -> m ()
 runBgTasks ChainDB.Internal{..} = do

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -4,7 +4,6 @@
 module Test.Ouroboros.Storage.ImmutableDB.Mock (openDBMock) where
 
 import           Data.Bifunctor (first)
-import           Data.Tuple (swap)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util ((...:), (.:))
@@ -55,7 +54,7 @@ openDBMock chunkInfo ccfg = do
         update_ f = atomically $ modifyTVar dbVar f
 
         update :: (DBModel blk -> (a, DBModel blk)) -> m a
-        update f = atomically $ stateTVar dbVar (swap . f)
+        update f = atomically $ stateTVar dbVar f
 
         updateE_ :: (DBModel blk -> Either (ImmutableDBError blk) (DBModel blk)) -> m ()
         updateE_ f = atomically $ do

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -268,7 +268,7 @@ run env@ImmutableDBEnv {
 
     giveWithEq :: a -> IO (WithEq a)
     giveWithEq a =
-      fmap (`WithEq` a) $ atomically $ stateTVar varNextId $ \i -> (succ i, i)
+      fmap (`WithEq` a) $ atomically $ stateTVar varNextId $ \i -> (i, succ i)
 
     streamAll :: ImmutableDB IO TestBlock -> IO [AllComponents TestBlock]
     streamAll db =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Follower.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Follower.hs
@@ -93,7 +93,7 @@ newFollower ::
   -> m (Follower m blk b)
 newFollower h registry blockComponent = getEnv h $ \CDB{..} -> do
     -- The following operations don't need to be done in a single transaction
-    followerKey  <- atomically $ stateTVar cdbNextFollowerKey $ \r -> (succ r, r)
+    followerKey  <- atomically $ stateTVar cdbNextFollowerKey $ \r -> (r, succ r)
     varFollower <- newTVarIO FollowerInit
     let followerHandle = mkFollowerHandle varFollower
     atomically $ modifyTVar cdbFollowers $ Map.insert followerKey followerHandle
@@ -498,7 +498,7 @@ forward registry varFollower blockComponent CDB{..} = \pts -> do
     updateState :: FollowerState m blk b -> m ()
     updateState newFollowerState = join $ atomically $
       stateTVar varFollower $ \followerState ->
-        (newFollowerState, ) $ case followerState of
+        (, newFollowerState) $ case followerState of
           -- Return a continuation (that we'll 'join') that closes the
           -- previous iterator.
           FollowerInImmutableDB _ immIt -> ImmutableDB.iteratorClose immIt

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -68,7 +68,6 @@ import           Data.Maybe (catMaybes, listToMaybe)
 import           Data.Proxy
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Tuple (swap)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (InspectHeapNamed (..), OnlyCheckWhnfNamed (..),
@@ -511,7 +510,7 @@ updateState :: forall m a. IOLike m
             -> State (RegistryState m) a
             -> m a
 updateState rr f =
-    atomically $ stateTVar (registryState rr) (swap . runState f)
+    atomically $ stateTVar (registryState rr) (runState f)
 
 -- | Attempt to allocate a resource in a registry which is closed
 --


### PR DESCRIPTION
This PR requires a careful review.  There are various places where
```
stateTVar :: MonadSTM m => StrictTVar m s -> (s -> (s, s)) -> STM m s
```
is used, and thus the change made is not visible in types.

`IOLike` module in consensus exports `Control.Monad.Class.MonadSTM.Strict` so
this inlucdes all the places in consensus which use it.

- io-sim-classes: fix type signature of `Strict.stateTVar`
- Updated call sites of `Strict.stateTVar`
