### PR TITLE
Server2 test

### DIFF
--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -25,7 +25,8 @@ source-repository head
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Control.Monad.IOSim
+  exposed-modules:     Data.List.Octopus
+                     , Control.Monad.IOSim
   other-modules:       Control.Monad.IOSim.Internal
   default-language:    Haskell2010
   other-extensions:    BangPatterns,

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -37,7 +38,10 @@ module Control.Monad.IOSim.Internal (
   ThreadId,
   ThreadLabel,
   Labelled (..),
-  Trace (..),
+  Trace,
+  Octopus (Trace, TraceMainReturn, TraceMainException, TraceDeadlock),
+  EventCtx (..),
+  Value (..),
   TraceEvent (..),
   liftST,
   execReadTVar
@@ -49,6 +53,7 @@ import           Data.Dynamic (Dynamic, toDyn)
 import           Data.Foldable (traverse_)
 import           Data.Function (on)
 import qualified Data.List as List
+import           Data.List.Octopus (Octopus (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.OrdPSQ (OrdPSQ)
@@ -587,11 +592,42 @@ labelledThreads threadMap =
 -- See also: 'traceEvents', 'traceResult', 'selectTraceEvents',
 -- 'selectTraceEventsDynamic' and 'printTraceEventsSay'.
 --
-data Trace a = Trace !Time !ThreadId !(Maybe ThreadLabel) !TraceEvent (Trace a)
-             | TraceMainReturn    !Time a             ![Labelled ThreadId]
-             | TraceMainException !Time SomeException ![Labelled ThreadId]
-             | TraceDeadlock      !Time               ![Labelled ThreadId]
-  deriving Show
+data EventCtx = EventCtx {
+    ecTime        :: !Time,
+    ecThreadId    :: !ThreadId,
+    ecThreadLabel :: !(Maybe ThreadLabel),
+    ecTraceEvent  :: !TraceEvent
+  }
+
+data Value a
+    = MainReturn    !Time a             ![Labelled ThreadId]
+    | MainException !Time SomeException ![Labelled ThreadId]
+    | Deadlock      !Time               ![Labelled ThreadId]
+    deriving Show
+
+
+type Trace a = Octopus (Value a) EventCtx
+
+pattern Trace :: Time -> ThreadId -> Maybe ThreadLabel -> TraceEvent -> Trace a
+              -> Trace a
+pattern Trace time threadId threadLabel traceEvent trace =
+    Cons (EventCtx time threadId threadLabel traceEvent)
+         trace
+
+pattern TraceMainReturn :: Time -> a -> [Labelled ThreadId]
+                        -> Trace a
+pattern TraceMainReturn time a threads = Nil (MainReturn time a threads)
+
+pattern TraceMainException :: Time -> SomeException -> [Labelled ThreadId]
+                           -> Trace a
+pattern TraceMainException time err threads = Nil (MainException time err threads)
+
+pattern TraceDeadlock :: Time -> [Labelled ThreadId]
+                      -> Trace a
+pattern TraceDeadlock time threads = Nil (Deadlock time threads)
+
+{-# COMPLETE Trace, TraceMainReturn, TraceMainException, TraceDeadlock #-}
+
 
 data TraceEvent
   = EventSay  String

--- a/io-sim/src/Data/List/Octopus.hs
+++ b/io-sim/src/Data/List/Octopus.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE DeriveFunctor #-}
+
+module Data.List.Octopus
+  ( Octopus (..)
+  , toList
+  , fromList
+  , head
+  , tail
+  , filter
+  , length
+  ) where
+
+import           Prelude hiding (filter, head, length, tail)
+
+import           Control.Applicative (Alternative (..))
+import           Control.Monad (MonadPlus (..))
+import           Control.Monad.Fix (MonadFix (..), fix)
+import           Data.Bifunctor
+import           Data.Bifoldable
+import           Data.Bitraversable
+import           Data.Functor.Classes
+
+-- | A 'cons' list with polymorphic 'nil', thus an octopus.
+--
+-- * @'Octopus' Void a@ is an infinite stream
+-- * @'Octopus' () a@ is isomorphic to @[a]@
+--
+-- Usually used with @a@ being a non empty sum type.
+--
+data Octopus a b
+    = Cons b (Octopus a b)
+    | Nil a
+    deriving (Show, Eq, Ord, Functor)
+
+head :: Octopus a b -> b
+head (Cons b _) = b
+head _ = error "Octopus.head: empty"
+
+tail :: Octopus a b -> Octopus a b
+tail (Cons _ o) = o
+tail Nil {} = error "Octopus.tail: empty"
+
+filter :: (b -> Bool) -> Octopus a b -> Octopus a b
+filter _fn o@Nil {}   = o
+filter  fn (Cons b o) =
+    case fn b of
+      True  -> Cons b (filter fn o)
+      False ->         filter fn o
+
+length :: Octopus a b -> Int
+length (Cons _ o) = (+) 1 $! length o
+length  Nil {}    = 0
+
+toList :: Octopus a b -> [b]
+toList = bifoldr (\_ bs -> bs) (:) []
+
+fromList :: a -> [b] -> Octopus a b
+fromList a = foldr Cons (Nil a)
+
+instance Bifunctor Octopus where
+    bimap f g (Cons b bs) = Cons (g b) (bimap f g bs)
+    bimap f _ (Nil a)     = Nil (f a)
+
+instance Bifoldable Octopus where
+    bifoldMap f g (Cons b bs) = g b <> bifoldMap f g bs
+    bifoldMap f _ (Nil a)     = f a
+
+instance Bitraversable Octopus where
+    bitraverse f g (Cons b bs) = Cons <$> g b <*> bitraverse f g bs
+    bitraverse f _ (Nil a)     = Nil <$> f a
+
+instance Semigroup a => Semigroup (Octopus a b) where
+    Cons b o  <> o'          = Cons b (o <> o')
+    o@Nil {}  <> (Cons b o') = Cons b (o <> o')
+    Nil a     <> Nil a'      = Nil (a <> a')
+
+instance Monoid a => Monoid (Octopus a b) where
+    mempty = Nil mempty
+
+instance Monoid a => Applicative (Octopus a) where
+    pure b = Cons b (Nil mempty)
+    Cons f fs <*> o = fmap f o <> (fs <*> o)
+    Nil a <*> _     = Nil a
+
+instance Monoid a => Monad (Octopus a) where
+    return  = pure
+    -- @bifoldMap Nil id@ is the @join@ of @Octopus a@
+    o >>= f = bifoldMap Nil id $ fmap f o
+
+instance Monoid a => MonadFail (Octopus a) where
+    fail _ = mzero
+
+instance Monoid a => Alternative (Octopus a) where
+    empty = mempty
+    (<|>) = (<>)
+
+instance Monoid a => MonadPlus (Octopus a) where
+    mzero = mempty
+    mplus = (<>)
+
+instance Monoid a => MonadFix (Octopus a) where
+    mfix f = case fix (f . head) of
+      o@Nil {} -> o
+      Cons b _ -> Cons b (mfix (tail . f))
+
+instance Eq a => Eq1 (Octopus a) where
+    liftEq f (Cons b o) (Cons b' o') = f b b' && liftEq f o o'
+    liftEq _ Nil  {}     Cons {}     = False
+    liftEq _ Cons {}     Nil  {}     = False
+    liftEq _ (Nil a)    (Nil a')     = a == a'
+
+instance Ord a => Ord1 (Octopus a) where
+    liftCompare f (Cons b o) (Cons b' o') = f b b' `compare` liftCompare f o o'
+    liftCompare _  Nil  {}    Cons {}     = LT
+    liftCompare _  Cons {}    Nil {}      = GT
+    liftCompare _ (Nil a)    (Nil a')     = a `compare` a'
+
+instance Show a => Show1 (Octopus a) where
+    liftShowsPrec  showsPrec_ showsList_ prec (Cons b o)
+      = showString "Cons "
+      . showsPrec_ prec b
+      . showChar ' '
+      . showParen True (liftShowsPrec showsPrec_ showsList_ prec o)
+    liftShowsPrec _showsPrec _showsList _prec (Nil a)
+      = showString "Nil "
+      . shows a

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -67,8 +67,6 @@ data MuxErrorType = MuxUnknownMiniProtocol
                   -- ^ Result of runMiniProtocol's completionAction in case of an error.
                   | MuxCleanShutdown
                   -- ^ Mux stopped by 'stopMux'
-                  | MuxBlockedOnCompletionVar !MiniProtocolNum
-                  -- ^  Mux blocked on @completionVar@.
                   deriving (Show, Eq)
 
 instance Exception MuxError where

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -39,10 +39,13 @@ module Network.Mux.Types (
     , msLength
     , RemoteClockModel (..)
     , remoteClockPrecision
+
+    , MuxRuntimeError (..)
     ) where
 
 import           Prelude hiding (read)
 
+import           Control.Exception (Exception)
 import           Data.Functor (void)
 import           Data.Ix (Ix (..))
 import           Data.Word
@@ -173,7 +176,7 @@ data MiniProtocolState mode m = MiniProtocolState {
      }
 
 data MiniProtocolStatus = StatusIdle | StatusStartOnDemand | StatusRunning
-  deriving Eq
+  deriving (Eq, Show)
 
 data MuxSDUHeader = MuxSDUHeader {
       mhTimestamp :: !RemoteClockModel
@@ -255,3 +258,15 @@ muxBearerAsChannel bearer ptclNum ptclDir =
 
       noTimeout :: TimeoutFn m
       noTimeout _ r = Just <$> r
+
+--
+-- Errors
+--
+
+data MuxRuntimeError =
+    ProtocolAlreadyRunning    !MiniProtocolNum !MiniProtocolDir !MiniProtocolStatus
+  | UnknownProtocol           !MiniProtocolNum !MiniProtocolDir
+  | MuxBlockedOnCompletionVar !MiniProtocolNum
+  deriving Show
+
+instance Exception MuxRuntimeError

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -705,8 +705,8 @@ withConnectionManager ConnectionManagerArguments {
                                               }
                                  ]
 
-                    traceCounters stateVar
                     traverse_ (traceWith trTracer . TransitionTrace peerAddr) trs
+                    traceCounters stateVar
 
       -- start connection thread
       connThread <- asyncWithUnmask $ \unmask ->
@@ -986,9 +986,9 @@ withConnectionManager ConnectionManagerArguments {
                        , Nothing
                        , UnsupportedState TerminatedSt )
 
+      traverse_ (traceWith trTracer . TransitionTrace peerAddr) mbTransition
       traverse_ cancel mbThread
       traceCounters stateVar
-      traverse_ (traceWith trTracer . TransitionTrace peerAddr) mbTransition
       return result
 
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -843,7 +843,7 @@ data Transition' state = Transition
     { fromState :: !state
     , toState   :: !state
     }
-  deriving (Show, Functor)
+  deriving (Eq, Functor, Show)
 
 type Transition state   = Transition' (MaybeUnknown state)
 type AbstractTransition = Transition' AbstractState

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -84,6 +84,8 @@ import qualified Ouroboros.Network.InboundGovernor.ControlChannel as ControlChan
 inboundGovernor :: forall (muxMode :: MuxMode) socket peerAddr versionNumber m a b.
                    ( MonadAsync    m
                    , MonadCatch    m
+                   , MonadThrow    m
+                   , MonadThrow   (STM m)
                    , MonadTime     m
                    , MonadTimer    m
                    , MonadEvaluate m
@@ -403,6 +405,7 @@ runResponder :: forall (mode :: MuxMode) m a b.
                  ( HasResponder mode ~ True
                  , MonadAsync m
                  , MonadCatch m
+                 , MonadThrow (STM m)
                  )
               => Mux.Mux mode m
               -> MiniProtocol mode ByteString m a b

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
@@ -107,6 +107,7 @@ data ServerArguments (muxMode  :: MuxMode) socket peerAddr versionNumber bytes m
 run :: forall muxMode socket peerAddr versionNumber m a b.
        ( MonadAsync    m
        , MonadCatch    m
+       , MonadThrow   (STM m)
        , MonadTime     m
        , MonadTimer    m
        , MonadEvaluate m

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
@@ -25,6 +25,7 @@
 
 module Test.Ouroboros.Network.ConnectionManager
   ( tests
+  , verifyAbstractTransition
   ) where
 
 import           Prelude hiding (read)
@@ -1766,6 +1767,8 @@ verifyAbstractTransition Transition { fromState, toState } =
       -- @Negotiated^{Unidirectional}_{Inbound}
       (UnnegotiatedSt Inbound, InboundIdleSt Unidirectional) -> True
 
+      -- 'unregisterOutboundConnection' might perfrom
+      (InboundIdleSt Duplex, InboundIdleSt Duplex) -> True
       -- @Awake^{Duplex}_{Remote}
       (InboundIdleSt Duplex, InboundSt Duplex) -> True
       -- @Commit^{Duplex}

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -34,8 +37,9 @@ import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 import           Codec.Serialise.Class (Serialise)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Functor (($>), (<&>))
-import           Data.List (mapAccumL, intercalate)
+import           Data.List (mapAccumL, intercalate, (\\), tails, delete)
 import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
@@ -75,6 +79,7 @@ import           Ouroboros.Network.Server2 (ServerArguments (..))
 import qualified Ouroboros.Network.Server2 as Server
 import           Ouroboros.Network.Snocket (Snocket, TestAddress (..), socketSnocket)
 import qualified Ouroboros.Network.Snocket as Snocket
+import           Ouroboros.Network.Testing.Utils (genDelayWithPrecision)
 import           Simulation.Network.Snocket
 
 import           Test.Ouroboros.Network.Orphans ()  -- ShowProxy ReqResp instance
@@ -87,6 +92,7 @@ tests =
   , testProperty "unidirectional_Sim" prop_unidirectional_Sim
   , testProperty "bidirectional_IO"   prop_bidirectional_IO
   , testProperty "bidirectional_Sim"  prop_bidirectional_Sim
+  , testProperty "multinode_Sim"      prop_multinode_Sim
   ]
 
 --
@@ -243,6 +249,7 @@ withInitiatorOnlyConnectionManager
     -> Snocket m socket peerAddr
     -- ^ series of request possible to do with the bidirectional connection
     -- manager towards some peer.
+    -> Maybe peerAddr
     -> Bundle (ConnectionId peerAddr -> STM m [req])
     -- ^ Functions to get the next requests for a given connection
     -> (MuxConnectionManager
@@ -250,7 +257,7 @@ withInitiatorOnlyConnectionManager
           UnversionedProtocol ByteString m [resp] Void
        -> m a)
     -> m a
-withInitiatorOnlyConnectionManager name snocket nextRequests k = do
+withInitiatorOnlyConnectionManager name snocket localAddr nextRequests k = do
     mainThreadId <- myThreadId
     let muxTracer = (name,) `contramap` nullTracer -- mux tracer
     withConnectionManager
@@ -262,7 +269,7 @@ withInitiatorOnlyConnectionManager name snocket nextRequests k = do
                         `contramap` nullTracer,
          -- MuxTracer
           cmMuxTracer = muxTracer,
-          cmIPv4Address = Nothing,
+          cmIPv4Address = localAddr,
           cmIPv6Address = Nothing,
           cmAddressType = \_ -> Just IPv4Address,
           cmSnocket = snocket,
@@ -347,10 +354,10 @@ withInitiatorOnlyConnectionManager name snocket nextRequests k = do
 --
 
 protocolIdleTimeout :: DiffTime
-protocolIdleTimeout = 0.1
+protocolIdleTimeout = 30
 
 timeWaitTimeout :: DiffTime
-timeWaitTimeout = 0.1
+timeWaitTimeout = 30
 
 outboundIdleTimeout :: DiffTime
 outboundIdleTimeout = 0.1
@@ -551,13 +558,13 @@ withBidirectionalConnectionManager name snocket socket localAddress
       -> acc
       -> STM m [req]
       -> RunMiniProtocol InitiatorResponderMode ByteString m [resp] acc
-    reqRespInitiatorAndResponder protocolNum accInit nextRequests_ =
+    reqRespInitiatorAndResponder protocolNum accInit nextRequest =
       InitiatorAndResponderProtocol
         (MuxPeer
           ((name,"Initiator",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
           codecReqResp
           (Effect $ do
-            reqs <- atomically nextRequests_
+            reqs <- atomically nextRequest
             pure $ reqRespClientPeer (reqRespClientMap reqs)))
         (MuxPeer
           ((name,"Responder",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
@@ -684,7 +691,7 @@ unidirectionalExperiment snocket socket clientAndServerData = do
     nextReqs <- oneshotNextRequests clientAndServerData
     noServerReqs <- noNextRequests
     withInitiatorOnlyConnectionManager
-      "client" snocket nextReqs
+      "client" snocket Nothing nextReqs
       $ \connectionManager ->
         withBidirectionalConnectionManager "server" snocket socket Nothing
                                            [accumulatorInit clientAndServerData] noServerReqs
@@ -930,14 +937,422 @@ prop_bidirectional_IO data0 data1 =
               data1
 
 
+--- Multi-node experiment
+
+-- | A test case for the multi-node property contains a sequence of connection events. The
+--   `DiffTime` in each constructor is relative to the previous event in the sequence.
+data ConnectionEvent req peerAddr
+  = StartClient DiffTime peerAddr
+    -- ^ Start a new client at the given address
+  | StartServer DiffTime peerAddr req
+    -- ^ Start a new server at the given address
+  | InboundConnection DiffTime peerAddr
+    -- ^ Create a connection from client or server with the given address to the central server.
+  | OutboundConnection DiffTime peerAddr
+    -- ^ Create a connection from the central server to another server.
+  | InboundMiniprotocols DiffTime peerAddr (Bundle [req])
+    -- ^ Run a bundle of mini protocols on the inbound connection from the given address.
+  | OutboundMiniprotocols DiffTime peerAddr (Bundle [req])
+    -- ^ Run a bundle of mini protocols on the outbound connection to the given address.
+  | CloseInboundConnection DiffTime peerAddr
+    -- ^ Close an inbound connection.
+  | CloseOutboundConnection DiffTime peerAddr
+    -- ^ Close an outbound connection.
+  deriving (Show, Functor)
+
+-- | A sequence of connection events that make up a test scenario for `prop_multinode_Sim`.
+newtype MultiNodeScript req peerAddr = MultiNodeScript [ConnectionEvent req peerAddr]
+  deriving (Show, Functor)
+
+-- | To generate well-formed scripts we need to keep track of what nodes are started and what
+--   connections they've made.
+data ScriptState peerAddr = ScriptState { startedClients      :: [peerAddr]
+                                        , startedServers      :: [peerAddr]
+                                        , clientConnections   :: [peerAddr]
+                                        , inboundConnections  :: [peerAddr]
+                                        , outboundConnections :: [peerAddr] }
+
+-- | Update the state after a connection event.
+nextState :: Eq peerAddr => ConnectionEvent req peerAddr -> ScriptState peerAddr -> ScriptState peerAddr
+nextState e s@ScriptState{..} =
+  case e of
+    StartClient             _ a   -> s{ startedClients      = a : startedClients }
+    StartServer             _ a _ -> s{ startedServers      = a : startedServers }
+    InboundConnection       _ a   -> s{ inboundConnections  = a : inboundConnections }
+    OutboundConnection      _ a   -> s{ outboundConnections = a : outboundConnections }
+    CloseInboundConnection  _ a   -> s{ inboundConnections  = delete a inboundConnections }
+    CloseOutboundConnection _ a   -> s{ outboundConnections = delete a outboundConnections }
+    InboundMiniprotocols{}        -> s
+    OutboundMiniprotocols{}       -> s
+
+-- | Check if an event makes sense in a given state.
+isValidEvent :: Eq peerAddr => ConnectionEvent req peerAddr -> ScriptState peerAddr -> Bool
+isValidEvent e ScriptState{..} =
+  case e of
+    StartClient             _ a   -> notElem a (startedClients ++ startedServers)
+    StartServer             _ a _ -> notElem a (startedClients ++ startedServers)
+    InboundConnection       _ a   -> elem a (startedServers ++ startedClients) && notElem a inboundConnections
+    OutboundConnection      _ a   -> elem a startedServers && notElem a outboundConnections
+    CloseInboundConnection  _ a   -> elem a inboundConnections
+    CloseOutboundConnection _ a   -> elem a outboundConnections
+    InboundMiniprotocols    _ a _ -> elem a inboundConnections
+    OutboundMiniprotocols   _ a _ -> elem a outboundConnections
+
+-- This could be an Arbitrary instance, but it would be an orphan.
+genBundle :: Arbitrary a => Gen (Bundle a)
+genBundle = traverse id $ pure arbitrary
+
+shrinkBundle :: Arbitrary a => Bundle a -> [Bundle a]
+shrinkBundle (Bundle (WithHot hot) (WithWarm warm) (WithEstablished est)) =
+  (shrink hot  <&> \ hot'  -> Bundle (WithHot hot') (WithWarm warm)  (WithEstablished est)) ++
+  (shrink warm <&> \ warm' -> Bundle (WithHot hot)  (WithWarm warm') (WithEstablished est)) ++
+  (shrink est  <&> \ est'  -> Bundle (WithHot hot)  (WithWarm warm)  (WithEstablished est'))
+
+instance (Arbitrary peerAddr, Arbitrary req, Eq peerAddr) =>
+         Arbitrary (MultiNodeScript req peerAddr) where
+  arbitrary = do
+      NonNegative len <- scale (`div` 2) arbitrary
+      MultiNodeScript <$> go (ScriptState [] [] [] [] []) (len :: Integer)
+    where     -- Divide delays by 100 to avoid running in to protocol and SDU timeouts if waiting
+              -- too long between connections and mini protocols.
+      delay = frequency [(1, pure 0), (3, (/ 100) <$> genDelayWithPrecision 2)]
+      go _ 0 = pure []
+      go s@ScriptState{..} n = do
+        event <- frequency $
+                    [ (1, StartClient             <$> delay <*> newClient)
+                    , (1, StartServer             <$> delay <*> newServer <*> arbitrary) ] ++
+                    [ (4, InboundConnection       <$> delay <*> elements possibleInboundConnections)  | not $ null possibleInboundConnections] ++
+                    [ (4, OutboundConnection      <$> delay <*> elements possibleOutboundConnections) | not $ null possibleOutboundConnections] ++
+                    [ (4, CloseInboundConnection  <$> delay <*> elements inboundConnections)  | not $ null $ inboundConnections ] ++
+                    [ (4, CloseOutboundConnection <$> delay <*> elements outboundConnections) | not $ null $ outboundConnections ] ++
+                    [ (16, InboundMiniprotocols   <$> delay <*> elements inboundConnections  <*> genBundle) | not $ null inboundConnections ] ++
+                    [ (16, OutboundMiniprotocols  <$> delay <*> elements outboundConnections <*> genBundle) | not $ null outboundConnections ]
+        (event :) <$> go (nextState event s) (n - 1)
+        where
+          possibleInboundConnections  = (startedClients ++ startedServers) \\ inboundConnections
+          possibleOutboundConnections = startedServers \\ outboundConnections
+          newClient = arbitrary `suchThat` (`notElem` (startedClients ++ startedServers))
+          newServer = arbitrary `suchThat` (`notElem` (startedClients ++ startedServers))
+
+  shrink (MultiNodeScript events) = MultiNodeScript . makeValid <$> shrinkList shrinkEvent events
+    where
+      makeValid = go (ScriptState [] [] [] [] [])
+        where
+          go _ [] = []
+          go s (e : es)
+            | isValidEvent e s = e : go (nextState e s) es
+            | otherwise        = go s es
+
+      shrinkDelay = map fromRational . shrink . toRational
+
+      shrinkEvent (StartServer d a p) =
+        (shrink p      <&> \ p' -> StartServer d  a p') ++
+        (shrinkDelay d <&> \ d' -> StartServer d' a p)
+      shrinkEvent (StartClient             d a) = shrinkDelay d <&> \ d' -> StartClient d' a
+      shrinkEvent (InboundConnection       d a) = shrinkDelay d <&> \ d' -> InboundConnection  d' a
+      shrinkEvent (OutboundConnection      d a) = shrinkDelay d <&> \ d' -> OutboundConnection d' a
+      shrinkEvent (CloseInboundConnection  d a) = shrinkDelay d <&> \ d' -> CloseInboundConnection  d' a
+      shrinkEvent (CloseOutboundConnection d a) = shrinkDelay d <&> \ d' -> CloseOutboundConnection d' a
+      shrinkEvent (InboundMiniprotocols    d a r) =
+        (shrinkBundle r <&> \ r' -> InboundMiniprotocols d  a r') ++
+        (shrinkDelay  d <&> \ d' -> InboundMiniprotocols d' a r)
+      shrinkEvent (OutboundMiniprotocols d a r) =
+        (shrinkBundle r <&> \ r' -> OutboundMiniprotocols d  a r') ++
+        (shrinkDelay  d <&> \ d' -> OutboundMiniprotocols d' a r)
+
+-- | We use a wrapper for test addresses since the Arbitrary instance for Snocket.TestAddress only
+--   generates addresses between 1 and 4.
+newtype TestAddr = TestAddr { unTestAddr :: Snocket.TestAddress Int }
+  deriving (Show, Eq, Ord)
+
+instance Arbitrary TestAddr where
+  arbitrary = TestAddr . Snocket.TestAddress <$> choose (1, 100)
+
+-- | Each node in the multi-node experiment is controlled by a thread responding to these messages.
+data ConnectionHandlerMessage peerAddr req
+  = NewConnection peerAddr [req]
+    -- ^ Connect to the server at the given address. Needs to know the `accumulatorInit` of the
+    --   server in order to validate the responses.
+  | Disconnect peerAddr
+    -- ^ Disconnect from the server at the given address.
+  | RunMiniProtocols peerAddr (Bundle [req])
+    -- ^ Run a bundle of mini protocols against the server at the given address (requires an active
+    --   connection).
+
+-- | Run a central server that talks to any number of clients and other nodes.
+multinodeExperiment
+    :: forall peerAddr socket acc req resp m.
+       ( ConnectionManagerMonad m
+       , MonadAsync m
+       , MonadLabelledSTM m
+       , MonadSay m
+       , acc ~ [req], resp ~ [req]
+       , Ord peerAddr, Show peerAddr, Typeable peerAddr, Eq peerAddr
+       , Eq (LazySTM.TVar m (ConnectionState
+                                peerAddr
+                                (Handle 'InitiatorMode peerAddr ByteString m [resp] Void)
+                                (HandleError 'InitiatorMode UnversionedProtocol)
+                                (UnversionedProtocol, UnversionedProtocolData)
+                                m))
+       , Eq (LazySTM.TVar m (ConnectionState_ InitiatorResponderMode peerAddr m [resp] acc))
+       , Serialise req, Show req
+       , Serialise resp, Show resp, Eq resp
+       , Typeable req, Typeable resp
+       )
+    => Snocket m socket peerAddr
+    -> Snocket.AddressFamily peerAddr
+    -> peerAddr
+    -> req
+    -> MultiNodeScript req peerAddr
+    -> m Property
+multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript script) = do
+  -- Avoid parallel connections. This can cause one side to think that the existing connection
+  -- should be used and the other side thinking that there should be two separate connections,
+  -- causing the latter to wait on messages that never come.
+  lock <- newTMVarIO ()
+  labelTMVarIO lock "lock"
+  -- TVar keeping the resulting property. Connection handler threads update this after each
+  -- mini-protocol run.
+  propVar <- newTVarIO (property True)
+  labelTVarIO propVar "propVar"
+  cc <- startServerConnectionHandler "main-server" [accInit] serverAddr lock propVar
+  loop lock (Map.singleton serverAddr [accInit]) (Map.singleton serverAddr cc) propVar script
+  where
+
+    loop :: StrictTMVar m ()
+         -> Map.Map peerAddr acc
+         -> Map.Map peerAddr (TQueue m (ConnectionHandlerMessage peerAddr req))
+         -> StrictTVar m Property
+         -> [ConnectionEvent req peerAddr]
+         -> m Property
+    loop _ _ _ propVar [] = do
+      threadDelay 3600
+      atomically $ readTVar propVar
+    loop lock nodeAccs servers propVar (event : events) =
+      case event of
+
+        StartClient delay localAddr -> do
+          threadDelay delay
+          cc <- startClientConnectionHandler ("client-" ++ show localAddr) localAddr lock propVar
+          loop lock nodeAccs (Map.insert localAddr cc servers) propVar events
+
+        StartServer delay localAddr nodeAcc -> do
+          threadDelay delay
+          cc <- startServerConnectionHandler ("node-" ++ show localAddr) [nodeAcc] localAddr lock propVar
+          loop lock (Map.insert localAddr [nodeAcc] nodeAccs) (Map.insert localAddr cc servers) propVar events
+
+        InboundConnection delay nodeAddr -> do
+          threadDelay delay
+          acc <- getAcc serverAddr
+          sendMsg nodeAddr $ NewConnection serverAddr acc
+          loop lock nodeAccs servers propVar events
+
+        OutboundConnection delay nodeAddr -> do
+          threadDelay delay
+          acc <- getAcc nodeAddr
+          sendMsg serverAddr $ NewConnection nodeAddr acc
+          loop lock nodeAccs servers propVar events
+
+        CloseInboundConnection delay remoteAddr -> do
+          threadDelay delay
+          sendMsg remoteAddr $ Disconnect serverAddr
+          loop lock nodeAccs servers propVar events
+
+        CloseOutboundConnection delay remoteAddr -> do
+          threadDelay delay
+          sendMsg serverAddr $ Disconnect remoteAddr
+          loop lock nodeAccs servers propVar events
+
+        InboundMiniprotocols delay nodeAddr reqs -> do
+          threadDelay delay
+          sendMsg nodeAddr $ RunMiniProtocols serverAddr reqs
+          loop lock nodeAccs servers propVar events
+
+        OutboundMiniprotocols delay nodeAddr reqs -> do
+          threadDelay delay
+          sendMsg serverAddr $ RunMiniProtocols nodeAddr reqs
+          loop lock nodeAccs servers propVar events
+      where
+        sendMsg :: peerAddr -> ConnectionHandlerMessage peerAddr req -> m ()
+        sendMsg addr msg = atomically $
+          case Map.lookup addr servers of
+            Nothing -> assertProperty propVar $ counterexample (show addr ++ " is not a started node") False
+            Just cc -> writeTQueue cc msg
+
+        getAcc :: peerAddr -> m acc
+        getAcc addr =
+          case Map.lookup addr nodeAccs of
+            Nothing  -> do
+              assertPropertyIO propVar $ counterexample (show addr ++ " is not a started server node") False
+              return []
+            Just acc -> return acc
+
+    mkNextRequests :: StrictTVar m (Map.Map (ConnectionId peerAddr) (Bundle (TQueue m [req]))) ->
+                      Bundle (ConnectionId peerAddr -> STM m [req])
+    mkNextRequests connVar = makeBundle next
+      where
+        next :: forall pt. TokProtocolTemperature pt -> ConnectionId peerAddr -> STM m [req]
+        next tok connId = do
+          connMap <- readTVar connVar
+          case Map.lookup connId connMap of
+            Nothing -> retry
+            Just qs -> readTQueue (projectBundle tok qs)
+
+    assertPropertyIO :: StrictTVar m Property -> Property -> m ()
+    assertPropertyIO propVar p = atomically $ assertProperty propVar p
+
+    assertProperty :: StrictTVar m Property -> Property -> STM m ()
+    assertProperty propVar p = modifyTVar propVar (.&&. p)
+
+    startClientConnectionHandler :: String -> peerAddr
+                                 -> StrictTMVar m ()
+                                 -> StrictTVar m Property
+                                 -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
+    startClientConnectionHandler name localAddr lock propVar = do
+        cc      <- atomically $ newTQueue
+        labelTQueueIO cc $ "cc/" ++ name
+        connVar <- newTVarIO Map.empty
+        labelTVarIO connVar $ "connVar/" ++ name
+        _ <- forkIO $ do
+          labelMe name
+          withInitiatorOnlyConnectionManager
+              name snocket (Just localAddr) (mkNextRequests connVar) $ \ connectionManager ->
+            connectionLoop SingInitiatorMode localAddr lock propVar cc connectionManager Map.empty connVar
+        return cc
+
+    startServerConnectionHandler :: String -> acc -> peerAddr
+                                 -> StrictTMVar m ()
+                                 -> StrictTVar m Property
+                                 -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
+    startServerConnectionHandler name serverAcc localAddr lock propVar = do
+        fd <- Snocket.open snocket addrFamily
+        Snocket.bind   snocket fd localAddr
+        Snocket.listen snocket fd
+        cc      <- atomically $ newTQueue
+        labelTQueueIO cc $ "cc/" ++ name
+        connVar <- newTVarIO Map.empty
+        labelTVarIO connVar $ "connVar/" ++ name
+        _ <- forkIO $ do
+          labelMe name
+          withBidirectionalConnectionManager
+                name snocket fd (Just localAddr) serverAcc
+                (mkNextRequests connVar) $ \ connectionManager _ serverAsync -> do
+            link serverAsync
+            connectionLoop SingInitiatorResponderMode localAddr lock propVar cc connectionManager Map.empty connVar
+        return cc
+
+    connectionLoop
+         :: (HasInitiator muxMode ~ True)
+         => SingMuxMode muxMode
+         -> peerAddr
+         -> StrictTMVar m ()
+         -> StrictTVar m Property
+         -> TQueue m (ConnectionHandlerMessage peerAddr req)                          -- control channel
+         -> MuxConnectionManager muxMode socket peerAddr UnversionedProtocol ByteString m [resp] a
+         -> Map.Map peerAddr (Handle muxMode peerAddr ByteString m [resp] a, acc)     -- active connections
+         -> StrictTVar m (Map.Map (ConnectionId peerAddr) (Bundle (TQueue m [req])))  -- mini protocol queues
+         -> m ()
+    connectionLoop muxMode localAddr lock propVar cc cm connMap connVar = atomically (readTQueue cc) >>= \ case
+      NewConnection remoteAddr remoteAcc -> do
+        let mkQueue :: forall pt. TokProtocolTemperature pt -> STM m (TQueue m [req])
+            mkQueue tok = do
+              q <- newTQueue
+              let temp = case tok of
+                    TokHot         -> "hot"
+                    TokWarm        -> "warm"
+                    TokEstablished -> "cold"
+              q <$ labelTQueue q ("protoVar." ++ temp ++ "@" ++ show localAddr)
+        qs <- atomically $ traverse id $ makeBundle mkQueue
+        atomically $ modifyTVar connVar $ Map.insert (connId remoteAddr) qs
+        connHandle <- withLock False lock $ requestOutboundConnection cm remoteAddr
+        case connHandle of
+          Connected _ _ h -> do
+            connectionLoop muxMode localAddr lock propVar cc cm (Map.insert remoteAddr (h, remoteAcc) connMap) connVar
+          Disconnected _ err ->
+            failureIO $ "connection failure: " ++ show err
+      Disconnect remoteAddr -> do
+        atomically $ modifyTVar connVar $ Map.delete (connId remoteAddr)
+        _ <- unregisterOutboundConnection cm remoteAddr
+        connectionLoop muxMode localAddr lock propVar cc cm (Map.delete remoteAddr connMap) connVar
+      RunMiniProtocols remoteAddr reqs -> do
+        atomically $ do
+          mqs <- (Map.lookup $ connId remoteAddr) <$> readTVar connVar
+          case mqs of
+            Nothing -> failure $ "No active connection " ++ show localAddr ++ " => " ++ show remoteAddr
+            Just qs -> do
+              sequence_ $ writeTQueue <$> qs <*> reqs
+        case Map.lookup remoteAddr connMap of
+          Nothing -> failureIO $ "no connection " ++ show localAddr ++ " => " ++ show remoteAddr
+          Just (Handle mux muxBundle _, acc)  -> do
+            rs <- try @_ @SomeException $ runInitiatorProtocols muxMode mux muxBundle
+            case rs of
+              Left err -> failureIO $ "protocol error: " ++ show err
+              Right r  -> assertPropertyIO propVar $ r === fmap (drop 2 . reverse .  tails . (++ acc) . reverse) reqs
+        connectionLoop muxMode localAddr lock propVar cc cm connMap connVar
+      where
+        connId remoteAddr = ConnectionId{ localAddress = localAddr, remoteAddress = remoteAddr }
+
+        failureIO :: String -> m ()
+        failureIO = atomically . failure
+
+        failure :: String -> STM m ()
+        failure err = assertProperty propVar $ counterexample err False
+
+-- | Property wrapping `multinodeExperiment`.
+prop_multinode_Sim :: Int -> MultiNodeScript Int TestAddr -> Property
+prop_multinode_Sim serverAcc script' =
+  simulatedPropertyWithTimeout 7200 $
+    withSnocket debugTracer (singletonScript noAttenuation) (TestAddress 10) $ \snocket ->
+    let script  = unTestAddr <$> script' in
+    counterexample (ppScript script) <$>
+      multinodeExperiment snocket Snocket.TestFamily (Snocket.TestAddress 0) serverAcc script
+
+ppScript :: (Show peerAddr, Show req) => MultiNodeScript peerAddr req -> String
+ppScript (MultiNodeScript script) = intercalate "\n" $ go 0 script
+  where
+    delay (StartServer             d _ _) = d
+    delay (StartClient             d _)   = d
+    delay (InboundConnection       d _)   = d
+    delay (OutboundConnection      d _)   = d
+    delay (InboundMiniprotocols    d _ _) = d
+    delay (OutboundMiniprotocols   d _ _) = d
+    delay (CloseInboundConnection  d _)   = d
+    delay (CloseOutboundConnection d _)   = d
+
+    ppEvent (StartServer             _ a i) = "Start server " ++ show a ++ " with accInit=" ++ show i
+    ppEvent (StartClient             _ a)   = "Start client " ++ show a
+    ppEvent (InboundConnection       _ a)   = "Connection from " ++ show a
+    ppEvent (OutboundConnection      _ a)   = "Connecting to " ++ show a
+    ppEvent (InboundMiniprotocols    _ a p) = "Miniprotocols from " ++ show a ++ ": " ++ ppData p
+    ppEvent (OutboundMiniprotocols   _ a p) = "Miniprotocols to " ++ show a ++ ": " ++ ppData p
+    ppEvent (CloseInboundConnection  _ a)   = "Close connection from " ++ show a
+    ppEvent (CloseOutboundConnection _ a)   = "Close connection to " ++ show a
+
+    ppData (Bundle hot warm est) =
+      concat [ "hot:", show (withoutProtocolTemperature hot)
+             , " warm:", show (withoutProtocolTemperature warm)
+             , " est:", show (withoutProtocolTemperature est)]
+
+    go _ [] = []
+    go t (e : es) = printf "%5s: %s" (show t') (ppEvent e) : go t' es
+      where t' = t + delay e
+
 --
 -- Utils
 --
+
+labelMe :: MonadFork m => String -> m ()
+labelMe l = myThreadId >>= (`labelThread` l)
 
 debugTracer :: (MonadSay m, MonadTime m, Show a) => Tracer m a
 debugTracer = Tracer $
   \msg -> (,msg) <$> getCurrentTime >>= say . show
 
+-- | Convenience function to create a Bundle. Could move to Ouroboros.Network.Mux.
+makeBundle :: (forall pt. TokProtocolTemperature pt -> a) -> Bundle a
+makeBundle f = Bundle (WithHot         $ f TokHot)
+                      (WithWarm        $ f TokWarm)
+                      (WithEstablished $ f TokEstablished)
 
 connectionManagerTracer
   :: ( MonadSay  m

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -21,7 +21,7 @@ module Test.Ouroboros.Network.Server2
   ) where
 
 import           Control.Exception (AssertionFailed)
-import           Control.Monad (replicateM)
+import           Control.Monad (replicateM, (>=>))
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadFork
@@ -635,24 +635,12 @@ runInitiatorProtocols
     -> m (Bundle a)
 runInitiatorProtocols
     singMuxMode mux
-    (Bundle (WithHot  [hotPtcl])
-            (WithWarm [warmPtcl])
-            (WithEstablished [establishedPtcl])) = do
-      -- start all protocols
-      hotSTM <- runInitiator hotPtcl
-      warmSTM <- runInitiator warmPtcl
-      establishedSTM <- runInitiator establishedPtcl
-
-      -- await for their termination
-      hotRes <- atomically hotSTM
-      warmRes <- atomically warmSTM
-      establishedRes <- atomically establishedSTM
-      case (hotRes, warmRes, establishedRes) of
-        (Left err, _, _) -> throwIO err
-        (_, Left err, _) -> throwIO err
-        (_, _, Left err) -> throwIO err
-        (Right hot, Right warm, Right established) ->
-          pure $ Bundle (WithHot hot) (WithWarm warm) (WithEstablished established)
+    bundle
+     = do -- start all mini-protocols
+          bundle' <- traverse runInitiator (head <$> bundle)
+          -- await for their termination
+          traverse (atomically >=> either throwIO return)
+                   bundle'
   where
     runInitiator :: MiniProtocol muxMode ByteString m a b
                  -> m (STM m (Either SomeException a))
@@ -669,10 +657,6 @@ runInitiatorProtocols
             InitiatorProtocolOnly initiator -> initiator
             InitiatorAndResponderProtocol initiator _ -> initiator)
           . fromChannel)
-
-runInitiatorProtocols _singMuxMode _mux (Bundle {}) =
-    error "runInitiatorProtocols: unsupported"
-
 
 --
 -- Experiments \/ Demos & Properties

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -85,7 +85,7 @@ import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
 import           Ouroboros.Network.Server2 (ServerArguments (..))
 import qualified Ouroboros.Network.Server2 as Server
-import           Ouroboros.Network.Snocket (Snocket, TestAddress (..), socketSnocket)
+import           Ouroboros.Network.Snocket (Snocket, socketSnocket)
 import qualified Ouroboros.Network.Snocket as Snocket
 import           Ouroboros.Network.Testing.Utils (genDelayWithPrecision)
 import           Simulation.Network.Snocket
@@ -756,7 +756,7 @@ prop_unidirectional_Sim clientAndServerData =
   simulatedPropertyWithTimeout 7200 $
     withSnocket nullTracer
                 (singletonScript noAttenuation)
-                (TestAddress 10) $ \snock ->
+                (Snocket.TestAddress 10) $ \snock ->
       bracket (Snocket.open snock Snocket.TestFamily)
               (Snocket.close snock) $ \fd -> do
         Snocket.bind   snock fd serverAddr
@@ -909,13 +909,14 @@ prop_bidirectional_Sim (NonFailingBearerInfoScript script) data0 data1 =
   simulatedPropertyWithTimeout 7200 $
     withSnocket debugTracer
                 script'
-                (TestAddress 10) $ \snock ->
+                (Snocket.TestAddress 10) $ \snock ->
       bracket ((,) <$> Snocket.open snock Snocket.TestFamily
                    <*> Snocket.open snock Snocket.TestFamily)
               (\ (socket0, socket1) -> Snocket.close snock socket0 >>
                                        Snocket.close snock socket1)
         $ \ (socket0, socket1) -> do
-          let addr0 = Snocket.TestAddress (0 :: Int)
+          let addr0, addr1 :: SimAddr
+              addr0 = Snocket.TestAddress 0
               addr1 = Snocket.TestAddress 1
           Snocket.bind   snock socket0 addr0
           Snocket.bind   snock socket1 addr1

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -1047,7 +1047,7 @@ shrinkBundle (Bundle (WithHot hot) (WithWarm warm) (WithEstablished est)) =
 instance (Arbitrary peerAddr, Arbitrary req, Eq peerAddr) =>
          Arbitrary (MultiNodeScript req peerAddr) where
   arbitrary = do
-      NonNegative len <- scale (`div` 2) arbitrary
+      Positive len <- scale ((* 2) . (`div` 3)) arbitrary
       MultiNodeScript <$> go (ScriptState [] [] [] [] []) (len :: Integer)
     where     -- Divide delays by 100 to avoid running in to protocol and SDU timeouts if waiting
               -- too long between connections and mini protocols.
@@ -1055,8 +1055,8 @@ instance (Arbitrary peerAddr, Arbitrary req, Eq peerAddr) =>
       go _ 0 = pure []
       go s@ScriptState{..} n = do
         event <- frequency $
-                    [ (1, StartClient             <$> delay <*> newClient)
-                    , (1, StartServer             <$> delay <*> newServer <*> arbitrary) ] ++
+                    [ (4, StartClient             <$> delay <*> newClient)
+                    , (4, StartServer             <$> delay <*> newServer <*> arbitrary) ] ++
                     [ (4, InboundConnection       <$> delay <*> elements possibleInboundConnections)  | not $ null possibleInboundConnections] ++
                     [ (4, OutboundConnection      <$> delay <*> elements possibleOutboundConnections) | not $ null possibleOutboundConnections] ++
                     [ (4, CloseInboundConnection  <$> delay <*> elements inboundConnections)  | not $ null $ inboundConnections ] ++

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -212,6 +212,33 @@ oneshotNextRequests ClientAndServerData {
         reqs : rest -> writeTVar requestsVar rest $> reqs
         []          -> pure []
 
+
+-- | Configurable timeouts.  We use different timeouts for 'IO' and 'IOSim' property tests.
+--
+data Timeouts = Timeouts {
+    tProtocolIdleTimeout :: DiffTime,
+    tOutboundIdleTimeout :: DiffTime,
+    tTimeWaitTimeout     :: DiffTime 
+  }
+
+-- | Timeouts for 'IO' tests.
+--
+ioTimeouts :: Timeouts
+ioTimeouts = Timeouts {
+    tProtocolIdleTimeout = 0.1,
+    tOutboundIdleTimeout = 0.1,
+    tTimeWaitTimeout     = 0.1
+  }
+
+-- | Timeouts for 'IOSim' tests.
+--
+simTimeouts :: Timeouts
+simTimeouts = Timeouts {
+    tProtocolIdleTimeout = 5,
+    tOutboundIdleTimeout = 5,
+    tTimeWaitTimeout     = 30
+  }
+
 --
 -- Various ConnectionManagers
 --
@@ -251,6 +278,7 @@ withInitiatorOnlyConnectionManager
        )
     => String
     -- ^ identifier (for logging)
+    -> Timeouts
     -> Snocket m socket peerAddr
     -- ^ series of request possible to do with the bidirectional connection
     -- manager towards some peer.
@@ -262,7 +290,7 @@ withInitiatorOnlyConnectionManager
           UnversionedProtocol ByteString m [resp] Void
        -> m a)
     -> m a
-withInitiatorOnlyConnectionManager name snocket localAddr nextRequests k = do
+withInitiatorOnlyConnectionManager name timeouts snocket localAddr nextRequests k = do
     mainThreadId <- myThreadId
     let muxTracer = (name,) `contramap` nullTracer -- mux tracer
     withConnectionManager
@@ -285,8 +313,8 @@ withInitiatorOnlyConnectionManager name snocket localAddr nextRequests k = do
               acceptedConnectionsSoftLimit = maxBound,
               acceptedConnectionsDelay     = 0
             },
-          cmTimeWaitTimeout = timeWaitTimeout,
-          cmOutboundIdleTimeout = outboundIdleTimeout
+          cmTimeWaitTimeout = tTimeWaitTimeout timeouts,
+          cmOutboundIdleTimeout = tOutboundIdleTimeout timeouts
         }
       (makeConnectionHandler
         muxTracer
@@ -356,19 +384,6 @@ withInitiatorOnlyConnectionManager name snocket localAddr nextRequests k = do
             pure $ reqRespClientPeer (reqRespClientMap reqs)))
 
 
---
--- Constants
---
-
-protocolIdleTimeout :: DiffTime
-protocolIdleTimeout = 30
-
-timeWaitTimeout :: DiffTime
-timeWaitTimeout = 30
-
-outboundIdleTimeout :: DiffTime
-outboundIdleTimeout = 0.1
-
 
 --
 -- Rethrow policies
@@ -417,6 +432,7 @@ withBidirectionalConnectionManager
        , MonadSay m, Show req
        )
     => String
+    -> Timeouts
     -- ^ identifier (for logging)
     -> Snocket m socket peerAddr
     -> socket
@@ -435,7 +451,7 @@ withBidirectionalConnectionManager
        -> Async m Void
        -> m a)
     -> m a
-withBidirectionalConnectionManager name snocket socket localAddress
+withBidirectionalConnectionManager name timeouts snocket socket localAddress
                                    accumulatorInit nextRequests k = do
     mainThreadId <- myThreadId
     inbgovControlChannel      <- Server.newControlChannel
@@ -456,8 +472,8 @@ withBidirectionalConnectionManager name snocket socket localAddress
           cmIPv6Address  = Nothing,
           cmAddressType  = \_ -> Just IPv4Address,
           cmSnocket      = snocket,
-          cmTimeWaitTimeout = timeWaitTimeout,
-          cmOutboundIdleTimeout = outboundIdleTimeout,
+          cmTimeWaitTimeout = tTimeWaitTimeout timeouts,
+          cmOutboundIdleTimeout = tOutboundIdleTimeout timeouts,
           connectionDataFlow = const Duplex,
           cmPrunePolicy = simplePrunePolicy,
           cmConnectionsLimits = AcceptedConnectionsLimit {
@@ -496,7 +512,7 @@ withBidirectionalConnectionManager name snocket socket localAddress
                     serverInboundGovernorTracer = (name,) `contramap` nullTracer, -- InboundGovernorTrace
                     serverConnectionLimits = AcceptedConnectionsLimit maxBound maxBound 0,
                     serverConnectionManager = connectionManager,
-                    serverInboundIdleTimeout = protocolIdleTimeout,
+                    serverInboundIdleTimeout = tProtocolIdleTimeout timeouts,
                     serverControlChannel = inbgovControlChannel,
                     serverObservableStateVar = observableStateVar
                   }
@@ -689,16 +705,18 @@ unidirectionalExperiment
        , Serialise resp, Show resp, Eq resp
        , Typeable req, Typeable resp
        )
