### PR TITLE
Incorporate Alonzo summands to CardanoBlock generators

### DIFF
--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -45,12 +45,13 @@ import           Test.Util.Serialisation.Roundtrip (SomeResult (..))
 import           Ouroboros.Consensus.Shelley.Protocol
                      (TPraosState (TPraosState))
 
-import           Test.Cardano.Ledger.Allegra.Examples.Consensus hiding
-                     (StandardAllegra)
-import           Test.Cardano.Ledger.Mary.Examples.Consensus hiding
-                     (StandardMary)
-import           Test.Shelley.Spec.Ledger.Examples.Consensus hiding
-                     (StandardShelley)
+import           Test.Cardano.Ledger.Allegra.Examples.Consensus
+                     (ledgerExamplesAllegra)
+import           Test.Cardano.Ledger.Mary.Examples.Consensus
+                     (ledgerExamplesMary)
+import           Test.Shelley.Spec.Ledger.Examples.Consensus
+                     (ShelleyLedgerExamples (..), ShelleyResultExamples (..),
+                     ledgerExamplesShelley, testShelleyGenesis)
 
 {-------------------------------------------------------------------------------
   Examples

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -39,7 +39,7 @@ import           Test.Cardano.Ledger.AllegraEraGen ()
 import           Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 import           Test.Cardano.Ledger.MaryEraGen ()
 import           Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
-import           Test.Consensus.Shelley.MockCrypto (CanMock, CanMockPreAlonzo)
+import           Test.Consensus.Shelley.MockCrypto (CanMock)
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as SL
 import           Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
 import           Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators
@@ -55,21 +55,21 @@ import           Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 
 -- | The upstream 'Arbitrary' instance for Shelley blocks does not generate
 -- coherent blocks, so neither does this.
-instance CanMockPreAlonzo era => Arbitrary (ShelleyBlock era) where
+instance CanMock era => Arbitrary (ShelleyBlock era) where
   arbitrary = mkShelleyBlock <$> arbitrary
 
 -- | This uses a different upstream generator to ensure the header and block
 -- body relate as expected.
-instance CanMockPreAlonzo era => Arbitrary (Coherent (ShelleyBlock era)) where
+instance CanMock era => Arbitrary (Coherent (ShelleyBlock era)) where
   arbitrary = Coherent . mkShelleyBlock <$> genCoherentBlock
 
-instance CanMockPreAlonzo era => Arbitrary (Header (ShelleyBlock era)) where
+instance CanMock era => Arbitrary (Header (ShelleyBlock era)) where
   arbitrary = getHeader <$> arbitrary
 
 instance SL.Mock c => Arbitrary (ShelleyHash c) where
   arbitrary = ShelleyHash <$> arbitrary
 
-instance CanMockPreAlonzo era => Arbitrary (GenTx (ShelleyBlock era)) where
+instance CanMock era => Arbitrary (GenTx (ShelleyBlock era)) where
   arbitrary = mkShelleyTx <$> arbitrary
 
 instance CanMock era => Arbitrary (GenTxId (ShelleyBlock era)) where

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
@@ -8,7 +8,6 @@
 module Test.Consensus.Shelley.MockCrypto (
     Block
   , CanMock
-  , CanMockPreAlonzo
   , MockCrypto
   , MockShelley
   ) where
@@ -24,7 +23,6 @@ import           Cardano.Ledger.Crypto (Crypto (..))
 import qualified Cardano.Ledger.Era as Core
 import           Control.State.Transition.Extended (PredicateFailure)
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BlockChain as SL
 import qualified Shelley.Spec.Ledger.Tx as SL (ValidateScript)
 
 import           Test.Cardano.Crypto.VRF.Fake (FakeVRF)
@@ -70,11 +68,5 @@ type CanMock era =
   , Arbitrary (Core.TxOut era)
   , Arbitrary (Core.Value era)
   , Arbitrary (PredicateFailure (SL.UTXOW era))
-  )
-
--- | A stronger 'CanMock' that is incompatible with Alonzo
-type CanMockPreAlonzo era =
-  ( CanMock era
-  , Core.TxSeq era ~ SL.TxSeq era
-  , Core.Witnesses era ~ SL.WitnessSet era
+  , Arbitrary (Core.Witnesses era)
   )


### PR DESCRIPTION
This PR builds on top of #3177. It will be set to merge into master once that one is already in.

Adresses the first bullet point in #3139.

Also `CanMockPreAlonzo` is now redundant so it was removed.