### PR TITLE
server2 iosim test

### DIFF
--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/IOSim.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/IOSim.hs
@@ -10,8 +10,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 
--- 'ShowProxy' instance for 'ReqResp' mini-protocol
-{-# OPTIONS_GHC -Wno-orphans        #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Test.Ouroboros.Network.IOSim
@@ -64,6 +62,8 @@ import           Network.TypedProtocol.ReqResp.Type
 import           Network.TypedProtocol.ReqResp.Client
 import           Network.TypedProtocol.ReqResp.Server
 
+import           Test.Ouroboros.Network.Orphans ()  -- ShowProxy ReqResp instance
+
 import           Test.QuickCheck hiding (Result (..))
 import           Test.QuickCheck.Instances.ByteString
 import           Test.Tasty (TestTree, testGroup)
@@ -102,9 +102,6 @@ pingClient = go True
     go !res []       = SendMsgDone (pure res)
     go !res (a : as) = SendMsgReq a $ \a' -> pure (go (a == a' && res) as)
 
-
-instance ShowProxy (ReqResp req resp) where
-    showProxy _ = "ReqResp"
 
 codecReqResp :: forall req resp m.
                 ( MonadST m

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -803,9 +803,9 @@ unidirectionalExperiment snocket socket clientAndServerData = do
                   )
             pure $
               foldr
