### PR TITLE
cabal.project: update cardano-ledger-specs dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -195,8 +195,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 8c732560b201b5da8e3bdf175c6eda73a32d64bc
-  --sha256: 0nwy03wyd2ks4qxg47py7lm18karjz6vs7p8knmn3zy72i3n9rfi
+  tag: cb0f19c85e5bb5299839ad4ed66af6fa61322cc4
+  --sha256: 0dnkfqcvbifbk3m5pg8kyjqjy0zj1l4vd23p39n6ym4q0bnib1cq
   subdir:
     base-deriving-via
     binary
@@ -211,8 +211,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 309178369eebe9ce02171987f6d23c7778f7db26
-  --sha256: 1a9cm3ykz9dzfrfv4yk8a2rw5pj4frlwrd6rpp97j5n8rrx34v5k
+  tag: 12a0ef69d64a55e737fbf4e846bd8ed9fb30a956
+  --sha256: 0mx1g18ypdd5m8ijc2cl9m1xmymlqfbwl1r362f92vxrmziacifv
   subdir:
     alonzo/impl
     alonzo/test
@@ -234,8 +234,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 985bd37845cd0996fc38eaccd1db1a9ad3edab3a
-  --sha256: 01rar14075b1privhpyhch1qvv1j7d36nbv1frha864w6pr8zmkx
+  tag: 2c8161ad142f56b14611cc0f66b0a2803016fe37
+  --sha256: 19sj9f4pxfjcqkdxq46kx7qiv0qw4lf670jy8jyzvkmwyjl5agwm
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -77,7 +77,7 @@ import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks (..))
 
 import           Cardano.Binary (ToCBOR (..))
-import           Cardano.Crypto.Hash (Hash, HashAlgorithm, MD5, ShortHash)
+import           Cardano.Crypto.Hash (Hash, HashAlgorithm, SHA256, ShortHash)
 import qualified Cardano.Crypto.Hash as Hash
 
 import           Ouroboros.Consensus.Block
@@ -529,7 +529,7 @@ data SimpleStandardCrypto
 data SimpleMockCrypto
 
 instance SimpleCrypto SimpleStandardCrypto where
-  type SimpleHash SimpleStandardCrypto = MD5
+  type SimpleHash SimpleStandardCrypto = SHA256
 
 instance SimpleCrypto SimpleMockCrypto where
   type SimpleHash SimpleMockCrypto = ShortHash

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
@@ -86,7 +86,7 @@ instance Condense Tx where
 
 type Ix     = Word
 type Amount = Word
-type TxId   = Hash MD5 Tx
+type TxId   = Hash SHA256 Tx
 type TxIn   = (TxId, Ix)
 type TxOut  = (Addr, Amount)
 type Utxo   = Map TxIn TxOut

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -61,7 +61,6 @@ import           Numeric.Natural
 import           Cardano.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Cardano.Crypto.Hash.Class (HashAlgorithm (..), hashToBytes,
                      hashWithSerialiser, sizeHash)
-import           Cardano.Crypto.Hash.MD5 (MD5)
 import           Cardano.Crypto.Hash.SHA256 (SHA256)
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.KES.Mock
@@ -619,7 +618,7 @@ instance PraosCrypto PraosStandardCrypto where
 instance PraosCrypto PraosMockCrypto where
   type PraosKES  PraosMockCrypto = MockKES 10000
   type PraosVRF  PraosMockCrypto = MockVRF
-  type PraosHash PraosMockCrypto = MD5
+  type PraosHash PraosMockCrypto = SHA256
 
 {-------------------------------------------------------------------------------
   Condense

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -377,7 +377,7 @@ ppTestSetup TestSetup { testInitialTxs
 
 ppTestTxWithHash :: TestTx -> String
 ppTestTxWithHash x = condense
-  (hashWithSerialiser toCBOR (simpleGenTx x) :: Hash MD5 Tx, x)
+  (hashWithSerialiser toCBOR (simpleGenTx x) :: Hash SHA256 Tx, x)
 
 -- | Given some transactions, calculate the sum of their sizes in bytes.
 txSizesInBytes :: [TestTx] -> TxSizeInBytes


### PR DESCRIPTION
Single commit, bumping to input-output-hk/cardano-ledger-specs@12a0ef69d64a55e737fbf4e846bd8ed9fb30a956

The involved `cardano-base` removed the `MD5` hash, as used in our mocks for testing. At least for now, I'm just replacing it with `SHA256`. We can revisit this later to perhaps choose eg a prefix of SHA256.