-    => Snocket m socket peerAddr
+    => Timeouts
+    -> Snocket m socket peerAddr
     -> socket
     -> ClientAndServerData req
     -> m Property
-unidirectionalExperiment snocket socket clientAndServerData = do
+unidirectionalExperiment timeouts snocket socket clientAndServerData = do
     nextReqs <- oneshotNextRequests clientAndServerData
     withInitiatorOnlyConnectionManager
-      "client" snocket Nothing nextReqs
+      "client" timeouts snocket Nothing nextReqs
       $ \connectionManager ->
-        withBidirectionalConnectionManager "server" snocket socket Nothing
+        withBidirectionalConnectionManager "server" timeouts
+                                           snocket socket Nothing
                                            [accumulatorInit clientAndServerData]
                                            noNextRequests
           $ \_ serverAddr _serverAsync -> do
@@ -740,7 +758,7 @@ prop_unidirectional_Sim clientAndServerData =
               (Snocket.close snock) $ \fd -> do
         Snocket.bind   snock fd serverAddr
         Snocket.listen snock fd
-        unidirectionalExperiment snock fd clientAndServerData
+        unidirectionalExperiment simTimeouts snock fd clientAndServerData
   where
     serverAddr = Snocket.TestAddress (0 :: Int)
 
@@ -759,6 +777,7 @@ prop_unidirectional_IO clientAndServerData =
               Socket.bind socket (Socket.addrAddress addr)
               Socket.listen socket maxBound
               unidirectionalExperiment
