### PR TITLE
diffusion using io-classes

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeApplications    #-}
 -- | Run the whole Node
 --
@@ -62,17 +66,16 @@ import           System.Random (StdGen, newStdGen, randomIO, randomRIO)
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
-import           Ouroboros.Network.Diffusion (DiffusionApplications,
-                     DiffusionArguments, DiffusionTracers, daDiffusionMode,
-                     getDiffusionArguments, mkDiffusionApplicationsNonP2P,
-                     mkDiffusionApplicationsP2P, runDataDiffusion)
+import qualified Ouroboros.Network.Diffusion as Diffusion
+import qualified Ouroboros.Network.Diffusion.NonP2P as NonP2P
+import qualified Ouroboros.Network.Diffusion.P2P as P2P
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.NodeToClient (ConnectionId, LocalAddress,
-                     NodeToClientVersionData (..), combineVersions,
+                     LocalSocket, NodeToClientVersionData (..), combineVersions,
                      simpleSingletonVersions)
 import           Ouroboros.Network.NodeToNode (DiffusionMode,
                      MiniProtocolParameters, NodeToNodeVersionData (..),
-                     RemoteAddress, blockFetchPipeliningMax,
+                     RemoteAddress, Socket, blockFetchPipeliningMax,
                      defaultMiniProtocolParameters)
 import           Ouroboros.Network.PeerSelection.LedgerPeers
                      (LedgerPeersConsensusInterface (..))
@@ -122,7 +125,7 @@ import           Ouroboros.Consensus.Storage.VolatileDB
 
 -- | Arguments expected from any invocation of 'runWith', whether by deployed
 -- code, tests, etc.
-data RunNodeArgs m addrNTN addrNTC blk = RunNodeArgs {
+data RunNodeArgs m addrNTN addrNTC blk (p2p :: Diffusion.P2P) = RunNodeArgs {
       -- | Consensus tracers
       rnTraceConsensus :: Tracers m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
 
@@ -144,7 +147,7 @@ data RunNodeArgs m addrNTN addrNTC blk = RunNodeArgs {
                        -> m ()
 
       -- | Network P2P Mode switch
-    , rnEnableP2P :: NetworkP2PMode
+    , rnEnableP2P :: NetworkP2PMode p2p
     }
 
 -- | Arguments that usually only tests /directly/ specify.
@@ -153,7 +156,9 @@ data RunNodeArgs m addrNTN addrNTC blk = RunNodeArgs {
 -- 'runWith'. The @cardano-node@, for example, instead calls the 'run'
 -- abbreviation, which uses 'stdLowLevelRunNodeArgsIO' to indirectly specify
 -- these low-level values from the higher-level 'StdRunNodeArgs'.
-data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk = LowLevelRunNodeArgs {
+data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk
+                         (p2p :: Diffusion.P2P) =
+   LowLevelRunNodeArgs {
 
       -- | How to manage the clean-shutdown marker on disk
       llrnWithCheckedDB :: forall a. (LastShutDownWasClean -> m a) -> m a
@@ -190,12 +195,11 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk = L
       -- 'run' will not return before this does.
     , llrnRunDataDiffusion ::
            ResourceRegistry m
-        -> DiffusionApplications
-             addrNTN
-             addrNTC
-             versionDataNTN
-             versionDataNTC
+        -> Diffusion.Applications
+             addrNTN NodeToNodeVersion   versionDataNTN
+             addrNTC NodeToClientVersion versionDataNTC
              m
+        -> Diffusion.ExtraApplications p2p addrNTN m
         -> m ()
 
     , llrnVersionDataNTC :: versionDataNTC
@@ -214,15 +218,18 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk = L
 
 -- | P2P Switch
 --
-data NetworkP2PMode = EnabledP2PMode
-                    | DisabledP2PMode
-  deriving (Eq, Show)
+data NetworkP2PMode (p2p :: Diffusion.P2P) where
+    EnabledP2PMode  :: NetworkP2PMode 'Diffusion.P2P
+    DisabledP2PMode :: NetworkP2PMode 'Diffusion.NonP2P
+
+deriving instance Eq   (NetworkP2PMode p2p)
+deriving instance Show (NetworkP2PMode p2p)
 
 -- | Combination of 'runWith' and 'stdLowLevelRunArgsIO'
-run :: forall blk.
+run :: forall blk p2p.
      RunNode blk
-  => RunNodeArgs IO RemoteAddress LocalAddress blk
-  -> StdRunNodeArgs IO blk
+  => RunNodeArgs IO RemoteAddress LocalAddress blk p2p
+  -> StdRunNodeArgs IO blk p2p
   -> IO ()
 run args stdArgs = stdLowLevelRunNodeArgsIO args stdArgs >>= runWith args
 
@@ -232,13 +239,13 @@ run args stdArgs = stdLowLevelRunNodeArgsIO args stdArgs >>= runWith args
 -- network layer.
 --
 -- This function runs forever unless an exception is thrown.
-runWith :: forall m addrNTN addrNTC versionDataNTN versionDataNTC blk.
+runWith :: forall m addrNTN addrNTC versionDataNTN versionDataNTC blk p2p.
      ( RunNode blk
      , IOLike m, MonadTime m, MonadTimer m
      , Hashable addrNTN, Ord addrNTN, Typeable addrNTN
      )
-  => RunNodeArgs m addrNTN addrNTC blk
-  -> LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk
+  => RunNodeArgs m addrNTN addrNTC blk p2p
+  -> LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk p2p
   -> m ()
 runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
 
@@ -312,7 +319,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
       peerMetrics <- newPeerMetric
       let ntnApps = mkNodeToNodeApps   nodeKernelArgs nodeKernel peerMetrics
           ntcApps = mkNodeToClientApps nodeKernelArgs nodeKernel
-          diffusionApplications = mkDiffusionApplications
+          (apps, appsExtra) = mkDiffusionApplications
                                     rnEnableP2P
                                     (miniProtocolParameters nodeKernelArgs)
                                     ntnApps
@@ -321,7 +328,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
                                     peerMetrics
                                     btime
 
-      llrnRunDataDiffusion registry diffusionApplications
+      llrnRunDataDiffusion registry apps appsExtra
   where
     ProtocolInfo
       { pInfoConfig       = cfg
@@ -368,7 +375,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
           (NTC.mkHandlers nodeKernelArgs nodeKernel)
 
     mkDiffusionApplications
-      :: NetworkP2PMode
+      :: NetworkP2PMode p2p
       -> MiniProtocolParameters
       -> (   BlockNodeToNodeVersion blk
           -> NTN.Apps
@@ -389,12 +396,12 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
       -> NodeKernel m remotePeer localPeer blk
       -> PeerMetrics m ntnAddr
       -> BlockchainTime m
-      -> DiffusionApplications
-           ntnAddr
-           ntcAddr
-           versionDataNTN
-           versionDataNTC
-           m
+      -> ( Diffusion.Applications
+             ntnAddr NodeToNodeVersion   versionDataNTN
+             ntcAddr NodeToClientVersion versionDataNTC
+             m
+         , Diffusion.ExtraApplications p2p ntnAddr m
+         )
     mkDiffusionApplications
       enP2P
       miniProtocolParams
@@ -405,23 +412,33 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
       btime =
       case enP2P of
         EnabledP2PMode ->
-          mkDiffusionApplicationsP2P
-            initiator
-            initiatorAndResponder
-            responder
-            ledgerPeersConsensusInterface
-            miniProtocolParams
-            (consensusRethrowPolicy (Proxy @blk))
-            localRethrowPolicy
-            peerMetrics
-            (getFetchMode (getChainDB kernel) btime)
+          ( Diffusion.Applications {
+              Diffusion.daApplicationInitiatorMode = initiator,
+              Diffusion.daApplicationInitiatorResponderMode = initiatorAndResponder,
+              Diffusion.daLocalResponderApplication = responder,
+              Diffusion.daLedgerPeersCtx = ledgerPeersConsensusInterface
+            }
+          , Diffusion.P2PApplications
+              P2P.ApplicationsExtra {
+                P2P.daMiniProtocolParameters = miniProtocolParams,
+                P2P.daRethrowPolicy = consensusRethrowPolicy (Proxy @blk),
+                P2P.daLocalRethrowPolicy = localRethrowPolicy,
+                P2P.daPeerMetrics = peerMetrics,
+                P2P.daBlockFetchMode = getFetchMode (getChainDB kernel) btime
+              }
+          )
         DisabledP2PMode ->
-          mkDiffusionApplicationsNonP2P
-            initiator
-            initiatorAndResponder
-            responder
-            ledgerPeersConsensusInterface
-            (consensusErrorPolicy (Proxy @blk))
+          ( Diffusion.Applications {
+              Diffusion.daApplicationInitiatorMode = initiator,
+              Diffusion.daApplicationInitiatorResponderMode = initiatorAndResponder,
+              Diffusion.daLocalResponderApplication = responder,
+              Diffusion.daLedgerPeersCtx = ledgerPeersConsensusInterface
+            }
+          , Diffusion.NonP2PApplications
+              NonP2P.ApplicationsExtra {
+                NonP2P.daErrorPolicies = consensusErrorPolicy (Proxy @blk)
+              }
+          )
       where
         initiator =
           combineVersions
@@ -449,6 +466,8 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
                 (NTC.responder version $ ntcApps blockVersion version)
             | (version, blockVersion) <- Map.toList llrnNodeToClientVersions
             ]
+
+        ledgerPeersConsensusInterface :: LedgerPeersConsensusInterface m
         ledgerPeersConsensusInterface =
           LedgerPeersConsensusInterface
             (getPeersFromCurrentLedgerAfterSlot kernel)
@@ -673,22 +692,28 @@ stdVersionDataNTC networkMagic = NodeToClientVersionData
     }
 
 stdRunDataDiffusion ::
-     DiffusionTracers
-  -> DiffusionArguments IO
-  -> DiffusionApplications
-       RemoteAddress
-       LocalAddress
-       NodeToNodeVersionData
-       NodeToClientVersionData
+     Diffusion.Tracers
+       RemoteAddress  NodeToNodeVersion
+       LocalAddress   NodeToClientVersion
        IO
+  -> Diffusion.ExtraTracers p2p
+  -> Diffusion.Arguments
+       Socket      RemoteAddress
+       LocalSocket LocalAddress
+  -> Diffusion.ExtraArguments p2p IO
+  -> Diffusion.Applications
+       RemoteAddress  NodeToNodeVersion   NodeToNodeVersionData
+       LocalAddress   NodeToClientVersion NodeToClientVersionData
+       IO
+  -> Diffusion.ExtraApplications p2p RemoteAddress IO
   -> IO ()
-stdRunDataDiffusion = runDataDiffusion
+stdRunDataDiffusion = Diffusion.run
 
 -- | Higher-level arguments that can determine the 'LowLevelRunNodeArgs' under
 -- some usual assumptions for realistic use cases such as in @cardano-node@.
 --
 -- See 'stdLowLevelRunNodeArgsIO'.
-data StdRunNodeArgs m blk = StdRunNodeArgs
+data StdRunNodeArgs m blk (p2p :: Diffusion.P2P) = StdRunNodeArgs
   { srnBfcMaxConcurrencyBulkSync   :: Maybe Word
   , srnBfcMaxConcurrencyDeadline   :: Maybe Word
   , srnChainDbValidateOverride     :: Bool
@@ -696,8 +721,15 @@ data StdRunNodeArgs m blk = StdRunNodeArgs
   , srnSnapshotInterval            :: SnapshotInterval
   , srnDatabasePath                :: FilePath
     -- ^ Location of the DBs
-  , srnDiffusionArguments          :: DiffusionArguments m
-  , srnDiffusionTracers            :: DiffusionTracers
+  , srnDiffusionArguments          :: Diffusion.Arguments
+                                        Socket      RemoteAddress
+                                        LocalSocket LocalAddress
+  , srnDiffusionArgumentsExtra     :: Diffusion.ExtraArguments p2p m
+  , srnDiffusionTracers            :: Diffusion.Tracers
+                                        RemoteAddress  NodeToNodeVersion
+                                        LocalAddress   NodeToClientVersion
+                                        IO
+  , srnDiffusionTracersExtra       :: Diffusion.ExtraTracers p2p
   , srnEnableInDevelopmentVersions :: Bool
     -- ^ If @False@, then the node will limit the negotiated NTN and NTC
     -- versions to the latest " official " release (as chosen by Network and
@@ -709,16 +741,17 @@ data StdRunNodeArgs m blk = StdRunNodeArgs
 -- | Conveniently packaged 'LowLevelRunNodeArgs' arguments from a standard
 -- non-testing invocation.
 stdLowLevelRunNodeArgsIO ::
-     forall blk. RunNode blk
-  => RunNodeArgs IO RemoteAddress LocalAddress blk
-  -> StdRunNodeArgs IO blk
+     forall blk p2p. RunNode blk
+  => RunNodeArgs IO RemoteAddress LocalAddress blk p2p
+  -> StdRunNodeArgs IO blk p2p
   -> IO (LowLevelRunNodeArgs
           IO
           RemoteAddress
           LocalAddress
           NodeToNodeVersionData
           NodeToClientVersionData
-          blk)
+          blk
+          p2p)
 stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo } StdRunNodeArgs{..} = do
     llrnBfcSalt      <- stdBfcSaltIO
     llrnKeepAliveRng <- stdKeepAliveRngIO
@@ -732,14 +765,18 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo } StdRunNodeArgs{..} = do
       , llrnCustomiseChainDbArgs = id
       , llrnCustomiseNodeKernelArgs
       , llrnRunDataDiffusion =
-          \_reg apps ->
-            stdRunDataDiffusion srnDiffusionTracers srnDiffusionArguments apps
+          \_reg apps extraApps ->
+            stdRunDataDiffusion srnDiffusionTracers
+                                srnDiffusionTracersExtra
+                                srnDiffusionArguments
+                                srnDiffusionArgumentsExtra
+                                apps extraApps
       , llrnVersionDataNTC =
           stdVersionDataNTC networkMagic
       , llrnVersionDataNTN =
           stdVersionDataNTN
             networkMagic
-            (daDiffusionMode (getDiffusionArguments srnDiffusionArguments))
+            (Diffusion.daDiffusionMode srnDiffusionArguments)
       , llrnNodeToNodeVersions =
           limitToLatestReleasedVersion
             fst

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -245,14 +245,14 @@ withBidirectionalConnectionManager snocket socket
               haHandshakeTracer = ("handshake",) `contramap` debugTracer,
               haHandshakeCodec = unversionedHandshakeCodec,
               haVersionDataCodec = cborTermVersionDataCodec unversionedProtocolDataCodec,
-              haVersions = unversionedProtocol
-                            (serverApplication
-                              hotRequestsVar
-                              warmRequestsVar
-                              establishedRequestsVar),
               haAcceptVersion = acceptableVersion,
               haTimeLimits = timeLimitsHandshake
             }
+          (unversionedProtocol
+             (serverApplication
+                hotRequestsVar
+                warmRequestsVar
+                establishedRequestsVar))
           (mainThreadId,   debugMuxErrorRethrowPolicy
                         <> debugIOErrorRethrowPolicy))
           (\_ -> HandshakeFailure)

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -26,6 +26,7 @@ import System.Exit
 
 import Ouroboros.Network.Socket
 import Ouroboros.Network.Snocket
+import qualified Ouroboros.Network.Snocket as Snocket
 import Ouroboros.Network.Mux
 import Ouroboros.Network.ErrorPolicy
 import Ouroboros.Network.IOManager
@@ -107,7 +108,7 @@ clientPingPong :: Bool -> IO ()
 clientPingPong pipelined =
     withIOManager $ \iomgr ->
     connectToNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -145,7 +146,7 @@ serverPingPong =
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
@@ -203,9 +204,9 @@ demoProtocol1 pingPong pingPong' =
 
 clientPingPong2 :: IO ()
 clientPingPong2 =
-    withIOManager $ \iomgr ->
+    withIOManager $ \iomgr -> do
     connectToNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -256,7 +257,7 @@ serverPingPong2 =
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
@@ -190,7 +190,8 @@ makeConnectionHandler
     -- evidence that we can use mux with it.
     -> MiniProtocolBundle muxMode
     -> HandshakeArguments (ConnectionId peerAddr) versionNumber versionData m
-                          (OuroborosBundle muxMode peerAddr ByteString m a b)
+    -> Versions versionNumber versionData
+                (OuroborosBundle muxMode peerAddr ByteString m a b)
     -> (ThreadId m, RethrowPolicy)
     -- ^ 'ThreadId' and rethrow policy.  Rethrow policy might throw an async
     -- exception to that thread, when trying to terminate the process.
@@ -198,6 +199,7 @@ makeConnectionHandler
 makeConnectionHandler muxTracer singMuxMode
                       miniProtocolBundle
                       handshakeArguments
+                      versionedApplication
                       (mainThreadId, rethrowPolicy) =
     ConnectionHandler {
         connectionHandler =
@@ -263,7 +265,8 @@ makeConnectionHandler muxTracer singMuxMode
             hsResult <-
               unmask (runHandshakeClient handshakeBearer
                                          connectionId
-                                         handshakeArguments)
+                                         handshakeArguments
+                                         versionedApplication)
               -- 'runHandshakeClient' only deals with protocol limit errors or
               -- handshake negotiation failures, but not with 'IOException's or
               -- 'MuxError's.
@@ -329,7 +332,8 @@ makeConnectionHandler muxTracer singMuxMode
             hsResult <-
               unmask (runHandshakeServer handshakeBearer
                                          connectionId
-                                         handshakeArguments)
+                                         handshakeArguments
+                                         versionedApplication)
               -- 'runHandshakeServer' only deals with protocol limit errors or
               -- handshake negotiation failures, but not with 'IOException's or
               -- 'MuxError's.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -99,7 +99,6 @@ import           Ouroboros.Network.ErrorPolicy
 import           Ouroboros.Network.Subscription.PeerState
 import           Ouroboros.Network.Protocol.Handshake
 import           Ouroboros.Network.Protocol.Handshake.Type
-import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.IOManager (IOManager)
 import           Ouroboros.Network.Snocket (Snocket)
@@ -256,10 +255,10 @@ connectToNode' sn handshakeCodec handshakeTimeLimits versionDataCodec NetworkCon
           haHandshakeTracer  = nctHandshakeTracer,
           haHandshakeCodec   = handshakeCodec,
           haVersionDataCodec = versionDataCodec,
-          haVersions         = versions,
           haAcceptVersion    = acceptVersion,
           haTimeLimits       = handshakeTimeLimits
         }
