### PR TITLE
Extra queries needed for CLI automation

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -354,10 +354,10 @@ pattern CardanoNodeToClientVersion7 =
     HardForkNodeToClientEnabled
       HardForkSpecificNodeToClientVersion2
       (  EraNodeToClientEnabled ByronNodeToClientVersion1
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion3
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion3
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion3
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion3
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion4
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion4
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion4
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion4
       :* Nil
       )
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -99,7 +99,7 @@ instance SerialiseNodeToNode (MockBlock ext) (GenTxId (MockBlock ext))
   possible.
 -------------------------------------------------------------------------------}
 
-instance Serialise ext => SerialiseNodeToClientConstraints (MockBlock ext)
+instance (Serialise ext, Typeable ext) => SerialiseNodeToClientConstraints (MockBlock ext)
 
 instance Serialise ext => SerialiseNodeToClient (MockBlock ext) (MockBlock ext) where
   encodeNodeToClient _ _ = defaultEncodeCBORinCBOR

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -24,6 +24,9 @@ data ShelleyNodeToClientVersion =
 
     -- | New query introduced
   | ShelleyNodeToClientVersion3
+
+    -- | New queries introduced
+  | ShelleyNodeToClientVersion4
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 instance HasNetworkProtocolVersion (ShelleyBlock era) where

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -354,6 +354,7 @@ querySupportedVersion = \case
     v1 = ShelleyNodeToClientVersion1
     v2 = ShelleyNodeToClientVersion2
     v3 = ShelleyNodeToClientVersion3
+    v4 = ShelleyNodeToClientVersion4
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -65,6 +65,8 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Proxy
+import           Data.Time.Calendar (fromGregorian)
+import           Data.Time.Clock (UTCTime (..))
 import           Data.Tree (Tree (..))
 import qualified Data.Tree as Tree
 import           Data.TreeDiff (ToExpr)
@@ -76,6 +78,7 @@ import           Test.QuickCheck hiding (Result)
 
 import           Cardano.Crypto.DSIGN
 
+import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Network.MockChain.Chain (Chain (..))
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
@@ -250,6 +253,15 @@ data instance StorageConfig TestBlock = TestBlockStorageConfig
 
 instance HasNetworkProtocolVersion TestBlock where
   -- Use defaults
