### PR TITLE
Remove snapshotTxsFor

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -354,11 +354,6 @@ data MempoolSnapshot blk idx = MempoolSnapshot {
     -- number greater than the one provided.
   , snapshotTxsAfter    :: idx -> [(Validated (GenTx blk), idx)]
 
-    -- | Get as many transactions (oldest to newest) from the mempool
-    -- snapshot, along with their ticket number, such that their combined size
-    -- is <= the given limit (in bytes).
-  , snapshotTxsForSize  :: Word32 -> [(Validated (GenTx blk), idx)]
-
     -- | Get a specific transaction from the mempool snapshot by its ticket
     -- number, if it exists.
   , snapshotLookupTx    :: idx -> Maybe (Validated (GenTx blk))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -24,7 +24,6 @@ module Ouroboros.Consensus.Mempool.Impl.Pure (
 import           Control.Exception (assert)
 import           Data.Maybe (isJust, isNothing)
 import qualified Data.Set as Set
-import           Data.Word (Word32)
 
 import           Control.Monad (join)
 import           Control.Tracer
@@ -302,7 +301,6 @@ implSnapshotFromIS
 implSnapshotFromIS is = MempoolSnapshot {
       snapshotTxs         = implSnapshotGetTxs         is
     , snapshotTxsAfter    = implSnapshotGetTxsAfter    is
-    , snapshotTxsForSize  = implSnapshotGetTxsForSize  is
     , snapshotLookupTx    = implSnapshotGetTx          is
     , snapshotHasTx       = implSnapshotHasTx          is
     , snapshotMempoolSize = implSnapshotGetMempoolSize is
@@ -319,12 +317,6 @@ implSnapshotFromIS is = MempoolSnapshot {
                           -> [(Validated (GenTx blk), TicketNo)]
   implSnapshotGetTxsAfter IS{isTxs} =
     TxSeq.toTuples . snd . TxSeq.splitAfterTicketNo isTxs
-
-  implSnapshotGetTxsForSize :: InternalState blk
-                            -> Word32
-                            -> [(Validated (GenTx blk), TicketNo)]
-  implSnapshotGetTxsForSize IS{isTxs} =
-    TxSeq.toTuples . fst . TxSeq.splitAfterTxSize isTxs
 
   implSnapshotGetTx :: InternalState blk
                     -> TicketNo


### PR DESCRIPTION
After PR #3224 was merged, snapshotTxsFor became a dead code. This
commits removes it.