### PR TITLE
FIXUP: ouroboros-consensus: using updated diffusion interface

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -385,7 +385,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
             ]
         , daMiniProtocolParameters = miniProtocolParams
         , daRethrowPolicy = consensusRethrowPolicy (Proxy @blk)
-        , daLocalRethrowPolicy = mempty
+        , daLocalRethrowPolicy = consensusRethrowPolicy (Proxy @blk)
         , daLedgerPeersCtx = LedgerPeersConsensusInterface (getPeersFromCurrentLedgerAfterSlot kernel)
         , daPeerMetrics = peerMetrics
         , daBlockFetchMode = getFetchMode (getChainDB kernel) btime


### PR DESCRIPTION
Local clients also need a rethrow policy to deal with db errors etc.