-                (\(r, expected) acc ->
+                (\ (r, expected) acc ->
                   case r of
-                    Left _ -> acc
+                    Left err -> counterexample (show err) False
                     Right a -> a === expected .&&. acc)
                 (property True)
                 $ zip rs (expectedResult clientAndServerData clientAndServerData)
@@ -926,17 +926,17 @@ bidirectionalExperiment
 
               pure $
                 foldr
-                  (\(r, expected) acc ->
+                  (\ (r, expected) acc ->
                     case r of
-                      Left _ -> acc
+                      Left err -> counterexample (show err) False
                       Right a -> a === expected .&&. acc)
                   (property True)
                   (zip rs0 (expectedResult clientAndServerData0 clientAndServerData1))
                 .&&.
                 foldr
-                  (\(r, expected) acc ->
+                  (\ (r, expected) acc ->
                     case r of
-                      Left _ -> acc
+                      Left err -> counterexample (show err) False
                       Right a -> a === expected .&&. acc)
                   (property True)
                   (zip rs1 (expectedResult clientAndServerData1 clientAndServerData0))

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -31,7 +31,7 @@ import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 
 import           Codec.Serialise.Class (Serialise)
 import           Data.ByteString.Lazy (ByteString)
-import           Data.Functor (($>))
+import           Data.Functor (($>), (<&>))
 import           Data.List (mapAccumL)
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Typeable (Typeable)
@@ -144,6 +144,13 @@ instance ( Arbitrary req
                           <*> arbitraryList
                           <*> arbitraryList
 
+    shrink (ClientAndServerData fun ini hot warm est) = concat
+      [ shrink fun  <&> \ fun'  -> ClientAndServerData fun' ini  hot  warm  est
+      , shrink ini  <&> \ ini'  -> ClientAndServerData fun  ini' hot  warm  est
+      , shrink hot  <&> \ hot'  -> ClientAndServerData fun  ini  hot' warm  est
+      , shrink warm <&> \ warm' -> ClientAndServerData fun  ini  hot  warm' est
+      , shrink est  <&> \ est'  -> ClientAndServerData fun  ini  hot  warm  est'
+      ]
 
 expectedResult :: ClientAndServerData req resp acc
                -> ClientAndServerData req resp acc

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -27,15 +28,19 @@ import qualified Control.Monad.Class.MonadSTM as LazySTM
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
+import           Control.Monad.IOSim
 import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 
 import           Codec.Serialise.Class (Serialise)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Functor (($>), (<&>))
-import           Data.List (mapAccumL)
+import           Data.List (mapAccumL, intercalate)
 import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.Maybe (fromMaybe)
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
+
+import           Text.Printf
 
 import           Test.QuickCheck
 import           Test.Tasty.QuickCheck
@@ -57,6 +62,7 @@ import           Ouroboros.Network.ConnectionManager.Core
 import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.ConnectionManager.Types
 import           Ouroboros.Network.IOManager
+import           Ouroboros.Network.IOSim
 import qualified Ouroboros.Network.InboundGovernor.ControlChannel as Server
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.MuxMode
@@ -70,19 +76,21 @@ import           Ouroboros.Network.Server2 (ServerArguments (..))
 import qualified Ouroboros.Network.Server2 as Server
 import           Ouroboros.Network.Snocket (Snocket, socketSnocket)
 import qualified Ouroboros.Network.Snocket as Snocket
-import qualified Debug.Trace as Debug
 
 import           Test.Ouroboros.Network.Orphans ()  -- ShowProxy ReqResp instance
+import           Test.Ouroboros.Network.IOSim (NonFailingBearerInfoScript(..), toBearerInfo)
 
 tests :: TestTree
 tests =
   testGroup "Ouroboros.Network.Server2"
-  [ testProperty "unidirectional_IO" prop_unidirectional_IO
-  , testProperty "bidirectional_IO"  prop_bidirectional_IO
+  [ testProperty "unidirectional_IO"  prop_unidirectional_IO
+  , testProperty "unidirectional_Sim" prop_unidirectional_Sim
+  , testProperty "bidirectional_IO"   prop_bidirectional_IO
+  , testProperty "bidirectional_Sim"  prop_bidirectional_Sim
   ]
 
 --
--- Server tests (IO only)
+-- Server tests
 --
 
 -- | The protocol will run three instances of  `ReqResp` protocol; one for each
@@ -301,9 +309,7 @@ withInitiatorOnlyConnectionManager
                     <> assertRethrowPolicy))
       (\_ -> HandshakeFailure)
       NotInResponderMode
-      (\cm ->
-        k cm `catch` \(e :: SomeException) -> Debug.traceShowM e
-                                           >> throwIO e)
+      k
   where
     clientMiniProtocolBundle :: Mux.MiniProtocolBundle InitiatorMode
     clientMiniProtocolBundle = Mux.MiniProtocolBundle
@@ -385,7 +391,7 @@ withInitiatorOnlyConnectionManager
                   (reqs : rest) -> do
                     writeTVar requestsVar rest $> reqs
                   [] -> pure []
-            pure $ 
+            pure $
               reqRespClientPeer (reqRespClientMap reqs)))
 
 
@@ -400,7 +406,7 @@ timeWaitTimeout :: DiffTime
 timeWaitTimeout = 0.1
 
 
--- 
+--
 -- Rethrow policies
 --
 
@@ -516,7 +522,7 @@ withBidirectionalConnectionManager name snocket socket localAddress
               haHandshakeCodec = unversionedHandshakeCodec,
               haVersionDataCodec = cborTermVersionDataCodec unversionedProtocolDataCodec,
               haVersions = unversionedProtocol
-                            (serverApplication 
+                            (serverApplication
                               hotRequestsVar
                               warmRequestsVar
                               establishedRequestsVar),
@@ -657,7 +663,7 @@ withBidirectionalConnectionManager name snocket socket localAddress
                   (reqs : rest) -> do
                     writeTVar requestsVar rest $> reqs
                   [] -> pure []
-            pure $ 
+            pure $
               reqRespClientPeer
               (reqRespClientMap reqs)))
         (MuxPeer
@@ -817,6 +823,18 @@ unidirectionalExperiment snocket socket clientAndServerData = do
                 (property True)
                 $ zip rs (expectedResult clientAndServerData clientAndServerData)
 
+prop_unidirectional_Sim :: ClientAndServerData Int Int Int -> Property
+prop_unidirectional_Sim clientAndServerData =
+  simulatedPropertyWithTimeout 7200 $ do
+    net   <- newNetworkState (singletonScript noAttenuation) 10
+    let snock = mkSnocket net debugTracer
+    fd <- Snocket.open snock Snocket.TestFamily
+    Snocket.bind   snock fd serverAddr
+    Snocket.listen snock fd
+    unidirectionalExperiment snock fd clientAndServerData
+  where
+    serverAddr = Snocket.TestAddress (0 :: Int)
+
 prop_unidirectional_IO
   :: ClientAndServerData Int Int Int
   -> Property
@@ -950,6 +968,26 @@ bidirectionalExperiment
                 ))
 
 