+
+instance ConfigSupportsNode TestBlock where
+  getSystemStart = const (SystemStart dummyDate)
+    where
+      --  This doesn't matter much
+      dummyDate = UTCTime (fromGregorian 2019 8 13) 0
+
+  getNetworkMagic = const (NetworkMagic 42)
+
 
 {-------------------------------------------------------------------------------
   NestedCtxt

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
@@ -814,7 +814,7 @@ hardForkEpochInfo ArbitraryChain{..} for =
                                  tickedHardForkLedgerViewTransition
                                  tickedHardForkLedgerViewPerEra
            in (
-             HF.toPureEpochInfo (HF.snapshotEpochInfo reconstructed)
+             HF.toPureEpochInfo (HF.summaryToEpochInfo reconstructed)
            , show view
            , show reconstructed
            )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -153,7 +153,7 @@ epochInfoLedger :: All SingleEraBlock xs
                 -> HardForkState LedgerState xs
                 -> EpochInfo (Except PastHorizonException)
 epochInfoLedger cfg st =
-    History.snapshotEpochInfo $
+    History.summaryToEpochInfo $
       reconstructSummaryLedger cfg st
 
 -- | Construct 'EpochInfo' given precomputed 'TransitionInfo'
@@ -163,7 +163,7 @@ epochInfoPrecomputedTransitionInfo ::
   -> HardForkState f xs
   -> EpochInfo (Except PastHorizonException)
 epochInfoPrecomputedTransitionInfo shape transition st =
-    History.snapshotEpochInfo $
+    History.summaryToEpochInfo $
       reconstructSummary shape transition st
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
@@ -6,7 +6,6 @@
 
 module Ouroboros.Consensus.HardFork.History.Caching (
     RunWithCachedSummary (..)
-  , cachedRunQueryThrow
   , runWithCachedSummary
   ) where
 
@@ -29,18 +28,9 @@ data RunWithCachedSummary (xs :: [Type]) m = RunWithCachedSummary {
       -- internal state (compute a new summary) and try again. If that /still/
       -- fails, the 'PastHorizonException' is returned.
       --
-      -- See also 'cachedRunQueryThrow'.
       cachedRunQuery :: forall a. Qry a
                      -> STM m (Either PastHorizonException a)
     }
-
--- | Wrapper around 'cachedRunQuery' which throws the 'PastHorizonException'
---
--- This is useful for callers who know that their queries should not be past
--- the horizon (and it would be a bug if they were).
-cachedRunQueryThrow :: (MonadSTM m, MonadThrow (STM m))
-                    => RunWithCachedSummary xs m -> Qry a -> STM m a
-cachedRunQueryThrow run qry = either throwIO return =<< cachedRunQuery run qry
 
 -- | Construct 'RunWithCachedSummary' given action that computes the summary
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
@@ -5,7 +5,7 @@
 -- | Derive 'EpochInfo'
 module Ouroboros.Consensus.HardFork.History.EpochInfo (
     dummyEpochInfo
-  , snapshotEpochInfo
+  , summaryToEpochInfo
   , toPureEpochInfo
   ) where
 
@@ -26,8 +26,8 @@ import           Ouroboros.Consensus.HardFork.History.Summary
 --
 -- When a particular request fails with a 'PastHorizon' error, we throw the
 -- error as a /pure/ exception. Such an exception would indicate a bug.
-snapshotEpochInfo :: forall xs. Summary xs -> EpochInfo (Except PastHorizonException)
-snapshotEpochInfo summary = EpochInfo {
+summaryToEpochInfo :: forall xs. Summary xs -> EpochInfo (Except PastHorizonException)
+summaryToEpochInfo summary = EpochInfo {
       epochInfoSize_  = \e -> runQuery' (epochToSize  e)
     , epochInfoFirst_ = \e -> runQuery' (epochToSlot' e)
     , epochInfoEpoch_ = \s -> runQuery' (fst <$> slotToEpoch' s)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes            #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE UndecidableInstances  #-}
 module Ouroboros.Consensus.Ledger.Query (
     BlockQuery
+  , ConfigSupportsNode (..)
   , Query (..)
   , QueryLedger (..)
   , QueryVersion (..)
@@ -20,15 +22,22 @@ module Ouroboros.Consensus.Ledger.Query (
   , queryEncodeNodeToClient
   ) where
 
-import           Codec.CBOR.Decoding
-import           Codec.CBOR.Encoding
+import           Control.Exception (Exception, throw)
 import           Data.Kind (Type)
 import           Data.Maybe (isJust)
+import           Data.Typeable (Typeable)
+
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import           Codec.CBOR.Decoding
+import           Codec.CBOR.Encoding
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
                      (ShowQuery (..))
 
 import           Ouroboros.Consensus.Block.Abstract (CodecConfig)
+import           Ouroboros.Consensus.BlockchainTime (SystemStart)
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query.Version
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -44,26 +53,53 @@ import           Ouroboros.Consensus.Util.DepPair
 
 -- | Different queries supported by the ledger for all block types, indexed
 -- by the result type.
-data Query blk result
-  = BlockQuery (BlockQuery blk result)
-  -- ^ This constructor is supported by all @QueryVersion@s. The @BlockQuery@
+--
+-- Additions to the set of queries is versioned by 'QueryVersion'
+data Query blk result where
+  -- | This constructor is supported by all @QueryVersion@s. The @BlockQuery@
   -- argument is versioned by the @BlockNodeToClientVersion blk@.
+  BlockQuery :: BlockQuery blk result -> Query blk result
+
+  -- | Get the 'SystemStart' time.
+  --
+  -- Supported by 'QueryVersion' >= 'QueryVersion1'.
+  GetSystemStart :: Query blk SystemStart
 
 instance (ShowProxy (BlockQuery blk)) => ShowProxy (Query blk) where
   showProxy (Proxy :: Proxy (Query blk)) = "Query (" ++ showProxy (Proxy @(BlockQuery blk)) ++ ")"
 
 instance (ShowQuery (BlockQuery blk)) => ShowQuery (Query blk) where
   showResult (BlockQuery blockQuery) = showResult blockQuery
+  showResult GetSystemStart          = show
 
 instance Eq (SomeSecond BlockQuery blk) => Eq (SomeSecond Query blk) where
   SomeSecond (BlockQuery blockQueryA) == SomeSecond (BlockQuery blockQueryB)
     = SomeSecond blockQueryA == SomeSecond blockQueryB
+  SomeSecond (BlockQuery _) == _ = False
+
+  SomeSecond GetSystemStart == SomeSecond GetSystemStart = True
+  SomeSecond GetSystemStart == _                         = False
 
 instance Show (SomeSecond BlockQuery blk) => Show (SomeSecond Query blk) where
   show (SomeSecond (BlockQuery blockQueryA)) = "Query " ++ show (SomeSecond blockQueryA)
+  show (SomeSecond GetSystemStart) = "Query GetSystemStart"
+
+
+-- | Exception thrown in the encoders
+data QueryEncoderException blk =
+    -- | A query was submitted that is not supported by the given 'QueryVersion'
+    QueryEncoderUnsupportedQuery
+         (SomeSecond Query blk)
+         QueryVersion
+
+deriving instance Show (SomeSecond BlockQuery blk) => Show (QueryEncoderException blk)
+instance (Typeable blk, Show (SomeSecond BlockQuery blk)) => Exception (QueryEncoderException blk)
 
 queryEncodeNodeToClient ::
-     forall blk. SerialiseNodeToClient blk (SomeSecond BlockQuery blk)
+     forall blk.
+     Typeable blk
+  => Show (SomeSecond BlockQuery blk)
+  => SerialiseNodeToClient blk (SomeSecond BlockQuery blk)
   => CodecConfig blk
   -> QueryVersion
   -> BlockNodeToClientVersion blk
@@ -71,20 +107,38 @@ queryEncodeNodeToClient ::
   -> Encoding
 queryEncodeNodeToClient codecConfig queryVersion blockVersion (SomeSecond query)
   = case queryVersion of
-    TopLevelQueryDisabled -> encodeBlockQuery
-      (case query of
-        BlockQuery blockQuery -> blockQuery
-      )
+
+    -- In "version 0" we only support BlockQuery and add no extra wrapping so
+    -- that it's backwards compatible with when there were no top level queries.
+    TopLevelQueryDisabled ->
+      case query of
+        BlockQuery blockQuery ->
+          encodeBlockQuery blockQuery
+        _ ->
+          throw $ QueryEncoderUnsupportedQuery (SomeSecond query) queryVersion
+
+    -- From version 1 onwards, we use normal constructor tags
+    QueryVersion1 ->
+      case query of
+        BlockQuery blockQuery ->
+            encodeListLen 2
+         <> encodeWord8 0
+         <> encodeBlockQuery blockQuery
+        GetSystemStart ->
+            encodeListLen 1
+         <> encodeWord8 1
   where
-    encodeBlockQuery blockQuery = encodeNodeToClient
-      @blk
-      @(SomeSecond BlockQuery blk)
-      codecConfig
-      blockVersion
-      (SomeSecond blockQuery)
+    encodeBlockQuery blockQuery =
+      encodeNodeToClient
+        @blk
+        @(SomeSecond BlockQuery blk)
+        codecConfig
+        blockVersion
+        (SomeSecond blockQuery)
 
 queryDecodeNodeToClient ::
-     forall blk. SerialiseNodeToClient blk (SomeSecond BlockQuery blk)
+     forall blk.
+     SerialiseNodeToClient blk (SomeSecond BlockQuery blk)
   => CodecConfig blk
   -> QueryVersion
   -> BlockNodeToClientVersion blk
@@ -92,6 +146,13 @@ queryDecodeNodeToClient ::
 queryDecodeNodeToClient codecConfig queryVersion blockVersion
   = case queryVersion of
       TopLevelQueryDisabled -> decodeBlockQuery
+      QueryVersion1 -> do
+        size <- decodeListLen
+        tag  <- decodeWord8
+        case (size, tag) of
+          (2, 0) -> decodeBlockQuery
+          (1, 1) -> return (SomeSecond GetSystemStart)
+          _      -> fail $ "Query: invalid size and tag" <> show (size, tag)
   where
     decodeBlockQuery = do
       SomeSecond blockQuery <- decodeNodeToClient
@@ -104,20 +165,36 @@ queryDecodeNodeToClient codecConfig queryVersion blockVersion
 instance SerialiseResult blk (BlockQuery blk) => SerialiseResult blk (Query blk) where
   encodeResult codecConfig blockVersion (BlockQuery blockQuery) result
     = encodeResult codecConfig blockVersion blockQuery result
+  encodeResult _ _ GetSystemStart result
+    = toCBOR result
 
   decodeResult codecConfig blockVersion (BlockQuery query)
     = decodeResult codecConfig blockVersion query
+  decodeResult _ _ GetSystemStart
+    = fromCBOR
 
 instance SameDepIndex (BlockQuery blk) => SameDepIndex (Query blk) where
   sameDepIndex (BlockQuery blockQueryA) (BlockQuery blockQueryB)
     = sameDepIndex blockQueryA blockQueryB
+  sameDepIndex (BlockQuery _) _
+    = Nothing
+  sameDepIndex GetSystemStart GetSystemStart
+    = Just Refl
+  sameDepIndex GetSystemStart _
+    = Nothing
 
 deriving instance Show (BlockQuery blk result) => Show (Query blk result)
 
 -- | Answer the given query about the extended ledger state.
-answerQuery :: QueryLedger blk => ExtLedgerCfg blk -> Query blk result -> ExtLedgerState blk -> result
+answerQuery ::
+     (QueryLedger blk, ConfigSupportsNode blk)
+  => ExtLedgerCfg blk
+  -> Query blk result
+  -> ExtLedgerState blk
+  -> result
 answerQuery cfg query st = case query of
   BlockQuery blockQuery -> answerBlockQuery cfg blockQuery st
+  GetSystemStart -> getSystemStart (topLevelConfigBlock (getExtLedgerCfg cfg))
 
 -- | Different queries supported by the ledger, indexed by the result type.
 data family BlockQuery blk :: Type -> Type

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query/Version.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query/Version.hs
@@ -8,8 +8,15 @@ import           Ouroboros.Network.NodeToClient.Version
 
 -- | Version of the `Query blk` type.
 data QueryVersion
+    -- | Only the 'BlockQuery' constructor of 'Query' is supported. The binary
+    -- encoding is backwards compatible: it does not introduce any constructor
+    -- tag around the 'BlockQuery'.
   = TopLevelQueryDisabled
-  -- ^ Only the @BlockQuery@ constructor of @Query@ is supported.
+
+    -- | Multiple top level queries are now supported. The encoding now has
+    -- constructor tags for the different top level queries. Specifically V1
+    -- adds support for 'GetSystemStart'.
+  | QueryVersion1
   deriving (Eq, Ord, Enum, Bounded, Show)
 
 -- | Get the @QueryVersion@ supported by this @NodeToClientVersion@.
@@ -23,4 +30,4 @@ nodeToClientVersionToQueryVersion x = case x of
   NodeToClientV_6 -> TopLevelQueryDisabled
   NodeToClientV_7 -> TopLevelQueryDisabled
   NodeToClientV_8 -> TopLevelQueryDisabled
-  NodeToClientV_9 -> TopLevelQueryDisabled
+  NodeToClientV_9 -> QueryVersion1

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -13,7 +13,7 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Util.IOLike
 
 localStateQueryServer ::
-     forall m blk. (IOLike m, QueryLedger blk)
+     forall m blk. (IOLike m, QueryLedger blk, ConfigSupportsNode blk)
   => ExtLedgerCfg blk
   -> STM m (Point blk)
      -- ^ Get tip point

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -103,6 +103,7 @@ mkHandlers
      , LedgerSupportsMempool blk
      , LedgerSupportsProtocol blk
      , QueryLedger blk
+     , ConfigSupportsNode blk
      )
   => NodeKernelArgs m remotePeer localPeer blk
   -> NodeKernel     m remotePeer localPeer blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -17,6 +17,8 @@ module Ouroboros.Consensus.Node.Run (
   , RunNode
   ) where
 
+import           Data.Typeable (Typeable)
+
 import           Ouroboros.Network.Block (Serialised)
 
 import           Ouroboros.Consensus.Block
@@ -64,7 +66,8 @@ class ( ConvertRawHash blk
   estimateBlockSize :: Header blk -> SizeInBytes
 
 -- | Serialisation constraints needed by the node-to-client protocols
-class ( ConvertRawHash blk
+class ( Typeable blk
+      , ConvertRawHash blk
       , SerialiseNodeToClient blk blk
       , SerialiseNodeToClient blk (Serialised blk)
       , SerialiseNodeToClient blk (GenTx blk)


### PR DESCRIPTION
This implements a number of extra queries for the local state query protocol. The intended use case of these queries is for the new API & CLI functionality to help automate the construction of transactions involving scripts. This automation uses ledger functions that need a small selection of ledger state.

In particular it needs:
1. the subset of the UTxO that the transaction intends to spend.
2. the set of stake pool ids, because if a pool is registered already or not affects the fees (admittedly it is a bit of a wart that this is not explicit in the tx)
3. enough time information to convert the tx validity interval from slots into utc time

For 1 we add `GetUTxOByTxIn`. For 2 we add `GetStakePools` and while we're at it we also add `GetStakePoolParams`. For 3 we add `GetSystemStart` and a new utility conversion function `interpreterToEpochInfo`.

The `GetSystemStart` is a new top level query, so this exercises the recently added scheme for supporting top level queries..