### PR TITLE
io-sim-classes: missing api

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -285,6 +285,7 @@ instance MonadSTM IO where
   newTVarIO       = STM.newTVarIO
   newTMVarIO      = STM.newTMVarIO
   newEmptyTMVarIO = STM.newEmptyTMVarIO
+  newTBQueueIO    = STM.newTBQueueIO
 
 -- | noop instance
 --
@@ -328,6 +329,7 @@ instance MonadSTM m => MonadSTM (ReaderT r m) where
   newTVarIO       = lift . newTVarM
   newTMVarIO      = lift . newTMVarM
   newEmptyTMVarIO = lift   newEmptyTMVarM
+  newTBQueueIO    = lift . newTBQueueIO
 
 --
 -- Default TMVar implementation in terms of TVars (used by sim)

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -114,6 +114,9 @@ class ( Monad stm
   stateTVar    :: TVar_ stm s -> (s -> (a, s)) -> stm a
   stateTVar    = stateTVarDefault
 
+  swapTVar     :: TVar_ stm a -> a -> stm a
+  swapTVar     = swapTVarDefault
+
   check        :: Bool -> stm ()
   check True = return ()
   check _    = retry
@@ -161,6 +164,11 @@ stateTVarDefault var f = do
    writeTVar var s'
    return a
 
+swapTVarDefault :: MonadSTMTx stm => TVar_ stm a -> a -> stm a
+swapTVarDefault var new = do
+    old <- readTVar var
+    writeTVar var new
+    return old
 
 type TVar    m = TVar_    (STM m)
 type TMVar   m = TMVar_   (STM m)
@@ -176,13 +184,17 @@ class (Monad m, MonadSTMTx (STM m)) => MonadSTM m where
   -- Helpful derived functions with default implementations
 
   newTVarIO        :: a -> m (TVar  m a)
+  readTVarIO       :: TVar m a -> m a
   newTMVarIO       :: a -> m (TMVar m a)
   newEmptyTMVarIO  ::      m (TMVar m a)
+  newTQueueIO      :: m (TQueue m a)
   newTBQueueIO     :: Natural -> m (TBQueue m a)
 
   newTVarIO       = atomically . newTVar
+  readTVarIO      = atomically . readTVar
   newTMVarIO      = atomically . newTMVar
   newEmptyTMVarIO = atomically   newEmptyTMVar
+  newTQueueIO     = atomically newTQueue
   newTBQueueIO    = atomically . newTBQueue
 
 
@@ -247,6 +259,7 @@ instance MonadSTMTx STM.STM where
   modifyTVar     = STM.modifyTVar
   modifyTVar'    = STM.modifyTVar'
   stateTVar      = STM.stateTVar
+  swapTVar       = STM.swapTVar
   check          = STM.check
   newTMVar       = STM.newTMVar
   newEmptyTMVar  = STM.newEmptyTMVar
@@ -283,8 +296,10 @@ instance MonadSTM IO where
   atomically = wrapBlockedIndefinitely . STM.atomically
 
   newTVarIO       = STM.newTVarIO
+  readTVarIO      = STM.readTVarIO
   newTMVarIO      = STM.newTMVarIO
   newEmptyTMVarIO = STM.newEmptyTMVarIO
+  newTQueueIO     = STM.newTQueueIO
   newTBQueueIO    = STM.newTBQueueIO
 
 -- | noop instance
@@ -327,8 +342,10 @@ instance MonadSTM m => MonadSTM (ReaderT r m) where
   type STM (ReaderT r m) = STM m
   atomically      = lift . atomically
   newTVarIO       = lift . newTVarM
+  readTVarIO      = lift . readTVarIO
   newTMVarIO      = lift . newTMVarM
   newEmptyTMVarIO = lift   newEmptyTMVarM
+  newTQueueIO     = lift   newTQueueIO
   newTBQueueIO    = lift . newTBQueueIO
 
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -28,7 +28,6 @@ module Ouroboros.Consensus.Util.MonadSTM.StrictMVar (
   , StrictMVar (..)
   ) where
 
-import           Control.Concurrent.STM (readTVarIO)
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import qualified Control.Monad.Class.MonadSTM as Lazy

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -15,7 +15,6 @@ module Ouroboros.Consensus.Util.Orphans () where
 
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.Serialise (Serialise (..))
-import           Control.Concurrent.STM (readTVarIO)
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.IntPSQ (IntPSQ)
@@ -77,7 +76,7 @@ instance NoThunks a => NoThunks (StrictTVar IO a) where
   wNoThunks ctxt tv = do
       -- We can't use @atomically $ readTVar ..@ here, as that will lead to a
       -- "Control.Concurrent.STM.atomically was nested" exception.
-      a <- readTVarIO (toLazyTVar tv)
+      a <- readTVarIO tv
       noThunks ctxt a
 
 instance (NoThunks k, NoThunks v)


### PR DESCRIPTION
Fixes issue #3189.

- io-sim-classes: newTBQueueIO for IO and ReaderT instances
- io-sim-classes: added missing api
