### PR TITLE
Add --no-create flag to consensus tests under nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,7 +41,7 @@ let
 
     checks = recurseIntoAttrs {
       # `checks.tests` collect results of executing the tests:
-      tests = collectChecks haskellPackages;
+      tests = collectChecks' haskellPackages;
     };
 
     # These are not run on hydra, but will be built separately in a nightly

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -5,10 +5,10 @@ with haskell-nix.haskellLib;
 
   inherit
     selectProjectPackages
+    collectChecks'
     collectComponents';
 
   inherit (extra)
-    recRecurseIntoAttrs
-    collectChecks;
+    recRecurseIntoAttrs;
 
 }


### PR DESCRIPTION
Here's one way how to change test suite CLI args in the Haskell.nix build. Sorry for stepping on your lawn with a PR, but I thought I may as well since it's a one-line change more or less.

- nix: Add `--no-create` flag to consensus tests.
- github actions: consensus tests are not executed.

Resolves #3251

### Comments

It's never simple, is it. CI was supposed to fail because of c4d9cae2c00bc1d01e72c40a0ae6fd94174ef844, but it hasn't. Perhaps I got the component/test-suite name wrong?