### PR TITLE
Move override support for max tx capacities into the ProtocolInfo constructors

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -195,21 +195,24 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: eb58eebc16ee898980c83bc325ab37a2c77b2414
-  --sha256: 1v5algrsa3g6lphl1nfih54xkc2xa5q1yfa3kgclcp6sxj1yjnnl
+  tag: 8c732560b201b5da8e3bdf175c6eda73a32d64bc
+  --sha256: 0nwy03wyd2ks4qxg47py7lm18karjz6vs7p8knmn3zy72i3n9rfi
   subdir:
+    base-deriving-via
     binary
     binary/test
     cardano-crypto-class
     cardano-crypto-praos
+    measures
+    orphans-deriving-via
     slotting
     strict-containers
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 136967cd3700f34c57cd70be7aceca8a5efca485
-  --sha256: 020sm2wsmc9qhkpmjz0qi8wl6w95lq5g0m1gvlivb0kc78w3lmhd
+  tag: 51561fcb13170e3849873eef82e634c1041ee1d6
+  --sha256: 1699hbz1i92hbjjzv9ym43qzji5xiz7gqbd0y8m2ylc353c0sxzn
   subdir:
     alonzo/impl
     alonzo/test

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -230,7 +230,7 @@ forgeDualByronBlock cfg curBlockNo curSlotNo tickedLedger vtxs isLeader =
     main :: ByronBlock
     main = forgeByronBlock
              (dualTopLevelConfigMain cfg)
-             TxLimits.noOverrides
+             (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
              curBlockNo
              curSlotNo
              (tickedDualLedgerStateMain tickedLedger)

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -38,6 +38,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.Extended
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -45,7 +46,7 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as S
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
-import           Ouroboros.Consensus.Util ((......:), (.:))
+import           Ouroboros.Consensus.Util ((.....:), (.:))
 
 import           Ouroboros.Consensus.Byron.Ledger
 import           Ouroboros.Consensus.Byron.Node
@@ -71,10 +72,10 @@ dualByronBlockForging creds = BlockForging {
     , updateForgeState = \cfg ->
         fmap castForgeStateUpdateInfo .: updateForgeState (dualTopLevelConfigMain cfg)
     , checkCanForge    = checkCanForge . dualTopLevelConfigMain
-    , forgeBlock       = return ......: forgeDualByronBlock
+    , forgeBlock       = return .....: forgeDualByronBlock
     }
   where
-    BlockForging {..} = byronBlockForging creds
+    BlockForging {..} = byronBlockForging TxLimits.noOverrides creds
 
 {-------------------------------------------------------------------------------
   ProtocolInfo

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -75,7 +75,10 @@ dualByronBlockForging creds = BlockForging {
     , forgeBlock       = return .....: forgeDualByronBlock
     }
   where
-    BlockForging {..} = byronBlockForging TxLimits.noOverrides creds
+    BlockForging {..} =
+      byronBlockForging
+        (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
+        creds
 
 {-------------------------------------------------------------------------------
   ProtocolInfo

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -37,6 +37,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT
@@ -123,10 +124,10 @@ exampleBlock :: ByronBlock
 exampleBlock =
     forgeRegularBlock
       cfg
+      TxLimits.noOverrides
       (BlockNo 1)
       (SlotNo 1)
       (applyChainTick ledgerConfig (SlotNo 1) ledgerStateAfterEBB)
-      NoMaxTxCapacityOverride
       [ValidatedByronTx exampleGenTx]
       (fakeMkIsLeader leaderCredentials)
   where

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -124,7 +124,7 @@ exampleBlock :: ByronBlock
 exampleBlock =
     forgeRegularBlock
       cfg
-      TxLimits.noOverrides
+      (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
       (BlockNo 1)
       (SlotNo 1)
       (applyChainTick ledgerConfig (SlotNo 1) ledgerStateAfterEBB)

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -63,7 +63,7 @@ mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
           , byronProtocolVersion        = theProposedProtocolVersion
           , byronSoftwareVersion        = theProposedSoftwareVersion
           , byronLeaderCredentials      = Just leaderCredentials
-          , byronMaxTxCapacityOverrides = TxLimits.noOverrides
+          , byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
           }
 
 mkLeaderCredentials

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -21,6 +21,7 @@ import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Crypto as Crypto
 
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.PBFT
@@ -62,6 +63,7 @@ mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
           , byronProtocolVersion        = theProposedProtocolVersion
           , byronSoftwareVersion        = theProposedSoftwareVersion
           , byronLeaderCredentials      = Just leaderCredentials
+          , byronMaxTxCapacityOverrides = TxLimits.noOverrides
           }
 
 mkLeaderCredentials

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
@@ -22,6 +22,7 @@ import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.Update as CC.Update
 
 import           Ouroboros.Consensus.Config
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Serialisation ()
 import           Ouroboros.Consensus.Util (Dict (..))
@@ -108,6 +109,7 @@ testCfg = pInfoConfig protocolInfo
         , byronProtocolVersion        = CC.Update.ProtocolVersion 1 0 0
         , byronSoftwareVersion        = CC.Update.SoftwareVersion (CC.Update.ApplicationName "Cardano Test") 2
         , byronLeaderCredentials      = Nothing
+        , byronMaxTxCapacityOverrides = TxLimits.noOverrides
         }
 
 -- | Matches the values used for the generators.

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
@@ -109,7 +109,7 @@ testCfg = pInfoConfig protocolInfo
         , byronProtocolVersion        = CC.Update.ProtocolVersion 1 0 0
         , byronSoftwareVersion        = CC.Update.SoftwareVersion (CC.Update.ApplicationName "Cardano Test") 2
         , byronLeaderCredentials      = Nothing
-        , byronMaxTxCapacityOverrides = TxLimits.noOverrides
+        , byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
 
 -- | Matches the values used for the generators.

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
@@ -1301,7 +1301,10 @@ mkRekeyUpd genesisConfig genesisSecrets cid pInfo eno newSK =
         Just _  ->
           let genSK = genesisSecretFor genesisConfig genesisSecrets cid
               creds' = updSignKey genSK bcfg cid (coerce eno) newSK
-              blockForging' = byronBlockForging TxLimits.noOverrides creds'
+              blockForging' =
+                byronBlockForging
+                  (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
+                  creds'
               pInfo' = pInfo { pInfoBlockForging = return [blockForging'] }
 
           in Just TestNodeInitialization

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
@@ -39,6 +39,7 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
@@ -1300,7 +1301,7 @@ mkRekeyUpd genesisConfig genesisSecrets cid pInfo eno newSK =
         Just _  ->
           let genSK = genesisSecretFor genesisConfig genesisSecrets cid
               creds' = updSignKey genSK bcfg cid (coerce eno) newSK
-              blockForging' = byronBlockForging creds'
+              blockForging' = byronBlockForging TxLimits.noOverrides creds'
               pInfo' = pInfo { pInfoBlockForging = return [blockForging'] }
 
           in Just TestNodeInitialization

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -146,14 +146,14 @@ forgeRegularBlock cfg maxTxCapacityOverrides bno sno st txs isLeader =
     epochSlots :: CC.Slot.EpochSlots
     epochSlots = byronEpochSlots cfg
 
