### PR TITLE
CAD-2907 blockfetch client:  add SendFetchRequest msg to TraceFetchClientState

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -190,6 +190,7 @@ blockFetchClient _version controlMessageSTM
                 Right lower = AF.last fragment
                 Right upper = AF.head fragment
 
+        traceWith tracer (SendFetchRequest fragment)
         return $
           SenderPipeline
             (ClientAgency TokIdle)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -370,6 +370,11 @@ data TraceFetchClientState header =
      | AcknowledgedFetchRequest
          (FetchRequest header)
 
+       -- | Mark the point when fetch request for a fragment is actually sent
+       -- over the wire.
+     | SendFetchRequest
+         (AnchoredFragment header)
+
        -- | Mark the start of receiving a streaming batch of blocks. This will
        -- be followed by one or more 'CompletedBlockFetch' and a final
        -- 'CompletedFetchBatch'.


### PR DESCRIPTION
A message to mark the point when a fragment request is actually sent to the peer.