+        versions
     ts_end <- getMonotonicTime
     case app_e of
          Left (HandshakeProtocolLimit err) -> do
@@ -383,10 +382,10 @@ beginConnection sn muxTracer handshakeTracer handshakeCodec handshakeTimeLimits 
               haHandshakeTracer  = handshakeTracer,
               haHandshakeCodec   = handshakeCodec,
               haVersionDataCodec = versionDataCodec,
-              haVersions         = versions,
               haAcceptVersion    = acceptVersion,
               haTimeLimits       = handshakeTimeLimits
             }
+           versions
 
         case app_e of
              Left (HandshakeProtocolLimit err) -> do

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -37,7 +37,6 @@ module Simulation.Network.Snocket
 
 import           Prelude hiding (read)
 
-import           Control.Monad (when)
 import qualified Control.Monad.Class.MonadSTM as LazySTM
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
@@ -53,8 +52,6 @@ import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
-import           Data.Set (Set)
-import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Numeric.Natural (Natural)
 
@@ -194,10 +191,6 @@ data NetworkState m addr = NetworkState {
       --
       nsConnections       :: StrictTVar m (Map (NormalisedId addr) (Connection m)),
 
-      -- | Set of all used addresses.
-      --
-      nsBoundAddresses    :: StrictTVar m (Set addr),
-
       -- | Get an unused ephemeral address.
       --
       nsNextEphemeralAddr :: STM m addr,
@@ -285,8 +278,6 @@ newNetworkState bearerInfoScript peerAddr = atomically $
     <$> newTVar Map.empty
     -- nsConnections
     <*> newTVar Map.empty
-    -- nsBoundAddresses
-    <*> newTVar Set.empty
     -- nsNextEphemeralAddr
     <*> do (v :: StrictTVar m peerAddr) <- newTVar peerAddr
            return $ do
@@ -437,11 +428,11 @@ instance Show addr => Show (FD_ m addr) where
                                     , show (connSDUSize conn)
                                     ]
     show (FDConnected connId conn)  = concat
-                                        [ "FDConnected "
-                                        , show connId
-                                        , " "
-                                        , show (connSDUSize conn)
-                                        ]
+                                    [ "FDConnected "
+                                    , show connId
+                                    , " "
+                                    , show (connSDUSize conn)
+                                    ]
     show (FDClosed mbConnId)        = "FDClosed " ++ show mbConnId
 
 
@@ -768,9 +759,6 @@ mkSnocket state tr = Snocket { getLocalAddr
     bind :: FD m (TestAddress addr) -> TestAddress addr -> m ()
     bind fd@FD { fdVar } addr = do
         res <- atomically $ do
-          boundSet <- readTVar (nsBoundAddresses state)
-          when (addr `Set.member` boundSet)
-               (throwSTM addressInUseError)
           fd_ <- readTVar fdVar
           case fd_ of
             FDUninitialised Nothing -> do

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -54,6 +54,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
 import           Data.Typeable (Typeable)
 import           Numeric.Natural (Natural)
+import           Text.Printf (printf)
 
 import           Data.Wedge
 
@@ -499,7 +500,8 @@ mkSnocket :: forall m addr.
              , MonadMask  m
              , MonadTime  m
              , MonadTimer m
-             , Ord addr
+             , Ord  addr
+             , Show addr
              )
           => NetworkState m (TestAddress addr)
           -> Tracer m (WithAddr (TestAddress addr)
@@ -518,38 +520,44 @@ mkSnocket state tr = Snocket { getLocalAddr
                              , toBearer
                              }
   where
-    getLocalAddrM :: FD m (TestAddress addr) -> m (Maybe (TestAddress addr))
+    getLocalAddrM :: FD m (TestAddress addr)
+                  -> m (Either (FD_ m (TestAddress addr))
+                               (TestAddress addr))
     getLocalAddrM FD { fdVar } = do
         fd_ <- atomically (readTVar fdVar)
         return $ case fd_ of
-          FDUninitialised Nothing         -> Nothing
-          FDUninitialised (Just peerAddr) -> Just peerAddr
-          FDListening peerAddr _          -> Just peerAddr
+          FDUninitialised Nothing         -> Left fd_
+          FDUninitialised (Just peerAddr) -> Right peerAddr
+          FDListening peerAddr _          -> Right peerAddr
           FDConnecting ConnectionId { localAddress } _
-                                          -> Just localAddress
+                                          -> Right localAddress
           FDConnected  ConnectionId { localAddress } _
-                                          -> Just localAddress
-          FDClosed {}                     -> Nothing
+                                          -> Right localAddress
+          FDClosed {}                     -> Left fd_
 
-    getRemoteAddrM :: FD m (TestAddress addr) -> m (Maybe (TestAddress addr))
+    getRemoteAddrM :: FD m (TestAddress addr)
+                   -> m (Either (FD_ m (TestAddress addr))
+                                (TestAddress addr))
     getRemoteAddrM FD { fdVar } = do
         fd_ <- atomically (readTVar fdVar)
         return $ case fd_ of
-          FDUninitialised {}         -> Nothing
-          FDListening {}             -> Nothing
+          FDUninitialised {}         -> Left fd_
+          FDListening {}             -> Left fd_
           FDConnecting ConnectionId { remoteAddress } _
-                                     -> Just remoteAddress
+                                     -> Right remoteAddress
           FDConnected  ConnectionId { remoteAddress } _
-                                     -> Just remoteAddress
-          FDClosed {}                -> Nothing
+                                     -> Right remoteAddress
+          FDClosed {}                -> Left fd_
 
     traceWith' :: FD m (TestAddress addr)
                -> SnocketTrace m (TestAddress addr)
                -> m ()
     traceWith' fd =
       let tr' :: Tracer m (SnocketTrace m (TestAddress addr))
-          tr' = (\ev -> (\a b -> WithAddr a b ev) <$> getLocalAddrM  fd
-                                                  <*> getRemoteAddrM fd)
+          tr' = (\ev -> (\a b -> WithAddr (hush a)
+                                          (hush b) ev)
+                    <$> getLocalAddrM  fd
+                    <*> getRemoteAddrM fd)
                 `contramapM` tr
       in traceWith tr'
 