-    computedMaxTxCapacity = computeMaxTxCapacity st maxTxCapacityOverrides
+    maxTxCapacity = computeMaxTxCapacity st maxTxCapacityOverrides
 
     blockPayloads :: BlockPayloads
     blockPayloads =
         foldr
           extendBlockPayloads
           initBlockPayloads
-          (takeLargestPrefixThatFits computedMaxTxCapacity txs)
+          (takeLargestPrefixThatFits maxTxCapacity txs)
 
     txPayload :: CC.UTxO.TxPayload
     txPayload = CC.UTxO.mkTxPayload (bpTxs blockPayloads)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -146,14 +146,12 @@ forgeRegularBlock cfg maxTxCapacityOverrides bno sno st txs isLeader =
     epochSlots :: CC.Slot.EpochSlots
     epochSlots = byronEpochSlots cfg
 
-    maxTxCapacity = computeMaxTxCapacity st maxTxCapacityOverrides
-
     blockPayloads :: BlockPayloads
     blockPayloads =
         foldr
           extendBlockPayloads
           initBlockPayloads
-          (takeLargestPrefixThatFits maxTxCapacity txs)
+          (takeLargestPrefixThatFits maxTxCapacityOverrides st txs)
 
     txPayload :: CC.UTxO.TxPayload
     txPayload = CC.UTxO.mkTxPayload (bpTxs blockPayloads)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -91,8 +91,6 @@ instance TxLimits ByronBlock where
   maxCapacity  = ByteSize . maxTxCapacity
   pointwiseMin = min
 
-type instance Overrides ByronBlock = ByteSize -> ByteSize
-
 {-------------------------------------------------------------------------------
   Transactions
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -85,10 +85,9 @@ import           Ouroboros.Consensus.Mempool.TxLimits
 -------------------------------------------------------------------------------}
 
 instance TxLimits ByronBlock where
