### PR TITLE
Cleanup unused dependencies in cabal files

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -25,7 +25,6 @@ library
                        ouroboros-consensus,
                        ouroboros-network,
                        ouroboros-network-framework,
-                       typed-protocols,
                        network-mux
 
   ghc-options:         -Wall

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -114,21 +114,17 @@ test-suite test
                        network-mux,
                        Win32-network,
 
-                       array,
                        binary,
                        bytestring,
                        cborg,
                        containers,
-                       hashable,
                        network,
                        process,
                        QuickCheck,
                        splitmix,
                        serialise,
-                       stm,
                        tasty,
                        tasty-quickcheck,
-                       tasty-hunit,
                        time
 
   if os(windows)
@@ -158,7 +154,6 @@ executable mux-demo
                        contra-tracer,
                        stm,
 
-                       binary,
                        bytestring,
                        cborg,
                        serialise

--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -82,7 +82,6 @@ test-suite test
                      , bytestring
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-test
                      , cardano-crypto-wrapper
                      , cardano-ledger-byron
                      , cardano-ledger-byron-test
@@ -94,9 +93,7 @@ test-suite test
                      , mtl
                      , QuickCheck
                      , tasty
-                     , tasty-hunit
                      , tasty-quickcheck
-                     , time
 
                      , byron-spec-chain
                      , byron-spec-ledger

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -85,13 +85,10 @@ executable db-converter
   build-depends:       base
                      , bytestring
                      , cardano-binary
-                     , cardano-crypto-wrapper
                      , cardano-ledger-byron
-                     , cardano-slotting
                      , directory
                      , filepath
                      , mtl
-                     , optparse-applicative
                      , optparse-generic
                      , resourcet
                      , streaming

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -37,7 +37,6 @@ library
                      , bimap             >=0.3   && <0.5
                      , cardano-binary
                      , cardano-ledger-byron-test
-                     , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -33,27 +33,18 @@ library
                        Test.ThreadNet.TxGen.Mary
 
   build-depends:       base
-                     , bytestring
-                     , cardano-binary
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
-                     , cardano-prelude
                      , cardano-slotting
-                     , cborg
                      , containers
-                     , hedgehog-quickcheck
                      , mtl
                      , QuickCheck
                      , sop-core
                      , strict-containers
-                     , tasty
-                     , tasty-quickcheck
-                     , time
 
                      , cardano-ledger-alonzo
                      , cardano-ledger-alonzo-test
                      , cardano-ledger-byron
-                     , cardano-ledger-byron-test
                      , cardano-ledger-core
                      , shelley-spec-ledger
                      , shelley-spec-ledger-test
@@ -93,27 +84,20 @@ test-suite test
 
   build-depends:       base
                      , bytestring
-                     , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-slotting
                      , cborg
                      , containers
                      , filepath
-                     , hedgehog-quickcheck
-                     , mtl
                      , QuickCheck
                      , sop-core
                      , tasty
                      , tasty-quickcheck
-                     , time
 
                      , cardano-ledger-core
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
-                     , cardano-ledger-byron-test
                      , shelley-spec-ledger
-                     , shelley-spec-ledger-test
 
                      , ouroboros-network
                      , ouroboros-consensus

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -39,13 +39,10 @@ library
                      , containers        >=0.5   && <0.7
                      , mtl               >=2.2   && <2.3
                      , nothunks
-                     , serialise         >=0.2   && <0.3
-                     , text              >=1.2   && <1.3
                      , these             >=1.1   && <1.2
 
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
                      , cardano-ledger-core
@@ -82,17 +79,12 @@ executable db-analyser
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
                      , cardano-ledger-core
-                     , cardano-ledger-shelley-ma
-                     , cardano-prelude
                      , containers
                      , contra-tracer
-                     , directory
-                     , filepath
                      , mtl
                      , optparse-applicative
                      , shelley-spec-ledger
                      , strict-containers
-                     , text
 
                      , ouroboros-consensus
                      , ouroboros-consensus-byron

