### PR TITLE
CAD-2918 model simulataneous open in sim-net

### DIFF
--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -209,6 +209,7 @@ runMux tracer Mux {muxMiniProtocols, muxControlCmdQueue, muxStatus} bearer = do
 miniProtocolJob
   :: forall mode m.
      ( MonadSTM m
+     , MonadThread m
      , MonadThrow (STM m)
      )
   => Tracer m MuxTrace
@@ -232,7 +233,9 @@ miniProtocolJob tracer egressQueue
                 (show miniProtocolNum ++ "." ++ show miniProtocolDirEnum)
   where
     jobAction = do
-      w       <- newTVarIO BL.empty
+      labelThisThread (case miniProtocolNum of
+                        MiniProtocolNum a -> "prtcl-" ++ show a)
+      w <- newTVarIO BL.empty
       let chan = muxChannel tracer egressQueue (Wanton w)
                            miniProtocolNum miniProtocolDirEnum
                            miniProtocolIngressQueue

--- a/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
+++ b/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
@@ -77,7 +77,9 @@ readQueueChannelSTM :: ( MonadSTM        m
 readQueueChannelSTM QueueChannel { qcRead } = do
     a <- readTVar qcRead >>= traverse readTQueue
     case a of
-      Nothing           -> throwSTM (resourceVanishedIOError "sim.readQueueChannel")
+      Nothing           -> throwSTM (resourceVanishedIOError
+                                      "AttenuatedChannel.readQueueChannel"
+                                      "channel vanished")
       Just msg@MsgClose -> writeTVar qcRead Nothing
                         >> return msg
       Just msg          -> return msg
@@ -192,7 +194,8 @@ newAttenuatedChannel tr Attenuation { aReadAttenuation
 
             ( d, Failure ) -> threadDelay d
                            >> throwIO (resourceVanishedIOError
-                                        "AttenuatedChannel.read")
+                                        "AttenuatedChannel.read"
+                                        "read attenuation")
 
     acWrite :: StrictTVar m Int
             -> BL.ByteString
@@ -205,12 +208,13 @@ newAttenuatedChannel tr Attenuation { aReadAttenuation
         Just limit  | wCount >= limit
                    -> throwIO $
                         resourceVanishedIOError
-                          "AttenuatedChannel.write: write limit reached"
+                          "AttenuatedChannel.write"
+                          "write limit reached (write attenuation)"
         _          -> return ()
 
       sent <- writeQueueChannel qc (MsgBytes bs)
       when (not sent) $
-        throwIO (resourceVanishedIOError "AttenuatedChannel.write")
+        throwIO (resourceVanishedIOError "AttenuatedChannel.write" "")
 
     acClose :: m ()
     acClose = do
@@ -319,12 +323,12 @@ data AttenuatedChannelTrace =
 -- Utils
 --
 
-resourceVanishedIOError :: String -> IOError
-resourceVanishedIOError ioe_location = IOError
+resourceVanishedIOError :: String -> String -> IOError
+resourceVanishedIOError ioe_location ioe_description = IOError
   { ioe_handle      = Nothing
   , ioe_type        = ResourceVanished
   , ioe_location
-  , ioe_description = ""
+  , ioe_description
   , ioe_errno       = Nothing
   , ioe_filename    = Nothing
   }

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
@@ -45,6 +47,9 @@ import           Data.Functor (void)
 import           Data.Ix (Ix (..))
 import           Data.Word
 import qualified Data.ByteString.Lazy as BL
+import           Quiet
+
+import           GHC.Generics (Generic)
 
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadSTM.Strict (StrictTVar)
@@ -217,7 +222,8 @@ data MuxBearer m = MuxBearer {
     }
 
 newtype SDUSize = SDUSize { getSDUSize :: Word16 }
-  deriving Show
+  deriving Generic
+  deriving Show via Quiet SDUSize
 
 -- | A channel which wraps each message as an 'MuxSDU' using giving
 -- 'MiniProtocolNum' and 'MiniProtocolDir'.

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -58,7 +58,6 @@ library
                        Ouroboros.Network.Server.RateLimiting
                        Ouroboros.Network.Server2
                        Ouroboros.Network.Snocket
-                       Ouroboros.Network.IOSim
                        Ouroboros.Network.Socket
 
                        Ouroboros.Network.Subscription
@@ -68,6 +67,8 @@ library
                        Ouroboros.Network.Subscription.PeerState
                        Ouroboros.Network.Subscription.Subscriber
                        Ouroboros.Network.Subscription.Worker
+
+                       Simulation.Network.Snocket
 
   other-modules:       Ouroboros.Network.Linger
   -- other-extensions:
@@ -131,7 +132,7 @@ test-suite test
                        Test.Ouroboros.Network.Socket
                        Test.Ouroboros.Network.Subscription
                        Test.Ouroboros.Network.RateLimiting
-                       Test.Ouroboros.Network.IOSim
+                       Test.Simulation.Network.Snocket
 
   build-depends:       base
                      , bytestring

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -21,6 +21,7 @@ extra-source-files:  CHANGELOG.md
 
 library
   exposed-modules:     Data.Monoid.Synchronisation
+                       Data.Wedge
                        Data.Cache
                        Ouroboros.Network.Codec
                        Ouroboros.Network.CodecCBORTerm

--- a/ouroboros-network-framework/src/Data/Wedge.hs
+++ b/ouroboros-network-framework/src/Data/Wedge.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveFunctor  #-}
+{-# LANGUAGE DeriveFoldable #-}
+
+module Data.Wedge where
+
+import           Control.Monad (ap)
+
+import           Data.Bifunctor
+import           Data.Bifoldable
+import           Data.Bitraversable
+
+-- | A wedge product
+-- <https://hackage.haskell.org/package/smash/docs/Data-Wedge.html#t:Wedge>
+--
+data Wedge a b =
+    Nowhere
+  | Here a
+  | There b
+  deriving (Eq, Ord, Foldable, Functor, Show)
+
+instance Bifunctor Wedge where
+    bimap _ _ Nowhere   = Nowhere
+    bimap f _ (Here a)  = Here  (f a)
+    bimap _ g (There b) = There (g b)
+
+instance Bifoldable Wedge where
+    bifoldMap _ _ Nowhere   = mempty
+    bifoldMap f _ (Here a)  = f a
+    bifoldMap _ g (There b) = g b
+
+instance Bitraversable Wedge where
+    bitraverse _ _ Nowhere   = pure Nowhere
+    bitraverse f _ (Here a)  = Here <$> f a
+    bitraverse _ g (There b) = There <$> g b
+
+instance Applicative (Wedge a) where
+    pure  = return
+    (<*>) = ap
+
+instance Monad (Wedge a) where
+    return = There
+
+    Nowhere >>= _ = Nowhere
+    Here a  >>= _ = Here a
+    There a >>= f = f a

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
@@ -246,13 +246,19 @@ makeConnectionHandler muxTracer singMuxMode
     outboundConnectionHandler socket
                               PromiseWriter { writePromise }
                               tracer
-                              connectionId@ConnectionId { remoteAddress }
+                              connectionId@ConnectionId { localAddress
+                                                        , remoteAddress }
                               mkMuxBearer
         = MaskedAction { runWithUnmask }
       where
         runWithUnmask :: (forall x. m x -> m x) -> m ()
         runWithUnmask unmask =
           classifyExceptions tracer remoteAddress OutboundError $ do
+            labelThisThread (concat ["out-conn-hndlr-"
+                                    , show localAddress
+                                    , "-"
+                                    , show remoteAddress
+                                    ])
             handshakeBearer <- mkMuxBearer sduHandshakeTimeout socket
             hsResult <-
               unmask (runHandshakeClient handshakeBearer
@@ -306,13 +312,19 @@ makeConnectionHandler muxTracer singMuxMode
     inboundConnectionHandler socket
                              PromiseWriter { writePromise }
                              tracer
-                             connectionId@ConnectionId { remoteAddress }
+                             connectionId@ConnectionId { localAddress
+                                                       , remoteAddress }
                              mkMuxBearer
         = MaskedAction { runWithUnmask }
       where
         runWithUnmask :: (forall x. m x -> m x) -> m ()
         runWithUnmask unmask =
           classifyExceptions tracer remoteAddress InboundError $ do
+            labelThisThread (concat ["in-conn-hndlr-"
+                                    , show localAddress
+                                    , "-"
+                                    , show remoteAddress
+                                    ])
             handshakeBearer <- mkMuxBearer sduHandshakeTimeout socket
             hsResult <-
               unmask (runHandshakeServer handshakeBearer

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -45,6 +45,7 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 
 import           Data.Monoid.Synchronisation
+import           Data.Wedge
 
 import           Network.Mux.Types (MuxMode)
 import           Network.Mux.Trace (MuxTrace, WithMuxBearer (..))
@@ -361,15 +362,6 @@ defaultProtocolIdleTimeout = 5
 
 defaultResetTimeout :: DiffTime
 defaultResetTimeout = 5
-
-
--- | A wedge product
--- <https://hackage.haskell.org/package/smash/docs/Data-Wedge.html#t:Wedge>
---
-data Wedge a b =
-    Nowhere
-  | Here a
-  | There b
 
 
 -- | Instruction used internally in @unregisterOutboundConnectionImpl@, e.g. in

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
@@ -105,10 +105,11 @@ data ServerArguments (muxMode  :: MuxMode) socket peerAddr versionNumber bytes m
 -- other is useful for running a server for the /Node-To-Client protocol/.
 --
 run :: forall muxMode socket peerAddr versionNumber m a b.
-       ( MonadAsync m
-       , MonadCatch m
-       , MonadTime  m
-       , MonadTimer m
+       ( MonadAsync    m
+       , MonadCatch    m
+       , MonadTime     m
+       , MonadTimer    m
+       , MonadEvaluate m
        , HasResponder muxMode ~ True
        , Ord      peerAddr
        )

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -21,6 +21,8 @@ module Simulation.Network.Snocket
   ( withSnocket
   , ResourceException (..)
   , SnocketTrace (..)
+  , SockType (..)
+  , OpenType (..)
 
   , BearerInfo (..)
   , SuccessOrFailure (..)
@@ -34,7 +36,6 @@ module Simulation.Network.Snocket
 
 import           Prelude hiding (read)
 
-import           Control.Exception (assert)
 import           Control.Monad (when)
 import qualified Control.Monad.Class.MonadSTM as LazySTM
 import           Control.Monad.Class.MonadSTM.Strict
@@ -86,9 +87,6 @@ stepScriptSTM scriptVar = do
       x':xs' -> LazySTM.writeTVar scriptVar (Script (x' :| xs'))
     return x
 
-stepScript :: MonadSTM m => LazySTM.TVar m (Script a) -> m a
-stepScript = atomically . stepScriptSTM
-
 
 data Connection m = Connection
     { -- | Attenuated channels of a connection.
@@ -99,7 +97,67 @@ data Connection m = Connection
       -- | SDU size of a connection.
       --
     , connSDUSize       :: !SDUSize
+
+      -- | Opening state of a connection.  This is used to detect simultaneous
+      -- open.
+      --
+    , connState         :: !OpenState
     }
+
+
+data OpenState
+    -- | Half opened connection is after calling `connect` but before the other
+    -- side picked it. Either using simultaneous open or normal open.
+  = HalfOpened
+
+    -- | This corresponds to established state of a tcp connection.
+  | Established
+
+
+dualConnection :: Connection m -> Connection m
+dualConnection conn@Connection { connChannelLocal, connChannelRemote } =
+    conn { connChannelLocal  = connChannelRemote
+         , connChannelRemote = connChannelLocal
+         }
+
+
+mkConnection :: ( MonadSTM   m
+                , MonadTime  m
+                , MonadTimer m
+                , MonadThrow m
+                , MonadThrow (STM m)
+                )
+             => Tracer m (WithAddr (TestAddress addr)
+                                   (SnocketTrace m (TestAddress addr)))
+             -> BearerInfo
+             -> ConnectionId (TestAddress addr)
+             -> STM m (Connection m)
+mkConnection tr bearerInfo connId@ConnectionId { localAddress, remoteAddress } = do
+    (channelLocal, channelRemote)  <-
+      newConnectedAttenuatedChannelPair
+        ( ( WithAddr (Just localAddress) (Just remoteAddress)
+          . STAttenuatedChannelTrace connId
+          )
+          `contramap` tr)
+        ( ( WithAddr (Just localAddress) (Just remoteAddress)
+          . STAttenuatedChannelTrace ConnectionId
+              { localAddress  = remoteAddress
+              , remoteAddress = localAddress
+              }
+          )
+         `contramap` tr)
+        Attenuation
+          { aReadAttenuation  = biOutboundAttenuation  bearerInfo
+          , aWriteAttenuation = biOutboundWriteFailure bearerInfo
+          }
+        Attenuation
+          { aReadAttenuation  = biInboundAttenuation  bearerInfo
+          , aWriteAttenuation = biInboundWriteFailure bearerInfo
+          }
+    return $ Connection channelLocal
+                        channelRemote
+                        (biSDUSize bearerInfo)
+                        HalfOpened
 
 
 -- | Connection id independent of who provisioned the connection. 'NormalisedId'
@@ -346,6 +404,11 @@ data FD_ m addr
         -- 'connect' is the producer of this queue;
         -- 'accept' is the consumer.
 
+    -- | 'FD_' was passed to 'connect' call, if needed an ephemeral address was
+    -- assigned to it.
+    --
+    | FDConnecting !(ConnectionId addr)
+                   !(Connection m)
 
     -- | 'FD_' for snockets in connected state.
     --
@@ -360,19 +423,25 @@ data FD_ m addr
     -- tracing purposes.
     --
     | FDClosed
-        !(Maybe (ConnectionId addr))
+        !(Wedge (ConnectionId addr) addr)
 
 
 instance Show addr => Show (FD_ m addr) where
-    show (FDUninitialised mbAddr)  = "FDUninitialised " ++ show mbAddr
-    show (FDListening addr _)      = "FDListening " ++ show addr
-    show (FDConnected connId conn) = concat
-                                       [ "FDConnected "
-                                       , show connId
-                                       , " "
-                                       , show (connSDUSize conn)
-                                       ]
-    show (FDClosed mbConnId)       = "FDClosed " ++ show mbConnId
+    show (FDUninitialised mbAddr)   = "FDUninitialised " ++ show mbAddr
+    show (FDListening addr _)       = "FDListening " ++ show addr
+    show (FDConnecting connId conn) = concat
+                                    [ "FDConnecting "
+                                    , show connId
+                                    , " "
+                                    , show (connSDUSize conn)
+                                    ]
+    show (FDConnected connId conn)  = concat
+                                        [ "FDConnected "
+                                        , show connId
+                                        , " "
+                                        , show (connSDUSize conn)
+                                        ]
+    show (FDClosed mbConnId)        = "FDClosed " ++ show mbConnId
 
 
 -- | File descriptor type.
@@ -385,24 +454,48 @@ newtype FD m peerAddr = FD { fdVar :: (StrictTVar m (FD_ m peerAddr)) }
 --
 
 data WithAddr addr event =
-    WithAddr { waLocalAddr :: Maybe addr
-             , waEvent     :: event
+    WithAddr { waLocalAddr  :: Maybe addr
+             , waRemoteAddr :: Maybe addr
+             , waEvent      :: event
              }
   deriving Show
 
+data SockType = ListeningSock
+              | ConnectionSock
+              | UnknownType
+  deriving Show
+
+mkSockType :: FD_ m addr -> SockType
+mkSockType FDUninitialised {} = UnknownType
+mkSockType FDListening {}     = ListeningSock
+mkSockType FDConnecting {}    = ConnectionSock
+mkSockType FDConnected {}     = ConnectionSock
+mkSockType FDClosed {}        = UnknownType
 
 data SnocketTrace m addr
     = STConnect      (FD_ m addr) addr
-    | STConnected    (FD_ m addr)
+    | STConnected    (FD_ m addr) OpenType
+    | STBearerInfo   BearerInfo
     | STConnectError (FD_ m addr) addr IOError
     | STBindError    (FD_ m addr) addr IOError
-    | STClosing      (FD_ m addr) Bool
-    | STClosed       (FD_ m addr)
+    | STClosing      SockType Bool
+    | STClosed       SockType
     | STClosingQueue Bool
     | STClosedQueue  Bool
     | STClosedWhenReading
     | STBearer       (FD_ m addr)
     | STAttenuatedChannelTrace (ConnectionId addr) AttenuatedChannelTrace
+  deriving Show
+
+-- | Either simultaneous open or normal open.  Unlike in TCP, only one side will
+-- will know that it is doing simultaneous open.
+--
+data OpenType =
+    -- | Simultaneous open
+      SimOpen
+
+    -- | Normal open
+    | NormalOpen
   deriving Show
 
 -- | Simulated 'Snocket' running in 'NetworkState'.  A single 'NetworkState'
@@ -440,18 +533,37 @@ mkSnocket state tr = Snocket { getLocalAddr
           FDUninitialised Nothing         -> Nothing
           FDUninitialised (Just peerAddr) -> Just peerAddr
           FDListening peerAddr _          -> Just peerAddr
-          FDConnected ConnectionId { localAddress } _
+          FDConnecting ConnectionId { localAddress } _
+                                          -> Just localAddress
+          FDConnected  ConnectionId { localAddress } _
                                           -> Just localAddress
           FDClosed {}                     -> Nothing
+
+    getRemoteAddrM :: FD m (TestAddress addr) -> m (Maybe (TestAddress addr))
+    getRemoteAddrM FD { fdVar } = do
+        fd_ <- atomically (readTVar fdVar)
+        return $ case fd_ of
+          FDUninitialised {}         -> Nothing
+          FDListening {}             -> Nothing
+          FDConnecting ConnectionId { remoteAddress } _
+                                     -> Just remoteAddress
+          FDConnected  ConnectionId { remoteAddress } _
+                                     -> Just remoteAddress
+          FDClosed {}                -> Nothing
 
     traceWith' :: FD m (TestAddress addr)
                -> SnocketTrace m (TestAddress addr)
                -> m ()
     traceWith' fd =
       let tr' :: Tracer m (SnocketTrace m (TestAddress addr))
-          tr' = (\ev -> flip WithAddr ev <$> getLocalAddrM fd)
+          tr' = (\ev -> (\a b -> WithAddr a b ev) <$> getLocalAddrM  fd
+                                                  <*> getRemoteAddrM fd)
                 `contramapM` tr
       in traceWith tr'
+
+    --
+    -- Snocket api
+    --
 
     getLocalAddr :: FD m (TestAddress addr) -> m (TestAddress addr)
     getLocalAddr fd = do
@@ -472,14 +584,11 @@ mkSnocket state tr = Snocket { getLocalAddr
                 }
 
     getRemoteAddr :: FD m (TestAddress addr) -> m (TestAddress addr)
-    getRemoteAddr FD { fdVar } = do
-        fd_ <- atomically (readTVar fdVar)
-        case fd_ of
-          FDUninitialised {}         -> throwIO ioe
-          FDListening {}             -> throwIO ioe
-          FDConnected ConnectionId { remoteAddress } _
-                                     -> return remoteAddress
-          FDClosed {}                -> throwIO ioe
+    getRemoteAddr fd = do
+      maddr <- getRemoteAddrM fd
+      case maddr of
+        Just addr -> return addr
+        Nothing   -> throwIO ioe
       where
         ioe = IOError
           { ioe_handle      = Nothing
@@ -511,73 +620,103 @@ mkSnocket state tr = Snocket { getLocalAddr
         traceWith' fd (STConnect fd_ remoteAddress)
         case fd_ of
           FDUninitialised mbLocalAddr -> do
-            bearerInfo <- stepScript (nsBearerInfo state)
-            threadDelay (biConnectionDelay bearerInfo)
-            res <- atomically $ do
+            (efd, connId, bearerInfo) <- atomically $ do
+              bearerInfo <- stepScriptSTM (nsBearerInfo state)
               localAddress <-
                 case mbLocalAddr of
                   Just addr -> return addr
                   Nothing   -> nsNextEphemeralAddr state
-              writeTVar fdVarLocal (FDUninitialised (Just localAddress))
-              lstMap <- readTVar (nsListeningFDs state)
+              let connId = ConnectionId { localAddress, remoteAddress }
+
               conMap <- readTVar (nsConnections state)
-              lstFd  <- traverse (readTVar . fdVar) (Map.lookup remoteAddress lstMap)
-              let connId = ConnectionId {localAddress, remoteAddress}
-              case (Map.lookup (normaliseId connId) conMap, lstFd) of
-
-                (Just _, _) ->
-                  -- connection exists
+              case Map.lookup (normaliseId connId) conMap of
+                Just      Connection { connState = Established } ->
                   throwSTM connectedIOError
+                Just conn@Connection { connState = HalfOpened } -> do
+                  let conn' = conn { connState = Established }
+                  writeTVar fdVarLocal (FDConnecting connId conn')
+                  modifyTVar (nsConnections state)
+                             (Map.adjust (const conn')
+                                         (normaliseId connId))
+                  return ( Left $ FDConnected connId conn'
+                         , connId
+                         , bearerInfo
+                         )
+                Nothing -> do
+                  conn <- mkConnection tr bearerInfo connId
+                  writeTVar fdVarLocal (FDConnecting connId conn)
+                  modifyTVar (nsConnections state)
+                             (Map.insert (normaliseId connId)
+                                         (dualConnection conn))
+                  return ( Right ( FDConnected connId conn
+                                 , conn
+                                 )
+                         , connId
+                         , bearerInfo
+                         )
 
-                (Nothing, Nothing) ->
-                  throwSTM connectIOError
-                (Nothing, Just FDUninitialised {}) ->
+            traceWith tr (WithAddr (Just (localAddress connId))
+                                   (Just remoteAddress)
+                                   (STBearerInfo bearerInfo))
+            -- connection delay
+            threadDelay (biConnectionDelay bearerInfo)
+
+            efd' <- atomically $ do
+              lstMap <- readTVar (nsListeningFDs state)
+              lstFd  <- traverse (readTVar . fdVar)
+                                 (Map.lookup remoteAddress lstMap)
+              case (efd, lstFd) of
+                -- error cases
+                (_, Nothing) ->
                   return (Left connectIOError)
-                (Nothing, Just FDConnected {}) ->
+                (_, Just FDUninitialised {}) ->
                   return (Left connectIOError)
-                (Nothing, Just (FDListening remoteAddress' queue)) ->
-                  assert (remoteAddress' == remoteAddress) $ do
-                  (channelLocal, channelRemote)  <-
-                    newConnectedAttenuatedChannelPair
-                      ( ( WithAddr (Just localAddress)
-                        . STAttenuatedChannelTrace connId
-                        )
-                        `contramap` tr)
-                      ( ( WithAddr (Just localAddress)
-                        . STAttenuatedChannelTrace ConnectionId
-                            { localAddress  = remoteAddress
-                            , remoteAddress = localAddress
-                            }
-                        )
-                       `contramap` tr)
-                      Attenuation
-                        { aReadAttenuation  = biOutboundAttenuation  bearerInfo
-                        , aWriteAttenuation = biOutboundWriteFailure bearerInfo
-                        }
-                      Attenuation
-                        { aReadAttenuation  = biInboundAttenuation  bearerInfo
-                        , aWriteAttenuation = biInboundWriteFailure bearerInfo
-                        }
-                  let conn = Connection channelLocal
-                                        channelRemote
-                                        (biSDUSize bearerInfo)
-                  let fd' = FDConnected connId conn
-                  writeTVar fdVarLocal fd'
-                  modifyTVar (nsConnections state) (Map.insert (normaliseId connId) conn)
-                  writeTBQueue queue
-                               ChannelWithInfo
-                                 { cwiAddress       = localAddress
-                                 , cwiSDUSize       = biSDUSize bearerInfo
-                                 , cwiChannelLocal  = channelRemote
-                                 , cwiChannelRemote = channelLocal
-                                 }
-                  return (Right fd')
-                (Nothing, Just FDClosed {}) ->
+                (_, Just FDConnecting {}) ->
+                  return (Left invalidError)
+                (_, Just FDConnected {}) ->
+                  return (Left connectIOError)
+                (_, Just FDClosed {}) ->
                   return (Left notConnectedIOError)
-            case res of
-              Left e    -> traceWith' fd (STConnectError fd_ remoteAddress e)
-                        >> throwIO e
-              Right fd' -> traceWith' fd (STConnected fd') 
+
+                -- successful simultaneous open
+                (Left  fd_', Just FDListening {}) -> do
+                  writeTVar fdVarLocal fd_'
+                  return (Right (fd_', SimOpen))
+
+                (Right ( fd_'
+                       , Connection { connChannelLocal, connChannelRemote })
+                       , Just (FDListening _ queue)
+                       ) -> do
+                  writeTVar fdVarLocal fd_'
+                  mConn <- Map.lookup (normaliseId connId) <$> readTVar (nsConnections state)
+                  case mConn of
+                    Just Connection { connState = Established } ->
+                      -- successful simultaneous open
+                      return ()
+                    Just Connection { connState = HalfOpened } -> do
+                      -- successful open
+                      modifyTVar (nsConnections state)
+                                 (Map.adjust (\s -> s { connState = Established })
+                                             (normaliseId connId))
+                      writeTBQueue queue
+                                   ChannelWithInfo
+                                     { cwiAddress       = localAddress connId
+                                     , cwiSDUSize       = biSDUSize bearerInfo
+                                     , cwiChannelLocal  = connChannelRemote
+                                     , cwiChannelRemote = connChannelLocal
+                                     }
+                    Nothing ->
+                      throwSTM connectIOError
+
+                  return (Right (fd_', NormalOpen))
+
+            case efd' of
+              Left e          -> traceWith' fd (STConnectError fd_ remoteAddress e)
+                              >> throwIO e
+              Right (fd_', o) -> traceWith' fd (STConnected fd_' o)
+
+          FDConnecting {} ->
+            throwIO invalidError
 
           FDConnected {} ->
             throwIO connectedIOError
@@ -611,6 +750,15 @@ mkSnocket state tr = Snocket { getLocalAddr
           , ioe_type        = AlreadyExists
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.connect"
           , ioe_description = "Transport endpoint is already connected"
+          , ioe_errno       = Nothing
+          , ioe_filename    = Nothing
+          }
+
+        invalidError = IOError
+          { ioe_handle      = Nothing
+          , ioe_type        = InvalidArgument
+          , ioe_location    = "Ouroboros.Network.Snocket.Sim.bind"
+          , ioe_description = "Invalid argument"
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
@@ -668,6 +816,8 @@ mkSnocket state tr = Snocket { getLocalAddr
             
           FDConnected {} ->
             throwSTM invalidError
+          FDConnecting {} ->
+            throwSTM invalidError
           FDListening {} ->
             return ()
           FDClosed {} ->
@@ -702,6 +852,10 @@ mkSnocket state tr = Snocket { getLocalAddr
               return ( AcceptFailure (toException invalidError)
                      , accept_
                      )
+            FDConnecting {} ->
+              return ( AcceptFailure (toException invalidError)
+                     , accept_
+                     )
             FDConnected {} ->
               return ( AcceptFailure (toException invalidError)
                      , accept_
@@ -722,6 +876,7 @@ mkSnocket state tr = Snocket { getLocalAddr
                                               { connChannelLocal  = channelLocal
                                               , connChannelRemote = channelRemote
                                               , connSDUSize       = sduSize
+                                              , connState         = Established
                                               })
               return ( Accepted fdRemote remoteAddress
                      , accept_
@@ -734,7 +889,6 @@ mkSnocket state tr = Snocket { getLocalAddr
         invalidError = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
-
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.accept"
           , ioe_description = "Invalid argument"
           , ioe_errno       = Nothing
@@ -744,38 +898,49 @@ mkSnocket state tr = Snocket { getLocalAddr
 
     close :: FD m (TestAddress addr)
           -> m ()
-    close fd@FD { fdVar } =
+    close FD { fdVar } =
       uninterruptibleMask_ $ do
-        (fd', mq) <- atomically $ do
+        (wConnId, fdType, mq) <- atomically $ do
           fd_ <- readTVar fdVar
-          let (wConnId, fd') = case fd_ of
-                     FDUninitialised {}   -> (Nowhere,     FDClosed Nothing)
-                     FDConnected connId _ -> (Here connId, FDClosed (Just connId))
-                     FDListening addr _   -> (There addr,  FDClosed Nothing)
-                     FDClosed    connId   -> (Nowhere,     FDClosed connId)
+          let wConnId = case fd_ of
+                     FDUninitialised {}    -> Nowhere
+                     FDConnecting connId _ -> Here connId
+                     FDConnected connId _  -> Here connId
+                     FDListening addr _    -> There addr
+                     FDClosed    wConnId_  -> wConnId_
               mq = case fd_ of
-                     FDConnected _ conn -> Just (connChannelLocal conn)
-                     _                  -> Nothing
+                     FDConnecting _ conn -> Just (connChannelLocal conn)
+                     FDConnected  _ conn -> Just (connChannelLocal conn)
+                     _                   -> Nothing
 
-          writeTVar fdVar fd'
+          writeTVar fdVar (FDClosed wConnId)
           bitraverse_
-            -- close a connection
+            -- close a connected socket
             (\connId -> modifyTVar (nsConnections state)
                                    (Map.delete (normaliseId connId)))
-
-            -- close listening connection; For berkely sockets, accepted
+            -- close a listening socket; For Berkeley sockets, accepted
             -- connections are not disturbed when one closes the listening
-            -- socket, but we exlude that through an assertion.
+            -- socket.
             (\addr   -> modifyTVar (nsListeningFDs state)
                                    (Map.delete addr))
             wConnId
+          return (wConnId, mkSockType fd_, mq)
 
-          return (fd', mq)
-        traceWith' fd (STClosing fd' (isJust mq))
+        let mbLocalAddr = case wConnId of
+              Here connId -> Just (localAddress connId)
+              There addr  -> Just addr
+              Nowhere     -> Nothing
+            mbRemoteAddr = case wConnId of
+              Here connId -> Just (remoteAddress connId)
+              _           -> Nothing
+
+        traceWith tr (WithAddr mbLocalAddr mbRemoteAddr
+                               (STClosing fdType (isJust mq)))
         case mq of
           Nothing -> return ()
           Just q  -> acClose q
-        traceWith' fd (STClosed fd')
+        traceWith tr (WithAddr mbLocalAddr mbRemoteAddr
+                               (STClosed fdType))
 
 
     toBearer :: DiffTime
@@ -789,6 +954,8 @@ mkSnocket state tr = Snocket { getLocalAddr
             throwIO (invalidError "uninitialised file descriptor")
           FDListening {} ->
             throwIO (invalidError "listening snocket")
+          FDConnecting _ _ -> do
+            throwIO (invalidError "connecting")
           FDConnected _ conn -> do
             traceWith' fd (STBearer fd_)
             return $ attenuationChannelAsMuxBearer (connSDUSize conn)

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -694,23 +694,23 @@ mkSnocket state tr = Snocket { getLocalAddr
         fd <- atomically (readTVar fdVar)
         case fd of
           FDUninitialised {} ->
-            throwIO invalidError
+            throwIO (invalidError "uninitialised file descriptor")
           FDListening {} ->
-            throwIO invalidError
+            throwIO (invalidError "listening snocket")
           FDConnected _ conn -> do
             traceWith tr (STBearer fd)
             return $ attenuationChannelAsMuxBearer (connSDUSize conn)
                                                    sduTimeout muxTracer
                                                    (connChannelLocal conn)
           FDClosed {} ->
-            throwIO invalidError
+            throwIO (invalidError "closed snocket")
       where
         -- io errors
-        invalidError = IOError
+        invalidError desc = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.toBearer"
-          , ioe_description = "Invalid argument"
+          , ioe_description = "Invalid argument: " ++ desc
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -17,9 +18,8 @@
 --
 module Simulation.Network.Snocket
   -- * Simulated Snocket
-  ( NetworkState
-  , newNetworkState
-  , mkSnocket
+  ( withSnocket
+  , ResourceException (..)
   , SnocketTrace (..)
 
   , BearerInfo (..)
@@ -41,17 +41,19 @@ import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadThrow
-import           Control.Tracer (Tracer, contramap, traceWith)
+import           Control.Tracer (Tracer, contramap, contramapM, traceWith)
 
 import           GHC.IO.Exception
 
 import           Data.Bifoldable (bitraverse_)
+import           Data.Foldable (traverse_)
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Typeable (Typeable)
 import           Numeric.Natural (Natural)
 
 import           Data.Wedge
@@ -236,6 +238,68 @@ newNetworkState bearerInfoScript peerAddr = atomically $
     <*> initScriptSTM bearerInfoScript
 
 
+data ResourceException addr
+  = NotReleasedListeningSockets [addr]              (Maybe SomeException)
+  | NotReleasedConnections      [NormalisedId addr] (Maybe SomeException)
+  deriving (Show, Typeable)
+
+instance (Typeable addr, Show addr)
+      => Exception (ResourceException addr)
+
+
+-- | A bracket which runs a network simulation.  When the simulation
+-- terminates it verifies that all listening sockets and all connections are
+-- closed.  It might throw 'ResourceException'.
+--
+withSnocket
+    :: forall m peerAddr a.
+       ( MonadSTM   m
+       , MonadCatch m
+       , MonadMask  m
+       , MonadTime  m
+       , MonadTimer m
+       , MonadThrow (STM m)
+       , Enum     peerAddr
+       , Ord      peerAddr
+       , Typeable peerAddr
+       , Show     peerAddr
+       )
+    => Tracer m (WithAddr (TestAddress peerAddr)
+                          (SnocketTrace m (TestAddress peerAddr)))
+    -> Script BearerInfo
+    -> TestAddress peerAddr
+    -- ^ the largest ephemeral address
+    -> (Snocket m (FD m (TestAddress peerAddr)) (TestAddress peerAddr)
+        -> m a)
+    -> m a
+withSnocket tr script (TestAddress peerAddr) k = do
+    st <- newNetworkState script peerAddr
+    a <- k (mkSnocket st tr)
+         `catch`
+         \e -> do re <- checkResources st (Just e)
+                  traverse_ throwIO re
+                  throwIO e
+    re <- checkResources st Nothing
+    traverse_ throwIO re
+    return a
+  where
+    -- verify that all sockets are closed
+    checkResources :: NetworkState m (TestAddress peerAddr)
+                   -> Maybe SomeException
+                   -> m (Maybe (ResourceException (TestAddress peerAddr)))
+    checkResources NetworkState { nsListeningFDs, nsConnections } err = do
+      (lstFDMap, connMap) <- atomically $ (,) <$> readTVar nsListeningFDs
+                                              <*> readTVar nsConnections
+      if |  not (Map.null lstFDMap)
+         -> return $ Just (NotReleasedListeningSockets (Map.keys lstFDMap) err)
+
+         |  not (Map.null connMap)
+         -> return $ Just (NotReleasedConnections      (Map.keys connMap) err)
+
+         |  otherwise
+         -> return   Nothing
+
+
 
 
 -- | Channel together with information needed by the other end, e.g. address of
@@ -320,6 +384,12 @@ newtype FD m peerAddr = FD { fdVar :: (StrictTVar m (FD_ m peerAddr)) }
 -- Simulated snockets
 --
 
+data WithAddr addr event =
+    WithAddr { waLocalAddr :: Maybe addr
+             , waEvent     :: event
+             }
+  deriving Show
+
 
 data SnocketTrace m addr
     = STConnect      (FD_ m addr) addr
@@ -347,7 +417,8 @@ mkSnocket :: forall m addr.
              , Ord addr
              )
           => NetworkState m (TestAddress addr)
-          -> Tracer m (SnocketTrace m (TestAddress addr))
+          -> Tracer m (WithAddr (TestAddress addr)
+                                (SnocketTrace m (TestAddress addr)))
           -> Snocket m (FD m (TestAddress addr)) (TestAddress addr)
 mkSnocket state tr = Snocket { getLocalAddr
                              , getRemoteAddr
@@ -362,17 +433,34 @@ mkSnocket state tr = Snocket { getLocalAddr
                              , toBearer
                              }
   where
-    getLocalAddr :: FD m (TestAddress addr) -> m (TestAddress addr)
-    getLocalAddr FD { fdVar } = do
+    getLocalAddrM :: FD m (TestAddress addr) -> m (Maybe (TestAddress addr))
+    getLocalAddrM FD { fdVar } = do
         fd_ <- atomically (readTVar fdVar)
-        case fd_ of
-          -- Socket would not error; it would return '0.0.0.0:0'.
-          FDUninitialised Nothing         -> throwIO ioe
-          FDUninitialised (Just peerAddr) -> return peerAddr
-          FDListening peerAddr _          -> return peerAddr
+        return $ case fd_ of
+          FDUninitialised Nothing         -> Nothing
+          FDUninitialised (Just peerAddr) -> Just peerAddr
+          FDListening peerAddr _          -> Just peerAddr
           FDConnected ConnectionId { localAddress } _
-                                          -> return localAddress
-          FDClosed {}                     -> throwIO ioe
+                                          -> Just localAddress
+          FDClosed {}                     -> Nothing
+
+    traceWith' :: FD m (TestAddress addr)
+               -> SnocketTrace m (TestAddress addr)
+               -> m ()
+    traceWith' fd =
+      let tr' :: Tracer m (SnocketTrace m (TestAddress addr))
+          tr' = (\ev -> flip WithAddr ev <$> getLocalAddrM fd)
+                `contramapM` tr
+      in traceWith tr'
+
+    getLocalAddr :: FD m (TestAddress addr) -> m (TestAddress addr)
+    getLocalAddr fd = do
+        maddr <- getLocalAddrM fd
+        case maddr of
+          Just addr -> return addr
+          -- Socket would not error for an @FDUninitialised Nothing@; it would
+          -- return '0.0.0.0:0'.
+          Nothing   -> throwIO ioe
       where
         ioe = IOError
                 { ioe_handle      = Nothing
@@ -418,10 +506,10 @@ mkSnocket state tr = Snocket { getLocalAddr
 
 
     connect :: FD m (TestAddress addr) -> TestAddress addr -> m ()
-    connect FD { fdVar = fdVarLocal } remoteAddress = do
-        fd <- atomically (readTVar fdVarLocal)
-        traceWith tr (STConnect fd remoteAddress)
-        case fd of
+    connect fd@FD { fdVar = fdVarLocal } remoteAddress = do
+        fd_ <- atomically (readTVar fdVarLocal)
+        traceWith' fd (STConnect fd_ remoteAddress)
+        case fd_ of
           FDUninitialised mbLocalAddr -> do
             bearerInfo <- stepScript (nsBearerInfo state)
             threadDelay (biConnectionDelay bearerInfo)
@@ -451,12 +539,16 @@ mkSnocket state tr = Snocket { getLocalAddr
                   assert (remoteAddress' == remoteAddress) $ do
                   (channelLocal, channelRemote)  <-
                     newConnectedAttenuatedChannelPair
-                      (STAttenuatedChannelTrace connId
-                       `contramap` tr)
-                      (STAttenuatedChannelTrace ConnectionId
-                        { localAddress  = remoteAddress
-                        , remoteAddress = localAddress
-                        }
+                      ( ( WithAddr (Just localAddress)
+                        . STAttenuatedChannelTrace connId
+                        )
+                        `contramap` tr)
+                      ( ( WithAddr (Just localAddress)
+                        . STAttenuatedChannelTrace ConnectionId
+                            { localAddress  = remoteAddress
+                            , remoteAddress = localAddress
+                            }
+                        )
                        `contramap` tr)
                       Attenuation
                         { aReadAttenuation  = biOutboundAttenuation  bearerInfo
@@ -483,9 +575,9 @@ mkSnocket state tr = Snocket { getLocalAddr
                 (Nothing, Just FDClosed {}) ->
                   return (Left notConnectedIOError)
             case res of
-              Left e    -> traceWith tr (STConnectError fd remoteAddress e)
+              Left e    -> traceWith' fd (STConnectError fd_ remoteAddress e)
                         >> throwIO e
-              Right fd' -> traceWith tr (STConnected fd') 
+              Right fd' -> traceWith' fd (STConnected fd') 
 
           FDConnected {} ->
             throwIO connectedIOError
@@ -525,22 +617,22 @@ mkSnocket state tr = Snocket { getLocalAddr
 
 
     bind :: FD m (TestAddress addr) -> TestAddress addr -> m ()
-    bind FD { fdVar } addr = do
+    bind fd@FD { fdVar } addr = do
         res <- atomically $ do
           boundSet <- readTVar (nsBoundAddresses state)
           when (addr `Set.member` boundSet)
                (throwSTM addressInUseError)
-          fd <- readTVar fdVar
-          case fd of
+          fd_ <- readTVar fdVar
+          case fd_ of
             FDUninitialised Nothing -> do
               writeTVar fdVar (FDUninitialised (Just addr))
               return Nothing
             _ ->
-              return (Just (fd, invalidError))
+              return (Just (fd_, invalidError))
         case res of
-          Nothing      -> return ()
-          Just (fd, e) -> traceWith tr (STBindError fd addr e)
-                       >> throwIO e
+          Nothing       -> return ()
+          Just (fd_, e) -> traceWith' fd (STBindError fd_ addr e)
+                        >> throwIO e
       where
         invalidError = IOError
           { ioe_handle      = Nothing
@@ -652,16 +744,16 @@ mkSnocket state tr = Snocket { getLocalAddr
 
     close :: FD m (TestAddress addr)
           -> m ()
-    close FD { fdVar } =
+    close fd@FD { fdVar } =
       uninterruptibleMask_ $ do
         (fd', mq) <- atomically $ do
-          fd <- readTVar fdVar
-          let (wConnId, fd') = case fd of
+          fd_ <- readTVar fdVar
+          let (wConnId, fd') = case fd_ of
                      FDUninitialised {}   -> (Nowhere,     FDClosed Nothing)
                      FDConnected connId _ -> (Here connId, FDClosed (Just connId))
                      FDListening addr _   -> (There addr,  FDClosed Nothing)
                      FDClosed    connId   -> (Nowhere,     FDClosed connId)
-              mq = case fd of
+              mq = case fd_ of
                      FDConnected _ conn -> Just (connChannelLocal conn)
                      _                  -> Nothing
 
@@ -679,26 +771,26 @@ mkSnocket state tr = Snocket { getLocalAddr
             wConnId
 
           return (fd', mq)
-        traceWith tr (STClosing fd' (isJust mq))
+        traceWith' fd (STClosing fd' (isJust mq))
         case mq of
           Nothing -> return ()
           Just q  -> acClose q
-        traceWith tr (STClosed fd')
+        traceWith' fd (STClosed fd')
 
 
     toBearer :: DiffTime
              -> Tracer m MuxTrace
              -> FD m (TestAddress addr)
              -> m (MuxBearer m)
-    toBearer sduTimeout muxTracer FD { fdVar } = do
-        fd <- atomically (readTVar fdVar)
-        case fd of
+    toBearer sduTimeout muxTracer fd@FD { fdVar } = do
+        fd_ <- atomically (readTVar fdVar)
+        case fd_ of
           FDUninitialised {} ->
             throwIO (invalidError "uninitialised file descriptor")
           FDListening {} ->
             throwIO (invalidError "listening snocket")
           FDConnected _ conn -> do
-            traceWith tr (STBearer fd)
+            traceWith' fd (STBearer fd_)
             return $ attenuationChannelAsMuxBearer (connSDUSize conn)
                                                    sduTimeout muxTracer
                                                    (connChannelLocal conn)

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -15,7 +15,7 @@
 -- library, since it is needed in `ouroboros-network-framework:test` and
 -- `ouroboros-network:test' components.
 --
-module Ouroboros.Network.IOSim
+module Simulation.Network.Snocket
   -- * Simulated Snocket
   ( NetworkState
   , newNetworkState

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -45,6 +45,7 @@ import           Control.Tracer (Tracer, contramap, traceWith)
 
 import           GHC.IO.Exception
 
+import           Data.Bifoldable (bitraverse_)
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -52,6 +53,8 @@ import           Data.Maybe (isJust)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Numeric.Natural (Natural)
+
+import           Data.Wedge
 
 import           Network.Mux.Bearer.AttenuatedChannel
 import           Network.Mux.Types (MuxBearer, SDUSize (..))
@@ -85,12 +88,50 @@ stepScript :: MonadSTM m => LazySTM.TVar m (Script a) -> m a
 stepScript = atomically . stepScriptSTM
 
 
+data Connection m = Connection
+    { -- | Attenuated channels of a connection.
+      --
+      connChannelLocal  :: !(AttenuatedChannel m)
+    , connChannelRemote :: !(AttenuatedChannel m)
+
+      -- | SDU size of a connection.
+      --
+    , connSDUSize       :: !SDUSize
+    }
+
+
+-- | Connection id independent of who provisioned the connection. 'NormalisedId'
+-- satisfies the invariant that for @NormalisedId {nidLow, nidHight}@ we have
+-- @nidLow <= nidHigh@.
+--
+data NormalisedId addr = UnsafeNormalisedId
+    { nidLow  :: !addr
+    , nidHigh :: !addr
+    }
+  deriving (Eq, Ord, Show)
+
+-- | Safe constructor of 'NormalisedId'
+--
+normaliseId :: Ord addr
+            => ConnectionId addr -> NormalisedId addr
+normaliseId
+  ConnectionId {localAddress, remoteAddress}
+    | localAddress <= remoteAddress
+    = UnsafeNormalisedId localAddress remoteAddress
+    | otherwise
+    = UnsafeNormalisedId remoteAddress localAddress
+
+
 -- | Simulation network environment consumed by 'simSnocket'.
 --
 data NetworkState m addr = NetworkState {
       -- | All listening 'FD's.
       --
       nsListeningFDs      :: StrictTVar m (Map addr (FD m addr)),
+
+      -- | Registry of active connections.
+      --
+      nsConnections       :: StrictTVar m (Map (NormalisedId addr) (Connection m)),
 
       -- | Set of all used addresses.
       --
@@ -181,6 +222,8 @@ newNetworkState bearerInfoScript peerAddr = atomically $
   NetworkState
     -- nsListeningFDs
     <$> newTVar Map.empty
+    -- nsConnections
+    <*> newTVar Map.empty
     -- nsBoundAddresses
     <*> newTVar Set.empty
     -- nsNextEphemeralAddr
@@ -199,9 +242,10 @@ newNetworkState bearerInfoScript peerAddr = atomically $
 -- the connecting host, shared 'SDUSize'.
 --
 data ChannelWithInfo m addr = ChannelWithInfo {
-    cwiAddress :: !addr,
-    cwiSDUSize :: !SDUSize,
-    cwiChannel :: !(AttenuatedChannel m)
+    cwiAddress       :: !addr,
+    cwiSDUSize       :: !SDUSize,
+    cwiChannelLocal  :: !(AttenuatedChannel m),
+    cwiChannelRemote :: !(AttenuatedChannel m)
   }
 
 
@@ -245,10 +289,8 @@ data FD_ m addr
     | FDConnected
         !(ConnectionId addr)
         -- ^ local and remote addresses
-        !(AttenuatedChannel m)
-        -- ^ communication channel @local → remote@
-        !SDUSize
-        -- ^ SDUSize for mux bearer
+        !(Connection m)
+        -- ^ connection
     
     -- | 'FD_' of a closed file descriptor; we keep 'ConnectionId' just for
     -- tracing purposes.
@@ -258,15 +300,15 @@ data FD_ m addr
 
 
 instance Show addr => Show (FD_ m addr) where
-    show (FDUninitialised mbAddr)       = "FDUninitialised " ++ show mbAddr
-    show (FDListening addr _)           = "FDListening " ++ show addr
-    show (FDConnected connId _ sduSize) = concat
-                                           [ "FDConnected "
-                                           , show connId
-                                           , " "
-                                           , show sduSize
-                                           ]
-    show (FDClosed mbConnId)           = "FDClosed " ++ show mbConnId
+    show (FDUninitialised mbAddr)  = "FDUninitialised " ++ show mbAddr
+    show (FDListening addr _)      = "FDListening " ++ show addr
+    show (FDConnected connId conn) = concat
+                                       [ "FDConnected "
+                                       , show connId
+                                       , " "
+                                       , show (connSDUSize conn)
+                                       ]
+    show (FDClosed mbConnId)       = "FDClosed " ++ show mbConnId
 
 
 -- | File descriptor type.
@@ -328,7 +370,7 @@ mkSnocket state tr = Snocket { getLocalAddr
           FDUninitialised Nothing         -> throwIO ioe
           FDUninitialised (Just peerAddr) -> return peerAddr
           FDListening peerAddr _          -> return peerAddr
-          FDConnected ConnectionId { localAddress } _ _
+          FDConnected ConnectionId { localAddress } _
                                           -> return localAddress
           FDClosed {}                     -> throwIO ioe
       where
@@ -347,7 +389,7 @@ mkSnocket state tr = Snocket { getLocalAddr
         case fd_ of
           FDUninitialised {}         -> throwIO ioe
           FDListening {}             -> throwIO ioe
-          FDConnected ConnectionId { remoteAddress } _ _
+          FDConnected ConnectionId { remoteAddress } _
                                      -> return remoteAddress
           FDClosed {}                -> throwIO ioe
       where
@@ -376,8 +418,8 @@ mkSnocket state tr = Snocket { getLocalAddr
 
 
     connect :: FD m (TestAddress addr) -> TestAddress addr -> m ()
-    connect FD { fdVar } remoteAddress = do
-        fd <- atomically (readTVar fdVar)
+    connect FD { fdVar = fdVarLocal } remoteAddress = do
+        fd <- atomically (readTVar fdVarLocal)
         traceWith tr (STConnect fd remoteAddress)
         case fd of
           FDUninitialised mbLocalAddr -> do
@@ -388,53 +430,58 @@ mkSnocket state tr = Snocket { getLocalAddr
                 case mbLocalAddr of
                   Just addr -> return addr
                   Nothing   -> nsNextEphemeralAddr state
-              writeTVar fdVar (FDUninitialised (Just localAddress))
+              writeTVar fdVarLocal (FDUninitialised (Just localAddress))
               lstMap <- readTVar (nsListeningFDs state)
-              case Map.lookup remoteAddress lstMap of
-                Nothing ->
+              conMap <- readTVar (nsConnections state)
+              lstFd  <- traverse (readTVar . fdVar) (Map.lookup remoteAddress lstMap)
+              let connId = ConnectionId {localAddress, remoteAddress}
+              case (Map.lookup (normaliseId connId) conMap, lstFd) of
+
+                (Just _, _) ->
+                  -- connection exists
+                  throwSTM connectedIOError
+
+                (Nothing, Nothing) ->
                   throwSTM connectIOError
-                Just (FD fdVarRemote) -> do
-                  fdRemote_ <- readTVar fdVarRemote
-                  case fdRemote_ of
-                    FDUninitialised {} -> do
-                      return (Left connectIOError)
-                    FDConnected {} -> do
-                      return (Left connectIOError)
-                    FDListening remoteAddress' queue ->
-                      assert (remoteAddress' == remoteAddress) $ do
-                      (chan, chan')  <-
-                        newConnectedAttenuatedChannelPair
-                          (STAttenuatedChannelTrace ConnectionId { localAddress,
-                                                                 remoteAddress
-                                                               }
-                           `contramap` tr)
-                          (STAttenuatedChannelTrace ConnectionId { localAddress = remoteAddress,
-                                                                 remoteAddress = localAddress
-                                                               }
-                           `contramap` tr)
-                          Attenuation
-                            { aReadAttenuation  = biOutboundAttenuation  bearerInfo
-                            , aWriteAttenuation = biOutboundWriteFailure bearerInfo
-                            }
-                          Attenuation
-                            { aReadAttenuation  = biInboundAttenuation  bearerInfo
-                            , aWriteAttenuation = biInboundWriteFailure bearerInfo
-                            }
-                      let fd' = FDConnected
-                                  ConnectionId { localAddress
-                                               , remoteAddress
-                                               }
-                                  chan (biSDUSize bearerInfo)
-                      writeTVar fdVar fd'
-                      writeTBQueue queue
-                                   ChannelWithInfo
-                                     { cwiAddress = localAddress
-                                     , cwiSDUSize = biSDUSize bearerInfo
-                                     , cwiChannel = chan'
-                                     }
-                      return (Right fd')
-                    FDClosed {} -> do
-                      return (Left notConnectedIOError)
+                (Nothing, Just FDUninitialised {}) ->
+                  return (Left connectIOError)
+                (Nothing, Just FDConnected {}) ->
+                  return (Left connectIOError)
+                (Nothing, Just (FDListening remoteAddress' queue)) ->
+                  assert (remoteAddress' == remoteAddress) $ do
+                  (channelLocal, channelRemote)  <-
+                    newConnectedAttenuatedChannelPair
+                      (STAttenuatedChannelTrace connId
+                       `contramap` tr)
+                      (STAttenuatedChannelTrace ConnectionId
+                        { localAddress  = remoteAddress
+                        , remoteAddress = localAddress
+                        }
+                       `contramap` tr)
+                      Attenuation
+                        { aReadAttenuation  = biOutboundAttenuation  bearerInfo
+                        , aWriteAttenuation = biOutboundWriteFailure bearerInfo
+                        }
+                      Attenuation
+                        { aReadAttenuation  = biInboundAttenuation  bearerInfo
+                        , aWriteAttenuation = biInboundWriteFailure bearerInfo
+                        }
+                  let conn = Connection channelLocal
+                                        channelRemote
+                                        (biSDUSize bearerInfo)
+                  let fd' = FDConnected connId conn
+                  writeTVar fdVarLocal fd'
+                  modifyTVar (nsConnections state) (Map.insert (normaliseId connId) conn)
+                  writeTBQueue queue
+                               ChannelWithInfo
+                                 { cwiAddress       = localAddress
+                                 , cwiSDUSize       = biSDUSize bearerInfo
+                                 , cwiChannelLocal  = channelRemote
+                                 , cwiChannelRemote = channelLocal
+                                 }
+                  return (Right fd')
+                (Nothing, Just FDClosed {}) ->
+                  return (Left notConnectedIOError)
             case res of
               Left e    -> traceWith tr (STConnectError fd remoteAddress e)
                         >> throwIO e
@@ -569,15 +616,21 @@ mkSnocket state tr = Snocket { getLocalAddr
                      )
             FDListening localAddress queue -> do
               ChannelWithInfo
-                { cwiAddress = remoteAddress
-                , cwiSDUSize = sduSize
-                , cwiChannel = chan
+                { cwiAddress       = remoteAddress
+                , cwiSDUSize       = sduSize
+                , cwiChannelLocal  = channelLocal
+                , cwiChannelRemote = channelRemote
                 } <- readTBQueue queue
               fdRemote <- FD <$> newTVar (FDConnected
-                                            ConnectionId { localAddress
-                                                         , remoteAddress
-                                                         }
-                                            chan sduSize)
+                                            ConnectionId
+                                              { localAddress
+                                              , remoteAddress
+                                              }
+                                            Connection
+                                              { connChannelLocal  = channelLocal
+                                              , connChannelRemote = channelRemote
+                                              , connSDUSize       = sduSize
+                                              })
               return ( Accepted fdRemote remoteAddress
                      , accept_
                      )
@@ -603,16 +656,28 @@ mkSnocket state tr = Snocket { getLocalAddr
       uninterruptibleMask_ $ do
         (fd', mq) <- atomically $ do
           fd <- readTVar fdVar
-          let fd' = case fd of
-                     FDUninitialised {}     -> FDClosed Nothing
-                     FDConnected connId _ _ -> FDClosed (Just connId)
-                     FDListening {}         -> FDClosed Nothing
-                     FDClosed    mConnId    -> FDClosed mConnId
+          let (wConnId, fd') = case fd of
+                     FDUninitialised {}   -> (Nowhere,     FDClosed Nothing)
+                     FDConnected connId _ -> (Here connId, FDClosed (Just connId))
+                     FDListening addr _   -> (There addr,  FDClosed Nothing)
+                     FDClosed    connId   -> (Nowhere,     FDClosed connId)
               mq = case fd of
-                     FDConnected _ q _ -> Just q
-                     _                 -> Nothing
+                     FDConnected _ conn -> Just (connChannelLocal conn)
+                     _                  -> Nothing
 
           writeTVar fdVar fd'
+          bitraverse_
+            -- close a connection
+            (\connId -> modifyTVar (nsConnections state)
+                                   (Map.delete (normaliseId connId)))
+
+            -- close listening connection; For berkely sockets, accepted
+            -- connections are not disturbed when one closes the listening
+            -- socket, but we exlude that through an assertion.
+            (\addr   -> modifyTVar (nsListeningFDs state)
+                                   (Map.delete addr))
+            wConnId
+
           return (fd', mq)
         traceWith tr (STClosing fd' (isJust mq))
         case mq of
@@ -632,9 +697,11 @@ mkSnocket state tr = Snocket { getLocalAddr
             throwIO invalidError
           FDListening {} ->
             throwIO invalidError
-          FDConnected _ chan sduSize -> do
+          FDConnected _ conn -> do
             traceWith tr (STBearer fd)
-            return $ attenuationChannelAsMuxBearer sduSize sduTimeout muxTracer chan
+            return $ attenuationChannelAsMuxBearer (connSDUSize conn)
+                                                   sduTimeout muxTracer
+                                                   (connChannelLocal conn)
           FDClosed {} ->
             throwIO invalidError
       where

--- a/ouroboros-network-framework/test/Main.hs
+++ b/ouroboros-network-framework/test/Main.hs
@@ -7,11 +7,11 @@ import qualified Test.Network.TypedProtocol.PingPong.Codec as PingPong
 import qualified Test.Network.TypedProtocol.ReqResp.Codec as ReqResp
 import qualified Test.Ouroboros.Network.ConnectionManager as ConnectionManager
 import qualified Test.Ouroboros.Network.Driver as Driver
-import qualified Test.Ouroboros.Network.IOSim as IOSim
 import qualified Test.Ouroboros.Network.Server2 as Server2
 import qualified Test.Ouroboros.Network.Socket as Socket
 import qualified Test.Ouroboros.Network.Subscription as Subscription
 import qualified Test.Ouroboros.Network.RateLimiting as RateLimiting
+import qualified Test.Simulation.Network.Snocket as Snocket
 
 main :: IO ()
 main = defaultMain tests
@@ -28,7 +28,7 @@ tests =
   , Subscription.tests
   , RateLimiting.tests
   , Synchronisation.tests
-  , IOSim.tests
+  , Snocket.tests
   ]
 
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -62,7 +62,6 @@ import           Ouroboros.Network.ConnectionManager.Core
 import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.ConnectionManager.Types
 import           Ouroboros.Network.IOManager
-import           Ouroboros.Network.IOSim
 import qualified Ouroboros.Network.InboundGovernor.ControlChannel as Server
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.MuxMode
@@ -76,9 +75,10 @@ import           Ouroboros.Network.Server2 (ServerArguments (..))
 import qualified Ouroboros.Network.Server2 as Server
 import           Ouroboros.Network.Snocket (Snocket, socketSnocket)
 import qualified Ouroboros.Network.Snocket as Snocket
+import           Simulation.Network.Snocket
 
 import           Test.Ouroboros.Network.Orphans ()  -- ShowProxy ReqResp instance
-import           Test.Ouroboros.Network.IOSim (NonFailingBearerInfoScript(..), toBearerInfo)
+import           Test.Simulation.Network.Snocket (NonFailingBearerInfoScript(..), toBearerInfo)
 
 tests :: TestTree
 tests =

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -73,7 +73,7 @@ import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..))
 import           Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
 import           Ouroboros.Network.Server2 (ServerArguments (..))
 import qualified Ouroboros.Network.Server2 as Server
-import           Ouroboros.Network.Snocket (Snocket, socketSnocket)
+import           Ouroboros.Network.Snocket (Snocket, TestAddress (..), socketSnocket)
 import qualified Ouroboros.Network.Snocket as Snocket
 import           Simulation.Network.Snocket
 
@@ -830,13 +830,15 @@ unidirectionalExperiment snocket socket clientAndServerData = do
 
 prop_unidirectional_Sim :: ClientAndServerData Int Int Int -> Property
 prop_unidirectional_Sim clientAndServerData =
-  simulatedPropertyWithTimeout 7200 $ do
-    net   <- newNetworkState (singletonScript noAttenuation) 10
-    let snock = mkSnocket net debugTracer
-    fd <- Snocket.open snock Snocket.TestFamily
-    Snocket.bind   snock fd serverAddr
-    Snocket.listen snock fd
-    unidirectionalExperiment snock fd clientAndServerData
+  simulatedPropertyWithTimeout 7200 $
+    withSnocket nullTracer
+                (singletonScript noAttenuation)
+                (TestAddress 10) $ \snock ->
+      bracket (Snocket.open snock Snocket.TestFamily)
+              (Snocket.close snock) $ \fd -> do
+        Snocket.bind   snock fd serverAddr
+        Snocket.listen snock fd
+        unidirectionalExperiment snock fd clientAndServerData
   where
     serverAddr = Snocket.TestAddress (0 :: Int)
 
@@ -975,21 +977,22 @@ bidirectionalExperiment
 
 prop_bidirectional_Sim :: NonFailingBearerInfoScript -> ClientAndServerData Int Int Int -> ClientAndServerData Int Int Int -> Property
 prop_bidirectional_Sim (NonFailingBearerInfoScript script) data0 data1 =
-  simulatedPropertyWithTimeout 7200 $ do
-    net <- newNetworkState script' 10
-    let snock = mkSnocket net debugTracer
-    bracket ((,) <$> Snocket.open snock Snocket.TestFamily
-                 <*> Snocket.open snock Snocket.TestFamily)
-            (\ (socket0, socket1) -> Snocket.close snock socket0 >>
-                                     Snocket.close snock socket1)
-      $ \ (socket0, socket1) -> do
-        let addr0 = Snocket.TestAddress (0 :: Int)
-            addr1 = Snocket.TestAddress 1
-        Snocket.bind   snock socket0 addr0
-        Snocket.bind   snock socket1 addr1
-        Snocket.listen snock socket0
-        Snocket.listen snock socket1
-        bidirectionalExperiment snock socket0 socket1 addr0 addr1 data0 data1
+  simulatedPropertyWithTimeout 7200 $
+    withSnocket debugTracer
+                script'
+                (TestAddress 10) $ \snock ->
+      bracket ((,) <$> Snocket.open snock Snocket.TestFamily
+                   <*> Snocket.open snock Snocket.TestFamily)
+              (\ (socket0, socket1) -> Snocket.close snock socket0 >>
+                                       Snocket.close snock socket1)
+        $ \ (socket0, socket1) -> do
+          let addr0 = Snocket.TestAddress (0 :: Int)
+              addr1 = Snocket.TestAddress 1
+          Snocket.bind   snock socket0 addr0
+          Snocket.bind   snock socket1 addr1
+          Snocket.listen snock socket0
+          Snocket.listen snock socket1
+          bidirectionalExperiment snock socket0 socket1 addr0 addr1 data0 data1
   where
     script' = toBearerInfo <$> script
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -879,7 +879,8 @@ bidirectionalExperiment
        , Typeable req, Typeable resp
        , Show acc
        )
-    => Snocket m socket peerAddr
+    => Bool
+    -> Snocket m socket peerAddr
     -> socket
     -> socket
     -> peerAddr
@@ -888,13 +889,9 @@ bidirectionalExperiment
     -> ClientAndServerData req resp acc
     -> m Property
 bidirectionalExperiment
-    snocket socket0 socket1 localAddr0 localAddr1
+    useLock snocket socket0 socket1 localAddr0 localAddr1
     clientAndServerData0 clientAndServerData1 = do
       lock <- newTMVarIO ()
-      -- connect lock: only one side can run 'requestOutboundConnection' in
-      -- turn.  Otherwise when both sides call 'requestOutboundConnection' they
-      -- both will run 'connect' and one of the calls will fail.  Using a lock
-      -- forces to block until negotiation is done, which is not ideal.
       withBidirectionalConnectionManager
         "node-0" snocket socket0 (Just localAddr0) clientAndServerData0
         (\connectionManager0 _serverAddr0 serverAsync0 ->
@@ -915,7 +912,7 @@ bidirectionalExperiment
                 (replicateM
                   (numberOfRounds clientAndServerData0)
                   (bracket
-                    (withLock lock
+                    (withLock useLock lock
                       (requestOutboundConnection
                         connectionManager0
                         localAddr1))
@@ -937,7 +934,7 @@ bidirectionalExperiment
                 (replicateM
                   (numberOfRounds clientAndServerData1)
                   (bracket
-                    (withLock lock
+                    (withLock useLock lock
                       (requestOutboundConnection
                         connectionManager1
                         localAddr0))
@@ -992,7 +989,7 @@ prop_bidirectional_Sim (NonFailingBearerInfoScript script) data0 data1 =
           Snocket.bind   snock socket1 addr1
           Snocket.listen snock socket0
           Snocket.listen snock socket1
-          bidirectionalExperiment snock socket0 socket1 addr0 addr1 data0 data1
+          bidirectionalExperiment False snock socket0 socket1 addr0 addr1 data0 data1
   where
     script' = toBearerInfo <$> script
 
@@ -1030,6 +1027,7 @@ prop_bidirectional_IO data0 data1 =
             Socket.listen socket1 10
 
             bidirectionalExperiment
+              True
               (socketSnocket iomgr)
               socket0
               socket1
@@ -1076,10 +1074,12 @@ connectionManagerTracer =
 withLock :: ( MonadSTM   m
             , MonadThrow m
             )
-         => StrictTMVar m ()
+         => Bool
+         -> StrictTMVar m ()
          -> m a
          -> m a
-withLock v m =
+withLock False _v m = m
+withLock True   v m =
     bracket (atomically $ takeTMVar v)
             (atomically . putTMVar v)
             (const m)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -1095,10 +1095,16 @@ simulatedPropertyWithTimeout t test =
     tr = runSimTrace $ timeout t test
 
 ppTrace :: Trace a -> String
-ppTrace tr = intercalate "\n" $ map fmt events
+ppTrace tr = concat
+    [     "====== Trace ======\n"
+    , intercalate "\n" $ map fmt events
+    , "\n\n====== Say Events ======\n"
+    , intercalate "\n" $ selectTraceEventsSay' tr
+    , "\n"
+    ]
   where
     events = traceEvents tr
     w      = maximum [ length name | (_, _, Just name, _) <- events ]
 
-    fmt (t, tid, lbl, e) = printf "%-10s - %-13s %-*s - %s" (show t) (show tid) w (fromMaybe "" lbl) (show e)
+    fmt (t, tid, lbl, e) = printf "%-24s - %-13s %-*s - %s" (show t) (show tid) w (fromMaybe "" lbl) (show e)
 

--- a/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
@@ -185,12 +185,12 @@ clientServerSimulation
     => Script BearerInfo
     -> [payload]
     -> m (Maybe Bool)
-clientServerSimulation script payloads = do
-    ns <- newNetworkState script 0
-    withAsync (server ns) $ \_serverAsync -> do
-      res <- untilSuccess (client ns)
-      say $ "SIMULATION RESULT: " ++ show res
-      return (Just res)
+clientServerSimulation script payloads =
+    withSnocket nullTracer script (TestAddress 0) $ \snocket ->
+      withAsync (server snocket) $ \_serverAsync -> do
+        res <- untilSuccess (client snocket)
+        say $ "SIMULATION RESULT: " ++ show res
+        return (Just res)
 
   where
     reqRespProtocolNum :: MiniProtocolNum
@@ -205,9 +205,9 @@ clientServerSimulation script payloads = do
     clientPeer :: Peer (ReqResp payload payload) AsClient StIdle m Bool
     clientPeer = reqRespClientPeer (pingClient payloads)
 
-    server :: NetworkState m TestAddr
+    server :: TestSnocket m
            -> m ()
-    server ns = do
+    server snocket = do
         labelThisThread "server"
         threadsVar <- newTVarIO Set.empty
         bracket (open snocket TestFamily)
@@ -220,13 +220,6 @@ clientServerSimulation script payloads = do
             threads <- atomically (readTVar threadsVar)
             traverse_ cancel threads
       where
-        snocket :: TestSnocket m
-        snocket = mkSnocket ns (("server",) `contramap`
-                                  traceTime
-                                   (   Tracer (say . show)
-                                    -- <> Tracer Debug.traceShowM
-                                   ))
-
         acceptLoop :: StrictTVar m (Set (Async m ()))
                    -> Accept m (TestFD m) TestAddr
                    -> m ()
@@ -284,9 +277,9 @@ clientServerSimulation script payloads = do
                   say $ "SERVER HANDLER " ++ show res
 
 
-    client :: NetworkState m TestAddr
+    client :: TestSnocket m
            -> m Bool
-    client ns = do
+    client snocket = do
         labelThisThread "client"
         bracket (openToConnect snocket serverAddr)
                 (close snocket)
@@ -332,13 +325,6 @@ clientServerSimulation script payloads = do
                         (Left err) -> throwIO err
                         (Right b)  -> return b
                         -- Right _         -> error "client: mux died"
-      where
-        snocket :: TestSnocket m
-        snocket = mkSnocket ns (("client",) `contramap`
-                                  traceTime
-                                   (   Tracer (say . show)
-                                    -- <> Tracer Debug.traceShowM
-                                   ))
 
 --
 -- Generators

--- a/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
@@ -12,7 +12,7 @@
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
-module Test.Ouroboros.Network.IOSim
+module Test.Simulation.Network.Snocket
   ( tests
   , BearerInfoScript(..)
   , NonFailingBearerInfoScript(..)
@@ -55,9 +55,9 @@ import           Ouroboros.Network.Codec
 import           Ouroboros.Network.ConnectionId
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Snocket
-import           Ouroboros.Network.IOSim
 import           Ouroboros.Network.Util.ShowProxy
 import           Ouroboros.Network.Testing.Utils (Delay (..))
+import           Simulation.Network.Snocket
 
 import           Network.Mux
 import           Network.Mux.Types (SDUSize (..))
@@ -77,7 +77,7 @@ import qualified Debug.Trace as Debug
 
 tests :: TestTree
 tests =
-    testGroup "Ouroboros.Network.IOSim"
+    testGroup "Simulation.Network.Snocket"
     [ testGroup "generators"
       [ testProperty "shrinker AbsBearerInfo" prop_shrinker_AbsBearerInfo
       , testProperty "shrinker BearerInfoScript" prop_shrinker_BearerInfoScript

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -260,6 +260,7 @@ library ouroboros-protocol-tests
 
                        io-sim,
                        io-sim-classes,
+                       network-mux,
                        ouroboros-network,
                        ouroboros-network-framework,
                        ouroboros-network-testing,

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Network.Protocol.Handshake.Test where
@@ -26,11 +27,16 @@ import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow ( MonadCatch
                                                 , MonadThrow
+                                                , bracket
                                                 )
 import           Control.Tracer (nullTracer)
 
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Proofs
+import           Network.Mux.Types ( MiniProtocolNum (..)
+                                   , MiniProtocolDir (..)
+                                   , muxBearerAsChannel
+                                   )
 
 import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
                      prop_codec_valid_cbor_encoding, splits2, splits3)
@@ -42,6 +48,9 @@ import           Ouroboros.Network.Driver.Simple ( runPeer
                                                  , runConnectedPeers
                                                  , runConnectedPeersAsymmetric
                                                  )
+import           Ouroboros.Network.Snocket (TestAddress (..))
+import qualified Ouroboros.Network.Snocket as Snocket
+import           Simulation.Network.Snocket
 
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Client
@@ -68,6 +77,8 @@ tests =
         , testProperty "channel asymmetric IO" prop_channel_asymmetric_IO
         , testProperty "simultaneous open ST"  prop_channel_simultaneous_open_ST
         , testProperty "simultaneous open IO"  prop_channel_simultaneous_open_IO
+        , testProperty "simultaneous open SimNet"
+                                               prop_channel_simultaneous_open_SimNet
         , testProperty "pipe asymmetric IO"    prop_pipe_asymmetric_IO
         , testProperty "codec RefuseReason"    prop_codec_RefuseReason
         , testProperty "codec"                 prop_codec_Handshake
@@ -574,9 +585,13 @@ prop_channel_simultaneous_open createChannels clientVersions serverVersions =
                     acceptableVersion
                     serverVersions
     (clientRes', serverRes') <-
-      (fst <$> runPeer nullTracer versionNumberHandshakeCodec clientChannel client)
+      (fst <$> runPeer nullTracer
+                      -- (("client",) `contramap` Tracer Debug.traceShowM)
+                       versionNumberHandshakeCodec clientChannel client)
         `concurrently`
-      (fst <$> runPeer nullTracer versionNumberHandshakeCodec serverChannel client')
+      (fst <$> runPeer nullTracer
+                      -- (("server",) `contramap` Tracer Debug.traceShowM)
+                       versionNumberHandshakeCodec serverChannel client')
     pure $
       case (clientRes', serverRes') of
         -- both succeeded, we just check that the application (which is
@@ -610,6 +625,63 @@ prop_channel_simultaneous_open_IO (ArbitraryVersions clientVersions serverVersio
                  createConnectedChannels
                  clientVersions
                  serverVersions
+
+
+prop_channel_simultaneous_open_SimNet :: ArbitraryVersions -> Property
+prop_channel_simultaneous_open_SimNet
+  (ArbitraryVersions clientVersions serverVersions) =
+  runSimOrThrow $
+    let attenuation = noAttenuation { biConnectionDelay = 1 } in
+    withSnocket nullTracer
+                (singletonScript attenuation)
+                (TestAddress (0 :: Int)) $ \sn -> do
+      let addr  = Snocket.TestAddress 1
+          addr' = Snocket.TestAddress 2
+      -- listening snockets
+      bracket (Snocket.open  sn Snocket.TestFamily)
+              (Snocket.close sn) $ \fdLst ->
+        bracket (Snocket.open  sn Snocket.TestFamily)
+                (Snocket.close sn) $ \fdLst' -> do
+          Snocket.bind sn fdLst  addr
+          Snocket.bind sn fdLst' addr'
+          Snocket.listen sn fdLst
+          Snocket.listen sn fdLst'
+          -- connection snockets
+          bracket ((,) <$> Snocket.open sn Snocket.TestFamily
+                       <*> Snocket.open sn Snocket.TestFamily
+                  )
+                  (\(fdConn, fdConn') -> 
+                      -- we need concurrently close both sockets: they need to
+                      -- communicate between each other while they close.
+                      Snocket.close sn fdConn
+                      `concurrently_`
+                      Snocket.close sn fdConn'
+                  ) $ \(fdConn, fdConn') -> do
+            Snocket.bind sn fdConn  addr
+            Snocket.bind sn fdConn' addr'
+            concurrently_
+              (Snocket.connect sn fdConn  addr')
+              (Snocket.connect sn fdConn' addr)
+            bearer  <- Snocket.toBearer
+                        sn 1
+                        nullTracer
+                        -- (("client",) `contramap` Tracer Debug.traceShowM)
+                        fdConn
+            bearer' <- Snocket.toBearer
+                        sn 1
+                        nullTracer
+                        -- (("server",) `contramap` Tracer Debug.traceShowM)
+                        fdConn'
+            let chann  = fromChannel
+                       $ muxBearerAsChannel bearer  (MiniProtocolNum 0) InitiatorDir
+                chann' = fromChannel
+                       $ muxBearerAsChannel bearer' (MiniProtocolNum 0) InitiatorDir
+            res <- prop_channel_simultaneous_open
+              (pure (chann, chann'))
+              clientVersions
+              serverVersions
+            return res
+          
 
 --
 -- Codec tests


### PR DESCRIPTION
- Wedge data type
- sim-net: connection registry
- sim-net: improve error messages
- sim-net: support simultaneous open
- sim-net: assert connection life time
- sim-net: withNetworkState
- handshake: test simultaneous open using simulated network
- sim-net: renamed as Simulation.Network.Snocket