-  type Measure ByronBlock = ByteSize
-  txMeasure    = ByteSize . txInBlockSize . txForgetValidated
-  maxCapacity  = ByteSize . txsMaxBytes
-  pointwiseMin = min
+  type TxMeasure ByronBlock = ByteSize
+  txMeasure        = ByteSize . txInBlockSize . txForgetValidated
+  txsBlockCapacity = ByteSize . txsMaxBytes
 
 {-------------------------------------------------------------------------------
   Transactions

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -88,7 +88,7 @@ instance TxLimits ByronBlock where
   type Measure ByronBlock = ByteSize
   lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
-  maxCapacity  = ByteSize . maxTxCapacity
+  maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min
 
 {-------------------------------------------------------------------------------
@@ -139,7 +139,7 @@ instance LedgerSupportsMempool ByronBlock where
     where
       validationMode = CC.ValidationMode CC.NoBlockValidation Utxo.TxValidationNoCrypto
 
-  maxTxCapacity st =
+  txsMaxBytes st =
     CC.getMaxBlockSize (tickedByronLedgerState st) - byronBlockEncodingOverhead
 
   txInBlockSize =

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -86,7 +86,6 @@ import           Ouroboros.Consensus.Mempool.TxLimits
 
 instance TxLimits ByronBlock where
   type Measure ByronBlock = ByteSize
-  lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
   maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -55,7 +55,7 @@ instance LedgerSupportsMempool ByronSpecBlock where
       $ applyTx cfg DoNotIntervene slot (forgetValidatedByronSpecGenTx vtx) st
 
   -- Dummy values, as these are not used in practice.
-  maxTxCapacity = const maxBound
+  txsMaxBytes   = const maxBound
   txInBlockSize = const 0
 
   txForgetValidated = forgetValidatedByronSpecGenTx

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -257,7 +257,7 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
           protocolParamsShelleyBased
           ()  -- trivial translation context
           protVer1
-          TxLimits.noOverrides
+          (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
 
     eraParams1 :: History.EraParams
     eraParams1 = shelleyEraParams genesis1
@@ -290,7 +290,7 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
             }
           transCtxt2
           protVer2
-          TxLimits.noOverrides
+          (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
 
     eraParams2 :: History.EraParams
     eraParams2 = shelleyEraParams genesis2

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -46,7 +46,8 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import qualified Cardano.Ledger.Era as SL
 import qualified Shelley.Spec.Ledger.API as SL
 
-import           Ouroboros.Consensus.Mempool.TxLimits
+import           Ouroboros.Consensus.Mempool.TxLimits (TxLimits)
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger
 import           Ouroboros.Consensus.Shelley.Node
@@ -256,6 +257,7 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
           protocolParamsShelleyBased
           ()  -- trivial translation context
           protVer1
+          TxLimits.noOverrides
 
     eraParams1 :: History.EraParams
     eraParams1 = shelleyEraParams genesis1
@@ -288,6 +290,7 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
             }
           transCtxt2
           protVer2
+          TxLimits.noOverrides
 
     eraParams2 :: History.EraParams
     eraParams2 = shelleyEraParams genesis2

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -493,7 +493,7 @@ mkProtocolCardanoAndHardForkTxs
           , byronProtocolVersion        = propPV
           , byronSoftwareVersion        = softVerByron
           , byronLeaderCredentials      = Just leaderCredentialsByron
-          , byronMaxTxCapacityOverrides = TxLimits.noOverrides
+          , byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
           }
         ProtocolParamsShelleyBased {
             shelleyBasedGenesis           = genesisShelley
@@ -502,19 +502,19 @@ mkProtocolCardanoAndHardForkTxs
           }
         ProtocolParamsShelley {
             shelleyProtVer                = SL.ProtVer shelleyMajorVersion 0
-          , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
+          , shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
           }
         ProtocolParamsAllegra {
             allegraProtVer                = SL.ProtVer allegraMajorVersion 0
-          , allegraMaxTxCapacityOverrides = TxLimits.noOverrides
+          , allegraMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
           }
         ProtocolParamsMary {
             maryProtVer                   = SL.ProtVer maryMajorVersion    0
-          , maryMaxTxCapacityOverrides    = TxLimits.noOverrides
+          , maryMaxTxCapacityOverrides    = TxLimits.mkOverrides TxLimits.noOverridesMeasure
           }
         ProtocolParamsAlonzo {
             alonzoProtVer                 = SL.ProtVer alonzoMajorVersion  0
-          , alonzoMaxTxCapacityOverrides  = TxLimits.noOverrides
+          , alonzoMaxTxCapacityOverrides  = TxLimits.mkOverrides TxLimits.noOverridesMeasure
           }
         protocolParamsByronShelley
         ProtocolTransitionParamsShelleyBased {

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -24,6 +24,7 @@ import           Cardano.Slotting.Slot (EpochSize (..), SlotNo (..))
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
@@ -492,6 +493,7 @@ mkProtocolCardanoAndHardForkTxs
           , byronProtocolVersion        = propPV
           , byronSoftwareVersion        = softVerByron
           , byronLeaderCredentials      = Just leaderCredentialsByron
+          , byronMaxTxCapacityOverrides = TxLimits.noOverrides
           }
         ProtocolParamsShelleyBased {
             shelleyBasedGenesis           = genesisShelley
@@ -499,16 +501,20 @@ mkProtocolCardanoAndHardForkTxs
           , shelleyBasedLeaderCredentials = [leaderCredentialsShelley]
           }
         ProtocolParamsShelley {
-            shelleyProtVer = SL.ProtVer shelleyMajorVersion 0
+            shelleyProtVer                = SL.ProtVer shelleyMajorVersion 0
+          , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
           }
         ProtocolParamsAllegra {
-            allegraProtVer = SL.ProtVer allegraMajorVersion 0
+            allegraProtVer                = SL.ProtVer allegraMajorVersion 0
+          , allegraMaxTxCapacityOverrides = TxLimits.noOverrides
           }
         ProtocolParamsMary {
-            maryProtVer    = SL.ProtVer maryMajorVersion    0
+            maryProtVer                   = SL.ProtVer maryMajorVersion    0
+          , maryMaxTxCapacityOverrides    = TxLimits.noOverrides
           }
         ProtocolParamsAlonzo {
-            alonzoProtVer  = SL.ProtVer alonzoMajorVersion  0
+            alonzoProtVer                 = SL.ProtVer alonzoMajorVersion  0
+          , alonzoMaxTxCapacityOverrides  = TxLimits.noOverrides
           }
         protocolParamsByronShelley
         ProtocolTransitionParamsShelleyBased {

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
@@ -141,5 +141,5 @@ mkByronProtocolInfo genesisConfig signatureThreshold =
       , byronProtocolVersion        = Update.ProtocolVersion 1 0 0
       , byronSoftwareVersion        = Update.SoftwareVersion (Update.ApplicationName "db-analyser") 2
       , byronLeaderCredentials      = Nothing
-      , byronMaxTxCapacityOverrides = TxLimits.noOverrides
+      , byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
       }

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
@@ -26,6 +26,7 @@ import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.UTxO as Chain
 import qualified Cardano.Chain.Update as Update
 
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
@@ -140,4 +141,5 @@ mkByronProtocolInfo genesisConfig signatureThreshold =
       , byronProtocolVersion        = Update.ProtocolVersion 1 0 0
       , byronSoftwareVersion        = Update.SoftwareVersion (Update.ApplicationName "db-analyser") 2
       , byronLeaderCredentials      = Nothing
+      , byronMaxTxCapacityOverrides = TxLimits.noOverrides
       }

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -24,6 +24,7 @@ import qualified Cardano.Chain.Update as Byron.Update
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock (..),
                      OneEraBlock (..), OneEraHash (..))
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo
 
 import qualified Cardano.Ledger.Alonzo.Genesis as SL (AlonzoGenesis)
@@ -105,6 +106,7 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         , byronProtocolVersion        = Byron.Update.ProtocolVersion 1 2 0
         , byronSoftwareVersion        = Byron.Update.SoftwareVersion (Byron.Update.ApplicationName "db-analyser") 2
         , byronLeaderCredentials      = Nothing