@@ -561,16 +569,17 @@ mkSnocket state tr = Snocket { getLocalAddr
     getLocalAddr fd = do
         maddr <- getLocalAddrM fd
         case maddr of
-          Just addr -> return addr
+          Right addr -> return addr
           -- Socket would not error for an @FDUninitialised Nothing@; it would
           -- return '0.0.0.0:0'.
-          Nothing   -> throwIO ioe
+          Left fd_   -> throwIO (ioe fd_)
       where
-        ioe = IOError
+        ioe :: FD_ m (TestAddress addr) -> IOError
+        ioe fd_ = IOError
                 { ioe_handle      = Nothing
                 , ioe_type        = InvalidArgument
                 , ioe_location    = "Ouroboros.Network.Snocket.Sim.getLocalAddr"
-                , ioe_description = "Transport endpoint is not connected"
+                , ioe_description = printf "Transport endpoint (%s) is not connected" (show fd_)
                 , ioe_errno       = Nothing
                 , ioe_filename    = Nothing
                 }
@@ -579,14 +588,15 @@ mkSnocket state tr = Snocket { getLocalAddr
     getRemoteAddr fd = do
       maddr <- getRemoteAddrM fd
       case maddr of
-        Just addr -> return addr
-        Nothing   -> throwIO ioe
+        Right addr -> return addr
+        Left fd_   -> throwIO (ioe fd_)
       where
-        ioe = IOError
+        ioe :: FD_ m (TestAddress addr) -> IOError
+        ioe fd_ = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.getRemoteAddr"
-          , ioe_description = "Transport endpoint is not connected"
+          , ioe_description = printf "Transport endpoint is not connected" (show fd_)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
@@ -623,7 +633,7 @@ mkSnocket state tr = Snocket { getLocalAddr
               conMap <- readTVar (nsConnections state)
               case Map.lookup (normaliseId connId) conMap of
                 Just      Connection { connState = Established } ->
-                  throwSTM connectedIOError
+                  throwSTM (connectedIOError fd_)
                 Just conn@Connection { connState = HalfOpened } -> do
                   let conn' = conn { connState = Established }
                   writeTVar fdVarLocal (FDConnecting connId conn')
@@ -660,13 +670,13 @@ mkSnocket state tr = Snocket { getLocalAddr
               case (efd, lstFd) of
                 -- error cases
                 (_, Nothing) ->
-                  return (Left connectIOError)
+                  return (Left (connectIOError connId))
                 (_, Just FDUninitialised {}) ->
-                  return (Left connectIOError)
+                  return (Left (connectIOError connId))
                 (_, Just FDConnecting {}) ->
-                  return (Left invalidError)
+                  return (Left (invalidError fd_))
                 (_, Just FDConnected {}) ->
-                  return (Left connectIOError)
+                  return (Left (connectIOError connId))
                 (_, Just FDClosed {}) ->
                   return (Left notConnectedIOError)
 
@@ -698,7 +708,7 @@ mkSnocket state tr = Snocket { getLocalAddr
                                      , cwiChannelRemote = connChannelLocal
                                      }
                     Nothing ->
-                      throwSTM connectIOError
+                      throwSTM (connectIOError connId)
 
                   return (Right (fd_', NormalOpen))
 
@@ -708,13 +718,13 @@ mkSnocket state tr = Snocket { getLocalAddr
               Right (fd_', o) -> traceWith' fd (STConnected fd_' o)
 
           FDConnecting {} ->
-            throwIO invalidError
+            throwIO (invalidError fd_)
 
           FDConnected {} ->
-            throwIO connectedIOError
+            throwIO (connectedIOError fd_)
 
           FDListening {} ->
-            throwIO connectedIOError
+            throwIO (connectedIOError fd_)
 
           FDClosed {} ->
             throwIO notConnectedIOError
@@ -728,29 +738,32 @@ mkSnocket state tr = Snocket { getLocalAddr
           , ioe_filename    = Nothing
           }
 
-        connectIOError = IOError
+        connectIOError :: ConnectionId (TestAddress addr) -> IOError
+        connectIOError connId = IOError
           { ioe_handle      = Nothing
           , ioe_type        = OtherError
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.connect"
-          , ioe_description = "connect failure"
+          , ioe_description = printf "connect failure (%s)" (show connId)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
 
-        connectedIOError = IOError
+        connectedIOError :: FD_ m (TestAddress addr) -> IOError
+        connectedIOError fd_ = IOError
           { ioe_handle      = Nothing
           , ioe_type        = AlreadyExists
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.connect"
-          , ioe_description = "Transport endpoint is already connected"
+          , ioe_description = printf "Transport endpoint (%s) is already connected" (show fd_)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
 
-        invalidError = IOError
+        invalidError :: FD_ m (TestAddress addr) -> IOError
+        invalidError fd_ = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.bind"
-          , ioe_description = "Invalid argument"
+          , ioe_description = printf "Invalid argument (%s)" (show fd_)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
@@ -765,26 +778,17 @@ mkSnocket state tr = Snocket { getLocalAddr
               writeTVar fdVar (FDUninitialised (Just addr))
               return Nothing
             _ ->
-              return (Just (fd_, invalidError))
+              return (Just (fd_, invalidError fd_))
         case res of
           Nothing       -> return ()
           Just (fd_, e) -> traceWith' fd (STBindError fd_ addr e)
                         >> throwIO e
       where
-        invalidError = IOError
+        invalidError fd_ = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.bind"
-          , ioe_description = "Invalid argument"
-          , ioe_errno       = Nothing
-          , ioe_filename    = Nothing
-          }
-
-        addressInUseError = IOError
-          { ioe_handle      = Nothing
-          , ioe_type        = ResourceBusy
-          , ioe_location    = "Ouroboros.Network.Snocket.Sim.bind"
-          , ioe_description = "Address already in use"
+          , ioe_description = printf "Invalid argument (%s)" (show fd_)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
@@ -796,7 +800,7 @@ mkSnocket state tr = Snocket { getLocalAddr
         case fd_ of
           FDUninitialised Nothing ->
             -- Berkeley socket would not error; but then 'bind' would fail;
-            throwSTM invalidError
+            throwSTM $ invalidError fd_
 
           FDUninitialised (Just addr) -> do
             queue <- newTBQueue bound
@@ -804,23 +808,24 @@ mkSnocket state tr = Snocket { getLocalAddr
             modifyTVar (nsListeningFDs state) (Map.insert addr fd)
             
           FDConnected {} ->
-            throwSTM invalidError
+            throwSTM $ invalidError fd_
           FDConnecting {} ->
-            throwSTM invalidError
+            throwSTM $ invalidError fd_
           FDListening {} ->
             return ()
           FDClosed {} ->
-            throwSTM invalidError
+            throwSTM $ invalidError fd_
       where
         -- TODO: 'listen' should take this as an explicit argument
         bound :: Natural
         bound = 10
 
-        invalidError = IOError
+        invalidError :: FD_ m (TestAddress addr) -> IOError
+        invalidError fd_ = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.listen"
-          , ioe_description = "Invalid argument"
+          , ioe_description = printf "Invalid argument (%s)" (show fd_)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
@@ -838,15 +843,15 @@ mkSnocket state tr = Snocket { getLocalAddr
               -- 'berkeleyAccept' used by 'socketSnocket' will return
               -- 'IOException's with 'AcceptFailure', we match this behaviour
               -- here.
-              return ( AcceptFailure (toException invalidError)
+              return ( AcceptFailure (toException $ invalidError fd)
                      , accept_
                      )
             FDConnecting {} ->
-              return ( AcceptFailure (toException invalidError)
+              return ( AcceptFailure (toException $ invalidError fd)
                      , accept_
                      )
             FDConnected {} ->
-              return ( AcceptFailure (toException invalidError)
+              return ( AcceptFailure (toException $ invalidError fd)
                      , accept_
                      )
             FDListening localAddress queue -> do
@@ -871,15 +876,16 @@ mkSnocket state tr = Snocket { getLocalAddr
                      , accept_
                      )
             FDClosed {} ->
-              return ( AcceptFailure (toException invalidError)
+              return ( AcceptFailure (toException $ invalidError fd)
                      , accept_
                      )
 
-        invalidError = IOError
+        invalidError :: FD_ m (TestAddress addr) -> IOError
+        invalidError fd = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.accept"
-          , ioe_description = "Invalid argument"
+          , ioe_description = printf "Invalid argument (%s)" (show fd)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
@@ -940,25 +946,32 @@ mkSnocket state tr = Snocket { getLocalAddr
         fd_ <- atomically (readTVar fdVar)
         case fd_ of
           FDUninitialised {} ->
-            throwIO (invalidError "uninitialised file descriptor")
+            throwIO (invalidError fd_)
           FDListening {} ->
-            throwIO (invalidError "listening snocket")
+            throwIO (invalidError fd_)
           FDConnecting _ _ -> do
-            throwIO (invalidError "connecting")
+            throwIO (invalidError fd_)
           FDConnected _ conn -> do
             traceWith' fd (STBearer fd_)
             return $ attenuationChannelAsMuxBearer (connSDUSize conn)
                                                    sduTimeout muxTracer
                                                    (connChannelLocal conn)
           FDClosed {} ->
-            throwIO (invalidError "closed snocket")
+            throwIO (invalidError fd_)
       where
         -- io errors
-        invalidError desc = IOError
+        invalidError :: FD_ m (TestAddress addr) -> IOError
+        invalidError fd_ = IOError
           { ioe_handle      = Nothing
           , ioe_type        = InvalidArgument
           , ioe_location    = "Ouroboros.Network.Snocket.Sim.toBearer"
-          , ioe_description = "Invalid argument: " ++ desc
+          , ioe_description = printf "Invalid argument (%s)" (show fd_)
           , ioe_errno       = Nothing
           , ioe_filename    = Nothing
           }
+
+
+hush :: Either a b -> Maybe b
+hush Left {}   = Nothing
+hush (Right a) = Just a
+{-# INLINE hush #-}

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -336,10 +336,10 @@ withInitiatorOnlyConnectionManager name timeouts trTracer snocket localAddr next
             haHandshakeTracer = (name,) `contramap` nullTracer,
             haHandshakeCodec = unversionedHandshakeCodec,
             haVersionDataCodec = cborTermVersionDataCodec unversionedProtocolDataCodec,
-            haVersions = unversionedProtocol clientApplication,
             haAcceptVersion = acceptableVersion,
             haTimeLimits = noTimeLimitsHandshake
           }
+        (unversionedProtocol clientApplication)
         (mainThreadId, debugMuxErrorRethrowPolicy
                     <> debugMuxRuntimeErrorRethrowPolicy
                     <> debugIOErrorRethrowPolicy
@@ -510,10 +510,10 @@ withBidirectionalConnectionManager name timeouts trTracer snocket socket localAd
               haHandshakeTracer = WithName name `contramap` nullTracer,
               haHandshakeCodec = unversionedHandshakeCodec,
               haVersionDataCodec = cborTermVersionDataCodec unversionedProtocolDataCodec,
-              haVersions = unversionedProtocol serverApplication,
               haAcceptVersion = acceptableVersion,
               haTimeLimits = noTimeLimitsHandshake
             }
+          (unversionedProtocol serverApplication)
           (mainThreadId,   debugMuxErrorRethrowPolicy
                         <> debugMuxRuntimeErrorRethrowPolicy
                         <> debugIOErrorRethrowPolicy

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -152,7 +152,7 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
     forConcurrently_ (zip [0..] sockPaths) $ \(index, sockPath) -> do
       threadDelay (50000 * index)
       connectToNode
-        (localSnocket iocp sockPath)
+        (localSnocket iocp)
         unversionedHandshakeCodec
         noTimeLimitsHandshake
         (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -182,7 +182,7 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iocp defaultLocalSocketAddrPath)
+      (localSnocket iocp)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
@@ -366,7 +366,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
     peerAsyncs <- sequence
                     [ async $
                         connectToNode
-                          (localSnocket iocp defaultLocalSocketAddrPath)
+                          (localSnocket iocp)
                           unversionedHandshakeCodec
                           noTimeLimitsHandshake
                           (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -418,7 +418,7 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iocp defaultLocalSocketAddrPath)
+      (localSnocket iocp)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -64,6 +64,8 @@ library
                        Ouroboros.Network.Counter
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.Diffusion
+                       Ouroboros.Network.Diffusion.P2P
+                       Ouroboros.Network.Diffusion.NonP2P
                        Ouroboros.Network.Diffusion.Policies
                        Ouroboros.Network.KeepAlive
                        Ouroboros.Network.Magic
@@ -129,8 +131,6 @@ library
                        Ouroboros.Network.TxSubmission.Mempool.Reader
                        Ouroboros.Network.TxSubmission.Outbound
   other-modules:       Ouroboros.Network.Diffusion.Common
-                       Ouroboros.Network.Diffusion.P2P
-                       Ouroboros.Network.Diffusion.NonP2P
                        Ouroboros.Network.PeerSelection.Governor.ActivePeers
                        Ouroboros.Network.PeerSelection.Governor.EstablishedPeers
                        Ouroboros.Network.PeerSelection.Governor.KnownPeers

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -121,7 +121,7 @@ newtype DiffusionTracers =
                 (P2P.DiffusionTracersExtra
                        RemoteAddress NodeToNodeVersion   NodeToNodeVersionData
                        LocalAddress  NodeToClientVersion NodeToClientVersionData
-                       IO))
+                       IOException IO))
         RemoteAddress NodeToNodeVersion
         LocalAddress  NodeToClientVersion
         IO)
@@ -334,12 +334,12 @@ mkDiffusionTracersP2P
   -> Tracer
        IO
        (DebugPeerSelection
-          SockAddr (P2P.NodeToNodePeerConnectionHandle 'InitiatorMode SockAddr Void))
+          SockAddr (P2P.NodeToNodePeerConnectionHandle 'InitiatorMode SockAddr IO Void))
   -> Tracer
        IO
        (DebugPeerSelection
           SockAddr
-          (P2P.NodeToNodePeerConnectionHandle 'InitiatorResponderMode SockAddr ()))
+          (P2P.NodeToNodePeerConnectionHandle 'InitiatorResponderMode SockAddr IO ()))
   -> Tracer IO PeerSelectionCounters
   -> Tracer IO (PeerSelectionActionsTrace SockAddr)
   -> Tracer

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -329,7 +329,7 @@ mkDiffusionTracersP2P
   -> Tracer IO NTC.HandshakeTr
   -> Tracer IO DiffusionInitializationTracer
   -> Tracer IO TraceLedgerPeers
-  -> Tracer IO (TraceLocalRootPeers IOException)
+  -> Tracer IO (TraceLocalRootPeers SockAddr IOException)
   -> Tracer IO TracePublicRootPeers
   -> Tracer IO (TracePeerSelection SockAddr)
   -> Tracer

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -85,29 +85,29 @@ import qualified Ouroboros.Network.NodeToClient as NTC
 import           Ouroboros.Network.RethrowPolicy (RethrowPolicy)
 import           Ouroboros.Network.BlockFetch (FetchMode)
 import           Ouroboros.Network.Mux
-                 ( Bundle
-                 , MiniProtocol
-                 , MuxMode (..)
-                 , OuroborosApplication
-                 , ControlMessage
-                 )
+                  ( Bundle
+                  , MiniProtocol
+                  , MuxMode (..)
+                  , OuroborosApplication
+                  , ControlMessage
+                  )
 import           Ouroboros.Network.PeerSelection.LedgerPeers
-                 ( LedgerPeersConsensusInterface
-                 , TraceLedgerPeers
-                 , RelayAddress
-                 , UseLedgerAfter
-                 )
+                  ( LedgerPeersConsensusInterface
+                  , TraceLedgerPeers
+                  , RelayAddress
+                  , UseLedgerAfter
+                  )
 import           Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics)
 
 import qualified Ouroboros.Network.Diffusion.Common as Common
 import           Ouroboros.Network.Diffusion.Common
-                 ( DiffusionInitializationTracer
-                 , DiffusionFailure
-                 , daDiffusionMode
-                 , dtExtra
-                 , daExtra
-                 , dapExtra
-                 )
+                  ( DiffusionInitializationTracer
+                  , DiffusionFailure
+                  , daDiffusionMode
+                  , dtExtra
+                  , daExtra
+                  , dapExtra
+                  )
 import qualified Ouroboros.Network.Diffusion.P2P as P2P
 import qualified Ouroboros.Network.Diffusion.NonP2P as NonP2P
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/NonP2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/NonP2P.hs
@@ -349,14 +349,14 @@ runDataDiffusion tracers
                    (Socket.SockAddrUnix path) -> do
                      traceWith dtDiffusionInitializationTracer
                       $ UsingSystemdSocket path
-                     return (LocalSocket sd, Snocket.localSnocket iocp path)
+                     return (LocalSocket sd, Snocket.localSnocket iocp)
                    unsupportedAddr -> do
                      traceWith dtDiffusionInitializationTracer
                       $ UnsupportedLocalSystemdSocket unsupportedAddr
                      throwIO UnsupportedLocalSocketType
 #endif
             Right addr -> do
-              let sn = Snocket.localSnocket iocp addr
+              let sn = Snocket.localSnocket iocp
               traceWith dtDiffusionInitializationTracer
                 $ CreateSystemdSocketForSnocketPath addr
               sd <- Snocket.open

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -17,15 +17,18 @@
 #define POSIX
 #endif
 
+-- | This module is expected to be imported qualified (it will clash
+-- with the "Ouroboros.Network.Diffusion.NonP2P").
+--
 module Ouroboros.Network.Diffusion.P2P
-  ( DiffusionTracersExtra (..)
+  ( TracersExtra (..)
   , nullTracers
-  , DiffusionArgumentsExtra (..)
+  , ArgumentsExtra (..)
   , AcceptedConnectionsLimit (..)
-  , DiffusionApplicationsExtra (..)
-  , runDataDiffusion
-  , DiffusionInterfaces (..)
-  , runDataDiffusionM
+  , ApplicationsExtra (..)
+  , run
+  , Interfaces (..)
+  , runM
 
   , NodeToNodePeerConnectionHandle
   )
@@ -151,10 +154,10 @@ import           Ouroboros.Network.Diffusion.Common hiding (nullTracers)
 
 -- | P2P DiffusionTracers Extras
 --
-data DiffusionTracersExtra ntnAddr ntnVersion ntnVersionData
+data TracersExtra ntnAddr ntnVersion ntnVersionData
                            ntcAddr ntcVersion ntcVersionData
                            resolverError m =
-    DiffusionTracersExtra {
+    TracersExtra {
       dtTraceLocalRootPeersTracer
         :: Tracer m (TraceLocalRootPeers ntnAddr resolverError)
 
@@ -223,12 +226,12 @@ data DiffusionTracersExtra ntnAddr ntnVersion ntnVersionData
     }
 
 nullTracers :: Applicative m
-            => DiffusionTracersExtra ntnAddr ntnVersion ntnVersionData
-                                     ntcAddr ntcVersion ntcVersionData
-                                     resolverError m
+            => TracersExtra ntnAddr ntnVersion ntnVersionData
+                            ntcAddr ntcVersion ntcVersionData
+                            resolverError m
 nullTracers = 
-    DiffusionTracersExtra {
-      dtTraceLocalRootPeersTracer                    = nullTracer
+    TracersExtra {
+        dtTraceLocalRootPeersTracer                  = nullTracer
       , dtTracePublicRootPeersTracer                 = nullTracer
       , dtTracePeerSelectionTracer                   = nullTracer
       , dtDebugPeerSelectionInitiatorTracer          = nullTracer
@@ -245,7 +248,7 @@ nullTracers =
 
 -- | P2P DiffusionArguments Extras
 --
-data DiffusionArgumentsExtra m = DiffusionArgumentsExtra {
+data ArgumentsExtra m = ArgumentsExtra {
       -- | selection targets for the peer governor
       --
       daPeerSelectionTargets :: PeerSelectionTargets
@@ -325,8 +328,8 @@ combineMiniProtocolBundles (MiniProtocolBundle initiators)
 
 -- | P2P DiffusionApplications Extras
 --
-data DiffusionApplicationsExtra ntnAddr m =
-    DiffusionApplicationsExtra {
+data ApplicationsExtra ntnAddr m =
+    ApplicationsExtra {
     -- | configuration of mini-protocol parameters; they impact size limits of
     -- mux ingress queues.
     --
@@ -354,7 +357,7 @@ data DiffusionApplicationsExtra ntnAddr m =
 -- configurations, i.e. 'InitiatorOnlyDiffusionMode', it will not run the
 -- responder side.  This type allows to reflect this.
 --
--- This is only used internally by 'runDataDiffusion'; This type allows to
+-- This is only used internally by 'run'; This type allows to
 -- construct configuration upfront, before all services like connection manager
 -- or server are initialised \/ started.
 --
@@ -500,11 +503,11 @@ type NodeToNodePeerSelectionActions (mode :: MuxMode) ntnAddr m a =
       (NodeToNodePeerConnectionHandle mode ntnAddr m a)
       m
 
-data DiffusionInterfaces ntnFd ntnAddr ntnVersion ntnVersionData
-                         ntcFd ntcAddr ntcVersion ntcVersionData
-                         resolver resolverError
-                         m =
-    DiffusionInterfaces {
+data Interfaces ntnFd ntnAddr ntnVersion ntnVersionData
+                ntcFd ntcAddr ntcVersion ntcVersionData
+                resolver resolverError
+                m =
+    Interfaces {
         -- | node-to-node snocket
         --
         diNtnSnocket 
@@ -570,7 +573,7 @@ data DiffusionInterfaces ntnFd ntnAddr ntnVersion ntnVersionData
           :: DNSActions resolver resolverError m
       }
 
-runDataDiffusionM
+runM
     :: forall m ntnFd ntnAddr ntnVersion ntnVersionData
                 ntcFd ntcAddr ntcVersion ntcVersionData
                 resolver resolverError.
@@ -595,75 +598,97 @@ runDataDiffusionM
        , Ord       ntcVersion
        , Exception resolverError
        )
-    => DiffusionInterfaces ntnFd ntnAddr ntnVersion ntnVersionData
-                           ntcFd ntcAddr ntcVersion ntcVersionData
-                           resolver resolverError
-                           m
-    -- ^ interfaces
-    -> DiffusionTracers (DiffusionTracersExtra ntnAddr ntnVersion ntnVersionData
-                                               ntcAddr ntcVersion ntcVersionData
-                                               resolverError m)
-                        ntnAddr ntnVersion
+    => -- | interfaces
+       Interfaces ntnFd ntnAddr ntnVersion ntnVersionData
+                  ntcFd ntcAddr ntcVersion ntcVersionData
+                  resolver resolverError
+                  m
+    -> -- | tracers
+       Tracers ntnAddr ntnVersion
                         ntcAddr ntcVersion
                         m
-    -- ^ tracers
-    -> DiffusionArguments (DiffusionArgumentsExtra m)
-                          ntnFd ntnAddr
+    -> -- | p2p tracers
+       TracersExtra ntnAddr ntnVersion ntnVersionData
+                             ntcAddr ntcVersion ntcVersionData
+                             resolverError m
+    -> -- | configuration
+       Arguments ntnFd ntnAddr
                           ntcFd ntcAddr
+    -> -- | p2p configuration
+       ArgumentsExtra m
 
-    -- ^ configuration
-    -> DiffusionApplications
-         (DiffusionApplicationsExtra ntnAddr m)
+    -> -- | protocol handlers
+       Applications
          ntnAddr ntnVersion ntnVersionData
          ntcAddr ntcVersion ntcVersionData
          m
-    -- ^ protocol handlers
+    -> -- | p2p protocol handlers
+       ApplicationsExtra ntnAddr m
     -> m Void
-runDataDiffusionM DiffusionInterfaces
-                  { diNtnSnocket 
-                  , diNtnHandshakeArguments
-                  , diNtnAddressType
-                  , diNtnDataFlow
-                  , diNtnToPeerAddr
-                  , diNtnDomainResolver
-                  , diNtcSnocket
-                  , diNtcHandshakeArguments
-                  , diNtcGetFileDescriptor
-                  , diRng
-                  , diInstallSigUSR1Handler
-                  , diDnsActions
-                  }
-
-                  tracers
-                  DiffusionArguments
-                  { daIPv4Address
-                  , daIPv6Address
-                  , daLocalAddress
-                  , daAcceptedConnectionsLimit
-                  , daDiffusionMode
-                  , daExtra = DiffusionArgumentsExtra
-                    { daPeerSelectionTargets
-                    , daReadLocalRootPeers
-                    , daReadPublicRootPeers
-                    , daReadUseLedgerAfter
-                    , daProtocolIdleTimeout
-                    , daTimeWaitTimeout
-                    }
-                  }
-
-                  DiffusionApplications
-                  { daApplicationInitiatorMode
-                  , daApplicationInitiatorResponderMode
-                  , daLocalResponderApplication
-                  , daLedgerPeersCtx
-                  , dapExtra = DiffusionApplicationsExtra
-                    { daMiniProtocolParameters
-                    , daRethrowPolicy
-                    , daLocalRethrowPolicy
-                    , daPeerMetrics
-                    , daBlockFetchMode
-                    }
-                  } =
+runM Interfaces
+       { diNtnSnocket 
+       , diNtnHandshakeArguments
+       , diNtnAddressType
+       , diNtnDataFlow
+       , diNtnToPeerAddr
+       , diNtnDomainResolver
+       , diNtcSnocket
+       , diNtcHandshakeArguments
+       , diNtcGetFileDescriptor
+       , diRng
+       , diInstallSigUSR1Handler
+       , diDnsActions
+       }
+     Tracers
+       { dtMuxTracer
+       , dtLocalMuxTracer
+       , dtLedgerPeersTracer
+       , dtDiffusionInitializationTracer = tracer
+       }
+     TracersExtra
+       { dtTracePeerSelectionTracer
+       , dtDebugPeerSelectionInitiatorTracer
+       , dtDebugPeerSelectionInitiatorResponderTracer
+       , dtTracePeerSelectionCounters
+       , dtPeerSelectionActionsTracer
+       , dtTraceLocalRootPeersTracer
+       , dtTracePublicRootPeersTracer
+       , dtConnectionManagerTracer
+       , dtServerTracer
+       , dtInboundGovernorTracer
+       , dtLocalConnectionManagerTracer
+       , dtLocalServerTracer
+       , dtLocalInboundGovernorTracer
+       }
+     Arguments
+       { daIPv4Address
+       , daIPv6Address
+       , daLocalAddress
+       , daAcceptedConnectionsLimit
+       , daDiffusionMode
+       }
+     ArgumentsExtra
+       { daPeerSelectionTargets
+       , daReadLocalRootPeers
+       , daReadPublicRootPeers
+       , daReadUseLedgerAfter
+       , daProtocolIdleTimeout
+       , daTimeWaitTimeout
+       }
+     Applications
+       { daApplicationInitiatorMode
+       , daApplicationInitiatorResponderMode
+       , daLocalResponderApplication
+       , daLedgerPeersCtx
+       }
+     ApplicationsExtra
+       { daMiniProtocolParameters
+       , daRethrowPolicy
+       , daLocalRethrowPolicy
+       , daPeerMetrics
+       , daBlockFetchMode
+       }
+      =
     -- TODO: this is wrong, the 'withTimeoutSerial' cannot be shared between
     -- concurrent threads!
     withTimeoutSerial $ \timeoutFn -> do
@@ -1119,30 +1144,6 @@ runDataDiffusionM DiffusionInterfaces
     (fuzzRng,        rng4) = split rng3
     (ntnInbgovRng,   ntcInbgovRng) = split rng4
 
-    DiffusionTracers {
-      dtMuxTracer
-      , dtLocalMuxTracer
-      , dtLedgerPeersTracer
-      -- the tracer
-      , dtDiffusionInitializationTracer = tracer
-      , dtExtra = DiffusionTracersExtra {
-          dtTracePeerSelectionTracer
-          , dtDebugPeerSelectionInitiatorTracer
-          , dtDebugPeerSelectionInitiatorResponderTracer
-          , dtTracePeerSelectionCounters
-          , dtPeerSelectionActionsTracer
-          , dtTraceLocalRootPeersTracer
-          , dtTracePublicRootPeersTracer
-          , dtConnectionManagerTracer
-          , dtServerTracer
-          , dtInboundGovernorTracer
-          , dtLocalConnectionManagerTracer
-          , dtLocalServerTracer
-          , dtLocalInboundGovernorTracer
-        }
-      } = tracers
-
-
     miniProtocolBundleInitiatorResponderMode
       :: MiniProtocolBundle InitiatorResponderMode
     miniProtocolBundleInitiatorResponderMode =
@@ -1248,24 +1249,27 @@ runDataDiffusionM DiffusionInterfaces
 --   information from the running system.  This is used by 'cardano-cli' or
 --   a wallet and a like local services.
 --
-runDataDiffusion
-    :: DiffusionTracers (DiffusionTracersExtra 
-                           RemoteAddress NodeToNodeVersion   NodeToNodeVersionData
-                           LocalAddress  NodeToClientVersion NodeToClientVersionData
-                           IOException IO)
-                        RemoteAddress NodeToNodeVersion
-                        LocalAddress  NodeToClientVersion
-                        IO
-    -> DiffusionArguments (DiffusionArgumentsExtra IO)
-                          Socket      RemoteAddress
-                          LocalSocket LocalAddress
-    -> DiffusionApplications
-         (DiffusionApplicationsExtra RemoteAddress IO)
-         RemoteAddress NodeToNodeVersion   NodeToNodeVersionData
-         LocalAddress  NodeToClientVersion NodeToClientVersionData
-         IO
+run :: -- | tracers
+       Tracers RemoteAddress NodeToNodeVersion
+               LocalAddress  NodeToClientVersion
+               IO
+    -> -- | p2p tracers
+       TracersExtra RemoteAddress NodeToNodeVersion   NodeToNodeVersionData
+                    LocalAddress  NodeToClientVersion NodeToClientVersionData
+                    IOException IO
+    -> -- | configuration
+       Arguments Socket      RemoteAddress
+                 LocalSocket LocalAddress
+    -> -- | p2p configuration
+       ArgumentsExtra IO
+    -> -- | protocol handlers
+       Applications RemoteAddress NodeToNodeVersion   NodeToNodeVersionData
+                    LocalAddress  NodeToClientVersion NodeToClientVersionData
+                    IO
+    -> -- | p2p protocol handlers
+       ApplicationsExtra RemoteAddress IO
     -> IO Void
-runDataDiffusion tracers args apps = do
+run tracers p2pTracers args p2pArgs apps p2pApps = do
     -- We run two services: for /node-to-node/ and /node-to-client/.  The
     -- naming convention is that we use /local/ prefix for /node-to-client/
     -- related terms, as this is a local only service running over a unix
@@ -1311,7 +1315,7 @@ runDataDiffusion tracers args apps = do
                      Signals.sigUSR1
                      (Signals.Catch
                        (do state <- readState connectionManager
-                           traceWith (dtConnectionManagerTracer . dtExtra $ tracers)
+                           traceWith (dtConnectionManagerTracer p2pTracers)
                                      (TrState state)
                        )
                      )
@@ -1325,29 +1329,28 @@ runDataDiffusion tracers args apps = do
                                   -> IO (Map DomainAddress (Set Socket.SockAddr))
                    diNtnDomainResolver =
                      resolveDomainAddresses
-                       (dtTracePublicRootPeersTracer . dtExtra $ tracers)
+                       (dtTracePublicRootPeersTracer p2pTracers)
                        timeoutFn
                        DNS.defaultResolvConf
                        ioDNSActions
                diRng <- newStdGen
-               runDataDiffusionM
-                  DiffusionInterfaces {
-                    diNtnSnocket,
-                    diNtnHandshakeArguments,
-                    diNtnAddressType = socketAddressType,
-                    diNtnDataFlow = nodeDataFlow,
-                    diNtnToPeerAddr = curry IP.toSockAddr,
-                    diNtnDomainResolver,
+               runM Interfaces {
+                      diNtnSnocket,
+                      diNtnHandshakeArguments,
+                      diNtnAddressType = socketAddressType,
+                      diNtnDataFlow = nodeDataFlow,
+                      diNtnToPeerAddr = curry IP.toSockAddr,
+                      diNtnDomainResolver,
 
-                    diNtcSnocket,
-                    diNtcHandshakeArguments,
-                    diNtcGetFileDescriptor = localSocketFileDescriptor,
+                      diNtcSnocket,
+                      diNtcHandshakeArguments,
+                      diNtcGetFileDescriptor = localSocketFileDescriptor,
 
-                    diRng,
-                    diInstallSigUSR1Handler,
-                    diDnsActions = ioDNSActions
-                  }
-                  tracers args apps
+                      diRng,
+                      diInstallSigUSR1Handler,
+                      diDnsActions = ioDNSActions
+                    }
+                    tracers p2pTracers args p2pArgs apps p2pApps
 
 --
 -- Data flow
@@ -1384,7 +1387,7 @@ withSockets :: forall m ntnFd ntnAddr ntcAddr a.
                , Typeable ntnAddr
                , Show     ntnAddr
                )
-            => Tracer m (DiffusionInitializationTracer ntnAddr ntcAddr)
+            => Tracer m (InitializationTracer ntnAddr ntcAddr)
             -> Snocket m ntnFd ntnAddr
             -> [Either ntnFd ntnAddr]
             -> (NonEmpty ntnFd -> NonEmpty ntnAddr -> m a)
@@ -1392,7 +1395,7 @@ withSockets :: forall m ntnFd ntnAddr ntcAddr a.
 withSockets tracer sn addresses k = go [] addresses
   where
     go !acc (a : as) = withSocket a (\sa -> go (sa : acc) as)
-    go []   []       = throwIO (NoSocket :: DiffusionFailure ntnAddr)
+    go []   []       = throwIO (NoSocket :: Failure ntnAddr)
     go !acc []       =
       let acc' = NonEmpty.fromList (reverse acc)
       in (k $! (fst <$> acc')) $! (snd <$> acc')
@@ -1427,7 +1430,7 @@ withLocalSocket :: forall ntnAddr ntcFd ntcAddr m a.
                    , Typeable ntnAddr
                    , Show     ntnAddr
                    )
-                => Tracer m (DiffusionInitializationTracer ntnAddr ntcAddr)
+                => Tracer m (InitializationTracer ntnAddr ntcAddr)
                 -> (ntcFd -> m FileDescriptor)
                 -> Snocket m ntcFd ntcAddr
                 -> Either ntcFd ntcAddr
@@ -1440,8 +1443,8 @@ withLocalSocket tracer getFileDescriptor sn localAddress k =
 #if defined(mingw32_HOST_OS)
          -- Windows uses named pipes so can't take advantage of existing sockets
          Left _ -> traceWith tracer (UnsupportedReadySocketCase
-                                       :: DiffusionInitializationTracer ntnAddr ntcAddr)
-                >> throwIO (UnsupportedReadySocket :: DiffusionFailure ntnAddr)
+                                       :: InitializationTracer ntnAddr ntcAddr)
+                >> throwIO (UnsupportedReadySocket :: Failure ntnAddr)
 #else
          Left sd -> do
              addr <- Snocket.getLocalAddr sn sd

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -32,6 +32,7 @@ import           Control.Monad.Class.MonadTime
 import           Control.Exception
 import           Control.Tracer (Tracer, nullTracer, traceWith)
 import           Data.Foldable (asum)
+import qualified Data.IP as IP
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map (Map)
@@ -143,7 +144,7 @@ import           Ouroboros.Network.Diffusion.Common
 --
 data DiffusionTracersExtra = DiffusionTracersExtra {
       dtTraceLocalRootPeersTracer
-        :: Tracer IO (TraceLocalRootPeers IOException)
+        :: Tracer IO (TraceLocalRootPeers SockAddr IOException)
 
     , dtTracePublicRootPeersTracer
         :: Tracer IO TracePublicRootPeers
@@ -697,6 +698,7 @@ runDataDiffusion tracers
           Async.withAsync
             (runLedgerPeers
               ledgerPeersRng
+              (curry IP.toSockAddr)
               dtLedgerPeersTracer
               daReadUseLedgerAfter
               daLedgerPeersCtx
@@ -803,6 +805,7 @@ runDataDiffusion tracers
                     withPeerSelectionActions
                       dtTraceLocalRootPeersTracer
                       dtTracePublicRootPeersTracer
+                      (curry IP.toSockAddr)
                       timeout
                       (readTVar peerSelectionTargetsVar)
                       daReadLocalRootPeers
@@ -940,6 +943,7 @@ runDataDiffusion tracers
                     withPeerSelectionActions
                       dtTraceLocalRootPeersTracer
                       dtTracePublicRootPeersTracer
+                      (curry IP.toSockAddr)
                       timeout
                       (readTVar peerSelectionTargetsVar)
                       daReadLocalRootPeers

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -315,22 +315,25 @@ data DiffusionApplicationsExtra ntnAddr m =
     -- | configuration of mini-protocol parameters; they impact size limits of
     -- mux ingress queues.
     --
-    daMiniProtocolParameters :: MiniProtocolParameters
+      daMiniProtocolParameters :: MiniProtocolParameters
 
     -- | /node-to-node/ rethrow policy
     --
-    , daRethrowPolicy      :: RethrowPolicy
+    , daRethrowPolicy          :: RethrowPolicy
 
     -- | /node-to-client/ rethrow policy
     --
-    , daLocalRethrowPolicy :: RethrowPolicy
+    , daLocalRethrowPolicy     :: RethrowPolicy
 
-    , daPeerMetrics        :: PeerMetrics m ntnAddr
+    -- | 'PeerMetrics' used by peer selection policy (see
+    -- 'simplePeerSelectionPolicy')
+    --
+    , daPeerMetrics            :: PeerMetrics m ntnAddr
 
     -- | Used by churn-governor
     --
-    , daBlockFetchMode     :: STM m FetchMode
-    }
+    , daBlockFetchMode         :: STM m FetchMode
+  }
 
 -- | Diffusion will always run initiator of node-to-node protocols, but in some
 -- configurations, i.e. 'InitiatorOnlyDiffusionMode', it will not run the

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -9,6 +9,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
+-- `withLocalSocket` has some constraints that are only required on Windows.
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
 #if !defined(mingw32_HOST_OS)
 #define POSIX
 #endif
@@ -28,16 +31,19 @@ module Ouroboros.Network.Diffusion.P2P
 import qualified Control.Monad.Class.MonadAsync as Async
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
-import           Control.Exception
+import           Control.Exception (IOException)
 import           Control.Tracer (Tracer, nullTracer, traceWith)
 import           Data.Foldable (asum)
+import           Data.IP (IP)
 import qualified Data.IP as IP
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map (Map)
 import           Data.Maybe (catMaybes, maybeToList)
 import           Data.Set (Set)
+import           Data.Typeable (Typeable)
 import           Data.Void (Void)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Kind (Type)
@@ -53,18 +59,21 @@ import           Network.Mux
                   )
 import           Network.Mux.Timeout (withTimeoutSerial)
 import qualified Network.DNS as DNS
-import           Network.Socket (SockAddr (..), Socket, AddrInfo)
+import           Network.Socket (Socket)
 import qualified Network.Socket as Socket
 
 import           Ouroboros.Network.Snocket
                   ( LocalAddress
                   , LocalSnocket
                   , LocalSocket (..)
+                  , FileDescriptor
+                  , Snocket
                   , SocketSnocket
                   , localSocketFileDescriptor
                   )
 import qualified Ouroboros.Network.Snocket as Snocket
 
+import           Ouroboros.Network.ConnectionId
 import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.Protocol.Handshake
 import           Ouroboros.Network.Protocol.Handshake.Version
@@ -80,6 +89,7 @@ import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..))
 import           Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics (..))
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
                   ( resolveDomainAddresses
+                  , DomainAddress
                   , RelayAddress(..)
                   , TraceLocalRootPeers(..)
                   , TracePublicRootPeers(..)
@@ -129,61 +139,60 @@ import           Ouroboros.Network.NodeToNode
                   , blockFetchProtocolLimits
                   , txSubmissionProtocolLimits
                   , keepAliveProtocolLimits
-                  , nodeToNodeHandshakeCodec
                   )
 import qualified Ouroboros.Network.NodeToNode   as NodeToNode
-import           Ouroboros.Network.Diffusion.Common
-                  ( DiffusionTracers(..)
-                  , DiffusionArguments(..)
-                  , DiffusionApplications(..)
-                  , DiffusionInitializationTracer(..)
-                  , DiffusionFailure(..)
-                  )
+import           Ouroboros.Network.Diffusion.Common hiding (nullTracers)
 
 -- | P2P DiffusionTracers Extras
 --
-data DiffusionTracersExtra = DiffusionTracersExtra {
+data DiffusionTracersExtra ntnAddr ntnVersion ntnVersionData
+                           ntcAddr ntcVersion ntcVersionData m =
+    DiffusionTracersExtra {
       dtTraceLocalRootPeersTracer
-        :: Tracer IO (TraceLocalRootPeers SockAddr IOException)
+        :: Tracer m (TraceLocalRootPeers ntnAddr IOException)
 
     , dtTracePublicRootPeersTracer
-        :: Tracer IO TracePublicRootPeers
+        :: Tracer m TracePublicRootPeers
 
     , dtTracePeerSelectionTracer
-        :: Tracer IO (TracePeerSelection SockAddr)
+        :: Tracer m (TracePeerSelection ntnAddr)
 
     , dtDebugPeerSelectionInitiatorTracer
-        :: Tracer IO (DebugPeerSelection
-                       SockAddr
-                         (NodeToNodePeerConnectionHandle
-                            InitiatorMode
-                            Void))
+        :: Tracer m (DebugPeerSelection
+                       ntnAddr
+                       (PeerConnectionHandle
+                         InitiatorMode
+                         ntnAddr
+                         ByteString
+                         m () Void))
 
     , dtDebugPeerSelectionInitiatorResponderTracer
-        :: Tracer IO (DebugPeerSelection
-                       SockAddr
-                         (NodeToNodePeerConnectionHandle
-                            InitiatorResponderMode
-                            ()))
+        :: Tracer m (DebugPeerSelection
+                       ntnAddr
+                       (PeerConnectionHandle
+                         InitiatorResponderMode
+                         ntnAddr
+                         ByteString
+                         m () ()))
 
     , dtTracePeerSelectionCounters
-        :: Tracer IO PeerSelectionCounters
+        :: Tracer m PeerSelectionCounters
 
     , dtPeerSelectionActionsTracer
-        :: Tracer IO (PeerSelectionActionsTrace SockAddr)
+        :: Tracer m (PeerSelectionActionsTrace ntnAddr)
 
     , dtConnectionManagerTracer
-        :: Tracer IO (ConnectionManagerTrace
-                       SockAddr
-                       (ConnectionHandlerTrace
-                          NodeToNodeVersion
-                          NodeToNodeVersionData))
+        :: Tracer m (ConnectionManagerTrace
+                      ntnAddr
+                      (ConnectionHandlerTrace
+                         ntnVersion
+                         ntnVersionData))
 
     , dtServerTracer
-        :: Tracer IO (ServerTrace SockAddr)
+        :: Tracer m (ServerTrace ntnAddr)
 
     , dtInboundGovernorTracer
-        :: Tracer IO (InboundGovernorTrace SockAddr)
+        :: Tracer m (InboundGovernorTrace ntnAddr)
 
       --
       -- NodeToClient tracers
@@ -191,25 +200,26 @@ data DiffusionTracersExtra = DiffusionTracersExtra {
 
       -- | Connection manager tracer for local clients
     , dtLocalConnectionManagerTracer
-        :: Tracer IO (ConnectionManagerTrace
-                       LocalAddress
+        :: Tracer m (ConnectionManagerTrace
+                       ntcAddr
                        (ConnectionHandlerTrace
-                          NodeToClientVersion
-                          NodeToClientVersionData))
+                          ntcVersion
+                          ntcVersionData))
 
       -- | Server tracer for local clients
     , dtLocalServerTracer
-        :: Tracer IO (ServerTrace LocalAddress)
+        :: Tracer m (ServerTrace ntcAddr)
 
       -- | Inbound protocol governor tracer for local clients
     , dtLocalInboundGovernorTracer
-        :: Tracer IO (InboundGovernorTrace LocalAddress)
+        :: Tracer m (InboundGovernorTrace ntcAddr)
     }
 
-nullTracers :: DiffusionTracersExtra
-nullTracers = p2pNullTracers
-  where
-  p2pNullTracers =
+nullTracers :: Applicative m
+            => DiffusionTracersExtra ntnAddr ntnVersion ntnVersionData
+                                     ntcAddr ntcVersion ntcVersionData
+                                     m
+nullTracers = 
     DiffusionTracersExtra {
       dtTraceLocalRootPeersTracer                    = nullTracer
       , dtTracePublicRootPeersTracer                 = nullTracer
@@ -308,9 +318,6 @@ combineMiniProtocolBundles (MiniProtocolBundle initiators)
 
 -- | P2P DiffusionApplications Extras
 --
--- TODO: we need initiator only mode for Deadalus, there's no reason why it
--- should run a node-to-node server side.
---
 data DiffusionApplicationsExtra ntnAddr m =
     DiffusionApplicationsExtra {
     -- | configuration of mini-protocol parameters; they impact size limits of
@@ -358,17 +365,17 @@ data HasMuxMode (f :: MuxMode -> Type) where
 -- | Node-To-Node connection manager requires extra data when running in
 -- 'InitiatorResponderMode'.
 --
-data ConnectionManagerDataInMode (mode :: MuxMode) where
+data ConnectionManagerDataInMode peerAddr (mode :: MuxMode) where
     CMDInInitiatorMode
-      :: ConnectionManagerDataInMode InitiatorMode
+      :: ConnectionManagerDataInMode peerAddr InitiatorMode
 
     CMDInInitiatorResponderMode
       :: Server.ControlChannel IO
           (Server.NewConnection
-            SockAddr
-            (Handle InitiatorResponderMode SockAddr ByteString IO () ()))
+            peerAddr
+            (Handle InitiatorResponderMode peerAddr ByteString IO () ()))
       -> StrictTVar IO Server.InboundGovernorObservableState
-      -> ConnectionManagerDataInMode InitiatorResponderMode
+      -> ConnectionManagerDataInMode peerAddr InitiatorResponderMode
 
 
 --
@@ -377,40 +384,43 @@ data ConnectionManagerDataInMode (mode :: MuxMode) where
 -- Node-To-Client diffusion is only used in 'ResponderMode'.
 --
 
-type NodeToClientHandle =
-    Handle ResponderMode LocalAddress ByteString IO Void ()
+type NodeToClientHandle ntcAddr =
+    Handle ResponderMode ntcAddr ByteString IO Void ()
 
-type NodeToClientHandleError =
-    HandleError ResponderMode NodeToClientVersion
+type NodeToClientHandleError ntcVersion =
+    HandleError ResponderMode ntcVersion
 
-type NodeToClientConnectionHandler =
+type NodeToClientConnectionHandler
+      ntcFd ntcAddr ntcVersion ntcVersionData =
     ConnectionHandler
       ResponderMode
-      (ConnectionHandlerTrace NodeToClientVersion NodeToClientVersionData)
-      LocalSocket
-      LocalAddress
-      NodeToClientHandle
-      NodeToClientHandleError
-      (NodeToClientVersion, NodeToClientVersionData)
+      (ConnectionHandlerTrace ntcVersion ntcVersionData)
+      ntcFd
+      ntcAddr
+      (NodeToClientHandle ntcAddr)
+      (NodeToClientHandleError ntcVersion)
+      (ntcVersion, ntcVersionData)
       IO
 
-type NodeToClientConnectionManagerArguments =
+type NodeToClientConnectionManagerArguments
+      ntcFd ntcAddr ntcVersion ntcVersionData =
     ConnectionManagerArguments
-      (ConnectionHandlerTrace NodeToClientVersion NodeToClientVersionData)
-      LocalSocket
-      LocalAddress
-      NodeToClientHandle
-      NodeToClientHandleError
-      (NodeToClientVersion, NodeToClientVersionData)
+      (ConnectionHandlerTrace ntcVersion ntcVersionData)
+      ntcFd
+      ntcAddr
+      (NodeToClientHandle ntcAddr)
+      (NodeToClientHandleError ntcVersion)
+      (ntcVersion, ntcVersionData)
       IO
 
-type NodeToClientConnectionManager =
+type NodeToClientConnectionManager
+      ntcFd ntcAddr ntcVersion ntcVersionData =
     ConnectionManager
       ResponderMode
-      LocalSocket
-      LocalAddress
-      NodeToClientHandle
-      NodeToClientHandleError
+      ntcFd
+      ntcAddr
+      (NodeToClientHandle ntcAddr)
+      (NodeToClientHandleError ntcVersion)
       IO
 
 --
@@ -419,63 +429,72 @@ type NodeToClientConnectionManager =
 -- Node-To-Node diffusion runs in either 'InitiatorMode' or 'InitiatorResponderMode'.
 --
 
-type NodeToNodeHandle (mode :: MuxMode) a =
-    Handle mode SockAddr ByteString IO () a
+type NodeToNodeHandle
+       (mode :: MuxMode)
+       ntnAddr
+       a =
+    Handle mode ntnAddr ByteString IO () a
 
-type NodeToNodeHandleError (mode :: MuxMode) =
-    HandleError mode NodeToNodeVersion
-
-type NodeToNodeConnectionHandler (mode :: MuxMode) a =
+type NodeToNodeConnectionHandler
+       (mode :: MuxMode)
+       ntnFd ntnAddr ntnVersion ntnVersionData
+       a =
     ConnectionHandler
       mode
-     (ConnectionHandlerTrace NodeToNodeVersion NodeToNodeVersionData)
-     Socket
-     SockAddr
-      (NodeToNodeHandle mode a)
-      (NodeToNodeHandleError mode)
-     (NodeToNodeVersion, NodeToNodeVersionData)
-     IO
-
-type NodeToNodeConnectionManagerArguments (mode :: MuxMode) a =
-    ConnectionManagerArguments
-      (ConnectionHandlerTrace NodeToNodeVersion NodeToNodeVersionData)
-      Socket
-      SockAddr
-      (NodeToNodeHandle mode a)
-      (NodeToNodeHandleError mode)
-      (NodeToNodeVersion, NodeToNodeVersionData)
+      (ConnectionHandlerTrace ntnVersion ntnVersionData)
+      ntnFd
+      ntnAddr
+      (NodeToNodeHandle mode ntnAddr a)
+      (HandleError mode ntnVersion)
+      (ntnVersion, ntnVersionData)
       IO
 
-type NodeToNodeConnectionManager (mode :: MuxMode) a =
+type NodeToNodeConnectionManagerArguments
+       (mode :: MuxMode)
+       ntnFd ntnAddr ntnVersion ntnVersionData
+       a =
+    ConnectionManagerArguments
+      (ConnectionHandlerTrace ntnVersion ntnVersionData)
+      ntnFd
+      ntnAddr
+      (NodeToNodeHandle mode ntnAddr a)
+      (HandleError mode ntnVersion)
+      (ntnVersion, ntnVersionData)
+      IO
+
+type NodeToNodeConnectionManager
+       (mode :: MuxMode)
+       ntnFd ntnAddr ntnVersion
+       a =
     ConnectionManager
       mode
-      Socket
-      SockAddr
-      (NodeToNodeHandle mode a)
-      (NodeToNodeHandleError mode)
+      ntnFd
+      ntnAddr
+      (NodeToNodeHandle mode ntnAddr a)
+      (HandleError mode ntnVersion)
       IO
 
 --
 -- Governor type aliases
 --
 
-type NodeToNodePeerConnectionHandle (mode :: MuxMode) a =
+type NodeToNodePeerConnectionHandle (mode :: MuxMode) ntnAddr a =
     PeerConnectionHandle
       mode
-      SockAddr
+      ntnAddr
       ByteString
       IO () a
 
-type NodeToNodePeerStateActions (mode :: MuxMode) a =
+type NodeToNodePeerStateActions (mode :: MuxMode) ntnAddr a =
     Governor.PeerStateActions
-      SockAddr
-      (NodeToNodePeerConnectionHandle mode a)
+      ntnAddr
+      (NodeToNodePeerConnectionHandle mode ntnAddr a)
       IO
 
-type NodeToNodePeerSelectionActions (mode :: MuxMode) a =
+type NodeToNodePeerSelectionActions (mode :: MuxMode) ntnAddr a =
     Governor.PeerSelectionActions
-      SockAddr
-      (NodeToNodePeerConnectionHandle mode a)
+      ntnAddr
+      (NodeToNodePeerConnectionHandle mode ntnAddr a)
       IO
 
 -- | Main entry point for data diffusion service.  It allows to:
@@ -488,74 +507,180 @@ type NodeToNodePeerSelectionActions (mode :: MuxMode) a =
 --   a wallet and a like local services.
 --
 runDataDiffusion
-    :: DiffusionTracers DiffusionTracersExtra
+    :: DiffusionTracers (DiffusionTracersExtra 
+                           RemoteAddress NodeToNodeVersion   NodeToNodeVersionData
+                           LocalAddress  NodeToClientVersion NodeToClientVersionData
+                           IO)
+                        RemoteAddress NodeToNodeVersion
+                        LocalAddress  NodeToClientVersion
+                        IO
     -> DiffusionArguments (DiffusionArgumentsExtra IO)
+                          Socket      RemoteAddress
+                          LocalSocket LocalAddress
     -> DiffusionApplications
          (DiffusionApplicationsExtra RemoteAddress IO)
-         RemoteAddress
-         LocalAddress
-         NodeToNodeVersionData
-         NodeToClientVersionData
+         RemoteAddress NodeToNodeVersion   NodeToNodeVersionData
+         LocalAddress  NodeToClientVersion NodeToClientVersionData
          IO
     -> IO Void
-runDataDiffusion tracers
-                 DiffusionArguments
-                 { daIPv4Address
-                 , daIPv6Address
-                 , daLocalAddress
-                 , daAcceptedConnectionsLimit
-                 , daDiffusionMode
-                 , daExtra = DiffusionArgumentsExtra
-                   { daPeerSelectionTargets
-                   , daReadLocalRootPeers
-                   , daReadPublicRootPeers
-                   , daReadUseLedgerAfter
-                   , daProtocolIdleTimeout
-                   , daTimeWaitTimeout
-                   }
-                 }
-                 DiffusionApplications
-                 { daApplicationInitiatorMode
-                 , daApplicationInitiatorResponderMode
-                 , daLocalResponderApplication
-                 , daLedgerPeersCtx
-                 , dapExtra = DiffusionApplicationsExtra
-                   { daMiniProtocolParameters
-                   , daRethrowPolicy
-                   , daLocalRethrowPolicy
-                   , daPeerMetrics
-                   , daBlockFetchMode
-                   }
-                 } =
+runDataDiffusion tracers args apps = do
     -- We run two services: for /node-to-node/ and /node-to-client/.  The
     -- naming convention is that we use /local/ prefix for /node-to-client/
     -- related terms, as this is a local only service running over a unix
     -- socket / windows named pipe.
-    handle (\e -> traceWith tracer (DiffusionErrored e)
-               >> throwIO e) $
-    withIOManager $ \iocp ->
+    handle (\e -> traceWith (dtDiffusionInitializationTracer tracers)
+                            (DiffusionErrored e)
+               >> throwIO e)
+         $ withIOManager $ \iocp -> do
+             let ntnSnocket :: SocketSnocket
+                 ntnSnocket = Snocket.socketSnocket iocp
+
+                 ntcSnocket :: LocalSnocket
+                 ntcSnocket = Snocket.localSnocket iocp
+
+                 ntnHandshakeArgs =
+                   HandshakeArguments {
+                       haHandshakeTracer = dtHandshakeTracer tracers,
+                       haHandshakeCodec  = NodeToNode.nodeToNodeHandshakeCodec,
+                       haVersionDataCodec =
+                         cborTermVersionDataCodec
+                           NodeToNode.nodeToNodeCodecCBORTerm,
+                       haAcceptVersion = acceptableVersion,
+                       haTimeLimits = timeLimitsHandshake
+                     }
+                 ntcHandshakeArgs =
+                   HandshakeArguments {
+                       haHandshakeTracer  = dtLocalHandshakeTracer tracers,
+                       haHandshakeCodec   = NodeToClient.nodeToClientHandshakeCodec,
+                       haVersionDataCodec =
+                         cborTermVersionDataCodec
+                           NodeToClient.nodeToClientCodecCBORTerm,
+                       haAcceptVersion = acceptableVersion,
+                       haTimeLimits = noTimeLimitsHandshake
+                     }
+             withTimeoutSerial $ \timeoutFn ->
+               let domainResolver :: [DomainAddress]
+                                  -> IO (Map DomainAddress (Set Socket.SockAddr))
+                   domainResolver =
+                     resolveDomainAddresses
+                       (dtTracePublicRootPeersTracer . dtExtra $ tracers)
+                       timeoutFn
+                       DNS.defaultResolvConf
+                       ioDNSActions
+               in runDataDiffusionM
+                    ntnSnocket
+                    ntnHandshakeArgs
+                    socketAddressType
+                    nodeDataFlow
+                    (curry IP.toSockAddr)
+                    domainResolver
+                    ntcSnocket
+                    ntcHandshakeArgs
+                    localSocketFileDescriptor
+                    tracers args apps
+
+
+runDataDiffusionM
+    :: forall m ntnFd ntnAddr ntnVersion ntnVersionData
+                ntcFd ntcAddr ntcVersion ntcVersionData.
+       ( Monad m
+       , Typeable ntnAddr
+       , Ord      ntnAddr
+       , Show     ntnAddr
+       , Typeable ntnVersion
+       , Ord      ntnVersion
+       , Show     ntnVersion
+       , Typeable ntcAddr
+       , Ord      ntcAddr
+       , Show     ntcAddr
+       , Ord      ntcVersion
+       , m ~ IO
+       )
+    => Snocket m ntnFd ntnAddr
+    -> HandshakeArguments (ConnectionId ntnAddr) ntnVersion ntnVersionData m
+    -> (ntnAddr -> Maybe AddressType)
+    -> (ntnVersion -> ntnVersionData -> DataFlow)
+    -> (IP -> Socket.PortNumber -> ntnAddr)
+    -> ([DomainAddress] -> m (Map DomainAddress (Set ntnAddr)))
+    -> Snocket m ntcFd ntcAddr
+    -> HandshakeArguments (ConnectionId ntcAddr) ntcVersion ntcVersionData m
+    -> (ntcFd -> m FileDescriptor)
+    -> DiffusionTracers (DiffusionTracersExtra ntnAddr ntnVersion ntnVersionData
+                                               ntcAddr ntcVersion ntcVersionData
+                                               m)
+                        ntnAddr ntnVersion
+                        ntcAddr ntcVersion
+                        m
+    -> DiffusionArguments (DiffusionArgumentsExtra m)
+                          ntnFd ntnAddr
+                          ntcFd ntcAddr
+    -> DiffusionApplications
+         (DiffusionApplicationsExtra ntnAddr m)
+         ntnAddr ntnVersion ntnVersionData
+         ntcAddr ntcVersion ntcVersionData
+         m
+    -> m Void
+runDataDiffusionM ntnSnocket ntnHandshakeArgs
+                  ntnAddressType ntnDataFlow
+                  ntnToPeerAddr
+                  domainResolver
+                  ntcSnocket ntcHandshakeArgs
+                  ntcGetFileDescriptor
+                  tracers
+                  DiffusionArguments
+                  { daIPv4Address
+                  , daIPv6Address
+                  , daLocalAddress
+                  , daAcceptedConnectionsLimit
+                  , daDiffusionMode
+                  , daExtra = DiffusionArgumentsExtra
+                    { daPeerSelectionTargets
+                    , daReadLocalRootPeers
+                    , daReadPublicRootPeers
+                    , daReadUseLedgerAfter
+                    , daProtocolIdleTimeout
+                    , daTimeWaitTimeout
+                    }
+                  }
+                  DiffusionApplications
+                  { daApplicationInitiatorMode
+                  , daApplicationInitiatorResponderMode
+                  , daLocalResponderApplication
+                  , daLedgerPeersCtx
+                  , dapExtra = DiffusionApplicationsExtra
+                    { daMiniProtocolParameters
+                    , daRethrowPolicy
+                    , daLocalRethrowPolicy
+                    , daPeerMetrics
+                    , daBlockFetchMode
+                    }
+                  } =
+    -- TODO: this is wrong, the 'withTimeoutSerial' cannot be shared between
+    -- concurrent threads!
     withTimeoutSerial $ \timeout -> do
 
     -- Thread to which 'RethrowPolicy' will throw fatal exceptions.
     mainThreadId <- myThreadId
 
     cmIPv4Address
-      <- traverse (either Socket.getSocketName (pure . Socket.addrAddress))
+      <- traverse (either (Snocket.getLocalAddr ntnSnocket) pure)
                   daIPv4Address
     case cmIPv4Address of
-      Just SockAddrInet  {} -> pure ()
-      Just SockAddrInet6 {} -> throwIO UnexpectedIPv6Address
-      Just SockAddrUnix  {} -> throwIO UnexpectedUnixAddress
-      Nothing               -> pure ()
+      Just addr | Just IPv4Address <- ntnAddressType addr
+                -> pure ()
+                | otherwise
+                -> throwIO (UnexpectedIPv4Address addr)
+      Nothing   -> pure ()
 
     cmIPv6Address
-      <- traverse (either Socket.getSocketName (pure . Socket.addrAddress))
+      <- traverse (either (Snocket.getLocalAddr ntnSnocket) pure)
                   daIPv6Address
     case cmIPv6Address of
-      Just SockAddrInet {}  -> throwIO UnexpectedIPv4Address
-      Just SockAddrInet6 {} -> pure ()
-      Just SockAddrUnix {}  -> throwIO UnexpectedUnixAddress
-      Nothing               -> pure ()
+      Just addr | Just IPv6Address <- ntnAddressType addr
+                -> pure ()
+                | otherwise
+                -> throwIO (UnexpectedIPv6Address addr)
+      Nothing   -> pure ()
 
     -- control channel for the server; only required in
     -- @'InitiatorResponderMode' :: 'MuxMode'@
@@ -586,12 +711,12 @@ runDataDiffusion tracers
     churnModeVar <- newTVarIO ChurnModeNormal
 
     -- Request interface, supply the number of peers desired.
-    ledgerPeersReq <- newEmptyTMVarIO :: IO (StrictTMVar IO NumberOfPeers)
+    ledgerPeersReq <- newEmptyTMVarIO :: m (StrictTMVar m NumberOfPeers)
     -- Response interface, returns a Set of peers. Nothing indicates that the
     -- ledger hasn't caught up to `useLedgerAfter`. May return less than
     -- the number of peers requested.
     ledgerPeersRsp <- newEmptyTMVarIO
-                      :: IO (StrictTMVar IO (Maybe (Set SockAddr, DiffTime)))
+                      :: m (StrictTMVar m (Maybe (Set ntnAddr, DiffTime)))
 
 
     peerSelectionTargetsVar <- newTVarIO $ daPeerSelectionTargets {
@@ -601,38 +726,26 @@ runDataDiffusion tracers
           min 2 (targetNumberOfActivePeers daPeerSelectionTargets)
       }
 
-    let -- snocket for remote communication.
-        snocket :: SocketSnocket
-        snocket = Snocket.socketSnocket iocp
-
-        localConnectionLimits = AcceptedConnectionsLimit maxBound maxBound 0
+    let localConnectionLimits = AcceptedConnectionsLimit maxBound maxBound 0
 
         --
         -- local connection manager
         --
-        localThread :: Maybe (IO Void)
+        localThread :: Maybe (m Void)
         localThread =
           case daLocalAddress of
             Nothing -> Nothing
             Just localAddr ->
-               Just $ withLocalSocket iocp tracer localAddr
-                       $ \localSnocket localSocket -> do
+              Just $ withLocalSocket tracer ntcGetFileDescriptor ntcSnocket localAddr
+                       $ \localSocket -> do
                 let localConnectionHandler :: NodeToClientConnectionHandler
+                                                ntcFd ntcAddr ntcVersion ntcVersionData
                     localConnectionHandler =
                       makeConnectionHandler
                         dtLocalMuxTracer
                         SingResponderMode
                         localMiniProtocolBundle
-                        HandshakeArguments {
-                            haHandshakeTracer = dtLocalHandshakeTracer,
-                            haHandshakeCodec =
-                              NodeToClient.nodeToClientHandshakeCodec,
-                            haVersionDataCodec =
-                              cborTermVersionDataCodec
-                                NodeToClient.nodeToClientCodecCBORTerm,
-                            haAcceptVersion = acceptableVersion,
-                            haTimeLimits = noTimeLimitsHandshake
-                          }
+                        ntcHandshakeArgs
                         ( ( \ (OuroborosApplication apps)
                            -> Bundle
                                 (WithHot apps)
@@ -643,6 +756,7 @@ runDataDiffusion tracers
 
                     localConnectionManagerArguments
                       :: NodeToClientConnectionManagerArguments
+                           ntcFd ntcAddr ntcVersion ntcVersionData
                     localConnectionManagerArguments =
                       ConnectionManagerArguments {
                           cmTracer              = dtLocalConnectionManagerTracer,
@@ -651,7 +765,7 @@ runDataDiffusion tracers
                           cmIPv4Address         = Nothing,
                           cmIPv6Address         = Nothing,
                           cmAddressType         = const Nothing,
-                          cmSnocket             = localSnocket,
+                          cmSnocket             = ntcSnocket,
                           cmTimeWaitTimeout     = local_TIME_WAIT_TIMEOUT,
                           cmOutboundIdleTimeout = local_PROTOCOL_IDLE_TIMEOUT,
                           connectionDataFlow    = uncurry localDataFlow,
@@ -665,7 +779,8 @@ runDataDiffusion tracers
                   localConnectionHandler
                   classifyHandleError
                   (InResponderMode localControlChannel)
-                  $ \(localConnectionManager :: NodeToClientConnectionManager)
+                  $ \(localConnectionManager :: NodeToClientConnectionManager
+                                                  ntcFd ntcAddr ntcVersion ntcVersionData) 
                     -> do
 
                   --
@@ -673,13 +788,13 @@ runDataDiffusion tracers
                   --
 
                   traceWith tracer . RunLocalServer
-                    =<< Snocket.getLocalAddr localSnocket localSocket
+                    =<< Snocket.getLocalAddr ntcSnocket localSocket
 
                   Async.withAsync
                     (Server.run
                       ServerArguments {
                           serverSockets               = localSocket :| [],
-                          serverSnocket               = localSnocket,
+                          serverSnocket               = ntcSnocket,
                           serverTracer                = dtLocalServerTracer,
                           serverInboundGovernorTracer = dtLocalInboundGovernorTracer,
                           serverInboundIdleTimeout    = local_PROTOCOL_IDLE_TIMEOUT,
@@ -693,21 +808,16 @@ runDataDiffusion tracers
         -- remote connection manager
         --
 
-        remoteThread :: IO Void
+        remoteThread :: m Void
         remoteThread =
           Async.withAsync
             (runLedgerPeers
               ledgerPeersRng
-              (curry IP.toSockAddr)
+              ntnToPeerAddr
               dtLedgerPeersTracer
               daReadUseLedgerAfter
               daLedgerPeersCtx
-              (resolveDomainAddresses
-                dtTracePublicRootPeersTracer
-                timeout
-                DNS.defaultResolvConf
-                ioDNSActions
-                )
+              domainResolver
               (takeTMVar ledgerPeersReq)
               (putTMVar ledgerPeersRsp)
             )
@@ -718,7 +828,10 @@ runDataDiffusion tracers
               -- Run peer selection only
               HasInitiator CMDInInitiatorMode -> do
                 let connectionManagerArguments
-                      :: NodeToNodeConnectionManagerArguments InitiatorMode Void
+                      :: NodeToNodeConnectionManagerArguments
+                           InitiatorMode
+                           ntnFd ntnAddr ntnVersion ntnVersionData
+                           Void
                     connectionManagerArguments =
                       ConnectionManagerArguments {
                           cmTracer              = dtConnectionManagerTracer,
@@ -726,9 +839,9 @@ runDataDiffusion tracers
                           cmMuxTracer           = dtMuxTracer,
                           cmIPv4Address,
                           cmIPv6Address,
-                          cmAddressType         = socketAddressType,
-                          cmSnocket             = snocket,
-                          connectionDataFlow    = uncurry nodeDataFlow,
+                          cmAddressType         = ntnAddressType,
+                          cmSnocket             = ntnSnocket,
+                          connectionDataFlow    = uncurry ntnDataFlow,
                           cmPrunePolicy         =
                             case cmdInMode of
                               HasInitiator CMDInInitiatorMode ->
@@ -743,21 +856,16 @@ runDataDiffusion tracers
                         }
 
                     connectionHandler
-                      :: NodeToNodeConnectionHandler InitiatorMode Void
+                      :: NodeToNodeConnectionHandler
+                           InitiatorMode
+                           ntnFd ntnAddr ntnVersion ntnVersionData
+                           Void
                     connectionHandler =
                       makeConnectionHandler
                         dtMuxTracer
                         SingInitiatorMode
                         miniProtocolBundleInitiatorMode
-                        HandshakeArguments {
-                            haHandshakeTracer = dtHandshakeTracer,
-                            haHandshakeCodec = nodeToNodeHandshakeCodec,
-                            haVersionDataCodec =
-                              cborTermVersionDataCodec
-                                NodeToNode.nodeToNodeCodecCBORTerm,
-                            haAcceptVersion = acceptableVersion,
-                            haTimeLimits = timeLimitsHandshake
-                          }
+                        ntnHandshakeArgs
                         daApplicationInitiatorMode
                         (mainThreadId, rethrowPolicy <> daRethrowPolicy)
 
@@ -767,7 +875,9 @@ runDataDiffusion tracers
                   classifyHandleError
                   NotInResponderMode
                   $ \(connectionManager
-                      :: NodeToNodeConnectionManager InitiatorMode Void) -> do
+                      :: NodeToNodeConnectionManager
+                           InitiatorMode ntnFd ntnAddr ntnVersion Void)
+                    -> do
 #ifdef POSIX
                   _ <- Signals.installHandler
                     Signals.sigUSR1
@@ -797,7 +907,7 @@ runDataDiffusion tracers
                         spsConnectionManager = connectionManager
                       }
                     $ \(peerStateActions
-                          :: NodeToNodePeerStateActions InitiatorMode Void) ->
+                          :: NodeToNodePeerStateActions InitiatorMode ntnAddr Void) ->
                     --
                     -- Run peer selection (p2p governor)
                     --
@@ -805,7 +915,7 @@ runDataDiffusion tracers
                     withPeerSelectionActions
                       dtTraceLocalRootPeersTracer
                       dtTracePublicRootPeersTracer
-                      (curry IP.toSockAddr)
+                      ntnToPeerAddr
                       timeout
                       (readTVar peerSelectionTargetsVar)
                       daReadLocalRootPeers
@@ -816,7 +926,7 @@ runDataDiffusion tracers
                       $ \mbLocalPeerRootProviderThread
                          (peerSelectionActions
                             :: NodeToNodePeerSelectionActions
-                                 InitiatorMode Void) ->
+                                 InitiatorMode ntnAddr Void) ->
 
                         Async.withAsync
                           (Governor.peerSelectionGovernor
@@ -857,6 +967,7 @@ runDataDiffusion tracers
                 let connectionManagerArguments
                       :: NodeToNodeConnectionManagerArguments
                           InitiatorResponderMode
+                          ntnFd ntnAddr ntnVersion ntnVersionData
                           ()
                     connectionManagerArguments =
                       ConnectionManagerArguments {
@@ -865,9 +976,9 @@ runDataDiffusion tracers
                           cmMuxTracer           = dtMuxTracer,
                           cmIPv4Address,
                           cmIPv6Address,
-                          cmAddressType         = socketAddressType,
-                          cmSnocket             = snocket,
-                          connectionDataFlow    = uncurry nodeDataFlow,
+                          cmAddressType         = ntnAddressType,
+                          cmSnocket             = ntnSnocket,
+                          connectionDataFlow    = uncurry ntnDataFlow,
                           cmPrunePolicy         =
                             case cmdInMode of
                               HasInitiatorResponder (CMDInInitiatorResponderMode _ serverStateVar) ->
@@ -880,21 +991,14 @@ runDataDiffusion tracers
                     connectionHandler
                       :: NodeToNodeConnectionHandler
                           InitiatorResponderMode
+                          ntnFd ntnAddr ntnVersion ntnVersionData
                           ()
                     connectionHandler =
                       makeConnectionHandler
                          dtMuxTracer
                          SingInitiatorResponderMode
                          miniProtocolBundleInitiatorResponderMode
-                         HandshakeArguments {
-                             haHandshakeTracer = dtHandshakeTracer,
-                             haHandshakeCodec = nodeToNodeHandshakeCodec,
-                             haVersionDataCodec =
-                              cborTermVersionDataCodec
-                                NodeToNode.nodeToNodeCodecCBORTerm,
-                             haAcceptVersion = acceptableVersion,
-                             haTimeLimits = timeLimitsHandshake
-                           }
+                         ntnHandshakeArgs
                          daApplicationInitiatorResponderMode
                          (mainThreadId, rethrowPolicy <> daRethrowPolicy)
 
@@ -904,7 +1008,9 @@ runDataDiffusion tracers
                   classifyHandleError
                   (InResponderMode controlChannel)
                   $ \(connectionManager
-                        :: NodeToNodeConnectionManager InitiatorResponderMode ()) -> do
+                        :: NodeToNodeConnectionManager
+                             InitiatorResponderMode ntnFd ntnAddr ntnVersion ()
+                     ) -> do
 #ifdef POSIX
                   _ <- Signals.installHandler
                     Signals.sigUSR1
@@ -934,7 +1040,7 @@ runDataDiffusion tracers
                       }
                     $ \(peerStateActions
                           :: NodeToNodePeerStateActions
-                               InitiatorResponderMode ()) ->
+                               InitiatorResponderMode ntnAddr ()) ->
 
                     --
                     -- Run peer selection (p2p governor)
@@ -943,7 +1049,7 @@ runDataDiffusion tracers
                     withPeerSelectionActions
                       dtTraceLocalRootPeersTracer
                       dtTracePublicRootPeersTracer
-                      (curry IP.toSockAddr)
+                      ntnToPeerAddr
                       timeout
                       (readTVar peerSelectionTargetsVar)
                       daReadLocalRootPeers
@@ -954,7 +1060,7 @@ runDataDiffusion tracers
                       $ \mbLocalPeerRootProviderThread
                         (peerSelectionActions
                            :: NodeToNodePeerSelectionActions
-                                InitiatorResponderMode ()) ->
+                                InitiatorResponderMode ntnAddr ()) ->
 
                       Async.withAsync
                         (Governor.peerSelectionGovernor
@@ -965,17 +1071,13 @@ runDataDiffusion tracers
                           peerSelectionActions
                           (Diffusion.Policies.simplePeerSelectionPolicy
                             policyRngVar (readTVar churnModeVar) daPeerMetrics))
-                        $ \governorThread -> do
-                        let mkAddr :: AddrInfo -> (Socket.Family, SockAddr)
-                            mkAddr addr = ( Socket.addrFamily  addr
-                                          , Socket.addrAddress addr
-                                          )
-
-                        withSockets tracer snocket
-                                    (catMaybes
-                                      [ fmap (fmap mkAddr) daIPv4Address
-                                      , fmap (fmap mkAddr) daIPv6Address
-                                      ])
+                        $ \governorThread ->
+                        withSockets tracer ntnSnocket
+                                    ( catMaybes
+                                        [ daIPv4Address
+                                        , daIPv6Address
+                                        ]
+                                    )
                                     $ \sockets addresses -> do
                           --
                           -- Run server
@@ -985,7 +1087,7 @@ runDataDiffusion tracers
                             (Server.run
                               ServerArguments {
                                   serverSockets               = sockets,
-                                  serverSnocket               = snocket,
+                                  serverSnocket               = ntnSnocket,
                                   serverTracer                = dtServerTracer,
                                   serverInboundGovernorTracer = dtInboundGovernorTracer,
                                   serverConnectionLimits      = daAcceptedConnectionsLimit,
@@ -1026,8 +1128,6 @@ runDataDiffusion tracers
     DiffusionTracers {
       dtMuxTracer
       , dtLocalMuxTracer
-      , dtHandshakeTracer
-      , dtLocalHandshakeTracer
       , dtLedgerPeersTracer
       -- the tracer
       , dtDiffusionInitializationTracer = tracer
@@ -1164,8 +1264,8 @@ nodeDataFlow _ _ = Unidirectional
 
 -- | For Node-To-Client protocol all connection are considered 'Unidirectional'.
 --
-localDataFlow :: NodeToClientVersion
-              -> NodeToClientVersionData
+localDataFlow :: ntcVersion
+              -> ntcVersionData
               -> DataFlow
 localDataFlow _ _ = Unidirectional
 
@@ -1174,33 +1274,38 @@ localDataFlow _ _ = Unidirectional
 -- Socket utility functions
 --
 
-withSockets :: Tracer IO DiffusionInitializationTracer
-            -> SocketSnocket
-            -> [Either Socket.Socket (Socket.Family, SockAddr)]
-            -> (NonEmpty Socket.Socket -> NonEmpty Socket.SockAddr -> IO a)
-            -> IO a
+withSockets :: forall m ntnFd ntnAddr ntcAddr a.
+               ( MonadThrow m
+               , Typeable ntnAddr
+               , Show     ntnAddr
+               )
+            => Tracer m (DiffusionInitializationTracer ntnAddr ntcAddr)
+            -> Snocket m ntnFd ntnAddr
+            -> [Either ntnFd ntnAddr]
+            -> (NonEmpty ntnFd -> NonEmpty ntnAddr -> m a)
+            -> m a
 withSockets tracer sn addresses k = go [] addresses
   where
     go !acc (a : as) = withSocket a (\sa -> go (sa : acc) as)
-    go []   []       = throw NoSocket
+    go []   []       = throwIO (NoSocket :: DiffusionFailure ntnAddr)
     go !acc []       =
       let acc' = NonEmpty.fromList (reverse acc)
       in (k $! (fst <$> acc')) $! (snd <$> acc')
 
-    withSocket :: Either Socket.Socket (Socket.Family, SockAddr)
-               -> ((Socket.Socket, Socket.SockAddr) -> IO a)
-               -> IO a
+    withSocket :: Either ntnFd ntnAddr
+               -> ((ntnFd, ntnAddr) -> m a)
+               -> m a
     withSocket (Left sock) f =
       bracket
         (pure sock)
         (Snocket.close sn)
         $ \_sock -> do
-          !addr <- Socket.getSocketName sock
+          !addr <- Snocket.getLocalAddr sn sock
           f (sock, addr)
-    withSocket (Right (fam, !addr)) f =
+    withSocket (Right addr) f =
       bracket
         (do traceWith tracer (CreatingServerSocket addr)
-            Snocket.open sn (Snocket.SocketFamily fam))
+            Snocket.open sn (Snocket.addrFamily sn addr))
         (Snocket.close sn)
         $ \sock -> do
           traceWith tracer $ ConfiguringServerSocket addr
@@ -1211,57 +1316,56 @@ withSockets tracer sn addresses k = go [] addresses
           f (sock, addr)
 
 
-withLocalSocket :: IOManager
-                -> Tracer IO DiffusionInitializationTracer
-                -> Either Socket.Socket FilePath
-                -> (LocalSnocket -> LocalSocket -> IO a)
-                -> IO a
-withLocalSocket iocp tracer localAddress k =
+withLocalSocket :: forall ntnAddr ntcFd ntcAddr m a.
+                   ( MonadThrow m
+                     -- Win32 only constraints:
+                   , Typeable ntnAddr
+                   , Show     ntnAddr
+                   )
+                => Tracer m (DiffusionInitializationTracer ntnAddr ntcAddr)
+                -> (ntcFd -> m FileDescriptor)
+                -> Snocket m ntcFd ntcAddr
+                -> Either ntcFd ntcAddr
+                -> (ntcFd -> m a)
+                -> m a
+withLocalSocket tracer getFileDescriptor sn localAddress k =
   bracket
     (
       case localAddress of
 #if defined(mingw32_HOST_OS)
          -- Windows uses named pipes so can't take advantage of existing sockets
-         Left _ -> traceWith tracer UnsupportedReadySocketCase
-                >> throwIO UnsupportedReadySocket
+         Left _ -> traceWith tracer (UnsupportedReadySocketCase
+                                       :: DiffusionInitializationTracer ntnAddr ntcAddr)
+                >> throwIO (UnsupportedReadySocket :: DiffusionFailure ntnAddr)
 #else
          Left sd -> do
-             addr <- Socket.getSocketName sd
-             case addr of
-                  (Socket.SockAddrUnix path) -> do
-                    traceWith tracer (UsingSystemdSocket path)
-                    return (Left ( Snocket.localSnocket iocp
-                                 , LocalSocket sd
-                                 ))
-                  _  -> do
-                    traceWith tracer $ UnsupportedLocalSystemdSocket addr
-                    throwIO UnsupportedLocalSocketType
+             addr <- Snocket.getLocalAddr sn sd
+             traceWith tracer (UsingSystemdSocket addr)
+             return (Left sd)
 #endif
          Right addr -> do
-             let sn :: LocalSnocket
-                 sn = Snocket.localSnocket iocp
              traceWith tracer $ CreateSystemdSocketForSnocketPath addr
-             sd <- Snocket.open sn (Snocket.LocalFamily (Snocket.LocalAddress addr))
+             sd <- Snocket.open sn (Snocket.addrFamily sn addr)
              traceWith tracer $ CreatedLocalSocket addr
-             return (Right (sn, sd, addr))
+             return (Right (sd, addr))
     )
     -- We close the socket here, even if it was provided to us.
     (\case
-      Left  (sn, sd)    -> Snocket.close sn sd
-      Right (sn, sd, _) -> Snocket.close sn sd
+      Right (sd, _) -> Snocket.close sn sd
+      Left   sd     -> Snocket.close sn sd
     )
     $ \case
       -- unconfigured socket
-      Right (sn, sd, addr) -> do
+      Right (sd, addr) -> do
         traceWith tracer . ConfiguringLocalSocket addr
-           =<< localSocketFileDescriptor sd
-        Snocket.bind sn sd (NodeToClient.LocalAddress addr)
+           =<< getFileDescriptor sd
+        Snocket.bind sn sd addr
         traceWith tracer . ListeningLocalSocket addr
-           =<< localSocketFileDescriptor sd
+           =<< getFileDescriptor sd
         Snocket.listen sn sd
         traceWith tracer . LocalSocketUp addr
-           =<< localSocketFileDescriptor sd
-        k sn sd
+           =<< getFileDescriptor sd
+        k sd
 
       -- pre-configured systemd socket
-      Left (sn, sd) -> k sn sd
+      Left sd -> k sd

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1227,7 +1227,7 @@ withLocalSocket iocp tracer localAddress k =
              case addr of
                   (Socket.SockAddrUnix path) -> do
                     traceWith tracer (UsingSystemdSocket path)
-                    return (Left ( Snocket.localSnocket iocp path
+                    return (Left ( Snocket.localSnocket iocp
                                  , LocalSocket sd
                                  ))
                   _  -> do
@@ -1236,9 +1236,9 @@ withLocalSocket iocp tracer localAddress k =
 #endif
          Right addr -> do
              let sn :: LocalSnocket
-                 sn = Snocket.localSnocket iocp addr
+                 sn = Snocket.localSnocket iocp
              traceWith tracer $ CreateSystemdSocketForSnocketPath addr
-             sd <- Snocket.open sn Snocket.LocalFamily
+             sd <- Snocket.open sn (Snocket.LocalFamily (Snocket.LocalAddress addr))
              traceWith tracer $ CreatedLocalSocket addr
              return (Right (sn, sd, addr))
     )

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -629,16 +629,15 @@ runDataDiffusion tracers
                             haVersionDataCodec =
                               cborTermVersionDataCodec
                                 NodeToClient.nodeToClientCodecCBORTerm,
-                            haVersions =
-                                  (\(OuroborosApplication apps)
-                                    -> Bundle
-                                        (WithHot apps)
-                                        (WithWarm (\_ _ -> []))
-                                        (WithEstablished (\_ _ -> [])))
-                              <$> daLocalResponderApplication,
                             haAcceptVersion = acceptableVersion,
                             haTimeLimits = noTimeLimitsHandshake
                           }
+                        ( ( \ (OuroborosApplication apps)
+                           -> Bundle
+                                (WithHot apps)
+                                (WithWarm (\_ _ -> []))
+                                (WithEstablished (\_ _ -> []))
+                          ) <$> daLocalResponderApplication )
                         (mainThreadId, rethrowPolicy <> daLocalRethrowPolicy)
 
                     localConnectionManagerArguments
@@ -754,10 +753,10 @@ runDataDiffusion tracers
                             haVersionDataCodec =
                               cborTermVersionDataCodec
                                 NodeToNode.nodeToNodeCodecCBORTerm,
-                            haVersions = daApplicationInitiatorMode,
                             haAcceptVersion = acceptableVersion,
                             haTimeLimits = timeLimitsHandshake
                           }
+                        daApplicationInitiatorMode
                         (mainThreadId, rethrowPolicy <> daRethrowPolicy)
 
                 withConnectionManager
@@ -890,10 +889,10 @@ runDataDiffusion tracers
                              haVersionDataCodec =
                               cborTermVersionDataCodec
                                 NodeToNode.nodeToNodeCodecCBORTerm,
-                             haVersions = daApplicationInitiatorResponderMode,
                              haAcceptVersion = acceptableVersion,
                              haTimeLimits = timeLimitsHandshake
                            }
+                         daApplicationInitiatorResponderMode
                          (mainThreadId, rethrowPolicy <> daRethrowPolicy)
 
                 withConnectionManager

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -124,16 +124,6 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics = PeerSelectionPolicy {
              . Map.assocs
              $ available'
 
-    _simpleDemotionPolicy :: PickPolicy SockAddr m
-    _simpleDemotionPolicy _ _ _ available pickNum = do
-      available' <- addRand available (,)
-      return $ Set.fromList
-             . map fst
-             . take pickNum
-             . sortOn snd
-             . Map.assocs
-             $ available'
-
     -- Failures lowers r
     failWeight :: (SockAddr -> Int)
                 -> SockAddr

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -124,8 +124,9 @@ import           Ouroboros.Network.Subscription.Worker (LocalAddresses (..))
 import           Ouroboros.Network.IOManager
 
 -- The Handshake tracer types are simply terrible.
-type HandshakeTr = WithMuxBearer (ConnectionId LocalAddress)
-    (TraceSendRecv (Handshake NodeToClientVersion CBOR.Term))
+type HandshakeTr ntcAddr ntcVersion =
+    WithMuxBearer (ConnectionId ntcAddr)
+                  (TraceSendRecv (Handshake ntcVersion CBOR.Term))
 
 
 -- | Recorod of node-to-client mini protocols.

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -45,7 +45,7 @@ module Ouroboros.Network.NodeToClient (
   , withIOManager
   , LocalSnocket
   , localSnocket
-  , LocalSocket
+  , LocalSocket (..)
   , LocalAddress (..)
 
     -- * Versions

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -153,8 +153,9 @@ import           Ouroboros.Network.Snocket
 
 
 -- The Handshake tracer types are simply terrible.
-type HandshakeTr = WithMuxBearer (ConnectionId Socket.SockAddr)
-    (TraceSendRecv (Handshake NodeToNodeVersion CBOR.Term))
+type HandshakeTr ntnAddr ntnVersion =
+    WithMuxBearer (ConnectionId ntnAddr)
+                  (TraceSendRecv (Handshake ntnVersion CBOR.Term))
 
 -- | 'Hanshake' codec for the @node-to-node@ protocol suite.
 --

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -75,6 +75,7 @@ module Ouroboros.Network.NodeToNode (
   , ProtocolLimitFailure
   , Handshake
   , LocalAddresses (..)
+  , Socket
 
   -- ** Error Policies and Peer state
   , ErrorPolicies (..)
@@ -115,6 +116,7 @@ import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Term as CBOR
 import           Network.Mux (WithMuxBearer (..))
 import           Network.Mux.Types (MuxRuntimeError (..))
+import           Network.Socket (Socket)
 import qualified Network.Socket as Socket
 
 import           Ouroboros.Network.Codec

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -401,7 +401,7 @@ publicRootPeersProvider tracer
 --
 resolveDomainAddresses
   :: forall exception resolver m.
-  (MonadThrow m, MonadAsync m, Exception exception)
+     (MonadThrow m, MonadAsync m, Exception exception)
   => Tracer m TracePublicRootPeers
   -> TimeoutFn m
   -> DNS.ResolvConf

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -14,10 +14,11 @@ module Ouroboros.Network.PeerSelection.Simple
 
 import           Data.Foldable (toList)
 import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Tracer (Tracer)
-import           Control.Exception (IOException)
 
 import           Data.Map (Map)
 import           Data.Set (Set)
@@ -34,31 +35,38 @@ import           Ouroboros.Network.PeerSelection.RootPeersDNS
 
 
 withPeerSelectionActions
-  :: forall peeraddr peerconn a.
-     Ord peeraddr
-  => Tracer IO (TraceLocalRootPeers peeraddr IOException)
-  -> Tracer IO TracePublicRootPeers
+  :: forall peeraddr peerconn resolver exception m a.
+     ( MonadAsync m
+     , MonadDelay m
+     , MonadThrow m
+     , Ord peeraddr
+     , Exception exception
+     )
+  => Tracer m (TraceLocalRootPeers peeraddr exception)
+  -> Tracer m TracePublicRootPeers
   -> (IP -> Socket.PortNumber -> peeraddr)
-  -> TimeoutFn IO
-  -> STM IO PeerSelectionTargets
-  -> STM IO [(Int, Map RelayAddress PeerAdvertise)]
+  -> DNSActions resolver exception m
+  -> TimeoutFn m
+  -> STM m PeerSelectionTargets
+  -> STM m [(Int, Map RelayAddress PeerAdvertise)]
   -- ^ local root peers
-  -> STM IO [RelayAddress]
+  -> STM m [RelayAddress]
   -- ^ public root peers
-  -> PeerStateActions peeraddr peerconn IO
-  -> (NumberOfPeers -> STM IO ())
-  -> STM IO (Maybe (Set peeraddr, DiffTime))
-  -> (Maybe (Async IO Void)
-      -> PeerSelectionActions peeraddr peerconn IO
-      -> IO a)
+  -> PeerStateActions peeraddr peerconn m
+  -> (NumberOfPeers -> STM m ())
+  -> STM m (Maybe (Set peeraddr, DiffTime))
+  -> (Maybe (Async m Void)
+      -> PeerSelectionActions peeraddr peerconn m
+      -> m a)
   -- ^ continuation, recieves a handle to the local roots peer provider thread
   -- (only if local root peers where non-empty).
-  -> IO a
+  -> m a
 withPeerSelectionActions
   localRootTracer
   publicRootTracer
   toPeerAddr
-  timeout
+  dnsActions
+  timeoutFn
   readTargets
   readLocalRootPeers
   readPublicRootPeers
@@ -70,7 +78,7 @@ withPeerSelectionActions
     let peerSelectionActions = PeerSelectionActions {
             readPeerSelectionTargets = readTargets,
             readLocalRootPeers = toList <$> readTVar localRootsVar,
-            requestPublicRootPeers = requestLedgerPeers ioDNSActions,
+            requestPublicRootPeers = requestLedgerPeers,
             requestPeerGossip = \_ -> pure [],
             peerStateActions
           }
@@ -78,34 +86,32 @@ withPeerSelectionActions
       (localRootPeersProvider
         localRootTracer
         toPeerAddr
-        timeout
+        timeoutFn
         DNS.defaultResolvConf
         localRootsVar
         readLocalRootPeers
-        ioDNSActions)
+        dnsActions)
       (\thread -> k (Just thread) peerSelectionActions)
   where
     -- We first try to get poublic root peers from the ledger, but if it fails
     -- (for example because the node hasn't synced far enough) we fall back
     -- to using the manually configured bootstrap root peers.
-    requestLedgerPeers :: DNSActions DNS.Resolver IOException IO
-                       -> Int -> IO (Set peeraddr, DiffTime)
-    requestLedgerPeers dnsActions n = do
+    requestLedgerPeers :: Int -> m (Set peeraddr, DiffTime)
+    requestLedgerPeers n = do
         atomically $ reqLedgerPeers $ NumberOfPeers $ fromIntegral n
         peers_m <- atomically getLedgerPeers
         case peers_m of
-             Nothing -> requestPublicRootPeers dnsActions n
+             Nothing    -> requestPublicRootPeers n
              Just peers -> return peers
 
     -- For each call we re-initialise the dns library which forces reading
     -- `/etc/resolv.conf`:
     -- https://github.com/input-output-hk/cardano-node/issues/731
-    requestPublicRootPeers :: DNSActions DNS.Resolver IOException IO
-                           -> Int -> IO (Set peeraddr, DiffTime)
-    requestPublicRootPeers dnsActions n =
+    requestPublicRootPeers :: Int -> m (Set peeraddr, DiffTime)
+    requestPublicRootPeers n =
       publicRootPeersProvider publicRootTracer
                               toPeerAddr
-                              timeout
+                              timeoutFn
                               DNS.defaultResolvConf
                               readPublicRootPeers
                               dnsActions

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -18,6 +18,7 @@ module Test.Ouroboros.Network.PeerSelection (tests) where
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function (on)
 import           Data.List (groupBy, foldl')
+import qualified Data.IP as IP
 import           Data.Maybe (listToMaybe, isNothing, fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -1898,6 +1899,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains =
     withTimeoutSerial $ \timeout ->
     publicRootPeersProvider
       tracer
+      (curry IP.toSockAddr)
       timeout
       DNS.defaultResolvConf
       readDomains

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -154,7 +154,7 @@ simpleMockRoots = MockRoots localRootPeers dnsMap (mkStdGen 60)
 -- Adds DNS Lookup function for IOSim with different timeout and lookup
 -- delays for every attempt.
 mockDNSActions :: forall exception s.
-               Map Domain [IPv4]
+                  Map Domain [IPv4]
                -> StrictTVar (IOSim s) StdGen
                -> DNSActions () exception (IOSim s)
 mockDNSActions dnsMap stdGenVar =
@@ -169,9 +169,9 @@ mockDNSActions dnsMap stdGenVar =
  where
    genDiffTime :: Integer -> Integer -> StdGen -> DiffTime
    genDiffTime lo hi =
-    picosecondsToDiffTime
-    . fst
-    . uniformR (lo * 1000000000, hi * 1000000000)
+       picosecondsToDiffTime
+     . fst
+     . uniformR (lo * 1_000_000_000, hi * 1_000_000_000)
 
    dnsResolverResource      _ = return (constantResource ())
    dnsAsyncResolverResource _ = return (constantResource ())
@@ -319,7 +319,7 @@ selectPublicRootResultEvents trace = [ (t, (domain, map fst r))
 --
 prop_local_preservesGroupNumberAndTargets :: MockRoots -> Property
 prop_local_preservesGroupNumberAndTargets mockRoots@(MockRoots lrp _ _) =
-    let tr = take 1000
+    let tr = take 1_000
               $ selectLocalRootGroupsEvents
               $ selectLocalRootPeersEvents
               $ selectRootPeerDNSTraceEvents
@@ -346,7 +346,7 @@ prop_local_preservesGroupNumberAndTargets mockRoots@(MockRoots lrp _ _) =
 --
 prop_local_resolvesDomainsCorrectly :: MockRoots -> Property
 prop_local_resolvesDomainsCorrectly mockRoots@(MockRoots _ dnsMap _) =
-    let tr = take 1000
+    let tr = take 1_000
               $ selectLocalRootResultEvents
               $ selectLocalRootPeersEvents
               $ selectRootPeerDNSTraceEvents
@@ -364,7 +364,7 @@ prop_local_resolvesDomainsCorrectly mockRoots@(MockRoots _ dnsMap _) =
 -- after a successful DNS lookup the result list is updated correctly.
 prop_local_updatesDomainsCorrectly :: MockRoots -> Property
 prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _) =
-    let tr = take 1000
+    let tr = take 1_000
               $ selectLocalRootPeersEvents
               $ selectRootPeerDNSTraceEvents
               $ runSimTrace
@@ -467,7 +467,7 @@ prop_public_resolvesDomainsCorrectly mockRoots@(MockRoots _ dnsMap _) n =
 prop_resolveDomainAddresses_resolvesDomainsCorrectly :: MockRoots -> Property
 prop_resolveDomainAddresses_resolvesDomainsCorrectly
   mockRoots@(MockRoots _ dnsMap _) =
-    within 1000000 $
+    within 1_000_000 $
       lookupLoop mockRoots dnsMap === dnsMap
   where
     -- Perform public root DNS lookup until no failures


### PR DESCRIPTION
This PR allows to run diffusion in io-sim.  It also refactors the p2p
/ non-p2p: using records instead of functions with many arguments and enables
to have simpler `cardano-node` integration.

- diffusion-policies: removed dead code
- ouroboros-network: various stylystic changes
- snocket: support getLocalName for named pipes (Windows)
- netenv: removed nsBoundAddresses
- netenv: more descriptive error messages
- handshake: remove versioned application from HandshakeArguments
- peer-selection: polymorphic address type
- diffusion: generalise to an abstract peer address
- diffusion: run diffusion in an abstract monad
- diffusion: simplify data diffusion
- node-to-client: export LocalSocket constructor