+                ioTimeouts
                 (socketSnocket iomgr)
                 socket
                 clientAndServerData
@@ -783,6 +802,7 @@ bidirectionalExperiment
        , Show acc
        )
     => Bool
+    -> Timeouts
     -> Snocket m socket peerAddr
     -> socket
     -> socket
@@ -792,17 +812,19 @@ bidirectionalExperiment
     -> ClientAndServerData req
     -> m Property
 bidirectionalExperiment
-    useLock snocket socket0 socket1 localAddr0 localAddr1
+    useLock timeouts snocket socket0 socket1 localAddr0 localAddr1
     clientAndServerData0 clientAndServerData1 = do
       lock <- newTMVarIO ()
       nextRequests0 <- oneshotNextRequests clientAndServerData0
       nextRequests1 <- oneshotNextRequests clientAndServerData1
-      withBidirectionalConnectionManager "node-0" snocket socket0
+      withBidirectionalConnectionManager "node-0" timeouts
+                                         snocket socket0
                                          (Just localAddr0)
                                          [accumulatorInit clientAndServerData0]
                                          nextRequests0
         (\connectionManager0 _serverAddr0 _serverAsync0 ->
-          withBidirectionalConnectionManager "node-1" snocket socket1
+          withBidirectionalConnectionManager "node-1" timeouts
+                                             snocket socket1
                                              (Just localAddr1)
                                              [accumulatorInit clientAndServerData1]
                                              nextRequests1
@@ -896,7 +918,10 @@ prop_bidirectional_Sim (NonFailingBearerInfoScript script) data0 data1 =
           Snocket.bind   snock socket1 addr1
           Snocket.listen snock socket0
           Snocket.listen snock socket1
-          bidirectionalExperiment False snock socket0 socket1 addr0 addr1 data0 data1
+          bidirectionalExperiment False simTimeouts snock
+                                        socket0 socket1
+                                        addr0 addr1
+                                        data0 data1
   where
     script' = toBearerInfo <$> script
 
@@ -935,6 +960,7 @@ prop_bidirectional_IO data0 data1 =
 
             bidirectionalExperiment
               True
+              ioTimeouts
               (socketSnocket iomgr)
               socket0
               socket1
@@ -1227,7 +1253,7 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
         forkJob jobpool
           $ Job
               ( withInitiatorOnlyConnectionManager
-                    name snocket (Just localAddr) (mkNextRequests connVar)
+                    name simTimeouts snocket (Just localAddr) (mkNextRequests connVar)
                   ( \ connectionManager -> do
                     connectionLoop SingInitiatorMode localAddr lock propVar cc connectionManager Map.empty connVar
                     return Nothing
@@ -1259,7 +1285,7 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
         forkJob jobpool
               $ Job
                   (  withBidirectionalConnectionManager
-                          name snocket fd (Just localAddr) serverAcc
+                          name simTimeouts snocket fd (Just localAddr) serverAcc
                           (mkNextRequests connVar)
                           (\ connectionManager _ _serverAsync -> do
                              connectionLoop SingInitiatorResponderMode localAddr lock propVar cc connectionManager Map.empty connVar

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -35,13 +35,17 @@ import           Control.Monad.IOSim
 import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 
 import           Codec.Serialise.Class (Serialise)
+import           Data.Bifoldable
+import           Data.Bifunctor
+import           Data.Bitraversable
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Functor (void, ($>), (<&>))
-import           Data.List (mapAccumL, intercalate, (\\), delete)
+import           Data.List (dropWhileEnd, find, mapAccumL, intercalate, (\\), delete)
 import           Data.List.NonEmpty (NonEmpty (..))
-import           Data.Map (Map)
+import qualified Data.List.Octopus as Octopus
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
+import           Data.Maybe (fromMaybe, fromJust, isJust)
+import           Data.Monoid (Sum (..))
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
 
@@ -98,6 +102,9 @@ tests =
   , testProperty "bidirectional_IO"   prop_bidirectional_IO
   , testProperty "bidirectional_Sim"  prop_bidirectional_Sim
   , testProperty "multinode_Sim"      prop_multinode_Sim
+  , testGroup "generators"
+    [ testProperty "MultiNodeScript"  prop_generator_MultiNodeScript
+    ]
   ]
 
 --
@@ -1082,6 +1089,51 @@ instance (Arbitrary peerAddr, Arbitrary req, Eq peerAddr) =>
         (shrinkBundle r <&> \ r' -> OutboundMiniprotocols d  a r') ++
         (shrinkDelay  d <&> \ d' -> OutboundMiniprotocols d' a r)
 
+
+prop_generator_MultiNodeScript :: MultiNodeScript Int TestAddr -> Property
+prop_generator_MultiNodeScript (MultiNodeScript script) =
+    label ("Number of events: " ++ within_ 10 (length script))
+  $ label ( "Number of servers: "
+          ++ ( within_ 2
+             . length
+             . filter (\ ev -> case ev of
+                         StartServer {} -> True
+                         _              -> False
+                      )
+                      $ script
+             ))
+  $ label ("Number of clients: "
+          ++ ( within_ 2
+             . length
+             . filter (\ ev -> case ev of
+                         StartClient {} -> True
+                         _              -> False
+                      )
+             $ script
+             ))
+  $ label ("Active connections: "
+          ++ ( within_ 5
+             . length
+             . filter (\ ev -> case ev of
+                         InboundMiniprotocols {}  -> True
+                         OutboundMiniprotocols {} -> True
+                         _                        -> False)
+             $ script
+             ))
+  $ label ("Closed connections: "
+          ++ ( within_ 5
+             . length
+             . filter (\ ev -> case ev of
+                         CloseInboundConnection {}  -> True
+                         CloseOutboundConnection {} -> True
+                         _                          -> False)
+             $ script
+             ))
+  $ True
+
+
+
+
 -- | The concrete address type used by simulations.
 --
 type SimAddr = Snocket.TestAddress Int
@@ -1338,6 +1390,83 @@ multinodeExperiment trTracer snocket addrFamily serverAddr accInit (MultiNodeScr
                                          , remoteAddress = remoteAddr }
 
 
+-- | Test property together with classifiction.
+data TestProperty = TestProperty {
+    tpProperty             :: !Property,
+    -- ^ 'True' if property is true
+
+    tpNumberOfTransitions :: !(Sum Int),
+    -- ^ number of all transitions
+
+    tpNumberOfConnections :: !(Sum Int),
+    -- ^ number of all connections
+   
+    --
+    -- classifcation of connections
+    --
+    tpNegotiatedDataFlows :: ![NegotiatedDataFlow],
+    tpEffectiveDataFlows  :: ![EffectiveDataFlow],
+    tpTerminationTypes    :: ![TerminationType],
+    tpActivityTypes       :: ![ActivityType],
+
+    tpTransitions         :: ![AbstractTransition]
+
+  }
+
+instance Show TestProperty where
+    show tp =
+      concat [ "TestProperty "
+             , "{ tpNumberOfTransitions = " ++ show (tpNumberOfTransitions tp)
+             , ", tpNumberOfConnections = " ++ show (tpNumberOfConnections tp)
+             , ", tpNegotiatedDataFlows = " ++ show (tpNegotiatedDataFlows tp)
+             , ", tpTerminationTypes = "    ++ show (tpTerminationTypes tp)
+             , ", tpActivityTypes = "       ++ show (tpActivityTypes tp)
+             , ", tpTransitions = "         ++ show (tpTransitions tp)
+             , "}"
+             ]
+
+instance Semigroup TestProperty where
+  (<>) (TestProperty a0 a1 a2 a3 a4 a5 a6 a7)
+       (TestProperty b0 b1 b2 b3 b4 b5 b6 b7) =
+      TestProperty (a0 .&&. b0)
+                   (a1 <> b1)
+                   (a2 <> b2)
+                   (a3 <> b3)
+                   (a4 <> b4)
+                   (a5 <> b5)
+                   (a6 <> b6)
+                   (a7 <> b7)
+
+instance Monoid TestProperty where
+    mempty = TestProperty (property True)
+                          mempty mempty mempty
+                          mempty mempty mempty mempty
+
+mkProperty :: TestProperty -> Property
+mkProperty TestProperty { tpProperty
+                        , tpNumberOfTransitions = Sum numberOfTransitions_
+                        , tpNumberOfConnections = Sum numberOfConnections_
+                        , tpNegotiatedDataFlows
+                        , tpEffectiveDataFlows
+                        , tpTerminationTypes
+                        , tpActivityTypes
+                        , tpTransitions
+                        } =
+     label (concat [ "Number of transitions: "
+                   , within_ 10 numberOfTransitions_
+                   ]
+           )
+   . label (concat [ "Number of connections: "
+                   , show numberOfConnections_
+                   ]
+           )
+   . tabulate "Negotiated DataFlow" (map show tpNegotiatedDataFlows)
+   . tabulate "Effective DataFLow"  (map show tpEffectiveDataFlows)
+   . tabulate "Termination"         (map show tpTerminationTypes)
+   . tabulate "Activity Type"       (map show tpActivityTypes)
+   . tabulate "Transitions"         (map ppTransition tpTransitions)
+   $ tpProperty
+
 newtype AllProperty = AllProperty { getAllProperty :: Property }
 
 instance Semigroup AllProperty where
@@ -1347,15 +1476,48 @@ instance Monoid AllProperty where
     mempty = AllProperty (property True)
 
 
+data ActivityType
+    = IdleConn
+
+    -- | Active connections are onces that reach any of the state:
+    --
+    -- - 'InboundSt'
+    -- - 'OutobundUniSt'
+    -- - 'OutboundDupSt'
+    -- - 'DuplexSt'
+    --
+    | ActiveConn
+    deriving (Eq, Show)
+
+data TerminationType
+    = ErroredTermination
+    | CleanTermination
+    deriving (Eq, Show)
+
+data NegotiatedDataFlow
+    = NotNegotiated
+
+    -- | Negotiated value of 'DataFlow'
+    | NegotiatedDataFlow DataFlow
+    deriving (Eq, Show)
+
+data EffectiveDataFlow
+    -- | Unlike the negotiated 'DataFlow' this indicates if the connection has
+    -- ever been in 'DuplexSt'
+    --
+    = EffectiveDataFlow DataFlow
+    deriving (Eq, Show)
+
 -- | Property wrapping `multinodeExperiment`.
 prop_multinode_Sim :: Int -> MultiNodeScript Int TestAddr -> Property
 prop_multinode_Sim serverAcc script =
-  let evs :: [AbstractTransitionTrace SimAddr]
-      evs = map wnEvent
-          . filter ((MainServer ==) . wnName)
-          $ (selectTraceEventsDynamic' (runSimTrace sim)
-              :: [WithName (Name SimAddr)
-                           (AbstractTransitionTrace SimAddr)])
+  let evs :: Octopus (Value ()) (AbstractTransitionTrace SimAddr)
+      evs = fmap wnEvent
+          . Octopus.filter ((MainServer ==) . wnName)
+          . octoSelectTraceEventsDynamic
+              @()
+              @(WithName (Name SimAddr) (AbstractTransitionTrace SimAddr))
+          $ runSimTrace sim
         where
           sim :: IOSim s ()
           sim = do
@@ -1375,42 +1537,123 @@ prop_multinode_Sim serverAcc script =
               Nothing -> throwIO (SimulationTimeout :: ExperimentError SimAddr)
               Just a  -> return a
 
-  in   counterexample (ppScript script)
-     . getAllProperty
-     . foldMap ( foldMap ( \ tr
-                          -> AllProperty
-                           . (counterexample $! ("\nUnexpected transition: " ++ ppTransition tr))
-                           . verifyAbstractTransition
-                           $ tr
-                         )
-               )
-     . concat
-     . Map.elems
-     . splitConns
-     $ evs
+  in counterexample (ppScript script)
+   . mkProperty
+   . bifoldMap
+      ( \ case
+          MainReturn {} -> mempty
+          v             -> mempty { tpProperty = counterexample (show v) False }
+      )
+      ( \ trs
+       -> TestProperty {
+            tpProperty =
+                (counterexample $!
+                  (  "\nconnection:\n"
+                  ++ intercalate "\n" (map ppTransition trs))
+                  )
+              . getAllProperty
+              . foldMap ( \ tr
+                         -> AllProperty
+                          . (counterexample $!
+                              (  "\nUnexpected transition: "
+                              ++ ppTransition tr)
+                              )
+                          . verifyAbstractTransition
+                          $ tr
+                        )
+              $ trs,
+            tpNumberOfTransitions = Sum (length trs),
+            tpNumberOfConnections = Sum 1,
+            tpNegotiatedDataFlows = [classifyNegotiatedDataFlow trs],
+            tpEffectiveDataFlows  = [classifyEffectiveDataFlow  trs],
+            tpTerminationTypes    = [classifyTermination        trs],
+            tpActivityTypes       = [classifyActivityType       trs],
+            tpTransitions         = trs
+         }
+      )
+   . splitConns
+   $ evs
   where
-    splitConns :: [AbstractTransitionTrace SimAddr]
-               -> Map SimAddr [[AbstractTransition]]
-    splitConns as = splitConn <$> tracesByAddr
-      where
-        splitConn :: [AbstractTransition] -> [[AbstractTransition]]
-        splitConn [] = []
-        splitConn (t : ts) =
-          case span (\  tr@Transition { fromState }
-                     -> fromState /= UnknownConnectionSt
-                     && tr        /= Transition TerminatedSt
-                                                (UnnegotiatedSt Inbound)
-                    ) ts of
-                 (cs, ts') -> (t : cs) : splitConn ts'
 
-        tracesByAddr :: Map SimAddr [AbstractTransition]
-        tracesByAddr =
-          Map.fromListWith
-            (flip (++))
-            ( map (\  TransitionTrace { ttPeerAddr, ttTransition }
-                   -> (ttPeerAddr, [ttTransition]))
-            $ as
-            )
+    -- classify negotiated data flow
+    classifyNegotiatedDataFlow :: [AbstractTransition] -> NegotiatedDataFlow
+    classifyNegotiatedDataFlow as =
+      case find ( \ tr
+                 -> case toState tr of
+                      OutboundUniSt    -> True
+                      OutboundDupSt {} -> True
+                      InboundIdleSt {} -> True
+                      _                -> False
+                ) as of
+         Nothing -> NotNegotiated
+         Just tr ->
+           case toState tr of
+             OutboundUniSt      -> NegotiatedDataFlow Unidirectional
+             OutboundDupSt {}   -> NegotiatedDataFlow Duplex
+             (InboundIdleSt df) -> NegotiatedDataFlow df
+             _                  -> error "impossible happened!"
+
+    -- classify effective data flow
+    classifyEffectiveDataFlow :: [AbstractTransition] -> EffectiveDataFlow
+    classifyEffectiveDataFlow as =
+      case find ((== DuplexSt) . toState) as of
+        Nothing -> EffectiveDataFlow Unidirectional
+        Just _  -> EffectiveDataFlow Duplex
+
+    -- classify termination
+    classifyTermination :: [AbstractTransition] -> TerminationType
+    classifyTermination as =
+      case last $ dropWhileEnd
+                    (== (Transition TerminatedSt TerminatedSt))
+                $ dropWhileEnd
+                    (== (Transition TerminatedSt UnknownConnectionSt))
+                $ as of
+        Transition { fromState = TerminatingSt
+                   , toState   = TerminatedSt
+                   } -> CleanTermination
+        _            -> ErroredTermination
+
+    -- classify if a connection is active or not
+    classifyActivityType :: [AbstractTransition] -> ActivityType
+    classifyActivityType as =
+      case find ( \ tr
+                 -> case toState tr of
+                      InboundSt     {} -> True
+                      OutboundUniSt    -> True
+                      OutboundDupSt {} -> True
+                      DuplexSt      {} -> True
+                      _                -> False
+                ) as of
+        Nothing -> IdleConn
+        Just {} -> ActiveConn
+
+splitConns :: Octopus (Value ()) (AbstractTransitionTrace SimAddr)
+           -> Octopus (Value ()) [AbstractTransition]
+splitConns =
+    bimap id fromJust
+  . Octopus.filter isJust
+  -- there might be some connections in the state, push them onto the 'Octopus'
+  . (\(s, o) -> foldr (\a as -> Octopus.Cons (Just a) as) o (Map.elems s))
+  . bimapAccumL
+      ( \ s a -> ( s, a))
+      ( \ s TransitionTrace { ttPeerAddr, ttTransition } ->
+          case ttTransition of
+            Transition _ UnknownConnectionSt ->
+              case ttPeerAddr `Map.lookup` s of
+                Nothing  -> ( Map.insert ttPeerAddr [ttTransition] s
+                            , Nothing
+                            )
+                Just trs -> ( Map.delete ttPeerAddr s
+                            , Just (reverse $ ttTransition : trs)
+                            )
+            _ ->            ( Map.alter ( \ case 
+                                              Nothing -> Just [ttTransition]
+                                              Just as -> Just (ttTransition : as)
+                                        ) ttPeerAddr s
+                            , Nothing
+                            )
+      )
+      Map.empty
 
 ppTransition :: AbstractTransition -> String
 ppTransition Transition {fromState, toState} =
@@ -1462,11 +1705,6 @@ debugTracer :: (MonadSay m, MonadTime m, Show a) => Tracer m a
 debugTracer = Tracer $
   \msg -> (,msg) <$> getCurrentTime >>= say . show
 
--- | Convenience function to create a Bundle. Could move to Ouroboros.Network.Mux.
-makeBundle :: (forall pt. TokProtocolTemperature pt -> a) -> Bundle a
-makeBundle f = Bundle (WithHot         $ f TokHot)
-                      (WithWarm        $ f TokWarm)
-                      (WithEstablished $ f TokEstablished)
 
 connectionManagerTracer
   :: ( MonadSay  m
@@ -1506,6 +1744,19 @@ withLock True   v m =
             (atomically . putTMVar v)
             (const m)
 
+
+-- | Convenience function to create a Bundle. Could move to Ouroboros.Network.Mux.
+makeBundle :: (forall pt. TokProtocolTemperature pt -> a) -> Bundle a
+makeBundle f = Bundle (WithHot         $ f TokHot)
+                      (WithWarm        $ f TokWarm)
+                      (WithEstablished $ f TokEstablished)
+
+
+
+-- TODO: we should use @traceResult True@; the `prop_unidirectional_Sim` and
+-- `prop_bidirectional_Sim` test are failing with `<<io-sim sloppy shutdown>>`
+-- exception.
+--
 simulatedPropertyWithTimeout :: DiffTime -> (forall s. IOSim s Property) -> Property
 simulatedPropertyWithTimeout t test =
   counterexample ("\nTrace:\n" ++ ppTrace tr) $
@@ -1530,3 +1781,13 @@ ppTrace tr = concat
 
     fmt (t, tid, lbl, e) = printf "%-24s - %-13s %-*s - %s" (show t) (show tid) w (fromMaybe "" lbl) (show e)
 
+
+within_ :: Int -> Int -> String
+within_ _ 0 = "0"
+within_ a b = let x = b `div` a in
+              concat [ if b < a
+                         then "1"
+                         else show $ x * a
+                     , " - "
+                     , show $ x * a + a - 1
+                     ]

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -501,7 +501,8 @@ withBidirectionalConnectionManager name snocket socket localAddress
                     serverObservableStateVar = observableStateVar
                   }
               )
-              (\serverAsync -> k connectionManager serverAddr serverAsync)
+              (\serverAsync -> link serverAsync
+                            >> k connectionManager serverAddr serverAsync)
           `catch` \(e :: SomeException) -> do
             say (show e)
             throwIO e
@@ -700,8 +701,7 @@ unidirectionalExperiment snocket socket clientAndServerData = do
         withBidirectionalConnectionManager "server" snocket socket Nothing
                                            [accumulatorInit clientAndServerData]
                                            noNextRequests
-          $ \_ serverAddr serverAsync -> do
-            link serverAsync
+          $ \_ serverAddr _serverAsync -> do
             -- client → server: connect
             (rs :: [Either SomeException (Bundle [resp])]) <-
                 replicateM
@@ -801,14 +801,12 @@ bidirectionalExperiment
                                          (Just localAddr0)
                                          [accumulatorInit clientAndServerData0]
                                          nextRequests0
-        (\connectionManager0 _serverAddr0 serverAsync0 ->
+        (\connectionManager0 _serverAddr0 _serverAsync0 ->
           withBidirectionalConnectionManager "node-1" snocket socket1
                                              (Just localAddr1)
                                              [accumulatorInit clientAndServerData1]
                                              nextRequests1
-            (\connectionManager1 _serverAddr1 serverAsync1 -> do
-              link serverAsync0
-              link serverAsync1
+            (\connectionManager1 _serverAddr1 _serverAsync1 -> do
               -- runInitiatorProtocols returns a list of results per each
               -- protocol in each bucket (warm \/ hot \/ established); but
               -- we run only one mini-protocol. We can use `concat` to
@@ -1263,8 +1261,7 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
                   (  withBidirectionalConnectionManager
                           name snocket fd (Just localAddr) serverAcc
                           (mkNextRequests connVar)
-                          (\ connectionManager _ serverAsync -> do
-                             link serverAsync
+                          (\ connectionManager _ _serverAsync -> do
                              connectionLoop SingInitiatorResponderMode localAddr lock propVar cc connectionManager Map.empty connVar
                              return Nothing
                           )

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -289,6 +289,7 @@ withInitiatorOnlyConnectionManager
     => name
     -- ^ identifier (for logging)
     -> Timeouts
+    -> Tracer m (WithName name (AbstractTransitionTrace peerAddr))
     -> Snocket m socket peerAddr
     -- ^ series of request possible to do with the bidirectional connection
     -- manager towards some peer.
@@ -300,7 +301,7 @@ withInitiatorOnlyConnectionManager
           UnversionedProtocol ByteString m [resp] Void
        -> m a)
     -> m a
-withInitiatorOnlyConnectionManager name timeouts snocket localAddr nextRequests k = do
+withInitiatorOnlyConnectionManager name timeouts trTracer snocket localAddr nextRequests k = do
     mainThreadId <- myThreadId
     let muxTracer = (name,) `contramap` nullTracer -- mux tracer
     withConnectionManager
@@ -309,14 +310,14 @@ withInitiatorOnlyConnectionManager name timeouts snocket localAddr nextRequests 
           cmTracer    = WithName name
                         `contramap` connectionManagerTracer,
           cmTrTracer  = (WithName name . fmap abstractState)
-                        `contramap` nullTracer,
+                        `contramap` trTracer,
          -- MuxTracer
           cmMuxTracer = muxTracer,
           cmIPv4Address = localAddr,
           cmIPv6Address = Nothing,
           cmAddressType = \_ -> Just IPv4Address,
           cmSnocket = snocket,
-          connectionDataFlow = const Duplex,
+          connectionDataFlow = const Unidirectional,
           cmPrunePolicy = simplePrunePolicy,
           cmConnectionsLimits = AcceptedConnectionsLimit {
               acceptedConnectionsHardLimit = maxBound,
@@ -716,7 +717,7 @@ unidirectionalExperiment
 unidirectionalExperiment timeouts snocket socket clientAndServerData = do
     nextReqs <- oneshotNextRequests clientAndServerData
     withInitiatorOnlyConnectionManager
-      "client" timeouts snocket Nothing nextReqs
+      "client" timeouts nullTracer snocket Nothing nextReqs
       $ \connectionManager ->
         withBidirectionalConnectionManager "server" timeouts nullTracer
                                            snocket socket Nothing
@@ -1208,13 +1209,16 @@ multinodeExperiment
                           (AbstractTransitionTrace peerAddr))
     -> Snocket m socket peerAddr
     -> Snocket.AddressFamily peerAddr
+    -- ^ either run the main node in 'Duplex' or 'Unidirectional' mode.
     -> peerAddr
     -> req
+    -> DataFlow
     -> MultiNodeScript req peerAddr
     -> m ()
-multinodeExperiment trTracer snocket addrFamily serverAddr accInit (MultiNodeScript script) =
+multinodeExperiment trTracer snocket addrFamily serverAddr accInit
+                             dataFlow0 (MultiNodeScript script) =
   withJobPool $ \jobpool -> do
-  cc <- startServerConnectionHandler MainServer [accInit] serverAddr jobpool
+  cc <- startServerConnectionHandler MainServer dataFlow0 [accInit] serverAddr jobpool
   loop (Map.singleton serverAddr [accInit]) (Map.singleton serverAddr cc) script jobpool
   where
 
@@ -1234,7 +1238,7 @@ multinodeExperiment trTracer snocket addrFamily serverAddr accInit (MultiNodeScr
 
         StartServer delay localAddr nodeAcc -> do
           threadDelay delay
-          cc <- startServerConnectionHandler (Node localAddr) [nodeAcc] localAddr jobpool
+          cc <- startServerConnectionHandler (Node localAddr) Duplex [nodeAcc] localAddr jobpool
           loop (Map.insert localAddr [nodeAcc] nodeAccs) (Map.insert localAddr cc servers) events jobpool
 
         InboundConnection delay nodeAddr -> do
@@ -1297,7 +1301,7 @@ multinodeExperiment trTracer snocket addrFamily serverAddr accInit (MultiNodeScr
         forkJob jobpool
           $ Job
               ( withInitiatorOnlyConnectionManager
-                    name simTimeouts snocket (Just localAddr) (mkNextRequests connVar)
+                    name simTimeouts nullTracer snocket (Just localAddr) (mkNextRequests connVar)
                   ( \ connectionManager -> do
                     connectionLoop SingInitiatorMode localAddr cc connectionManager Map.empty connVar
                     return Nothing
@@ -1313,11 +1317,12 @@ multinodeExperiment trTracer snocket addrFamily serverAddr accInit (MultiNodeScr
         return cc
 
     startServerConnectionHandler :: Name peerAddr
+                                 -> DataFlow
                                  -> acc
                                  -> peerAddr
                                  -> JobPool m (Maybe SomeException)
                                  -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
-    startServerConnectionHandler name serverAcc localAddr jobpool = do
+    startServerConnectionHandler name dataFlow serverAcc localAddr jobpool = do
         fd <- Snocket.open snocket addrFamily
         Snocket.bind   snocket fd localAddr
         Snocket.listen snocket fd
@@ -1326,26 +1331,45 @@ multinodeExperiment trTracer snocket addrFamily serverAddr accInit (MultiNodeScr
         connVar <- newTVarIO Map.empty
         labelTVarIO connVar $ "connVar/" ++ show name
         threadId <- myThreadId
-        forkJob jobpool
-              $ Job
-                  ( withBidirectionalConnectionManager
-                      name simTimeouts trTracer
-                      snocket fd (Just localAddr) serverAcc
-                      (mkNextRequests connVar)
-                      ( \ connectionManager _ _serverAsync -> do
-                        connectionLoop SingInitiatorResponderMode localAddr cc connectionManager Map.empty connVar
-                        return Nothing
+        let job =
+              case dataFlow of
+                Duplex ->
+                  Job ( withBidirectionalConnectionManager
+                          name simTimeouts trTracer snocket fd (Just localAddr) serverAcc
+                          (mkNextRequests connVar)
+                          ( \ connectionManager _ _serverAsync -> do
+                            connectionLoop SingInitiatorResponderMode localAddr cc connectionManager Map.empty connVar
+                            return Nothing
+                          )
+                        `catch` (\(e :: SomeException) ->
+                                case fromException e :: Maybe MuxRuntimeError of
+                                  Nothing -> throwIO e
+                                  Just {} -> throwTo threadId e
+                                          >> throwIO e)
+                        `finally` Snocket.close snocket fd
                       )
-                    `catch` (\(e :: SomeException) ->
-                            case fromException e :: Maybe MuxRuntimeError of
-                              Nothing -> throwIO e
-                              Just {} -> throwTo threadId e
-                                      >> throwIO e)
-                    `finally` Snocket.close snocket fd
-                  )
-                  Just
-                  (show name)
+                      Just
+                      (show name)
+                Unidirectional ->
+                  Job ( withInitiatorOnlyConnectionManager
+                          name simTimeouts trTracer snocket (Just localAddr)
+                          (mkNextRequests connVar)
+                          ( \ connectionManager -> do
+                            connectionLoop SingInitiatorMode localAddr cc connectionManager Map.empty connVar
+                            return Nothing
+                          )
+                        `catch` (\(e :: SomeException) ->
+                                case fromException e :: Maybe MuxRuntimeError of
+                                  Nothing -> throwIO e
+                                  Just {} -> throwTo threadId e
+                                          >> throwIO e)
+                        `finally` Snocket.close snocket fd
+                      )
+                      Just
+                      (show name)
+        forkJob jobpool job
         return cc
+      where
 
     connectionLoop
          :: (HasInitiator muxMode ~ True)
@@ -1483,6 +1507,15 @@ instance Semigroup AllProperty where
 instance Monoid AllProperty where
     mempty = AllProperty (property True)
 
+newtype ArbDataFlow = ArbDataFlow DataFlow
+  deriving Show
+
+instance Arbitrary ArbDataFlow where
+    arbitrary = ArbDataFlow <$> frequency [ (3, pure Duplex)
+                                          , (1, pure Unidirectional)
+                                          ]
+    shrink (ArbDataFlow Duplex)         = [ArbDataFlow Unidirectional]
+    shrink (ArbDataFlow Unidirectional) = []
 
 data ActivityType
     = IdleConn
@@ -1517,8 +1550,8 @@ data EffectiveDataFlow
     deriving (Eq, Show)
 
 -- | Property wrapping `multinodeExperiment`.
-prop_multinode_Sim :: Int -> MultiNodeScript Int TestAddr -> Property
-prop_multinode_Sim serverAcc script =
+prop_multinode_Sim :: Int -> ArbDataFlow -> MultiNodeScript Int TestAddr -> Property
+prop_multinode_Sim serverAcc (ArbDataFlow dataFlow) script =
   let evs :: Octopus (Value ()) (AbstractTransitionTrace SimAddr)
       evs = fmap wnEvent
           . Octopus.filter ((MainServer ==) . wnName)
@@ -1539,6 +1572,7 @@ prop_multinode_Sim serverAcc script =
                                            Snocket.TestFamily
                                            (Snocket.TestAddress 0)
                                            serverAcc
+                                           dataFlow
                                            (unTestAddr <$> script)
                     )
             case mb of

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -71,7 +71,6 @@ import           Ouroboros.Network.Channel (fromChannel)
 import           Ouroboros.Network.ConnectionId
 import           Ouroboros.Network.ConnectionHandler
 import           Ouroboros.Network.ConnectionManager.Core
-import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.ConnectionManager.Types
 import           Ouroboros.Network.IOManager
 import qualified Ouroboros.Network.InboundGovernor.ControlChannel as Server
@@ -82,6 +81,7 @@ import           Ouroboros.Network.Protocol.Handshake.Codec ( cborTermVersionDat
                                                             , noTimeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Unversioned
 import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..))
+import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
 import           Ouroboros.Network.Server2 (ServerArguments (..))
 import qualified Ouroboros.Network.Server2 as Server
@@ -340,6 +340,7 @@ withInitiatorOnlyConnectionManager name timeouts snocket localAddr nextRequests 
             haTimeLimits = noTimeLimitsHandshake
           }
         (mainThreadId, debugMuxErrorRethrowPolicy
+                    <> debugMuxRuntimeErrorRethrowPolicy
                     <> debugIOErrorRethrowPolicy
                     <> assertRethrowPolicy))
       (\_ -> HandshakeFailure)
@@ -407,6 +408,11 @@ debugMuxErrorRethrowPolicy =
           MuxIOException _ -> ShutdownPeer
           MuxBearerClosed  -> ShutdownPeer
           _                -> ShutdownNode
+
+debugMuxRuntimeErrorRethrowPolicy :: RethrowPolicy
+debugMuxRuntimeErrorRethrowPolicy =
+    mkRethrowPolicy $
+      \_ (_ :: MuxRuntimeError) -> ShutdownNode
 
 debugIOErrorRethrowPolicy :: RethrowPolicy
 debugIOErrorRethrowPolicy =
@@ -508,6 +514,7 @@ withBidirectionalConnectionManager name timeouts trTracer snocket socket localAd
               haTimeLimits = noTimeLimitsHandshake
             }
           (mainThreadId,   debugMuxErrorRethrowPolicy
+                        <> debugMuxRuntimeErrorRethrowPolicy
                         <> debugIOErrorRethrowPolicy
                         <> assertRethrowPolicy))
           (\_ -> HandshakeFailure)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -173,6 +173,33 @@ expectedResult client@ClientAndServerData
     go [] [] [] = []
     go _  _  _  = error "expectedResult: impossible happened"
 
+noNextRequests :: forall m req peerAddr. MonadSTM m => m (Bundle (ConnectionId peerAddr -> STM m [req]))
+noNextRequests = pure (pure $ \ _ -> pure []) -- Monadic only to pin down `m` since `STM` is a non-injective type family
+
+-- | Next requests bundle for bidirectional and unidirectional experiments.
+oneshotNextRequests
+  :: forall req peerAddr m. MonadSTM m
+  => ClientAndServerData req
+  -> m (Bundle (ConnectionId peerAddr -> STM m [req]))
+oneshotNextRequests ClientAndServerData {
+                      hotInitiatorRequests,
+                      warmInitiatorRequests,
+                      establishedInitiatorRequests
+                    } = do
+    -- we pass a `StricTVar` with all the reuqests to each initiator.  This way
+    -- the each round (which runs a single instance of `ReqResp` protocol) will
+    -- use its own request list.
+    hotRequestsVar         <- newTVarIO hotInitiatorRequests
+    warmRequestsVar        <- newTVarIO warmInitiatorRequests
+    establishedRequestsVar <- newTVarIO establishedInitiatorRequests
+    return $ Bundle (WithHot hotRequestsVar) (WithWarm warmRequestsVar) (WithEstablished establishedRequestsVar)
+              <&> \ reqVar _ -> popRequests reqVar
+  where
+    popRequests requestsVar = do
+      requests <- readTVar requestsVar
+      case requests of
+        reqs : rest -> writeTVar requestsVar rest $> reqs
+        []          -> pure []
 
 --
 -- Various ConnectionManagers
@@ -190,8 +217,6 @@ type ConnectionState_ muxMode peerAddr m a b =
                        (UnversionedProtocol, UnversionedProtocolData)
                        m
 
--- | Initiator only connection manager.
---
 withInitiatorOnlyConnectionManager
     :: forall peerAddr socket acc req resp m a.
        ( ConnectionManagerMonad m
@@ -216,29 +241,17 @@ withInitiatorOnlyConnectionManager
     => String
     -- ^ identifier (for logging)
     -> Snocket m socket peerAddr
-    -> ClientAndServerData req
     -- ^ series of request possible to do with the bidirectional connection
     -- manager towards some peer.
+    -> Bundle (ConnectionId peerAddr -> STM m [req])
+    -- ^ Functions to get the next requests for a given connection
     -> (MuxConnectionManager
           InitiatorMode socket peerAddr
           UnversionedProtocol ByteString m [resp] Void
        -> m a)
     -> m a
-withInitiatorOnlyConnectionManager
-    name snocket
-    ClientAndServerData {
-        hotInitiatorRequests,
-        warmInitiatorRequests,
-        establishedInitiatorRequests
-      }
-    k = do
+withInitiatorOnlyConnectionManager name snocket nextRequests k = do
     mainThreadId <- myThreadId
-    -- we pass a `StricTVar` with all the reuqests to each initiator.  This way
-    -- the each round (which runs a single instance of `ReqResp` protocol) will
-    -- use its own request list.
-    hotRequestsVar         <- newTVarIO hotInitiatorRequests
-    warmRequestsVar        <- newTVarIO warmInitiatorRequests
-    establishedRequestsVar <- newTVarIO establishedInitiatorRequests
     let muxTracer = (name,) `contramap` nullTracer -- mux tracer
     withConnectionManager
       ConnectionManagerArguments {
@@ -272,11 +285,7 @@ withInitiatorOnlyConnectionManager
             haHandshakeTracer = (name,) `contramap` nullTracer,
             haHandshakeCodec = unversionedHandshakeCodec,
             haVersionDataCodec = cborTermVersionDataCodec unversionedProtocolDataCodec,
-            haVersions = unversionedProtocol
-              (clientApplication
-                hotRequestsVar
-                warmRequestsVar
-                establishedRequestsVar),
+            haVersions = unversionedProtocol clientApplication,
             haAcceptVersion = acceptableVersion,
             haTimeLimits = noTimeLimitsHandshake
           }
@@ -306,69 +315,31 @@ withInitiatorOnlyConnectionManager
           }
         ]
 
-    clientApplication :: StrictTVar m [[req]]
-                      -> StrictTVar m [[req]]
-                      -> StrictTVar m [[req]]
-                      -> Bundle
+    clientApplication :: Bundle
                           (ConnectionId peerAddr
                             -> ControlMessageSTM m
                             -> [MiniProtocol InitiatorMode ByteString m [resp] Void])
-    clientApplication hotRequestsVar
-                      warmRequestsVar
-                      establishedRequestsVar = Bundle {
-        withHot = WithHot $ \_ _ ->
-          [ let miniProtocolNum = Mux.MiniProtocolNum 1
-            in MiniProtocol {
-                miniProtocolNum,
-                miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
-                miniProtocolRun =
-                  reqRespInitiator
-                    miniProtocolNum
-                    hotRequestsVar
-               }
-          ],
-        withWarm = WithWarm $ \_ _ ->
-          [ let miniProtocolNum = Mux.MiniProtocolNum 2
-            in MiniProtocol {
-                miniProtocolNum,
-                miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
-                miniProtocolRun =
-                  reqRespInitiator
-                    miniProtocolNum
-                    warmRequestsVar
-              }
-          ],
-        withEstablished = WithEstablished $ \_ _ ->
-          [ let miniProtocolNum = Mux.MiniProtocolNum 3
-            in MiniProtocol {
-                miniProtocolNum,
-                miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
-                miniProtocolRun =
-                  reqRespInitiator
-                    miniProtocolNum
-                    establishedRequestsVar
-              }
-          ]
-      }
+    clientApplication = mkProto <$> (Mux.MiniProtocolNum <$> nums) <*> nextRequests
+
+      where nums = Bundle (WithHot 1) (WithWarm 2) (WithEstablished 3)
+            mkProto miniProtocolNum nextRequest connId _ =
+              [MiniProtocol {
+                  miniProtocolNum,
+                  miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
+                  miniProtocolRun = reqRespInitiator miniProtocolNum (nextRequest connId)
+                }]
 
     reqRespInitiator :: Mux.MiniProtocolNum
-                     -> StrictTVar m [[req]]
+                     -> STM m [req]
                      -> RunMiniProtocol InitiatorMode ByteString m [resp] Void
-    reqRespInitiator protocolNum requestsVar =
+    reqRespInitiator protocolNum nextRequest =
       InitiatorProtocolOnly
         (MuxPeer
           ((name,"Initiator",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
           codecReqResp
           (Effect $ do
-            reqs <-
-              atomically $ do
-                requests <- readTVar requestsVar
-                case requests of
-                  (reqs : rest) -> do
-                    writeTVar requestsVar rest $> reqs
-                  [] -> pure []
-            pure $
-              reqRespClientPeer (reqRespClientMap reqs)))
+            reqs <- atomically nextRequest
+            pure $ reqRespClientPeer (reqRespClientMap reqs)))
 
 
 --
@@ -439,7 +410,10 @@ withBidirectionalConnectionManager
     -> socket
     -- ^ listening socket
     -> Maybe peerAddr
-    -> ClientAndServerData req
+    -> acc
+    -- ^ Initial state for the server
+    -> Bundle (ConnectionId peerAddr -> STM m [req])
+    -- ^ Functions to get the next requests for a given connection
     -- ^ series of request possible to do with the bidirectional connection
     -- manager towards some peer.
     -> (MuxConnectionManager
@@ -450,21 +424,9 @@ withBidirectionalConnectionManager
        -> m a)
     -> m a
 withBidirectionalConnectionManager name snocket socket localAddress
-                                   ClientAndServerData {
-                                       accumulatorInit,
-                                       hotInitiatorRequests,
-                                       warmInitiatorRequests,
-                                       establishedInitiatorRequests
-                                     }
-                                   k = do
+                                   accumulatorInit nextRequests k = do
     mainThreadId <- myThreadId
     inbgovControlChannel      <- Server.newControlChannel
-    -- as in the 'withInitiatorOnlyConnectionManager' we use a `StrictTVar` to
-    -- pass list of requests, but since we are also interested in the results we
-    -- need to have multable cells to pass the accumulators around.
-    hotRequestsVar            <- newTVarIO hotInitiatorRequests
-    warmRequestsVar           <- newTVarIO warmInitiatorRequests
-    establishedRequestsVar    <- newTVarIO establishedInitiatorRequests
     -- we are not using the randomness
     observableStateVar        <- Server.newObservableStateVarFromSeed 0
     let muxTracer = (name,) `contramap` nullTracer -- mux tracer
@@ -501,11 +463,7 @@ withBidirectionalConnectionManager name snocket socket localAddress
               haHandshakeTracer = (name,) `contramap` nullTracer,
               haHandshakeCodec = unversionedHandshakeCodec,
               haVersionDataCodec = cborTermVersionDataCodec unversionedProtocolDataCodec,
-              haVersions = unversionedProtocol
-                            (serverApplication
-                              hotRequestsVar
-                              warmRequestsVar
-                              establishedRequestsVar),
+              haVersions = unversionedProtocol serverApplication,
               haAcceptVersion = acceptableVersion,
               haTimeLimits = noTimeLimitsHandshake
             }
@@ -572,76 +530,35 @@ withBidirectionalConnectionManager name snocket socket localAddress
           }
         ]
 
-    serverApplication :: StrictTVar m [[req]]
-                      -> StrictTVar m [[req]]
-                      -> StrictTVar m [[req]]
-                      -> Bundle
+    serverApplication :: Bundle
                           (ConnectionId peerAddr
-                      -> ControlMessageSTM m
-                      -> [MiniProtocol InitiatorResponderMode ByteString m [resp] acc])
-    serverApplication hotRequestsVar
-                      warmRequestsVar
-                      establishedRequestsVar
-                      = Bundle {
-        withHot = WithHot $ \_ _ ->
-          [ let miniProtocolNum = Mux.MiniProtocolNum 1
-            in MiniProtocol {
-                miniProtocolNum,
-                miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
-                miniProtocolRun =
-                  reqRespInitiatorAndResponder
-                    miniProtocolNum
-                    [accumulatorInit]
-                    hotRequestsVar
-               }
-          ],
-        withWarm = WithWarm $ \_ _ ->
-          [ let miniProtocolNum = Mux.MiniProtocolNum 2
-            in MiniProtocol {
-                miniProtocolNum,
-                miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
-                miniProtocolRun =
-                  reqRespInitiatorAndResponder
-                    miniProtocolNum
-                    [accumulatorInit]
-                    warmRequestsVar
-              }
-          ],
-        withEstablished = WithEstablished $ \_ _ ->
-          [ let miniProtocolNum = Mux.MiniProtocolNum 3
-            in MiniProtocol {
-                miniProtocolNum,
-                miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
-                miniProtocolRun =
-                  reqRespInitiatorAndResponder
-                    (Mux.MiniProtocolNum 3)
-                    [accumulatorInit]
-                    establishedRequestsVar
-              }
-          ]
-      }
+                            -> ControlMessageSTM m
+                            -> [MiniProtocol InitiatorResponderMode ByteString m [resp] acc])
+    serverApplication = mkProto <$> (Mux.MiniProtocolNum <$> nums) <*> nextRequests
+      where nums = Bundle (WithHot 1) (WithWarm 2) (WithEstablished 3)
+            mkProto miniProtocolNum nextRequest connId _ =
+              [MiniProtocol {
+                  miniProtocolNum,
+                  miniProtocolLimits = Mux.MiniProtocolLimits maxBound,
+                  miniProtocolRun = reqRespInitiatorAndResponder
+                                        miniProtocolNum
+                                        accumulatorInit
+                                        (nextRequest connId)
+              }]
 
     reqRespInitiatorAndResponder
       :: Mux.MiniProtocolNum
       -> acc
-      -> StrictTVar m [[req]]
+      -> STM m [req]
       -> RunMiniProtocol InitiatorResponderMode ByteString m [resp] acc
-    reqRespInitiatorAndResponder protocolNum accInit requestsVar =
+    reqRespInitiatorAndResponder protocolNum accInit nextRequests_ =
       InitiatorAndResponderProtocol
         (MuxPeer
           ((name,"Initiator",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
           codecReqResp
           (Effect $ do
-            reqs <-
-              atomically $ do
-                requests <- readTVar requestsVar
-                case requests of
-                  (reqs : rest) -> do
-                    writeTVar requestsVar rest $> reqs
-                  [] -> pure []
-            pure $
-              reqRespClientPeer
-              (reqRespClientMap reqs)))
+            reqs <- atomically nextRequests_
+            pure $ reqRespClientPeer (reqRespClientMap reqs)))
         (MuxPeer
           ((name,"Responder",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
           codecReqResp
@@ -764,11 +681,13 @@ unidirectionalExperiment
     -> ClientAndServerData req
     -> m Property
 unidirectionalExperiment snocket socket clientAndServerData = do
+    nextReqs <- oneshotNextRequests clientAndServerData
+    noServerReqs <- noNextRequests
     withInitiatorOnlyConnectionManager
-      "client" snocket clientAndServerData
+      "client" snocket nextReqs
       $ \connectionManager ->
-        withBidirectionalConnectionManager
-          "server" snocket socket Nothing clientAndServerData
+        withBidirectionalConnectionManager "server" snocket socket Nothing
+                                           [accumulatorInit clientAndServerData] noServerReqs
           $ \_ serverAddr serverAsync -> do
             link serverAsync
             -- client → server: connect
@@ -864,11 +783,13 @@ bidirectionalExperiment
     useLock snocket socket0 socket1 localAddr0 localAddr1
     clientAndServerData0 clientAndServerData1 = do
       lock <- newTMVarIO ()
-      withBidirectionalConnectionManager
-        "node-0" snocket socket0 (Just localAddr0) clientAndServerData0
+      nextRequests0 <- oneshotNextRequests clientAndServerData0
+      nextRequests1 <- oneshotNextRequests clientAndServerData1
+      withBidirectionalConnectionManager "node-0" snocket socket0 (Just localAddr0)
+                                         [accumulatorInit clientAndServerData0] nextRequests0
         (\connectionManager0 _serverAddr0 serverAsync0 ->
-          withBidirectionalConnectionManager
-            "node-1" snocket socket1 (Just localAddr1) clientAndServerData1
+          withBidirectionalConnectionManager "node-1" snocket socket1 (Just localAddr1)
+                                             [accumulatorInit clientAndServerData1] nextRequests1
             (\connectionManager1 _serverAddr1 serverAsync1 -> do
               link serverAsync0
               link serverAsync1

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -50,7 +50,10 @@ import           Test.QuickCheck
 import           Test.Tasty.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 
+import           Control.Concurrent.JobPool
+
 import qualified Network.Mux as Mux
+import           Network.Mux.Types (MuxRuntimeError (..))
 import qualified Network.Socket as Socket
 import           Network.TypedProtocol.Core
 
@@ -1111,7 +1114,8 @@ multinodeExperiment
     -> req
     -> MultiNodeScript req peerAddr
     -> m Property
-multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript script) = do
+multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript script) =
+  withJobPool $ \jobpool -> do
   -- Avoid parallel connections. This can cause one side to think that the existing connection
   -- should be used and the other side thinking that there should be two separate connections,
   -- causing the latter to wait on messages that never come.
@@ -1121,8 +1125,8 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
   -- mini-protocol run.
   propVar <- newTVarIO (property True)
   labelTVarIO propVar "propVar"
-  cc <- startServerConnectionHandler "main-server" [accInit] serverAddr lock propVar
-  loop lock (Map.singleton serverAddr [accInit]) (Map.singleton serverAddr cc) propVar script
+  cc <- startServerConnectionHandler "main-server" [accInit] serverAddr lock propVar jobpool
+  loop lock (Map.singleton serverAddr [accInit]) (Map.singleton serverAddr cc) propVar script jobpool
   where
 
     loop :: StrictTMVar m ()
@@ -1130,54 +1134,55 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
          -> Map.Map peerAddr (TQueue m (ConnectionHandlerMessage peerAddr req))
          -> StrictTVar m Property
          -> [ConnectionEvent req peerAddr]
+         -> JobPool m (Maybe SomeException)
          -> m Property
-    loop _ _ _ propVar [] = do
+    loop _ _ _ propVar [] _ = do
       threadDelay 3600
       atomically $ readTVar propVar
-    loop lock nodeAccs servers propVar (event : events) =
+    loop lock nodeAccs servers propVar (event : events) jobpool =
       case event of
 
         StartClient delay localAddr -> do
           threadDelay delay
-          cc <- startClientConnectionHandler ("client-" ++ show localAddr) localAddr lock propVar
-          loop lock nodeAccs (Map.insert localAddr cc servers) propVar events
+          cc <- startClientConnectionHandler ("client-" ++ show localAddr) localAddr lock propVar jobpool
+          loop lock nodeAccs (Map.insert localAddr cc servers) propVar events jobpool
 
         StartServer delay localAddr nodeAcc -> do
           threadDelay delay
-          cc <- startServerConnectionHandler ("node-" ++ show localAddr) [nodeAcc] localAddr lock propVar
-          loop lock (Map.insert localAddr [nodeAcc] nodeAccs) (Map.insert localAddr cc servers) propVar events
+          cc <- startServerConnectionHandler ("node-" ++ show localAddr) [nodeAcc] localAddr lock propVar jobpool
+          loop lock (Map.insert localAddr [nodeAcc] nodeAccs) (Map.insert localAddr cc servers) propVar events jobpool
 
         InboundConnection delay nodeAddr -> do
           threadDelay delay
           acc <- getAcc serverAddr
           sendMsg nodeAddr $ NewConnection serverAddr acc
-          loop lock nodeAccs servers propVar events
+          loop lock nodeAccs servers propVar events jobpool
 
         OutboundConnection delay nodeAddr -> do
           threadDelay delay
           acc <- getAcc nodeAddr
           sendMsg serverAddr $ NewConnection nodeAddr acc
-          loop lock nodeAccs servers propVar events
+          loop lock nodeAccs servers propVar events jobpool
 
         CloseInboundConnection delay remoteAddr -> do
           threadDelay delay
           sendMsg remoteAddr $ Disconnect serverAddr
-          loop lock nodeAccs servers propVar events
+          loop lock nodeAccs servers propVar events jobpool
 
         CloseOutboundConnection delay remoteAddr -> do
           threadDelay delay
           sendMsg serverAddr $ Disconnect remoteAddr
-          loop lock nodeAccs servers propVar events
+          loop lock nodeAccs servers propVar events jobpool
 
         InboundMiniprotocols delay nodeAddr reqs -> do
           threadDelay delay
           sendMsg nodeAddr $ RunMiniProtocols serverAddr reqs
-          loop lock nodeAccs servers propVar events
+          loop lock nodeAccs servers propVar events jobpool
 
         OutboundMiniprotocols delay nodeAddr reqs -> do
           threadDelay delay
           sendMsg serverAddr $ RunMiniProtocols nodeAddr reqs
-          loop lock nodeAccs servers propVar events
+          loop lock nodeAccs servers propVar events jobpool
       where
         sendMsg :: peerAddr -> ConnectionHandlerMessage peerAddr req -> m ()
         sendMsg addr msg = atomically $
@@ -1213,24 +1218,38 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
     startClientConnectionHandler :: String -> peerAddr
                                  -> StrictTMVar m ()
                                  -> StrictTVar m Property
+                                 -> JobPool m (Maybe SomeException)
                                  -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
-    startClientConnectionHandler name localAddr lock propVar = do
+    startClientConnectionHandler name localAddr lock propVar jobpool = do
         cc      <- atomically $ newTQueue
         labelTQueueIO cc $ "cc/" ++ name
         connVar <- newTVarIO Map.empty
         labelTVarIO connVar $ "connVar/" ++ name
-        _ <- forkIO $ do
-          labelThisThread name
-          withInitiatorOnlyConnectionManager
-              name snocket (Just localAddr) (mkNextRequests connVar) $ \ connectionManager ->
-            connectionLoop SingInitiatorMode localAddr lock propVar cc connectionManager Map.empty connVar
+        threadId <- myThreadId
+        forkJob jobpool
+          $ Job
+              ( withInitiatorOnlyConnectionManager
+                    name snocket (Just localAddr) (mkNextRequests connVar)
+                  ( \ connectionManager -> do
+                    connectionLoop SingInitiatorMode localAddr lock propVar cc connectionManager Map.empty connVar
+                    return Nothing
+                  )
+                `catch` (\(e :: SomeException) ->
+                        case fromException e :: Maybe MuxRuntimeError of
+                          Nothing -> throwIO e
+                          Just {} -> throwTo threadId e
+                                  >> throwIO e)
+              )
+              Just
+              name
         return cc
 
     startServerConnectionHandler :: String -> acc -> peerAddr
                                  -> StrictTMVar m ()
                                  -> StrictTVar m Property
+                                 -> JobPool m (Maybe SomeException)
                                  -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
-    startServerConnectionHandler name serverAcc localAddr lock propVar = do
+    startServerConnectionHandler name serverAcc localAddr lock propVar jobpool = do
         fd <- Snocket.open snocket addrFamily
         Snocket.bind   snocket fd localAddr
         Snocket.listen snocket fd
@@ -1238,13 +1257,26 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
         labelTQueueIO cc $ "cc/" ++ name
         connVar <- newTVarIO Map.empty
         labelTVarIO connVar $ "connVar/" ++ name
-        _ <- forkIO $ do
-          labelThisThread name
-          withBidirectionalConnectionManager
-                name snocket fd (Just localAddr) serverAcc
-                (mkNextRequests connVar) $ \ connectionManager _ serverAsync -> do
-            link serverAsync
-            connectionLoop SingInitiatorResponderMode localAddr lock propVar cc connectionManager Map.empty connVar
+        threadId <- myThreadId
+        forkJob jobpool
+              $ Job
+                  (  withBidirectionalConnectionManager
+                          name snocket fd (Just localAddr) serverAcc
+                          (mkNextRequests connVar)
+                          (\ connectionManager _ serverAsync -> do
+                             link serverAsync
+                             connectionLoop SingInitiatorResponderMode localAddr lock propVar cc connectionManager Map.empty connVar
+                             return Nothing
+                          )
+                    `catch` (\(e :: SomeException) ->
+                            case fromException e :: Maybe MuxRuntimeError of
+                              Nothing -> throwIO e
+                              Just {} -> throwTo threadId e
+                                      >> throwIO e)
+                    `finally` Snocket.close snocket fd
+                  )
+                  Just
+                  name
         return cc
 
     connectionLoop

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -96,14 +96,10 @@ tests =
 -- | The protocol will run three instances of  `ReqResp` protocol; one for each
 -- state: warm, hot and established.
 --
-data ClientAndServerData req resp acc = ClientAndServerData {
-    responderAccumulatorFn       :: Fun (acc, req) (acc, resp),
-    -- ^ folding function as required by `mapAccumL`, `acc -> req -> (acc, res)`
-    -- written using QuickCheck's 'Fun' type; all three responders (hot \/ warm
-    -- and established) are using the same
-    -- accumulation function, but different initial values.
-    accumulatorInit              :: acc,
-    -- ^ initial value of accumulator
+data ClientAndServerData req = ClientAndServerData {
+    accumulatorInit              :: req,
+    -- ^ Initial value. In for each request the server sends back a list received requests (in
+    --   reverse order) terminating with the accumulatorInit.
     hotInitiatorRequests         :: [[req]],
     -- ^ list of requests run by the hot intiator in each round; Running
     -- multiple rounds allows us to test restarting of responders.
@@ -117,7 +113,7 @@ data ClientAndServerData req resp acc = ClientAndServerData {
 
 -- Number of rounds to exhoust all the requests.
 --
-numberOfRounds :: ClientAndServerData req resp acc ->  Int
+numberOfRounds :: ClientAndServerData req ->  Int
 numberOfRounds ClientAndServerData {
                   hotInitiatorRequests,
                   warmInitiatorRequests,
@@ -137,39 +133,29 @@ arbitraryList :: Arbitrary a =>  Gen [[a]]
 arbitraryList =
     resize 3 (listOf (resize 3 (listOf (resize 100 arbitrary))))
 
-instance ( Arbitrary req
-         , Arbitrary resp
-         , Arbitrary acc
-         , Function acc
-         , CoArbitrary acc
-         , Function req
-         , CoArbitrary req
-         ) => Arbitrary (ClientAndServerData req resp acc) where
+instance (Arbitrary req) => Arbitrary (ClientAndServerData req) where
     arbitrary =
       ClientAndServerData <$> arbitrary
-                          <*> arbitrary
                           <*> arbitraryList
                           <*> arbitraryList
                           <*> arbitraryList
 
-    shrink (ClientAndServerData fun ini hot warm est) = concat
-      [ shrink fun  <&> \ fun'  -> ClientAndServerData fun' ini  hot  warm  est
-      , shrink ini  <&> \ ini'  -> ClientAndServerData fun  ini' hot  warm  est
-      , shrink hot  <&> \ hot'  -> ClientAndServerData fun  ini  hot' warm  est
-      , shrink warm <&> \ warm' -> ClientAndServerData fun  ini  hot  warm' est
-      , shrink est  <&> \ est'  -> ClientAndServerData fun  ini  hot  warm  est'
+    shrink (ClientAndServerData ini hot warm est) = concat
+      [ shrink ini  <&> \ ini'  -> ClientAndServerData ini' hot  warm  est
+      , shrink hot  <&> \ hot'  -> ClientAndServerData ini  hot' warm  est
+      , shrink warm <&> \ warm' -> ClientAndServerData ini  hot  warm' est
+      , shrink est  <&> \ est'  -> ClientAndServerData ini  hot  warm  est'
       ]
 
-expectedResult :: ClientAndServerData req resp acc
-               -> ClientAndServerData req resp acc
-               -> [Bundle [resp]]
+expectedResult :: ClientAndServerData req
+               -> ClientAndServerData req
+               -> [Bundle [[req]]]
 expectedResult client@ClientAndServerData
                                    { hotInitiatorRequests
                                    , warmInitiatorRequests
                                    , establishedInitiatorRequests
                                    }
-               ClientAndServerData { responderAccumulatorFn
-                                   , accumulatorInit
+               ClientAndServerData { accumulatorInit
                                    } =
     go
       (take rounds $ hotInitiatorRequests         ++ repeat [])
@@ -177,23 +163,12 @@ expectedResult client@ClientAndServerData
       (take rounds $ establishedInitiatorRequests ++ repeat [])
   where
     rounds = numberOfRounds client
+    fn acc x = (x : acc, x : acc)
     go (a : as) (b : bs) (c : cs) =
       Bundle
-        (WithHot
-          (snd $ mapAccumL
-            (applyFun2 responderAccumulatorFn)
-            accumulatorInit
-            a))
-        (WithWarm
-          (snd $ mapAccumL
-            (applyFun2 responderAccumulatorFn)
-            accumulatorInit
-            b))
-        (WithEstablished
-          (snd $ mapAccumL
-            (applyFun2 responderAccumulatorFn)
-            accumulatorInit
-            c))
+        (WithHot         (snd $ mapAccumL fn [accumulatorInit] a))
+        (WithWarm        (snd $ mapAccumL fn [accumulatorInit] b))
+        (WithEstablished (snd $ mapAccumL fn [accumulatorInit] c))
       : go as bs cs
     go [] [] [] = []
     go _  _  _  = error "expectedResult: impossible happened"
@@ -221,9 +196,9 @@ withInitiatorOnlyConnectionManager
     :: forall peerAddr socket acc req resp m a.
        ( ConnectionManagerMonad m
 
+       , acc ~ [req], resp ~ [req]
        , Ord peerAddr, Show peerAddr, Typeable peerAddr
-       , Serialise req, Serialise resp
-       , Typeable req, Typeable resp
+       , Serialise req, Typeable req
        , Eq (LazySTM.TVar m (ConnectionState
                                 peerAddr
                                 (Handle 'InitiatorMode peerAddr ByteString m [resp] Void)
@@ -236,12 +211,12 @@ withInitiatorOnlyConnectionManager
        -- debugging
        , MonadAsync m
        , MonadLabelledSTM m
-       , MonadSay m, Show req, Show resp
+       , MonadSay m, Show req
        )
     => String
     -- ^ identifier (for logging)
     -> Snocket m socket peerAddr
-    -> ClientAndServerData req resp acc
+    -> ClientAndServerData req
     -- ^ series of request possible to do with the bidirectional connection
     -- manager towards some peer.
     -> (MuxConnectionManager
@@ -447,6 +422,7 @@ withBidirectionalConnectionManager
     :: forall peerAddr socket acc req resp m a.
        ( ConnectionManagerMonad m
 
+       , acc ~ [req], resp ~ [req]
        , Ord peerAddr, Show peerAddr, Typeable peerAddr
        , Serialise req, Serialise resp
        , Typeable req, Typeable resp
@@ -455,7 +431,7 @@ withBidirectionalConnectionManager
        -- debugging
        , MonadAsync m
        , MonadLabelledSTM m
-       , MonadSay m, Show req, Show resp
+       , MonadSay m, Show req
        )
     => String
     -- ^ identifier (for logging)
@@ -463,7 +439,7 @@ withBidirectionalConnectionManager
     -> socket
     -- ^ listening socket
     -> Maybe peerAddr
-    -> ClientAndServerData req resp acc
+    -> ClientAndServerData req
     -- ^ series of request possible to do with the bidirectional connection
     -- manager towards some peer.
     -> (MuxConnectionManager
@@ -475,7 +451,6 @@ withBidirectionalConnectionManager
     -> m a
 withBidirectionalConnectionManager name snocket socket localAddress
                                    ClientAndServerData {
-                                       responderAccumulatorFn,
                                        accumulatorInit,
                                        hotInitiatorRequests,
                                        warmInitiatorRequests,
@@ -616,8 +591,7 @@ withBidirectionalConnectionManager name snocket socket localAddress
                 miniProtocolRun =
                   reqRespInitiatorAndResponder
                     miniProtocolNum
-                    responderAccumulatorFn
-                    accumulatorInit
+                    [accumulatorInit]
                     hotRequestsVar
                }
           ],
@@ -629,8 +603,7 @@ withBidirectionalConnectionManager name snocket socket localAddress
                 miniProtocolRun =
                   reqRespInitiatorAndResponder
                     miniProtocolNum
-                    responderAccumulatorFn
-                    accumulatorInit
+                    [accumulatorInit]
                     warmRequestsVar
               }
           ],
@@ -642,8 +615,7 @@ withBidirectionalConnectionManager name snocket socket localAddress
                 miniProtocolRun =
                   reqRespInitiatorAndResponder
                     (Mux.MiniProtocolNum 3)
-                    responderAccumulatorFn
-                    accumulatorInit
+                    [accumulatorInit]
                     establishedRequestsVar
               }
           ]
@@ -651,11 +623,10 @@ withBidirectionalConnectionManager name snocket socket localAddress
 
     reqRespInitiatorAndResponder
       :: Mux.MiniProtocolNum
-      -> Fun (acc, req) (acc, resp)
       -> acc
       -> StrictTVar m [[req]]
       -> RunMiniProtocol InitiatorResponderMode ByteString m [resp] acc
-    reqRespInitiatorAndResponder protocolNum fn accInit requestsVar =
+    reqRespInitiatorAndResponder protocolNum accInit requestsVar =
       InitiatorAndResponderProtocol
         (MuxPeer
           ((name,"Initiator",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
@@ -674,13 +645,12 @@ withBidirectionalConnectionManager name snocket socket localAddress
         (MuxPeer
           ((name,"Responder",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
           codecReqResp
-          (reqRespServerPeer $ reqRespServerMapAccumL' (applyFun2 fn) accInit))
+          (reqRespServerPeer $ reqRespServerMapAccumL' accInit))
 
-    reqRespServerMapAccumL' :: (acc -> req -> (acc, resp))
-                            -> acc
-                            -> ReqRespServer req resp m acc
-    reqRespServerMapAccumL' fn = go
+    reqRespServerMapAccumL' :: acc -> ReqRespServer req resp m acc
+    reqRespServerMapAccumL' = go
       where
+        fn acc x = (x : acc, x : acc)
         go acc =
           ReqRespServer {
               recvMsgReq = \req ->
@@ -775,6 +745,7 @@ unidirectionalExperiment
        , MonadLabelledSTM m
        , MonadSay m
 
+       , acc ~ [req], resp ~ [req]
        , Ord peerAddr, Show peerAddr, Typeable peerAddr, Eq peerAddr
        , Eq (LazySTM.TVar m (ConnectionState
                                 peerAddr
@@ -790,7 +761,7 @@ unidirectionalExperiment
        )
     => Snocket m socket peerAddr
     -> socket
-    -> ClientAndServerData req resp acc
+    -> ClientAndServerData req
     -> m Property
 unidirectionalExperiment snocket socket clientAndServerData = do
     withInitiatorOnlyConnectionManager
@@ -828,7 +799,7 @@ unidirectionalExperiment snocket socket clientAndServerData = do
                 (property True)
                 $ zip rs (expectedResult clientAndServerData clientAndServerData)
 
-prop_unidirectional_Sim :: ClientAndServerData Int Int Int -> Property
+prop_unidirectional_Sim :: ClientAndServerData Int -> Property
 prop_unidirectional_Sim clientAndServerData =
   simulatedPropertyWithTimeout 7200 $
     withSnocket nullTracer
@@ -843,7 +814,7 @@ prop_unidirectional_Sim clientAndServerData =
     serverAddr = Snocket.TestAddress (0 :: Int)
 
 prop_unidirectional_IO
-  :: ClientAndServerData Int Int Int
+  :: ClientAndServerData Int
   -> Property
 prop_unidirectional_IO clientAndServerData =
     ioProperty $ do
@@ -871,6 +842,7 @@ bidirectionalExperiment
        , MonadLabelledSTM m
        , MonadSay m
 
+       , acc ~ [req], resp ~ [req]
        , Ord peerAddr, Show peerAddr, Typeable peerAddr, Eq peerAddr
        , Eq (LazySTM.TVar m (ConnectionState_ 'InitiatorResponderMode peerAddr m [resp] acc))
 
@@ -885,8 +857,8 @@ bidirectionalExperiment
     -> socket
     -> peerAddr
     -> peerAddr
-    -> ClientAndServerData req resp acc
-    -> ClientAndServerData req resp acc
+    -> ClientAndServerData req
+    -> ClientAndServerData req
     -> m Property
 bidirectionalExperiment
     useLock snocket socket0 socket1 localAddr0 localAddr1
@@ -972,7 +944,7 @@ bidirectionalExperiment
                 ))
 
 
-prop_bidirectional_Sim :: NonFailingBearerInfoScript -> ClientAndServerData Int Int Int -> ClientAndServerData Int Int Int -> Property
+prop_bidirectional_Sim :: NonFailingBearerInfoScript -> ClientAndServerData Int -> ClientAndServerData Int -> Property
 prop_bidirectional_Sim (NonFailingBearerInfoScript script) data0 data1 =
   simulatedPropertyWithTimeout 7200 $
     withSnocket debugTracer
@@ -994,8 +966,8 @@ prop_bidirectional_Sim (NonFailingBearerInfoScript script) data0 data1 =
     script' = toBearerInfo <$> script
 
 prop_bidirectional_IO
-    :: ClientAndServerData Int Int Int
-    -> ClientAndServerData Int Int Int
+    :: ClientAndServerData Int
+    -> ClientAndServerData Int
     -> Property
 prop_bidirectional_IO data0 data1 =
     ioProperty $ do

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -36,10 +36,11 @@ import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 
 import           Codec.Serialise.Class (Serialise)
 import           Data.ByteString.Lazy (ByteString)
-import           Data.Functor (($>), (<&>))
-import           Data.List (mapAccumL, intercalate, (\\), tails, delete)
+import           Data.Functor (void, ($>), (<&>))
+import           Data.List (mapAccumL, intercalate, (\\), delete)
 import           Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.Map as Map
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
@@ -87,6 +88,7 @@ import           Simulation.Network.Snocket
 
 import           Test.Ouroboros.Network.Orphans ()  -- ShowProxy ReqResp instance
 import           Test.Simulation.Network.Snocket (NonFailingBearerInfoScript(..), toBearerInfo)
+import           Test.Ouroboros.Network.ConnectionManager (verifyAbstractTransition)
 
 tests :: TestTree
 tests =
@@ -1080,9 +1082,13 @@ instance (Arbitrary peerAddr, Arbitrary req, Eq peerAddr) =>
         (shrinkBundle r <&> \ r' -> OutboundMiniprotocols d  a r') ++
         (shrinkDelay  d <&> \ d' -> OutboundMiniprotocols d' a r)
 
+-- | The concrete address type used by simulations.
+--
+type SimAddr = Snocket.TestAddress Int
+
 -- | We use a wrapper for test addresses since the Arbitrary instance for Snocket.TestAddress only
 --   generates addresses between 1 and 4.
-newtype TestAddr = TestAddr { unTestAddr :: Snocket.TestAddress Int }
+newtype TestAddr = TestAddr { unTestAddr :: SimAddr }
   deriving (Show, Eq, Ord)
 
 instance Arbitrary TestAddr where
@@ -1090,9 +1096,8 @@ instance Arbitrary TestAddr where
 
 -- | Each node in the multi-node experiment is controlled by a thread responding to these messages.
 data ConnectionHandlerMessage peerAddr req
-  = NewConnection peerAddr [req]
-    -- ^ Connect to the server at the given address. Needs to know the `accumulatorInit` of the
-    --   server in order to validate the responses.
+  = NewConnection peerAddr
+    -- ^ Connect to the server at the given address.
   | Disconnect peerAddr
     -- ^ Disconnect from the server at the given address.
   | RunMiniProtocols peerAddr (Bundle [req])
@@ -1110,6 +1115,14 @@ instance Show addr => Show (Name addr) where
     show (Node   addr) = "node-"   ++ show addr
     show  MainServer   = "main-server"
 
+
+data ExperimentError addr =
+      NodeNotRunningException addr
+    | NoActiveConnection addr addr
+    | SimulationTimeout
+  deriving (Typeable, Show)
+
+instance ( Show addr, Typeable addr ) => Exception (ExperimentError addr)
 
 -- | Run a central server that talks to any number of clients and other nodes.
 multinodeExperiment
@@ -1131,95 +1144,74 @@ multinodeExperiment
        , Serialise resp, Show resp, Eq resp
        , Typeable req, Typeable resp
        )
-    => Snocket m socket peerAddr
+    => Tracer m (WithName (Name peerAddr)
+                          (AbstractTransitionTrace peerAddr))
+    -> Snocket m socket peerAddr
     -> Snocket.AddressFamily peerAddr
     -> peerAddr
     -> req
     -> MultiNodeScript req peerAddr
-    -> m Property
-multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript script) =
+    -> m ()
+multinodeExperiment trTracer snocket addrFamily serverAddr accInit (MultiNodeScript script) =
   withJobPool $ \jobpool -> do
-  -- Avoid parallel connections. This can cause one side to think that the existing connection
-  -- should be used and the other side thinking that there should be two separate connections,
-  -- causing the latter to wait on messages that never come.
-  lock <- newTMVarIO ()
-  labelTMVarIO lock "lock"
-  -- TVar keeping the resulting property. Connection handler threads update this after each
-  -- mini-protocol run.
-  propVar <- newTVarIO (property True)
-  labelTVarIO propVar "propVar"
-  cc <- startServerConnectionHandler MainServer [accInit] serverAddr lock propVar jobpool
-  loop lock (Map.singleton serverAddr [accInit]) (Map.singleton serverAddr cc) propVar script jobpool
+  cc <- startServerConnectionHandler MainServer [accInit] serverAddr jobpool
+  loop (Map.singleton serverAddr [accInit]) (Map.singleton serverAddr cc) script jobpool
   where
 
-    loop :: StrictTMVar m ()
-         -> Map.Map peerAddr acc
+    loop :: Map.Map peerAddr acc
          -> Map.Map peerAddr (TQueue m (ConnectionHandlerMessage peerAddr req))
-         -> StrictTVar m Property
          -> [ConnectionEvent req peerAddr]
          -> JobPool m (Maybe SomeException)
-         -> m Property
-    loop _ _ _ propVar [] _ = do
-      threadDelay 3600
-      atomically $ readTVar propVar
-    loop lock nodeAccs servers propVar (event : events) jobpool =
+         -> m ()
+    loop _ _ [] _ = threadDelay 3600
+    loop nodeAccs servers (event : events) jobpool =
       case event of
 
         StartClient delay localAddr -> do
           threadDelay delay
-          cc <- startClientConnectionHandler (Client localAddr) localAddr lock propVar jobpool
-          loop lock nodeAccs (Map.insert localAddr cc servers) propVar events jobpool
+          cc <- startClientConnectionHandler (Client localAddr) localAddr jobpool
+          loop nodeAccs (Map.insert localAddr cc servers) events jobpool
 
         StartServer delay localAddr nodeAcc -> do
           threadDelay delay
-          cc <- startServerConnectionHandler (Node localAddr) [nodeAcc] localAddr lock propVar jobpool
-          loop lock (Map.insert localAddr [nodeAcc] nodeAccs) (Map.insert localAddr cc servers) propVar events jobpool
+          cc <- startServerConnectionHandler (Node localAddr) [nodeAcc] localAddr jobpool
+          loop (Map.insert localAddr [nodeAcc] nodeAccs) (Map.insert localAddr cc servers) events jobpool
 
         InboundConnection delay nodeAddr -> do
           threadDelay delay
-          acc <- getAcc serverAddr
-          sendMsg nodeAddr $ NewConnection serverAddr acc
-          loop lock nodeAccs servers propVar events jobpool
+          sendMsg nodeAddr $ NewConnection serverAddr
+          loop nodeAccs servers events jobpool
 
         OutboundConnection delay nodeAddr -> do
           threadDelay delay
-          acc <- getAcc nodeAddr
-          sendMsg serverAddr $ NewConnection nodeAddr acc
-          loop lock nodeAccs servers propVar events jobpool
+          sendMsg serverAddr $ NewConnection nodeAddr
+          loop nodeAccs servers events jobpool
 
         CloseInboundConnection delay remoteAddr -> do
           threadDelay delay
           sendMsg remoteAddr $ Disconnect serverAddr
-          loop lock nodeAccs servers propVar events jobpool
+          loop nodeAccs servers events jobpool
 
         CloseOutboundConnection delay remoteAddr -> do
           threadDelay delay
           sendMsg serverAddr $ Disconnect remoteAddr
-          loop lock nodeAccs servers propVar events jobpool
+          loop nodeAccs servers events jobpool
 
         InboundMiniprotocols delay nodeAddr reqs -> do
           threadDelay delay
           sendMsg nodeAddr $ RunMiniProtocols serverAddr reqs
-          loop lock nodeAccs servers propVar events jobpool
+          loop nodeAccs servers events jobpool
 
         OutboundMiniprotocols delay nodeAddr reqs -> do
           threadDelay delay
           sendMsg serverAddr $ RunMiniProtocols nodeAddr reqs
-          loop lock nodeAccs servers propVar events jobpool
+          loop nodeAccs servers events jobpool
       where
         sendMsg :: peerAddr -> ConnectionHandlerMessage peerAddr req -> m ()
         sendMsg addr msg = atomically $
           case Map.lookup addr servers of
-            Nothing -> assertProperty propVar $ counterexample (show addr ++ " is not a started node") False
+            Nothing -> throwIO (NodeNotRunningException addr)
             Just cc -> writeTQueue cc msg
-
-        getAcc :: peerAddr -> m acc
-        getAcc addr =
-          case Map.lookup addr nodeAccs of
-            Nothing  -> do
-              assertPropertyIO propVar $ counterexample (show addr ++ " is not a started server node") False
-              return []
-            Just acc -> return acc
 
     mkNextRequests :: StrictTVar m (Map.Map (ConnectionId peerAddr) (Bundle (TQueue m [req]))) ->
                       Bundle (ConnectionId peerAddr -> STM m [req])
@@ -1232,19 +1224,11 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
             Nothing -> retry
             Just qs -> readTQueue (projectBundle tok qs)
 
-    assertPropertyIO :: StrictTVar m Property -> Property -> m ()
-    assertPropertyIO propVar p = atomically $ assertProperty propVar p
-
-    assertProperty :: StrictTVar m Property -> Property -> STM m ()
-    assertProperty propVar p = modifyTVar propVar (.&&. p)
-
     startClientConnectionHandler :: Name peerAddr
                                  -> peerAddr
-                                 -> StrictTMVar m ()
-                                 -> StrictTVar m Property
                                  -> JobPool m (Maybe SomeException)
                                  -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
-    startClientConnectionHandler name localAddr lock propVar jobpool = do
+    startClientConnectionHandler name localAddr jobpool  = do
         cc      <- atomically $ newTQueue
         labelTQueueIO cc $ "cc/" ++ show name
         connVar <- newTVarIO Map.empty
@@ -1255,7 +1239,7 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
               ( withInitiatorOnlyConnectionManager
                     name simTimeouts snocket (Just localAddr) (mkNextRequests connVar)
                   ( \ connectionManager -> do
-                    connectionLoop SingInitiatorMode localAddr lock propVar cc connectionManager Map.empty connVar
+                    connectionLoop SingInitiatorMode localAddr cc connectionManager Map.empty connVar
                     return Nothing
                   )
                 `catch` (\(e :: SomeException) ->
@@ -1271,11 +1255,9 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
     startServerConnectionHandler :: Name peerAddr
                                  -> acc
                                  -> peerAddr
-                                 -> StrictTMVar m ()
-                                 -> StrictTVar m Property
                                  -> JobPool m (Maybe SomeException)
                                  -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
-    startServerConnectionHandler name serverAcc localAddr lock propVar jobpool = do
+    startServerConnectionHandler name serverAcc localAddr jobpool = do
         fd <- Snocket.open snocket addrFamily
         Snocket.bind   snocket fd localAddr
         Snocket.listen snocket fd
@@ -1286,14 +1268,14 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
         threadId <- myThreadId
         forkJob jobpool
               $ Job
-                  (  withBidirectionalConnectionManager
-                          name simTimeouts nullTracer
-                          snocket fd (Just localAddr) serverAcc
-                          (mkNextRequests connVar)
-                          (\ connectionManager _ _serverAsync -> do
-                             connectionLoop SingInitiatorResponderMode localAddr lock propVar cc connectionManager Map.empty connVar
-                             return Nothing
-                          )
+                  ( withBidirectionalConnectionManager
+                      name simTimeouts trTracer
+                      snocket fd (Just localAddr) serverAcc
+                      (mkNextRequests connVar)
+                      ( \ connectionManager _ _serverAsync -> do
+                        connectionLoop SingInitiatorResponderMode localAddr cc connectionManager Map.empty connVar
+                        return Nothing
+                      )
                     `catch` (\(e :: SomeException) ->
                             case fromException e :: Maybe MuxRuntimeError of
                               Nothing -> throwIO e
@@ -1309,15 +1291,13 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
          :: (HasInitiator muxMode ~ True)
          => SingMuxMode muxMode
          -> peerAddr
-         -> StrictTMVar m ()
-         -> StrictTVar m Property
          -> TQueue m (ConnectionHandlerMessage peerAddr req)                          -- control channel
          -> MuxConnectionManager muxMode socket peerAddr UnversionedProtocol ByteString m [resp] a
-         -> Map.Map peerAddr (Handle muxMode peerAddr ByteString m [resp] a, acc)     -- active connections
+         -> Map.Map peerAddr (Handle muxMode peerAddr ByteString m [resp] a)          -- active connections
          -> StrictTVar m (Map.Map (ConnectionId peerAddr) (Bundle (TQueue m [req])))  -- mini protocol queues
          -> m ()
-    connectionLoop muxMode localAddr lock propVar cc cm connMap connVar = atomically (readTQueue cc) >>= \ case
-      NewConnection remoteAddr remoteAcc -> do
+    connectionLoop muxMode localAddr cc cm connMap connVar = atomically (readTQueue cc) >>= \ case
+      NewConnection remoteAddr -> do
         let mkQueue :: forall pt. TokProtocolTemperature pt -> STM m (TQueue m [req])
             mkQueue tok = do
               q <- newTQueue
@@ -1328,48 +1308,113 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
               q <$ labelTQueue q ("protoVar." ++ temp ++ "@" ++ show localAddr)
         qs <- atomically $ traverse id $ makeBundle mkQueue
         atomically $ modifyTVar connVar $ Map.insert (connId remoteAddr) qs
-        connHandle <- withLock False lock $ requestOutboundConnection cm remoteAddr
+        connHandle <- requestOutboundConnection cm remoteAddr
         case connHandle of
-          Connected _ _ h -> do
-            connectionLoop muxMode localAddr lock propVar cc cm (Map.insert remoteAddr (h, remoteAcc) connMap) connVar
-          Disconnected _ err ->
-            failureIO $ "connection failure: " ++ show err
+          Connected _ _ h ->
+            connectionLoop muxMode localAddr cc cm (Map.insert remoteAddr h connMap) connVar
+          Disconnected {} -> return ()
       Disconnect remoteAddr -> do
         atomically $ modifyTVar connVar $ Map.delete (connId remoteAddr)
         _ <- unregisterOutboundConnection cm remoteAddr
-        connectionLoop muxMode localAddr lock propVar cc cm (Map.delete remoteAddr connMap) connVar
+        connectionLoop muxMode localAddr cc cm (Map.delete remoteAddr connMap) connVar
       RunMiniProtocols remoteAddr reqs -> do
         atomically $ do
           mqs <- (Map.lookup $ connId remoteAddr) <$> readTVar connVar
           case mqs of
-            Nothing -> failure $ "No active connection " ++ show localAddr ++ " => " ++ show remoteAddr
+            Nothing ->
+              throwIO (NoActiveConnection localAddr remoteAddr)
             Just qs -> do
               sequence_ $ writeTQueue <$> qs <*> reqs
         case Map.lookup remoteAddr connMap of
-          Nothing -> failureIO $ "no connection " ++ show localAddr ++ " => " ++ show remoteAddr
-          Just (Handle mux muxBundle _, acc)  -> do
-            rs <- try @_ @SomeException $ runInitiatorProtocols muxMode mux muxBundle
-            case rs of
-              Left err -> failureIO $ "protocol error: " ++ show err
-              Right r  -> assertPropertyIO propVar $ r === fmap (drop 2 . reverse .  tails . (++ acc) . reverse) reqs
-        connectionLoop muxMode localAddr lock propVar cc cm connMap connVar
+          Nothing -> throwIO (NoActiveConnection localAddr remoteAddr)
+          Just (Handle mux muxBundle _)  ->
+            -- TODO:
+            -- At times this throws 'ProtocolAlreadyRunning'.
+            void $ try @_ @SomeException
+                 $ runInitiatorProtocols muxMode mux muxBundle
+        connectionLoop muxMode localAddr cc cm connMap connVar
       where
-        connId remoteAddr = ConnectionId{ localAddress = localAddr, remoteAddress = remoteAddr }
+        connId remoteAddr = ConnectionId { localAddress  = localAddr
+                                         , remoteAddress = remoteAddr }
 
-        failureIO :: String -> m ()
-        failureIO = atomically . failure
 
-        failure :: String -> STM m ()
-        failure err = assertProperty propVar $ counterexample err False
+newtype AllProperty = AllProperty { getAllProperty :: Property }
+
+instance Semigroup AllProperty where
+    AllProperty a <> AllProperty b = AllProperty (a .&&. b)
+
+instance Monoid AllProperty where
+    mempty = AllProperty (property True)
+
 
 -- | Property wrapping `multinodeExperiment`.
 prop_multinode_Sim :: Int -> MultiNodeScript Int TestAddr -> Property
-prop_multinode_Sim serverAcc script' =
-  simulatedPropertyWithTimeout 7200 $
-    withSnocket debugTracer (singletonScript noAttenuation) (TestAddress 10) $ \snocket ->
-    let script  = unTestAddr <$> script' in
-    counterexample (ppScript script) <$>
-      multinodeExperiment snocket Snocket.TestFamily (Snocket.TestAddress 0) serverAcc script
+prop_multinode_Sim serverAcc script =
+  let evs :: [AbstractTransitionTrace SimAddr]
+      evs = map wnEvent
+          . filter ((MainServer ==) . wnName)
+          $ (selectTraceEventsDynamic' (runSimTrace sim)
+              :: [WithName (Name SimAddr)
+                           (AbstractTransitionTrace SimAddr)])
+        where
+          sim :: IOSim s ()
+          sim = do
+            mb <- timeout 7200
+                    ( withSnocket debugTracer
+                                  (singletonScript noAttenuation)
+                                  (Snocket.TestAddress 10)
+                    $ \snocket ->
+                       multinodeExperiment (Tracer traceM)
+                                           snocket
+                                           Snocket.TestFamily
+                                           (Snocket.TestAddress 0)
+                                           serverAcc
+                                           (unTestAddr <$> script)
+                    )
+            case mb of
+              Nothing -> throwIO (SimulationTimeout :: ExperimentError SimAddr)
+              Just a  -> return a
+
+  in   counterexample (ppScript script)
+     . getAllProperty
+     . foldMap ( foldMap ( \ tr
+                          -> AllProperty
+                           . (counterexample $! ("\nUnexpected transition: " ++ ppTransition tr))
+                           . verifyAbstractTransition
+                           $ tr
+                         )
+               )
+     . concat
+     . Map.elems
+     . splitConns
+     $ evs
+  where
+    splitConns :: [AbstractTransitionTrace SimAddr]
+               -> Map SimAddr [[AbstractTransition]]
+    splitConns as = splitConn <$> tracesByAddr
+      where
+        splitConn :: [AbstractTransition] -> [[AbstractTransition]]
+        splitConn [] = []
+        splitConn (t : ts) =
+          case span (\  tr@Transition { fromState }
+                     -> fromState /= UnknownConnectionSt
+                     && tr        /= Transition TerminatedSt
+                                                (UnnegotiatedSt Inbound)
+                    ) ts of
+                 (cs, ts') -> (t : cs) : splitConn ts'
+
+        tracesByAddr :: Map SimAddr [AbstractTransition]
+        tracesByAddr =
+          Map.fromListWith
+            (flip (++))
+            ( map (\  TransitionTrace { ttPeerAddr, ttTransition }
+                   -> (ttPeerAddr, [ttTransition]))
+            $ as
+            )
+
+ppTransition :: AbstractTransition -> String
+ppTransition Transition {fromState, toState} =
+    printf "%-30s → %s" (show fromState) (show toState)
 
 ppScript :: (Show peerAddr, Show req) => MultiNodeScript peerAddr req -> String
 ppScript (MultiNodeScript script) = intercalate "\n" $ go 0 script

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -256,7 +256,7 @@ type ConnectionState_ muxMode peerAddr m a b =
                        m
 
 withInitiatorOnlyConnectionManager
-    :: forall peerAddr socket req resp m a.
+    :: forall name peerAddr socket req resp m a.
        ( ConnectionManagerMonad m
 
        , resp ~ [req]
@@ -275,8 +275,9 @@ withInitiatorOnlyConnectionManager
        , MonadAsync m
        , MonadLabelledSTM m
        , MonadSay m, Show req
+       , Show name
        )
-    => String
+    => name
     -- ^ identifier (for logging)
     -> Timeouts
     -> Snocket m socket peerAddr
@@ -296,9 +297,9 @@ withInitiatorOnlyConnectionManager name timeouts snocket localAddr nextRequests 
     withConnectionManager
       ConnectionManagerArguments {
           -- ConnectionManagerTrace
-          cmTracer    = (name,)
+          cmTracer    = WithName name
                         `contramap` connectionManagerTracer,
-          cmTrTracer  = ((name,) . fmap abstractState)
+          cmTrTracer  = (WithName name . fmap abstractState)
                         `contramap` nullTracer,
          -- MuxTracer
           cmMuxTracer = muxTracer,
@@ -419,7 +420,7 @@ assertRethrowPolicy =
 -- across warm \/ how \/ established) protocols.
 --
 withBidirectionalConnectionManager
-    :: forall peerAddr socket acc req resp m a.
+    :: forall name peerAddr socket acc req resp m a.
        ( ConnectionManagerMonad m
 
        , acc ~ [req], resp ~ [req]
@@ -430,10 +431,12 @@ withBidirectionalConnectionManager
        , MonadAsync m
        , MonadLabelledSTM m
        , MonadSay m, Show req
+       , Show name
        )
-    => String
+    => name
     -> Timeouts
     -- ^ identifier (for logging)
+    -> Tracer m (WithName name (AbstractTransitionTrace peerAddr))
     -> Snocket m socket peerAddr
     -> socket
     -- ^ listening socket
@@ -451,21 +454,21 @@ withBidirectionalConnectionManager
        -> Async m Void
        -> m a)
     -> m a
-withBidirectionalConnectionManager name timeouts snocket socket localAddress
+withBidirectionalConnectionManager name timeouts trTracer snocket socket localAddress
                                    accumulatorInit nextRequests k = do
     mainThreadId <- myThreadId
     inbgovControlChannel      <- Server.newControlChannel
     -- we are not using the randomness
     observableStateVar        <- Server.newObservableStateVarFromSeed 0
-    let muxTracer = (name,) `contramap` nullTracer -- mux tracer
+    let muxTracer = WithName name `contramap` nullTracer -- mux tracer
 
     withConnectionManager
       ConnectionManagerArguments {
           -- ConnectionManagerTrace
-          cmTracer    = (name,)
+          cmTracer    = WithName name
                         `contramap` connectionManagerTracer,
-          cmTrTracer  = ((name,) . fmap abstractState)
-                        `contramap` nullTracer,
+          cmTrTracer  = (WithName name . fmap abstractState)
+                        `contramap` trTracer,
           -- MuxTracer
           cmMuxTracer    = muxTracer,
           cmIPv4Address  = localAddress,
@@ -488,7 +491,7 @@ withBidirectionalConnectionManager name timeouts snocket socket localAddress
           serverMiniProtocolBundle
           HandshakeArguments {
               -- TraceSendRecv
-              haHandshakeTracer = (name,) `contramap` nullTracer,
+              haHandshakeTracer = WithName name `contramap` nullTracer,
               haHandshakeCodec = unversionedHandshakeCodec,
               haVersionDataCodec = cborTermVersionDataCodec unversionedProtocolDataCodec,
               haVersions = unversionedProtocol serverApplication,
@@ -508,8 +511,8 @@ withBidirectionalConnectionManager name timeouts snocket socket localAddress
                 ServerArguments {
                     serverSockets = socket :| [],
                     serverSnocket = snocket,
-                    serverTracer = (name,) `contramap` nullTracer, -- ServerTrace
-                    serverInboundGovernorTracer = (name,) `contramap` nullTracer, -- InboundGovernorTrace
+                    serverTracer = WithName name `contramap` nullTracer, -- ServerTrace
+                    serverInboundGovernorTracer = WithName name `contramap` nullTracer, -- InboundGovernorTrace
                     serverConnectionLimits = AcceptedConnectionsLimit maxBound maxBound 0,
                     serverConnectionManager = connectionManager,
                     serverInboundIdleTimeout = tProtocolIdleTimeout timeouts,
@@ -583,13 +586,13 @@ withBidirectionalConnectionManager name timeouts snocket socket localAddress
     reqRespInitiatorAndResponder protocolNum accInit nextRequest =
       InitiatorAndResponderProtocol
         (MuxPeer
-          ((name,"Initiator",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
+          (WithName (name,"Initiator",protocolNum) `contramap` nullTracer) -- TraceSendRecv
           codecReqResp
           (Effect $ do
             reqs <- atomically nextRequest
             pure $ reqRespClientPeer (reqRespClientMap reqs)))
         (MuxPeer
-          ((name,"Responder",protocolNum,) `contramap` nullTracer) -- TraceSendRecv
+          (WithName (name,"Responder",protocolNum) `contramap` nullTracer) -- TraceSendRecv
           codecReqResp
           (reqRespServerPeer $ reqRespServerMapAccumL' accInit))
 
@@ -715,7 +718,7 @@ unidirectionalExperiment timeouts snocket socket clientAndServerData = do
     withInitiatorOnlyConnectionManager
       "client" timeouts snocket Nothing nextReqs
       $ \connectionManager ->
-        withBidirectionalConnectionManager "server" timeouts
+        withBidirectionalConnectionManager "server" timeouts nullTracer
                                            snocket socket Nothing
                                            [accumulatorInit clientAndServerData]
                                            noNextRequests
@@ -817,13 +820,13 @@ bidirectionalExperiment
       lock <- newTMVarIO ()
       nextRequests0 <- oneshotNextRequests clientAndServerData0
       nextRequests1 <- oneshotNextRequests clientAndServerData1
-      withBidirectionalConnectionManager "node-0" timeouts
+      withBidirectionalConnectionManager "node-0" timeouts nullTracer
                                          snocket socket0
                                          (Just localAddr0)
                                          [accumulatorInit clientAndServerData0]
                                          nextRequests0
         (\connectionManager0 _serverAddr0 _serverAsync0 ->
-          withBidirectionalConnectionManager "node-1" timeouts
+          withBidirectionalConnectionManager "node-1" timeouts nullTracer
                                              snocket socket1
                                              (Just localAddr1)
                                              [accumulatorInit clientAndServerData1]
@@ -1112,6 +1115,18 @@ data ConnectionHandlerMessage peerAddr req
     -- ^ Run a bundle of mini protocols against the server at the given address (requires an active
     --   connection).
 
+
+data Name addr = Client addr
+               | Node addr
+               | MainServer
+  deriving Eq
+
+instance Show addr => Show (Name addr) where
+    show (Client addr) = "client-" ++ show addr
+    show (Node   addr) = "node-"   ++ show addr
+    show  MainServer   = "main-server"
+
+
 -- | Run a central server that talks to any number of clients and other nodes.
 multinodeExperiment
     :: forall peerAddr socket acc req resp m.
@@ -1149,7 +1164,7 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
   -- mini-protocol run.
   propVar <- newTVarIO (property True)
   labelTVarIO propVar "propVar"
-  cc <- startServerConnectionHandler "main-server" [accInit] serverAddr lock propVar jobpool
+  cc <- startServerConnectionHandler MainServer [accInit] serverAddr lock propVar jobpool
   loop lock (Map.singleton serverAddr [accInit]) (Map.singleton serverAddr cc) propVar script jobpool
   where
 
@@ -1168,12 +1183,12 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
 
         StartClient delay localAddr -> do
           threadDelay delay
-          cc <- startClientConnectionHandler ("client-" ++ show localAddr) localAddr lock propVar jobpool
+          cc <- startClientConnectionHandler (Client localAddr) localAddr lock propVar jobpool
           loop lock nodeAccs (Map.insert localAddr cc servers) propVar events jobpool
 
         StartServer delay localAddr nodeAcc -> do
           threadDelay delay
-          cc <- startServerConnectionHandler ("node-" ++ show localAddr) [nodeAcc] localAddr lock propVar jobpool
+          cc <- startServerConnectionHandler (Node localAddr) [nodeAcc] localAddr lock propVar jobpool
           loop lock (Map.insert localAddr [nodeAcc] nodeAccs) (Map.insert localAddr cc servers) propVar events jobpool
 
         InboundConnection delay nodeAddr -> do
@@ -1239,16 +1254,17 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
     assertProperty :: StrictTVar m Property -> Property -> STM m ()
     assertProperty propVar p = modifyTVar propVar (.&&. p)
 
-    startClientConnectionHandler :: String -> peerAddr
+    startClientConnectionHandler :: Name peerAddr
+                                 -> peerAddr
                                  -> StrictTMVar m ()
                                  -> StrictTVar m Property
                                  -> JobPool m (Maybe SomeException)
                                  -> m (TQueue m (ConnectionHandlerMessage peerAddr req))
     startClientConnectionHandler name localAddr lock propVar jobpool = do
         cc      <- atomically $ newTQueue
-        labelTQueueIO cc $ "cc/" ++ name
+        labelTQueueIO cc $ "cc/" ++ show name
         connVar <- newTVarIO Map.empty
-        labelTVarIO connVar $ "connVar/" ++ name
+        labelTVarIO connVar $ "connVar/" ++ show name
         threadId <- myThreadId
         forkJob jobpool
           $ Job
@@ -1265,10 +1281,12 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
                                   >> throwIO e)
               )
               Just
-              name
+              (show name)
         return cc
 
-    startServerConnectionHandler :: String -> acc -> peerAddr
+    startServerConnectionHandler :: Name peerAddr
+                                 -> acc
+                                 -> peerAddr
                                  -> StrictTMVar m ()
                                  -> StrictTVar m Property
                                  -> JobPool m (Maybe SomeException)
@@ -1278,14 +1296,15 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
         Snocket.bind   snocket fd localAddr
         Snocket.listen snocket fd
         cc      <- atomically $ newTQueue
-        labelTQueueIO cc $ "cc/" ++ name
+        labelTQueueIO cc $ "cc/" ++ show name
         connVar <- newTVarIO Map.empty
-        labelTVarIO connVar $ "connVar/" ++ name
+        labelTVarIO connVar $ "connVar/" ++ show name
         threadId <- myThreadId
         forkJob jobpool
               $ Job
                   (  withBidirectionalConnectionManager
-                          name simTimeouts snocket fd (Just localAddr) serverAcc
+                          name simTimeouts nullTracer
+                          snocket fd (Just localAddr) serverAcc
                           (mkNextRequests connVar)
                           (\ connectionManager _ _serverAsync -> do
                              connectionLoop SingInitiatorResponderMode localAddr lock propVar cc connectionManager Map.empty connVar
@@ -1299,7 +1318,7 @@ multinodeExperiment snocket addrFamily serverAddr accInit (MultiNodeScript scrip
                     `finally` Snocket.close snocket fd
                   )
                   Just
-                  name
+                  (show name)
         return cc
 
     connectionLoop
@@ -1402,6 +1421,14 @@ ppScript (MultiNodeScript script) = intercalate "\n" $ go 0 script
 -- Utils
 --
 
+data WithName name event = WithName {
+    wnName  :: name,
+    wnEvent :: event
+  }
+  deriving Show
+
+type AbstractTransitionTrace addr = TransitionTrace' addr AbstractState
+
 debugTracer :: (MonadSay m, MonadTime m, Show a) => Tracer m a
 debugTracer = Tracer $
   \msg -> (,msg) <$> getCurrentTime >>= say . show
@@ -1418,22 +1445,22 @@ connectionManagerTracer
      , Show peerAddr
      , Show versionNumber
      , Show versionData
+     , Show name
      )
-  => Tracer m ( String
-              , ConnectionManagerTrace peerAddr
-                  (ConnectionHandlerTrace versionNumber versionData)
-              )
+  => Tracer m (WithName name
+                        (ConnectionManagerTrace peerAddr
+                           (ConnectionHandlerTrace versionNumber versionData)))
 connectionManagerTracer =
     Tracer
       $ \msg ->
         case msg of
-          (_, TrConnectError{})
+          WithName _ TrConnectError{}
             -> -- this way 'debugTracer' does not trigger a warning :)
               traceWith debugTracer msg
-          (_, TrConnectionHandler _ TrError {})
+          WithName _ (TrConnectionHandler _ TrError {})
             ->
               traceWith debugTracer msg
-          (_, _) ->
+          WithName _ _ ->
               pure ()
 
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -32,7 +32,7 @@ import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim
-import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
+import           Control.Tracer (Tracer (..), contramap, nullTracer)
 
 import           Codec.Serialise.Class (Serialise)
 import           Data.Bifoldable
@@ -308,7 +308,7 @@ withInitiatorOnlyConnectionManager name timeouts trTracer snocket localAddr next
       ConnectionManagerArguments {
           -- ConnectionManagerTrace
           cmTracer    = WithName name
-                        `contramap` connectionManagerTracer,
+                        `contramap` nullTracer,
           cmTrTracer  = (WithName name . fmap abstractState)
                         `contramap` trTracer,
          -- MuxTracer
@@ -482,7 +482,7 @@ withBidirectionalConnectionManager name timeouts trTracer snocket socket localAd
       ConnectionManagerArguments {
           -- ConnectionManagerTrace
           cmTracer    = WithName name
-                        `contramap` connectionManagerTracer,
+                        `contramap` nullTracer,
           cmTrTracer  = (WithName name . fmap abstractState)
                         `contramap` trTracer,
           -- MuxTracer
@@ -1746,31 +1746,6 @@ type AbstractTransitionTrace addr = TransitionTrace' addr AbstractState
 debugTracer :: (MonadSay m, MonadTime m, Show a) => Tracer m a
 debugTracer = Tracer $
   \msg -> (,msg) <$> getCurrentTime >>= say . show
-
-
-connectionManagerTracer
-  :: ( MonadSay  m
-     , MonadTime m
-     , Show peerAddr
-     , Show versionNumber
-     , Show versionData
-     , Show name
-     )
-  => Tracer m (WithName name
-                        (ConnectionManagerTrace peerAddr
-                           (ConnectionHandlerTrace versionNumber versionData)))
-connectionManagerTracer =
-    Tracer
-      $ \msg ->
-        case msg of
-          WithName _ TrConnectError{}
-            -> -- this way 'debugTracer' does not trigger a warning :)
-              traceWith debugTracer msg
-          WithName _ (TrConnectionHandler _ TrError {})
-            ->
-              traceWith debugTracer msg
-          WithName _ _ ->
-              pure ()
 
 
 withLock :: ( MonadSTM   m

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -96,6 +96,7 @@ import qualified Codec.CBOR.Term as CBOR
 
 import           Network.TypedProtocol (Peer)
 import           Network.Mux (WithMuxBearer (..))
+import           Network.Mux.Types (MuxRuntimeError (..))
 
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Driver (TraceSendRecv(..))
@@ -365,7 +366,6 @@ networkErrorPolicies = ErrorPolicies
                       MuxInitiatorOnly             -> Just ourBug
                       MuxShutdown {}               -> Just ourBug
                       MuxCleanShutdown             -> Just ourBug
-                      MuxBlockedOnCompletionVar {} -> Just ourBug
 
                       -- in case of bearer closed / or IOException we suspend
                       -- the peer for a short time
@@ -376,6 +376,13 @@ networkErrorPolicies = ErrorPolicies
                       MuxIOException{}        -> Just (SuspendPeer shortDelay shortDelay)
                       MuxSDUReadTimeout       -> Just (SuspendPeer shortDelay shortDelay)
                       MuxSDUWriteTimeout      -> Just (SuspendPeer shortDelay shortDelay)
+
+      , ErrorPolicy
+          $ \(e :: MuxRuntimeError)
+                -> case e of
+                     ProtocolAlreadyRunning {}    -> Just ourBug
+                     UnknownProtocol {}           -> Just ourBug
+                     MuxBlockedOnCompletionVar {} -> Just ourBug
 
         -- Error thrown by 'IOManager', this is fatal on Windows, and it will
         -- never fire on other platofrms.

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -114,6 +114,7 @@ import           Data.Word
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Term as CBOR
 import           Network.Mux (WithMuxBearer (..))
+import           Network.Mux.Types (MuxRuntimeError (..))
 import qualified Network.Socket as Socket
 
 import           Ouroboros.Network.Codec
@@ -591,7 +592,13 @@ remoteNetworkErrorPolicy = ErrorPolicies {
                         MuxSDUWriteTimeout           -> Just (SuspendPeer shortDelay shortDelay)
                         MuxShutdown {}               -> Just (SuspendPeer shortDelay shortDelay)
                         MuxCleanShutdown             -> Just (SuspendPeer shortDelay shortDelay)
-                        MuxBlockedOnCompletionVar {} -> Just (SuspendPeer shortDelay shortDelay)
+
+        , ErrorPolicy
+            $ \(e :: MuxRuntimeError)
+                  -> case e of
+                       ProtocolAlreadyRunning {}    -> Just (SuspendPeer shortDelay shortDelay)
+                       UnknownProtocol {}           -> Just Throw
+                       MuxBlockedOnCompletionVar {} -> Just (SuspendPeer shortDelay shortDelay)
 
           -- Error policy for TxSubmission protocol: outbound side (client role)
         , ErrorPolicy

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -538,6 +538,7 @@ withPeerStateActions
        ( MonadAsync         m
        , MonadCatch         m
        , MonadMask          m
+       , MonadThrow    (STM m)
        , HasInitiator muxMode ~ True
        , Typeable versionNumber
        , Show     versionNumber
@@ -974,6 +975,7 @@ mkApplicationHandleBundle muxBundle controlMessageBundle awaitVarsBundle =
 startProtocols :: forall (muxMode :: MuxMode) (pt :: ProtocolTemperature) peerAddr m a b.
                   ( MonadAsync m
                   , MonadCatch m
+                  , MonadThrow (STM m)
                   , HasInitiator muxMode ~ True
                   )
                => TokProtocolTemperature pt


### PR DESCRIPTION
- io-sim: Octopus
- Remove accumulator function from ClientAndServerData
- Generalise request handling in Server2 properties
- Property testing multiple nodes in server2
- Address review comments
- network-mux: mux runtime exceptions
- server-test: use a job pool in multinode test
- server-test: link server thread in withBidirectionalConnectionManager
- connection-manager: trace transition trace before canceling threads
- connection-manager: derive Eq instance for @Transitions'@
- connection-manager (tests): export verifyAbstractTransition
- server-test: use different timeouts for 'IO' and 'IOSim'.
- server-test: introduce WithName
- server-test: simplify runInitiatorProtocols
- server-test: multinode simulation
- server-test: log distribution
- server-test: added MuxRuntimeError rethrow policy
- server-test: adjust generators
- server-test: clean TestAddress usage
- server-test: test unidrectional server
- server-test: removed connectionManagerTracer