--- a/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
+++ b/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
@@ -62,9 +62,7 @@ test-suite test
                        Test.ThreadNet.Praos
 
   build-depends:       base
-                     , binary
                      , bytestring
-                     , cardano-crypto-class
                      , cardano-slotting
                      , cborg
                      , containers

--- a/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -52,7 +52,6 @@ library
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -30,21 +30,14 @@ library
 
   build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11
-                     , cardano-binary
                      , cardano-crypto-class
                      , cardano-ledger-core
-                     , cardano-prelude
                      , cardano-slotting
                      , containers        >=0.5   && <0.7
-                     , data-default-class
                      , generic-random
-                     , hedgehog-quickcheck
-                     , iproute
                      , quiet             >=0.2   && <0.3
                      , mtl               >=2.2   && <2.3
                      , QuickCheck
-                     , time
-                     , serialise         >=0.2   && <0.3
                      , strict-containers
                      , transformers
 
@@ -84,22 +77,18 @@ test-suite test
 
   build-depends:       base
                      , bytestring
-                     , cardano-binary
                      , cardano-crypto-class
                      , cardano-slotting
                      , cborg
                      , containers
                      , filepath
                      , QuickCheck
-                     , time
                      , tasty
-                     , tasty-hunit
                      , tasty-quickcheck
 
                        -- cardano-ledger-specs
                      , cardano-ledger-core
                      , shelley-spec-ledger
-                     , shelley-spec-ledger-test
 
                      , ouroboros-network
                      , ouroboros-consensus

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -51,9 +51,7 @@ library
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-praos
                      , cardano-ledger-core
-                     , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
@@ -69,7 +67,6 @@ library
                      , cardano-ledger-alonzo
                      , cardano-ledger-shelley-ma
                      , shelley-spec-ledger
-                     , shelley-spec-non-integral
                      , small-steps
 
                      , ouroboros-network

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -101,7 +101,6 @@ library
                      , strict-containers
                      , tasty
                      , tasty-golden
-                     , tasty-hunit
                      , tasty-quickcheck
                      , template-haskell
                      , text              >=1.2   && <1.3
@@ -112,7 +111,6 @@ library
 
                      , io-classes
                      , io-sim
-                     , typed-protocols
                      , ouroboros-network
                      , ouroboros-network-framework
                      , ouroboros-consensus
@@ -154,16 +152,12 @@ test-suite test-consensus
                      , bytestring
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-prelude
                      , cardano-slotting
                      , cborg
                      , containers
                      , contra-tracer
                      , directory
-                     , fgl
-                     , filepath
                      , generics-sop
-                     , graphviz
                      , mtl
                      , nothunks
                      , QuickCheck
@@ -175,7 +169,6 @@ test-suite test-consensus
                      , tasty-hunit
                      , tasty-quickcheck
                      , temporary
-                     , text
                      , time
                      , tree-diff
 
@@ -238,7 +231,6 @@ test-suite test-storage
                      , binary
                      , bytestring
                      , cardano-crypto-class
-                     , cardano-prelude
                      , cardano-slotting
                      , cborg
                      , containers
@@ -251,7 +243,6 @@ test-suite test-storage
                      , pretty-show
                      , QuickCheck
                      , quickcheck-state-machine >=0.7.0
-                     , quiet
                      , random
                      , serialise
                      , strict-containers
@@ -268,7 +259,6 @@ test-suite test-storage
                      , io-classes
                      , io-sim
                      , ouroboros-network
-                     , ouroboros-network-testing
                      , ouroboros-consensus
                      , ouroboros-consensus-test
 

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -83,8 +83,6 @@ library
                      , typed-protocols >=0.1   && < 0.2
                      , Win32-network   >=0.1   && < 0.2
 
-                       -- Used by the handshake protocol for now
-                     , serialise       >=0.2   && <0.3
                        -- Remove once codec is defined locally
                      , typed-protocols-examples
 
@@ -125,7 +123,6 @@ test-suite test
                      , iproute
                      , network
                      , serialise