+        , byronMaxTxCapacityOverrides = TxLimits.noOverrides
         }
       ProtocolParamsShelleyBased {
           shelleyBasedGenesis           = genesisShelley
@@ -112,16 +114,20 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         , shelleyBasedLeaderCredentials = []
         }
       ProtocolParamsShelley {
-          shelleyProtVer = ProtVer 2 0
+          shelleyProtVer                = ProtVer 2 0
+        , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
         }
       ProtocolParamsAllegra {
-          allegraProtVer = ProtVer 3 0
+          allegraProtVer                = ProtVer 3 0
+        , allegraMaxTxCapacityOverrides = TxLimits.noOverrides
         }
       ProtocolParamsMary {
-          maryProtVer    = ProtVer 4 0
+          maryProtVer                   = ProtVer 4 0
+        , maryMaxTxCapacityOverrides    = TxLimits.noOverrides
         }
       ProtocolParamsAlonzo {
-          alonzoProtVer  = ProtVer 5 0
+          alonzoProtVer                 = ProtVer 5 0
+        , alonzoMaxTxCapacityOverrides  = TxLimits.noOverrides
         }
       ProtocolTransitionParamsShelleyBased {
           transitionTranslationContext = ()

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -106,7 +106,7 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         , byronProtocolVersion        = Byron.Update.ProtocolVersion 1 2 0
         , byronSoftwareVersion        = Byron.Update.SoftwareVersion (Byron.Update.ApplicationName "db-analyser") 2
         , byronLeaderCredentials      = Nothing
-        , byronMaxTxCapacityOverrides = TxLimits.noOverrides
+        , byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsShelleyBased {
           shelleyBasedGenesis           = genesisShelley
@@ -115,19 +115,19 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         }
       ProtocolParamsShelley {
           shelleyProtVer                = ProtVer 2 0
-        , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
+        , shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsAllegra {
           allegraProtVer                = ProtVer 3 0
-        , allegraMaxTxCapacityOverrides = TxLimits.noOverrides
+        , allegraMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsMary {
           maryProtVer                   = ProtVer 4 0
-        , maryMaxTxCapacityOverrides    = TxLimits.noOverrides
+        , maryMaxTxCapacityOverrides    = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsAlonzo {
           alonzoProtVer                 = ProtVer 5 0
-        , alonzoMaxTxCapacityOverrides  = TxLimits.noOverrides
+        , alonzoMaxTxCapacityOverrides  = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolTransitionParamsShelleyBased {
           transitionTranslationContext = ()

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -25,6 +25,7 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as CL
 import qualified Shelley.Spec.Ledger.API as SL
 
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo
 
 import           Ouroboros.Consensus.Shelley.Eras (ShelleyBasedEra,
@@ -83,7 +84,8 @@ mkShelleyProtocolInfo genesis initialNonce =
         , shelleyBasedLeaderCredentials = []
         }
       ProtocolParamsShelley {
-          shelleyProtVer = SL.ProtVer 2 0
+          shelleyProtVer                = SL.ProtVer 2 0
+        , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
         }
 
 parseShelleyArgs :: Parser ShelleyBlockArgs

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -85,7 +85,7 @@ mkShelleyProtocolInfo genesis initialNonce =
         }
       ProtocolParamsShelley {
           shelleyProtVer                = SL.ProtVer 2 0
-        , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
+        , shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
 
 parseShelleyArgs :: Parser ShelleyBlockArgs

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -436,7 +436,7 @@ instance MockProtocolSpecific c ext
 
   -- Large value so that the Mempool tests never run out of capacity when they
   -- don't override it.
-  maxTxCapacity = const 1000000000
+  txsMaxBytes   = const 1000000000
   txInBlockSize = txSize
 
   txForgetValidated = forgetValidatedSimpleGenTx

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -47,12 +47,10 @@ forgeSimple :: forall c ext.
             -> BlockNo                                   -- ^ Current block number
             -> SlotNo                                    -- ^ Current slot number
             -> TickedLedgerState (SimpleBlock c ext)     -- ^ Current ledger
-            -> MaxTxCapacityOverride (SimpleBlock c ext) -- ^ Do we override max tx capacity defined
-                                                         --   by ledger (see MaxTxCapacityOverride)
             -> [GenTx (SimpleBlock c ext)]               -- ^ Txs to include
             -> IsLeader (BlockProtocol (SimpleBlock c ext))
             -> SimpleBlock c ext
-forgeSimple ForgeExt { forgeExt } cfg curBlock curSlot tickedLedger _mx txs proof =
+forgeSimple ForgeExt { forgeExt } cfg curBlock curSlot tickedLedger txs proof =
     forgeExt cfg proof $ SimpleBlock {
         simpleHeader = mkSimpleHeader encode stdHeader ()
       , simpleBody   = body

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -85,7 +85,7 @@ simpleBlockForging canBeLeader forgeExt = BlockForging {
     , canBeLeader      = canBeLeader
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge    = \_ _ _ _ _ -> return ()
-    , forgeBlock       = \cfg bno slot lst maxTxCapacityOverride txs proof ->
+    , forgeBlock       = \cfg bno slot lst txs proof ->
         return
           $ forgeSimple
               forgeExt
@@ -93,7 +93,6 @@ simpleBlockForging canBeLeader forgeExt = BlockForging {
               bno
               slot
               lst
-              maxTxCapacityOverride
               (map txForgetValidated txs)
               proof
     }

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -95,7 +95,7 @@ pbftBlockForging canBeLeader = BlockForging {
                                canBeLeader
                                slot
                                tickedPBftState
-    , forgeBlock       = \cfg slot bno lst maxTxCapacityOverride txs proof ->
+    , forgeBlock       = \cfg slot bno lst txs proof ->
         return
           $ forgeSimple
               forgePBftExt
@@ -103,7 +103,6 @@ pbftBlockForging canBeLeader = BlockForging {
               slot
               bno
               lst
-              maxTxCapacityOverride
               (map txForgetValidated txs)
               proof
     }

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -106,7 +106,7 @@ praosBlockForging cid initHotKey = do
                                  second forgeStateUpdateInfoFromUpdateInfo
                                . evolveKey sno
       , checkCanForge    = \_ _ _ _ _ -> return ()
-      , forgeBlock       = \cfg bno sno tickedLedgerSt maxTxCapacityOverride txs isLeader -> do
+      , forgeBlock       = \cfg bno sno tickedLedgerSt txs isLeader -> do
                                hotKey <- readMVar varHotKey
                                return $
                                  forgeSimple
@@ -114,7 +114,6 @@ praosBlockForging cid initHotKey = do
                                    cfg
                                    bno sno
                                    tickedLedgerSt
-                                   maxTxCapacityOverride
                                    (map txForgetValidated txs)
                                    isLeader
       }

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -71,6 +71,7 @@ test-suite test
   hs-source-dirs:      test
   main-is:             Main.hs
   other-modules:
+                       Test.Consensus.Shelley.Coherence
                        Test.Consensus.Shelley.Golden
                        Test.Consensus.Shelley.Serialisation
                        Test.ThreadNet.Shelley
@@ -87,6 +88,8 @@ test-suite test
                      , tasty-quickcheck
 
                        -- cardano-ledger-specs
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-alonzo-test
                      , cardano-ledger-core
                      , shelley-spec-ledger
 

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -419,7 +419,7 @@ mkProtocolShelley genesis initialNonce protVer coreNode =
         }
       ProtocolParamsShelley {
           shelleyProtVer                = protVer
-        , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
+        , shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
 {-------------------------------------------------------------------------------
   Necessary transactions for updating the 'DecentralizationParam'

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -62,6 +62,7 @@ import           Cardano.Crypto.VRF (SignKeyVRF, VRFAlgorithm, VerKeyVRF,
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
@@ -417,7 +418,8 @@ mkProtocolShelley genesis initialNonce protVer coreNode =
         , shelleyBasedLeaderCredentials = [mkLeaderCredentials coreNode]
         }
       ProtocolParamsShelley {
-          shelleyProtVer = protVer
+          shelleyProtVer                = protVer
+        , shelleyMaxTxCapacityOverrides = TxLimits.noOverrides
         }
 {-------------------------------------------------------------------------------
   Necessary transactions for updating the 'DecentralizationParam'

--- a/ouroboros-consensus-shelley-test/test/Main.hs
+++ b/ouroboros-consensus-shelley-test/test/Main.hs
@@ -5,6 +5,7 @@ import           Cardano.Crypto.Libsodium (sodiumInit)
 import           Test.Tasty
 import           Test.Util.Nightly
 
+import qualified Test.Consensus.Shelley.Coherence (tests)
 import qualified Test.Consensus.Shelley.Golden (tests)
 import qualified Test.Consensus.Shelley.Serialisation (tests)
 import qualified Test.ThreadNet.Shelley (tests)
@@ -15,7 +16,8 @@ main = sodiumInit >> defaultMainWithIohkNightly tests
 tests :: TestTree
 tests =
   testGroup "shelley"
-  [ Test.Consensus.Shelley.Golden.tests
+  [ Test.Consensus.Shelley.Coherence.tests
+  , Test.Consensus.Shelley.Golden.tests
   , Test.Consensus.Shelley.Serialisation.tests
   , Test.ThreadNet.Shelley.tests
   ]

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Coherence.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Coherence.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Consensus.Shelley.Coherence (tests) where
+
+import           Data.Word (Word32)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Cardano.Crypto.Hash (ShortHash)
+
+import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
+
+import           Cardano.Ledger.Alonzo.Scripts (ExUnits, pointWiseExUnits)
+import           Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+
+import           Ouroboros.Consensus.Shelley.Eras (AlonzoEra)
+import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.Ledger.Mempool (AlonzoMeasure (..))
+
+import           Test.Consensus.Shelley.MockCrypto (MockCrypto)
+
+tests :: TestTree
+tests = testGroup "Shelley coherences" [
+      testProperty "TxLimits.lessEq uses pointWiseExUnits (<=)" lessEqCoherence
+    ]
+
+-- | 'TxLimits.lessEq' and @'pointWiseExUnits' (<=)@ must agree
+lessEqCoherence :: Word32 -> ExUnits -> ExUnits -> Property
+lessEqCoherence w eu1 eu2 =
+    actual === expected
+  where
+    inj eu = AlonzoMeasure (TxLimits.ByteSize w) eu
+
+    actual =
+      TxLimits.lessEq
+        @(ShelleyBlock (AlonzoEra (MockCrypto ShortHash)))
+        (inj eu1)
+        (inj eu2)
+
+    expected = pointWiseExUnits (<=) eu1 eu2

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Coherence.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Coherence.hs
@@ -6,35 +6,24 @@ import           Data.Word (Word32)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Crypto.Hash (ShortHash)
-
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 
 import           Cardano.Ledger.Alonzo.Scripts (ExUnits, pointWiseExUnits)
 import           Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 
-import           Ouroboros.Consensus.Shelley.Eras (AlonzoEra)
-import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (AlonzoMeasure (..))
-
-import           Test.Consensus.Shelley.MockCrypto (MockCrypto)
 
 tests :: TestTree
 tests = testGroup "Shelley coherences" [
-      testProperty "TxLimits.lessEq uses pointWiseExUnits (<=)" lessEqCoherence
+      testProperty "TxLimits.<= uses pointWiseExUnits (<=)" leqCoherence
     ]
 
--- | 'TxLimits.lessEq' and @'pointWiseExUnits' (<=)@ must agree
-lessEqCoherence :: Word32 -> ExUnits -> ExUnits -> Property
-lessEqCoherence w eu1 eu2 =
+-- | 'TxLimits.<=' and @'pointWiseExUnits' (<=)@ must agree
+leqCoherence :: Word32 -> ExUnits -> ExUnits -> Property
+leqCoherence w eu1 eu2 =
     actual === expected
   where
     inj eu = AlonzoMeasure (TxLimits.ByteSize w) eu
 
-    actual =
-      TxLimits.lessEq
-        @(ShelleyBlock (AlonzoEra (MockCrypto ShortHash)))
-        (inj eu1)
-        (inj eu2)
-
+    actual   = inj eu1 TxLimits.<= inj eu2
     expected = pointWiseExUnits (<=) eu1 eu2

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -48,6 +48,7 @@ library
                        Ouroboros.Consensus.Shelley.ShelleyHFC
 
   build-depends:       base              >=4.9   && <4.15
+                     , base-deriving-via
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
@@ -56,8 +57,10 @@ library
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
                      , data-default-class
+                     , measures
                      , mtl               >=2.2   && <2.3
                      , nothunks
+                     , orphans-deriving-via
                      , serialise         >=0.2   && <0.3
                      , strict-containers
                      , text              >=1.2   && <1.3

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -71,11 +71,9 @@ forgeShelleyBlock hotKey canBeLeader cfg maxTxCapacityOverrides curNo curSlot ti
         SL.toTxSeq @era
       . Seq.fromList
       . fmap extractTx
-      $ takeLargestPrefixThatFits maxTxCapacity txs
+      $ takeLargestPrefixThatFits maxTxCapacityOverrides tickedLedger txs
 
-    maxTxCapacity = computeMaxTxCapacity tickedLedger maxTxCapacityOverrides
-
-    extractTx :: (Validated (GenTx (ShelleyBlock era))) -> Core.Tx era
+    extractTx :: Validated (GenTx (ShelleyBlock era)) -> Core.Tx era
     extractTx (ShelleyValidatedTx _txid vtx) = SL.extractTx vtx
 
     mkHeader TPraosFields { tpraosSignature, tpraosToSign } =

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -71,9 +71,9 @@ forgeShelleyBlock hotKey canBeLeader cfg maxTxCapacityOverrides curNo curSlot ti
         SL.toTxSeq @era
       . Seq.fromList
       . fmap extractTx
-      $ takeLargestPrefixThatFits computedMaxTxCapacity txs
+      $ takeLargestPrefixThatFits maxTxCapacity txs
 
-    computedMaxTxCapacity = computeMaxTxCapacity tickedLedger maxTxCapacityOverrides
+    maxTxCapacity = computeMaxTxCapacity tickedLedger maxTxCapacityOverrides
 
     extractTx :: (Validated (GenTx (ShelleyBlock era))) -> Core.Tx era
     extractTx (ShelleyValidatedTx _txid vtx) = SL.extractTx vtx

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -27,6 +27,8 @@ module Ouroboros.Consensus.Shelley.Ledger.Mempool (
   , mkShelleyTx
   , mkShelleyValidatedTx
   , perTxOverhead
+  -- * Exported for tests
+  , AlonzoMeasure (..)
   ) where
 
 import           Control.Monad.Except (Except)
@@ -42,7 +44,7 @@ import           Cardano.Binary (Annotator (..), FromCBOR (..),
 
 import           Ouroboros.Network.Block (unwrapCBORinCBOR, wrapCBORinCBOR)
 
-import           Cardano.Ledger.Alonzo.Scripts (ExUnits (..), pointWiseExUnits)
+import           Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
@@ -275,21 +277,18 @@ theLedgerLens f x =
 
 instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (ShelleyEra c)) where
   type Measure (ShelleyBlock (ShelleyEra c)) = ByteSize
-  lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
   maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min
 
 instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (AllegraEra c)) where
   type Measure (ShelleyBlock (AllegraEra c)) = ByteSize
-  lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
   maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min
 
 instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (MaryEra c)) where
   type Measure (ShelleyBlock (MaryEra c)) = ByteSize
-  lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
   maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min
@@ -310,9 +309,6 @@ instance ( SL.PraosCrypto c
          ) => TxLimits (ShelleyBlock (AlonzoEra c)) where
 
   type Measure (ShelleyBlock (AlonzoEra c)) = AlonzoMeasure
-
-  lessEq (AlonzoMeasure bs1 exu1) (AlonzoMeasure bs2 exu2) =
-    bs1 <= bs2 && pointWiseExUnits (<=) exu1 exu2
 
   txMeasure (ShelleyValidatedTx _txid vtx) =
     AlonzoMeasure {

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -294,8 +294,8 @@ instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (MaryEra c)) where
   pointwiseMin = min
 
 data AlonzoMeasure = AlonzoMeasure {
-    byteSize :: ByteSize
-  , exUnits  :: ExUnits
+    byteSize :: !ByteSize
+  , exUnits  :: !ExUnits
   } deriving stock (Show, Eq)
 
 instance Semigroup AlonzoMeasure where

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -272,8 +272,6 @@ theLedgerLens f x =
 {-------------------------------------------------------------------------------
   Tx Limits
 -------------------------------------------------------------------------------}
-type instance Overrides (ShelleyBlock era) =
-  Measure (ShelleyBlock era) -> Measure (ShelleyBlock era)
 
 instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (ShelleyEra c)) where
   type Measure (ShelleyBlock (ShelleyEra c)) = ByteSize

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -125,7 +125,7 @@ instance ShelleyBasedEra era
 
   reapplyTx = reapplyShelleyTx
 
-  maxTxCapacity TickedShelleyLedgerState { tickedShelleyLedgerState = shelleyState } =
+  txsMaxBytes TickedShelleyLedgerState { tickedShelleyLedgerState = shelleyState } =
       fromIntegral maxBlockBodySize - fixedBlockBodyOverhead
     where
       maxBlockBodySize = getField @"_maxBBSize" $ getPParams shelleyState
@@ -277,21 +277,21 @@ instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (ShelleyEra c)) where
   type Measure (ShelleyBlock (ShelleyEra c)) = ByteSize
   lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
-  maxCapacity  = ByteSize . maxTxCapacity
+  maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min
 
 instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (AllegraEra c)) where
   type Measure (ShelleyBlock (AllegraEra c)) = ByteSize
   lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
-  maxCapacity  = ByteSize . maxTxCapacity
+  maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min
 
 instance (SL.PraosCrypto c) => TxLimits (ShelleyBlock (MaryEra c)) where
   type Measure (ShelleyBlock (MaryEra c)) = ByteSize
   lessEq       = (<=)
   txMeasure    = ByteSize . txInBlockSize . txForgetValidated
-  maxCapacity  = ByteSize . maxTxCapacity
+  maxCapacity  = ByteSize . txsMaxBytes
   pointwiseMin = min
 
 data AlonzoMeasure = AlonzoMeasure {
@@ -323,7 +323,7 @@ instance ( SL.PraosCrypto c
   maxCapacity ledgerState =
     let pparams  = getPParams $ tickedShelleyLedgerState ledgerState
     in AlonzoMeasure {
-        byteSize = ByteSize $ maxTxCapacity ledgerState
+        byteSize = ByteSize $ txsMaxBytes ledgerState
       , exUnits  = getField @"_maxBlockExUnits" pparams
       }
 

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -813,11 +813,10 @@ runThreadNetwork systemTime ThreadNetworkArgs
             -> BlockNo
             -> SlotNo
             -> TickedLedgerState blk
-            -> MaxTxCapacityOverride blk
             -> [Validated (GenTx blk)]
             -> IsLeader (BlockProtocol blk)
             -> m blk
-          customForgeBlock origBlockForging cfg' currentBno currentSlot tickedLdgSt maxTxCapacityOverride txs prf = do
+          customForgeBlock origBlockForging cfg' currentBno currentSlot tickedLdgSt txs prf = do
             let currentEpoch = HFF.futureSlotToEpoch future currentSlot
 
             -- EBBs are only ever possible in the first era
@@ -842,7 +841,6 @@ runThreadNetwork systemTime ThreadNetworkArgs
                    currentBno
                    currentSlot
                    tickedLdgSt
-                   maxTxCapacityOverride
                    txs
                    prf
               Just forgeEbbEnv -> do
@@ -879,7 +877,6 @@ runThreadNetwork systemTime ThreadNetworkArgs
                            currentBno
                            currentSlot
                            tickedLdgSt'
-                           maxTxCapacityOverride
                            txs
                            prf
 
@@ -980,7 +977,6 @@ runThreadNetwork systemTime ThreadNetworkArgs
             , initChainDB             = nodeInitChainDB
             , blockForging            = blockForging
             , blockFetchSize          = estimateBlockSize
-            , maxTxCapacityOverride   = NoMaxTxCapacityOverride
             , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
             , keepAliveRng            = kaRng
             , miniProtocolParameters  = MiniProtocolParameters {

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -320,7 +320,7 @@ instance LedgerSupportsMempool BlockA where
 
   reapplyTx cfg slot = fmap fst .: (applyTx cfg DoNotIntervene slot . forgetValidatedGenTxA)
 
-  maxTxCapacity _ = maxBound
+  txsMaxBytes   _ = maxBound
   txInBlockSize _ = 0
 
   txForgetValidated = forgetValidatedGenTxA

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -284,7 +284,7 @@ blockForgingA = BlockForging {
    , canBeLeader      = ()
    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
-   , forgeBlock       = \cfg bno slot st _maxTxCapacityOverride txs proof -> return $
+   , forgeBlock       = \cfg bno slot st txs proof -> return $
        forgeBlockA cfg bno slot st (fmap txForgetValidated txs) proof
    }
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -260,7 +260,7 @@ instance LedgerSupportsMempool BlockB where
   applyTx   = \_ _ _wti tx -> case tx of {}
   reapplyTx = \_ _ vtx -> case vtx of {}
 
-  maxTxCapacity _ = maxBound
+  txsMaxBytes   _ = maxBound
   txInBlockSize _ = 0
 
   txForgetValidated = \case {}

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -236,7 +236,7 @@ blockForgingB = BlockForging {
    , canBeLeader      = ()
    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
-   , forgeBlock       = \cfg bno slot st _maxTxCapacityOverride txs proof -> return $
+   , forgeBlock       = \cfg bno slot st txs proof -> return $
        forgeBlockB cfg bno slot st (fmap txForgetValidated txs) proof
    }
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -280,6 +280,7 @@ library
                        ViewPatterns
 
   build-depends:       base              >=4.9 && <4.15
+                     , base-deriving-via
                      , base16-bytestring
                      , bimap             >=0.3   && <0.5
                      , binary            >=0.8   && <0.11
@@ -297,6 +298,7 @@ library
                      , filelock
                      , filepath          >=1.4   && <1.5
                      , hashable
+                     , measures
                      , mtl               >=2.2   && <2.3
                      , nothunks          >=0.1.2 && <0.2
                      , psqueues          >=0.2.3 && <0.3

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
@@ -174,13 +174,13 @@ takeLargestPrefixThatFits ::
   => TxLimits.Measure blk
   -> [Validated (GenTx blk)]
   -> [Validated (GenTx blk)]
-takeLargestPrefixThatFits computedMaxTxCapacity = go mempty
+takeLargestPrefixThatFits maxTxCapacity = go mempty
   where
     go acc = \case
       (tx : remainingTxs) | fits -> tx : go acc' remainingTxs
         where
           acc' = acc <> TxLimits.txMeasure tx
-          fits = TxLimits.lessEq @blk acc' computedMaxTxCapacity
+          fits = TxLimits.lessEq @blk acc' maxTxCapacity
       _ -> []
 
 data ShouldForge blk =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -35,9 +35,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Basics (
     -- ** Convenience re-exports
   , EpochInfo
   , Except
-    -- ** Overrides
-  , Overrides
-  , hardForkMaxTxCapacityOverrideToNP
   ) where
 
 import           Data.Kind (Type)
@@ -49,7 +46,6 @@ import           NoThunks.Class (NoThunks)
 import           Cardano.Slotting.EpochInfo
 
 import           Ouroboros.Consensus.Block.Abstract
-import           Ouroboros.Consensus.Block.Forging
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -135,20 +131,6 @@ newtype instance StorageConfig (HardForkBlock xs) = HardForkStorageConfig {
       hardForkStorageConfigPerEra :: PerEraStorageConfig xs
     }
   deriving newtype (NoThunks)
-
-{-------------------------------------------------------------------------------
-  Forging
--------------------------------------------------------------------------------}
-
-type instance Overrides (HardForkBlock xs) = NP MaxTxCapacityOverride xs
-
-hardForkMaxTxCapacityOverrideToNP ::
-     (All Top xs)
-  => MaxTxCapacityOverride (HardForkBlock xs)
-  -> NP MaxTxCapacityOverride xs
-hardForkMaxTxCapacityOverrideToNP = \case
-  NoMaxTxCapacityOverride -> hpure NoMaxTxCapacityOverride
-  MaxTxCapacityOverride v -> v
 
 {-------------------------------------------------------------------------------
   Ledger config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -193,10 +193,6 @@ instance Isomorphic BlockConfig where
   project = defaultProjectNP
   inject  = defaultInjectNP
 
-instance Isomorphic MaxTxCapacityOverride where
-  project = hd . hardForkMaxTxCapacityOverrideToNP
-  inject = MaxTxCapacityOverride . singletonNP
-
 instance Isomorphic CodecConfig where
   project = defaultProjectNP
   inject  = defaultInjectNP
@@ -444,14 +440,13 @@ instance Functor m => Isomorphic (BlockForging m) where
                                    (inject' (Proxy @(WrapIsLeader blk)) isLeader)
                                    (inject' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
 
-      , forgeBlock       = \cfg bno sno tickedLgrSt maxTxCapacityOverride txs isLeader ->
+      , forgeBlock       = \cfg bno sno tickedLgrSt txs isLeader ->
                                project' (Proxy @(I blk)) <$>
                                  forgeBlock
                                    (inject cfg)
                                    bno
                                    sno
                                    (unComp (inject (Comp tickedLgrSt)))
-                                   (inject maxTxCapacityOverride)
                                    (inject' (Proxy @(WrapValidatedGenTx blk)) <$> txs)
                                    (inject' (Proxy @(WrapIsLeader blk)) isLeader)
       }
@@ -488,14 +483,13 @@ instance Functor m => Isomorphic (BlockForging m) where
                                    (project' (Proxy @(WrapIsLeader blk)) isLeader)
                                    (project' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
 
-      , forgeBlock       = \cfg bno sno tickedLgrSt maxTxCapacityOverride txs isLeader ->
+      , forgeBlock       = \cfg bno sno tickedLgrSt txs isLeader ->
                                inject' (Proxy @(I blk)) <$>
                                  forgeBlock
                                    (project cfg)
                                    bno
                                    sno
                                    (unComp (project (Comp tickedLgrSt)))
-                                   (project maxTxCapacityOverride)
                                    (project' (Proxy @(WrapValidatedGenTx blk)) <$> txs)
                                    (project' (Proxy @(WrapIsLeader blk)) isLeader)
       }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -107,9 +107,9 @@ instance CanHardFork xs => LedgerSupportsMempool (HardForkBlock xs) where
           (WrapValidatedGenTx vtx)
           tls
 
-  maxTxCapacity =
+  txsMaxBytes =
         hcollapse
-      . hcmap proxySingle (K . maxTxCapacity . unComp)
+      . hcmap proxySingle (K . txsMaxBytes . unComp)
       . State.tip
       . tickedHardForkLedgerStatePerEra
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -599,7 +599,7 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
                                            tickedDualLedgerStateBridge
         }
 
-  maxTxCapacity = maxTxCapacity . tickedDualLedgerStateMain
+  txsMaxBytes   = txsMaxBytes . tickedDualLedgerStateMain
   txInBlockSize = txInBlockSize . dualGenTxMain
 
   txForgetValidated vtx =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -95,7 +95,7 @@ class ( UpdateLedger blk
   --
   -- This is (conservatively) computed by subtracting the header size and any
   -- other fixed overheads from the maximum block size.
-  maxTxCapacity :: TickedLedgerState blk -> Word32
+  txsMaxBytes :: TickedLedgerState blk -> Word32
 
   -- | Return the post-serialisation size in bytes of a 'GenTx' /when it is
   -- embedded in a block/. This size might differ from the size of the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -345,7 +345,7 @@ computeMempoolCapacity st = \case
     NoMempoolCapacityBytesOverride        -> noOverride
     MempoolCapacityBytesOverride override -> override
   where
-    noOverride = MempoolCapacityBytes (maxTxCapacity st * 2)
+    noOverride = MempoolCapacityBytes (txsMaxBytes st * 2)
 
 {-------------------------------------------------------------------------------
   Snapshot of the mempool

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -324,7 +324,7 @@ newtype MempoolCapacityBytes = MempoolCapacityBytes {
   deriving (Eq, Show, NoThunks)
 
 -- | An override for the default 'MempoolCapacityBytes' which is 2x the
--- maximum transaction capacity (see 'MaxTxCapacityOverride')
+-- maximum transaction capacity
 data MempoolCapacityBytesOverride
   = NoMempoolCapacityBytesOverride
     -- ^ Use 2x the maximum transaction capacity of a block. This will change

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -35,7 +35,6 @@ module Ouroboros.Consensus.Node (
   , IPSubscriptionTarget (..)
   , LastShutDownWasClean (..)
   , LowLevelRunNodeArgs (..)
-  , MaxTxCapacityOverride (..)
   , MempoolCapacityBytesOverride (..)
   , NodeKernel (..)
   , NodeKernelArgs (..)
@@ -502,7 +501,6 @@ mkNodeKernelArgs
       , blockForging
       , initChainDB             = nodeInitChainDB
       , blockFetchSize          = estimateBlockSize
-      , maxTxCapacityOverride   = NoMaxTxCapacityOverride
       , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
       , miniProtocolParameters  = defaultMiniProtocolParameters
       , blockFetchConfiguration = defaultBlockFetchConfiguration
@@ -625,7 +623,6 @@ data StdRunNodeArgs m blk = StdRunNodeArgs
     -- Consensus Team, with input from Node Team)
   , srnTraceChainDB                :: Tracer m (ChainDB.TraceEvent blk)
     -- ^ ChainDB Tracer
-  , srnMaxTxCapacityOverride       :: MaxTxCapacityOverride blk
   }
 
 -- | Conveniently packaged 'LowLevelRunNodeArgs' arguments from a standard
@@ -702,12 +699,8 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo } StdRunNodeArgs{..} = do
          NodeKernelArgs m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
       -> NodeKernelArgs m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
     llrnCustomiseNodeKernelArgs =
-        overrideMaxTxCapacityOverride
-      . (overBlockFetchConfiguration modifyBlockFetchConfiguration)
+        overBlockFetchConfiguration modifyBlockFetchConfiguration
       where
-        overrideMaxTxCapacityOverride args = args {
-              maxTxCapacityOverride = srnMaxTxCapacityOverride
-            }
         modifyBlockFetchConfiguration =
             maybe id
               (\mc bfc -> bfc { bfcMaxConcurrencyDeadline = mc })

--- a/scripts/buildkite/check-stylish.sh
+++ b/scripts/buildkite/check-stylish.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
-stylish-haskell -i `git ls-files -- 'ouroboros-consensus*/*.hs' | grep -v Setup.hs`
+# TODO the export of the <= operator TxLimits crashes stylish-haskell
+stylish-haskell -i $(git ls-files -- 'ouroboros-consensus*/*.hs' | grep -v -e 'Setup.hs' -e 'Ouroboros/Consensus/Mempool/TxLimits\.hs')
 
 git diff --exit-code


### PR DESCRIPTION
Fixes #3235 (again).

See the individual commit messages, some of which are extensive.