### PR TITLE
Update to latest haskell.nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d5d304d5b50db1e584ce62915c48fc8c0c8b626a",
-        "sha256": "0j70lnw99v62qshdd0a03ph37d0zyb9lqiiq48av3iw5g2f6h44z",
+        "rev": "8aa77fdbd848fe043551e653d837248b4bb76afd",
+        "sha256": "0shqr33kjivb9g8l97rsfhfdqngqd0m5m70pzc06hq2ldf9z9n5i",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/d5d304d5b50db1e584ce62915c48fc8c0c8b626a.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/8aa77fdbd848fe043551e653d837248b4bb76afd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hls-released": {


### PR DESCRIPTION
This also restores ability to enter nix shell be Mac users. In a
nutshell when entering a shell one would get an error stating that
PlutusCore.Evaluation.Result module does not exists. As
it turns out Mac is (most likely) case insensitive system. In
plutus-core they've added to gitignore 'results*'.

Change 20297c67255b19edf23cc2f9507981f3459d466f in haskell.nix fixed
it. This commit updated haskell.nix to the latest version that also
includes 20297c67255b19edf23cc2f9507981f3459d466f