+prop_bidirectional_Sim :: NonFailingBearerInfoScript -> ClientAndServerData Int Int Int -> ClientAndServerData Int Int Int -> Property
+prop_bidirectional_Sim (NonFailingBearerInfoScript script) data0 data1 =
+  simulatedPropertyWithTimeout 7200 $ do
+    net <- newNetworkState script' 10
+    let snock = mkSnocket net debugTracer
+    bracket ((,) <$> Snocket.open snock Snocket.TestFamily
+                 <*> Snocket.open snock Snocket.TestFamily)
+            (\ (socket0, socket1) -> Snocket.close snock socket0 >>
+                                     Snocket.close snock socket1)
+      $ \ (socket0, socket1) -> do
+        let addr0 = Snocket.TestAddress (0 :: Int)
+            addr1 = Snocket.TestAddress 1
+        Snocket.bind   snock socket0 addr0
+        Snocket.bind   snock socket1 addr1
+        Snocket.listen snock socket0
+        Snocket.listen snock socket1
+        bidirectionalExperiment snock socket0 socket1 addr0 addr1 data0 data1
+  where
+    script' = toBearerInfo <$> script
+
 prop_bidirectional_IO
     :: ClientAndServerData Int Int Int
     -> ClientAndServerData Int Int Int
@@ -1033,7 +1071,26 @@ withLock :: ( MonadSTM   m
          => StrictTMVar m ()
          -> m a
          -> m a
-withLock v m = 
+withLock v m =
     bracket (atomically $ takeTMVar v)
             (atomically . putTMVar v)
             (const m)
+
+simulatedPropertyWithTimeout :: DiffTime -> (forall s. IOSim s Property) -> Property
+simulatedPropertyWithTimeout t test =
+  counterexample ("\nTrace:\n" ++ ppTrace tr) $
+  case traceResult False tr of
+    Left failure ->
+      counterexample ("Failure:\n" ++ displayException failure) False
+    Right prop -> fromMaybe (counterexample "timeout" $ property False) prop
+  where
+    tr = runSimTrace $ timeout t test
+
+ppTrace :: Trace a -> String
+ppTrace tr = intercalate "\n" $ map fmt events
+  where
+    events = traceEvents tr
+    w      = maximum [ length name | (_, _, Just name, _) <- events ]
+
+    fmt (t, tid, lbl, e) = printf "%-10s - %-13s %-*s - %s" (show t) (show tid) w (fromMaybe "" lbl) (show e)
+

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -11,8 +11,6 @@
 
 -- just to use 'debugTracer'
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
--- `ShowProxy (ReqResp req resp)` is an orphaned instance
-{-# OPTIONS_GHC -Wno-orphans               #-}
 
 module Test.Ouroboros.Network.Server2
   ( tests
@@ -47,7 +45,6 @@ import qualified Network.Mux as Mux
 import qualified Network.Socket as Socket
 import           Network.TypedProtocol.Core
 
-import           Network.TypedProtocol.ReqResp.Type (ReqResp)
 import           Network.TypedProtocol.ReqResp.Codec.CBOR
 import           Network.TypedProtocol.ReqResp.Client
 import           Network.TypedProtocol.ReqResp.Server
@@ -73,9 +70,9 @@ import           Ouroboros.Network.Server2 (ServerArguments (..))
 import qualified Ouroboros.Network.Server2 as Server
 import           Ouroboros.Network.Snocket (Snocket, socketSnocket)
 import qualified Ouroboros.Network.Snocket as Snocket
-import           Ouroboros.Network.Util.ShowProxy
 import qualified Debug.Trace as Debug
 
+import           Test.Ouroboros.Network.Orphans ()  -- ShowProxy ReqResp instance
 
 tests :: TestTree
 tests =
@@ -83,9 +80,6 @@ tests =
   [ testProperty "unidirectional_IO" prop_unidirectional_IO
   , testProperty "bidirectional_IO"  prop_bidirectional_IO
   ]
-
-instance ShowProxy (ReqResp req resp) where
-    showProxy _ = "ReqResp"
 
 --
 -- Server tests (IO only)


### PR DESCRIPTION
- get ShowProxy instance from Orphans module
- Add NonFailingBearerInfoScript
- server2 test: fail property if protocol does not complete
- server2 test: shrink ClientAndServerData
- server2 test: IOSim versions of existing IO properties