-                     , text
                      , time
 
                      , QuickCheck
@@ -138,7 +135,6 @@ test-suite test
                      , io-classes
                      , network-mux
                      , ouroboros-network-framework
-                     , ouroboros-network-testing
                      , typed-protocols
                      , typed-protocols-examples
 
@@ -166,11 +162,7 @@ executable demo-ping-pong
                        async,
                        bytestring,
                        cborg,
-                       containers,
                        directory,
-                       network,
-                       stm,
-                       text,
 
                        contra-tracer,
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -162,13 +162,11 @@ library
                        dns,
                        fingertree        >=0.1.4.2 && <0.2,
                        iproute,
-                       mtl,
                        nothunks,
                        network           >=3.1.2 && <3.2,
                        psqueues          >=0.2.3 && <0.3,
                        serialise         >=0.2 && <0.3,
                        random,
-                       stm               >=2.4 && <2.6,
                        strict-containers,
 
                        cardano-binary,
@@ -246,7 +244,6 @@ library ouroboros-protocol-tests
                        tasty-quickcheck,
                        text,
 
-                       cardano-prelude,
                        cardano-slotting,
                        contra-tracer,
 
@@ -254,7 +251,6 @@ library ouroboros-protocol-tests
                        io-sim,
                        ouroboros-network,
                        ouroboros-network-framework,
-                       ouroboros-network-testing,
                        typed-protocols
 
   ghc-options:         -Wall
@@ -292,31 +288,20 @@ test-suite test
                        QuickCheck,
                        array,
                        async,
-                       binary,
                        bytestring,
                        cborg,
                        containers,
-                       directory,
                        dns,
-                       fingertree,
                        hashable,
-                       iproute,
                        mtl,
                        network,
-                       pipes,
                        process,
-                       psqueues,
                        random,
                        serialise,
-                       splitmix,
-                       stm,
-                       strict-containers,
                        tasty,
                        tasty-hunit,
                        tasty-quickcheck,
-                       text,
 
-                       cardano-binary,
                        cardano-prelude,
                        cardano-slotting,
                        contra-tracer,
@@ -357,10 +342,7 @@ test-suite cddl
                        containers,
                        directory,
                        filepath,
-                       fingertree,
-                       hashable,
                        mtl,
-                       pipes,
                        process-extras,
                        serialise,
                        text,
@@ -372,13 +354,6 @@ test-suite cddl
                        tasty-hunit,
                        tasty-quickcheck,
 
-                       cardano-binary,
-                       cardano-slotting,
-                       contra-tracer,
-
-                       io-classes,
-                       io-sim,
-                       network-mux,
                        typed-protocols,
                        ouroboros-network-framework,
                        ouroboros-network,
@@ -396,17 +371,13 @@ executable demo-chain-sync
                        bytestring,
                        containers,
                        directory,
-                       network,
                        random,
                        serialise,
                        stm,
 
-                       QuickCheck,
-
                        contra-tracer,
 
                        network-mux,
-                       typed-protocols,
                        ouroboros-network-framework,
                        ouroboros-network
 

--- a/typed-protocols-examples/typed-protocols-examples.cabal
+++ b/typed-protocols-examples/typed-protocols-examples.cabal
@@ -67,7 +67,6 @@ test-suite test
   other-modules:     Network.TypedProtocol.PingPong.Tests
                    , Network.TypedProtocol.ReqResp.Tests
   build-depends:     base
-                   , bytestring
                    , contra-tracer
                    , typed-protocols
                    , typed-protocols-examples
@@ -76,7 +75,6 @@ test-suite test
                    , QuickCheck
                    , tasty
                    , tasty-quickcheck
-                   , time
   default-language:  Haskell2010
   ghc-options:       -rtsopts
                      -Wall


### PR DESCRIPTION
I happened to find that several dependencies were listed in cabal files but were not used at all. Removing them results in no harm.

Feel free to point to specific dependencies that are removed in this PR but you want to be kept as they will be used shortly.