### PR TITLE
Mempool tracer without bang patterns

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -419,38 +419,38 @@ instance Monoid MempoolSize where
 -- | Events traced by the Mempool.
 data TraceEventMempool blk
   = TraceMempoolAddedTx
-      !(Validated (GenTx blk))
+      (Validated (GenTx blk))
       -- ^ New, valid transaction that was added to the Mempool.
-      !MempoolSize
+      MempoolSize
       -- ^ The size of the Mempool before adding the transaction.
-      !MempoolSize
+      MempoolSize
       -- ^ The size of the Mempool after adding the transaction.
   | TraceMempoolRejectedTx
-      !(GenTx blk)
+      (GenTx blk)
       -- ^ New, invalid transaction thas was rejected and thus not added to
       -- the Mempool.
-      !(ApplyTxErr blk)
+      (ApplyTxErr blk)
       -- ^ The reason for rejecting the transaction.
-      !MempoolSize
+      MempoolSize
       -- ^ The current size of the Mempool.
   | TraceMempoolRemoveTxs
-      ![Validated (GenTx blk)]
+      [Validated (GenTx blk)]
       -- ^ Previously valid transactions that are no longer valid because of
       -- changes in the ledger state. These transactions have been removed
       -- from the Mempool.
-      !MempoolSize
+      MempoolSize
       -- ^ The current size of the Mempool.
   | TraceMempoolManuallyRemovedTxs
-      ![GenTxId blk]
+      [GenTxId blk]
       -- ^ Transactions that have been manually removed from the Mempool.
-      ![Validated (GenTx blk)]
+      [Validated (GenTx blk)]
       -- ^ Previously valid transactions that are no longer valid because they
       -- dependend on transactions that were manually removed from the
       -- Mempool. These transactions have also been removed from the Mempool.
       --
       -- This list shares not transactions with the list of manually removed
       -- transactions.
-      !MempoolSize
+      MempoolSize
       -- ^ The current size of the Mempool.
 
 deriving instance ( Eq (GenTx blk)


### PR DESCRIPTION
For new tracing it is advisable/necessary  to remove the strictness annotations of the tracer type.

1. These objects are guaranteed to live only very short (with the new tracing framework).
2. Their is a great probability, that these messages will be filtered out, in which case laziness is better.
3. This is of all the dozens of tracer types the only one with such strictness annotations.
4. The new tracing infrastructure works prototype based. Since it is difficult to construct these objects, we use 'undefined' to make it work, which is not possible with these strictness annotations.  