### PR TITLE
peer-selection: test json instances

### DIFF
--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -27,6 +27,7 @@ import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Test (tests)
 import qualified Ouroboros.Network.Protocol.KeepAlive.Test (tests)
 import qualified Ouroboros.Network.Protocol.TipSample.Test (tests)
 import qualified Test.Ouroboros.Network.PeerSelection (tests)
+import qualified Test.Ouroboros.Network.PeerSelection.Json (tests)
 import qualified Test.Socket (tests)
 
 main :: IO ()
@@ -60,6 +61,7 @@ tests =
   , Test.PeerState.tests
   , Test.Ouroboros.Network.BlockFetch.tests
   , Test.Ouroboros.Network.PeerSelection.tests
+  , Test.Ouroboros.Network.PeerSelection.Json.tests
   , Test.Ouroboros.Network.KeepAlive.tests
   , Test.Ouroboros.Network.TxSubmission.tests
   , Test.Ouroboros.Network.NodeToNode.Version.tests

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -109,9 +109,6 @@ tests =
     , testProperty "progresses towards active local root peers target (from above)"
                    prop_governor_target_active_local_above
     ]
-  , testProperty "governor gossip reachable in 1hr" prop_governor_gossip_1hr
-  , testProperty "governor connection status"       prop_governor_connstatus
-  , testProperty "governor no livelock"             prop_governor_nolivelock
   ]
   --TODO: We should add separate properties to check that we do not overshoot
   -- our targets: known peers from below can overshoot, but all the others

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -49,7 +49,6 @@ import           Ouroboros.Network.PeerSelection.RootPeersDNS
 import           Test.Ouroboros.Network.PeerSelection.Instances
 import qualified Test.Ouroboros.Network.PeerSelection.LocalRootPeers
 import qualified Test.Ouroboros.Network.PeerSelection.RootPeersDNS
-import qualified Test.Ouroboros.Network.PeerSelection.Json
 import           Test.Ouroboros.Network.PeerSelection.MockEnvironment hiding (tests)
 import qualified Test.Ouroboros.Network.PeerSelection.MockEnvironment
 import           Test.Ouroboros.Network.PeerSelection.PeerGraph
@@ -110,7 +109,6 @@ tests =
     , testProperty "progresses towards active local root peers target (from above)"
                    prop_governor_target_active_local_above
     ]
-  , Test.Ouroboros.Network.PeerSelection.Json.tests
   , testProperty "governor gossip reachable in 1hr" prop_governor_gossip_1hr
   , testProperty "governor connection status"       prop_governor_connstatus
   , testProperty "governor no livelock"             prop_governor_nolivelock

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Json.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Json.hs
@@ -12,27 +12,29 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =
-  testGroup "PeerSelection Types JSON instances"
-  [ testProperty "DomainAddress roundtrip" prop_roundtrip_DomainAddress_JSON
-  , testProperty "RelayAddress roundtrip"  prop_roundtrip_RelayAddress_JSON
-  , testProperty "PeerAdvertise roundtrip" prop_roundtrip_PeerAdvertise_JSON
+  testGroup "Ouroboros.Network.PeerSelection"
+  [ testGroup "JSON"
+    [ testProperty "DomainAddress roundtrip" prop_roundtrip_DomainAddress_JSON
+    , testProperty "RelayAddress roundtrip"  prop_roundtrip_RelayAddress_JSON
+    , testProperty "PeerAdvertise roundtrip" prop_roundtrip_PeerAdvertise_JSON
+    ]
   ]
 
 prop_roundtrip_DomainAddress_JSON :: DomainAddress -> Property
 prop_roundtrip_DomainAddress_JSON da =
     decode (encode da) === Just da
-    .&.
+    .&&.
     fromJSON (toJSON da) === pure da
 
 prop_roundtrip_RelayAddress_JSON :: RelayAddress -> Property
 prop_roundtrip_RelayAddress_JSON ra =
     decode (encode ra) === Just ra
-    .&.
+    .&&.
     fromJSON (toJSON ra) === pure ra
 
 prop_roundtrip_PeerAdvertise_JSON :: PeerAdvertise -> Property
 prop_roundtrip_PeerAdvertise_JSON pa =
     decode (encode pa) === Just pa
-    .&.
+    .&&.
     fromJSON (toJSON pa) === pure pa
 


### PR DESCRIPTION
* use `.&&.`
* wire the tests at the top level; this makes it easier to find out how
  one can run them.
