### PR TITLE
consensus-cardano: enable the Alonzo era by default

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -385,8 +385,7 @@ instance CardanoHardForkConstraints c
       , (NodeToClientV_9, CardanoNodeToClientVersion7)
       ]
 
-  -- Do not yet enable Alonzo by default
-  latestReleasedNodeVersion _prx = (Just NodeToNodeV_6, Just NodeToClientV_8)
+  latestReleasedNodeVersion _prx = (Just NodeToNodeV_7, Just NodeToClientV_9)
 
 {-------------------------------------------------------------------------------
   ProtocolInfo


### PR DESCRIPTION
A node built against this commit will no longer need to set `TestEnableDevelopmentHardForkEras` in its configuration file in order to enable Alonzo for Cardano.