### PR TITLE
Draft: Genesis exploration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ launch-*
 stack.yaml.local.lock
 stack.yaml.local
 .envrc
+.dir-locals.el
 
 # latex files
 doc/*.fdb_latexmk

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -55,6 +55,7 @@ import           Cardano.Prelude (cborError)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.GenesisWindowLength
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
@@ -528,7 +529,10 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
           triggerHardForkAllegra
 
     kShelley :: SecurityParam
-    kShelley = SecurityParam $ sgSecurityParam genesisShelley
+    kShelley = tpraosSecurityParam tpraosParams
+
+    sShelley :: GenesisWindowLength
+    sShelley = tpraosGenesisWindowLength tpraosParams
 
     -- Allegra
 
@@ -607,6 +611,15 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
     k :: SecurityParam
     k = assert (kByron == kShelley) kByron
 
+    -- While the GenesisWindowLength is not defined for pre-Shelley eras due to
+    -- them not having an active-slot coefficient, the length that will be set
+    -- for the HardForkConsensusConfig.hardForkGenesisWindowLength will be the
+    -- one computed from the Shelley TPraosParams.
+    --
+    -- TODO @js: Is this okay?
+    s :: GenesisWindowLength
+    s = sShelley
+
     shape :: History.Shape (CardanoEras c)
     shape = History.Shape $ Exactly $
            K (Byron.byronEraParams     genesisByron)
@@ -620,6 +633,7 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
     cfg = TopLevelConfig {
         topLevelConfigProtocol = HardForkConsensusConfig {
             hardForkConsensusConfigK      = k
+          , hardForkGenesisWindowLength   = s
           , hardForkConsensusConfigShape  = shape
           , hardForkConsensusConfigPerEra = PerEraConsensusConfig
               (  WrapPartialConsensusConfig partialConsensusConfigByron

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/LeaderSchedule.hs
@@ -46,7 +46,8 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
   type ValidateView  (WithLeaderSchedule p) = ()
   type CanBeLeader   (WithLeaderSchedule p) = ()
 
-  protocolSecurityParam = protocolSecurityParam . wlsConfigP
+  protocolSecurityParam       = protocolSecurityParam       . wlsConfigP
+  protocolGenesisWindowLength = protocolGenesisWindowLength . wlsConfigP
 
   checkIsLeader WLSConfig{..} () slot _ =
     case Map.lookup slot $ getLeaderSchedule wlsConfigSchedule of

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -73,6 +73,7 @@ import           Cardano.Slotting.EpochInfo
 
 import           Data.Maybe (fromMaybe)
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config.GenesisWindowLength
 import           Ouroboros.Consensus.Mock.Ledger.Stake
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -444,6 +445,13 @@ data instance Ticked (PraosChainDepState c) = TickedPraosChainDepState {
 instance PraosCrypto c => ConsensusProtocol (Praos c) where
 
   protocolSecurityParam = praosSecurityParam . praosParams
+  protocolGenesisWindowLength p =
+    -- See the haddock of GenesisWindowLength. As this is a mock protocol, it is
+    -- set to the "default" value, 3k/f.
+      GenesisWindowLength
+    $ floor
+    $ 3 * (fromIntegral $ maxRollbacks $ protocolSecurityParam p)
+      / praosLeaderF (praosParams p)
 
   type LedgerView    (Praos c) = ()
   type IsLeader      (Praos c) = PraosProof           c

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -132,6 +132,8 @@ test-suite test-consensus
   main-is:             Main.hs
   other-modules:
                        Test.Consensus.BlockchainTime.Simple
+                       Test.Consensus.Genesis.Paper
+                       Test.Consensus.Genesis.Framework
                        Test.Consensus.HardFork.Forecast
                        Test.Consensus.HardFork.History
                        Test.Consensus.HardFork.Infra

--- a/ouroboros-consensus-test/test-consensus/Main.hs
+++ b/ouroboros-consensus-test/test-consensus/Main.hs
@@ -3,6 +3,8 @@ module Main (main) where
 import           Test.Tasty
 
 import qualified Test.Consensus.BlockchainTime.Simple (tests)
+import qualified Test.Consensus.Genesis.Framework (tests)
+import qualified Test.Consensus.Genesis.Paper (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.HardFork.Forecast (tests)
 import qualified Test.Consensus.HardFork.History (tests)
@@ -38,5 +40,9 @@ tests =
             Test.Consensus.HardFork.Forecast.tests
           , Test.Consensus.HardFork.Combinator.tests
           ]
+      ]
+  , testGroup "Genesis" [
+        Test.Consensus.Genesis.Framework.tests
+      , Test.Consensus.Genesis.Paper.tests
       ]
   ]

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Genesis/Framework.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Genesis/Framework.hs
@@ -1,0 +1,331 @@
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE TupleSections              #-}
+{-# OPTIONS_GHC -Wno-orphans            #-}
+
+module Test.Consensus.Genesis.Framework (
+    AnnotatedBlockTree (..)
+  , BlockTree (..)
+  , SlotDelta (..)
+  , isDominated
+  , pathsThroughTree
+  , tests
+  ) where
+
+import           Control.Monad (replicateM)
+import           Data.Function (on, (&))
+import qualified Data.List as L (groupBy, sortBy)
+import qualified Data.List.NonEmpty as NE (NonEmpty ((:|)), partition)
+import           Data.Tree
+import           Data.Word
+
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Cardano.Slotting.Slot
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Config.GenesisWindowLength
+import           Ouroboros.Network.AnchoredFragment hiding (head, length,
+                     successorBlock)
+import           Ouroboros.Network.AnchoredFragment.Completeness
+import           Test.Util.TestBlock hiding (BlockTree, Header)
+
+{-------------------------------------------------------------------------------
+ Types
+-------------------------------------------------------------------------------}
+
+newtype SlotDelta = SlotDelta SlotNo
+ deriving (Show, Num, Eq)
+
+instance Arbitrary SlotDelta where
+  arbitrary = SlotDelta . SlotNo <$> choose (1,2)
+  shrink (SlotDelta (SlotNo s)) =
+    [ SlotDelta $ SlotNo s' | s' <- shrink s ]
+
+instance Arbitrary GenesisWindowLength where
+  arbitrary = GenesisWindowLength <$> choose (3, 6)
+  shrink (GenesisWindowLength s) =
+    [ GenesisWindowLength s'
+    | s' <- shrink s
+    , s' > 2 ]
+
+-- | A BlockTree captures a random tree, which is then turned into a Dominated
+-- tree over the associated GenesisWindowLength.
+data BlockTree = BlockTree {
+    tree     :: Tree SlotDelta
+  , original :: Tree SlotDelta
+  , gwl      :: GenesisWindowLength
+  }
+
+instance Show BlockTree where
+  show BlockTree{..} =
+    "Original: \n" <>  (drawTree . fmap show $ original) <>
+    "Modified: \n" <>  (drawTree . fmap show $ tree) <>
+    "GenesisWindow: \n" <> show gwl
+
+-- | An AnnotatedBlockTree is a BlockTree that also has a FragmentCompleteness
+-- tag for each one of the paths in the resulting tree.
+data AnnotatedBlockTree = AnnotatedBlockTree {
+  bt          :: BlockTree,
+  annotations :: [FragmentCompleteness]
+  }
+
+instance Show AnnotatedBlockTree where
+  show AnnotatedBlockTree{..} =
+    "Original Tree:\n" <> drawTree (show <$> original bt) <>
+    "Tree:\n" <> drawTree (show <$> tree bt) <>
+    "Is tree dominated: "<> show (isDominated (gwl bt) (tree bt)) <> "\n" <>
+    "Paths:\n" <> unlines (zipWith (curry show) (pathsThroughTree bt) annotations) <>
+    "GenesisWindowLength:\n" <> show (gwl bt)
+
+instance Arbitrary FragmentCompleteness where
+  arbitrary = frequency [
+    (1, return FragmentComplete),
+    (1, return FragmentIncomplete)
+    ]
+  shrink _ = [] -- no shrinking
+
+instance Arbitrary AnnotatedBlockTree where
+  arbitrary = do
+    bt <- arbitrary
+    annotations <- replicateM (Prelude.length (pathsThroughTree bt)) arbitrary
+    return AnnotatedBlockTree{..}
+  shrink = const []
+  -- Shrinking is quite difficult as we have to re-tag the branches.
+
+data DecidedTree =
+    -- | A children was elected.
+    DNode SlotDelta DecidedTree [Tree SlotDelta]
+  | -- | We reached the end of the genesis window so the remaining tree must yet
+    -- be made dominated.
+    DUndecided (Tree SlotDelta)
+  | -- | We reached a node with no children, the decided tree is complete.
+    DLeaf SlotDelta
+  deriving Show
+
+{-------------------------------------------------------------------------------
+ Dominated tree generation
+-------------------------------------------------------------------------------}
+
+instance Arbitrary BlockTree where
+  arbitrary = do
+    s <- arbitrary
+    t <- arbitrary
+    let t' = makeDominated s t
+    return (BlockTree t' t s)
+
+  shrink BlockTree{..} = [ BlockTree tree' original gwl'
+                         | tree' <- shrinkTree tree
+                         , gwl' <- shrink gwl
+                         , isDominated gwl' tree'
+                         ]
+
+-- | Keeping the first root (could be changed but it is easier this way),
+-- generate a list of trees by removing a block somewhere.
+shrinkTree :: Tree SlotDelta -> [Tree SlotDelta]
+shrinkTree (Node s ts) =
+  concatMap (\x -> map (Node s . (map (ts !!) ([0..x-1] ++ [x+1 .. length ts -1]) ++)) $ shrinkTree' (ts !! x)) [0..length ts - 1]
+shrinkTree' :: Tree SlotDelta -> [[Tree SlotDelta]]
+shrinkTree' n@(Node s ts) =
+  -- remove this block (propagate distance in slots to children)
+  map (\n' -> n' { rootLabel = deltaToSlotDelta $ nodeDelta n  + nodeDelta n'}) ts :
+  -- for all the results of removing a block in the children, add this block and
+  -- the other unaltered children.
+  map (\x -> map (Node s . (map (ts !!) ([0..x-1] ++ [x+1 .. length ts -1]) ++)) . shrinkTree' $ (ts !! x)) [0..length ts - 1]
+
+{-------------------------------------------------------------------------------
+ Helpers
+-------------------------------------------------------------------------------}
+
+nodeDelta :: Tree SlotDelta -> Word64
+nodeDelta (Node (SlotDelta (SlotNo s)) _) = s
+
+deltaToSlotDelta :: Word64 -> SlotDelta
+deltaToSlotDelta = SlotDelta . SlotNo
+
+consumeWindow :: GenesisWindowLength -> SlotDelta -> GenesisWindowLength
+consumeWindow (GenesisWindowLength s) (SlotDelta (SlotNo s')) =
+  GenesisWindowLength (s - s')
+
+-- | Calculate the amount of blocks in the genesis window with the provided
+-- length.
+density :: GenesisWindowLength -> Tree SlotDelta -> Word64
+density (GenesisWindowLength g) = density' g
+  where
+    density' gl (Node (SlotDelta (SlotNo s')) ts)
+      | gl == s'
+      = 1
+      | s' > gl
+      = 0
+      | otherwise
+      = case ts of
+          []  -> 1
+          [t] -> 1 + density' (gl - s') t
+          _   -> 1 + maximum (map (density' (gl - s')) ts)
+
+-- | Extract all the paths through a tree as anchored fragments.
+pathsThroughTree :: BlockTree -> [AnchoredFragment (Header TestBlock)]
+pathsThroughTree =
+      paths (Empty AnchorGenesis :>
+             getHeader (TestBlock (TestHash (0 NE.:| [])) 0 True))
+    . (0,)
+    . tree
+  where
+    paths accFrag (idx, n) =
+      let
+        accFrag' = (accFrag :>) . getHeader $
+          case accFrag of
+            Empty _  -> error "unreachable"
+            _ :> tip ->
+              let
+                sb = (successorBlock $ testHeader tip)
+              in
+                  sb { tbSlot = tbSlot sb + SlotNo (nodeDelta n) - 1 }
+                & modifyFork (+ idx)
+      in
+        case subForest n of
+          [] -> [accFrag']
+          _  -> concatMap (paths accFrag') $ zip [0..] (subForest n)
+
+{-------------------------------------------------------------------------------
+ Check if a tree is dominated
+-------------------------------------------------------------------------------}
+
+-- | A tree is said to be dominated under a genesis window length if it contains
+-- one chain which in every intersection with other chains, it wins the density
+-- comparison on the window anchored at the intersection point.
+--
+-- TODO: maybe this is not doing as it should, because nodes are
+-- indistinguishable when they have the same SlotDelta. Probably should 1)
+-- annotate the tree with hashes 2) decide on window 3) extract winning anchored
+-- fragment 4) extract all paths through densest branch 5) check that winning
+-- fragment is part of the densest branch always.
+isDominated :: GenesisWindowLength -> Tree SlotDelta -> Bool
+isDominated _ (Node _ [])  = True
+isDominated s (Node _ [t]) = isDominated s t
+isDominated s (Node _ ts)  =
+    case  L.groupBy ((==) `on` fst)
+        $ L.sortBy  (flip compare `on` fst)
+        $ map (\x -> (density s x, x)) ts of
+      []           -> error "can't happen"
+      [(_, one)]:_ -> isDominated s one && areAllPartOf one one s (genesisWindowLength s)
+      _            -> False
+  where
+    areAllPartOf :: Tree SlotDelta -> Tree SlotDelta -> GenesisWindowLength -> Word64 -> Bool
+    areAllPartOf _              (Node _ [])  _          _               = True
+    areAllPartOf mustBelongIn n@(Node _ [t]) fullWindow remainingWindow =
+      areAllPartOf mustBelongIn t fullWindow (remainingWindow - nodeDelta n)
+    areAllPartOf mustBelongIn n@(Node _ trees) fullWindow remainingWindow =
+         nodeDelta n > remainingWindow
+      || case  L.groupBy ((==) `on` fst)
+             $ L.sortBy  (flip compare `on` fst)
+             $ map (\x -> (density fullWindow x, x)) trees of
+           []           -> error "can't happen"
+           [(_, one)]:_ ->
+             isSubTree one mustBelongIn
+             && areAllPartOf mustBelongIn one fullWindow (remainingWindow - nodeDelta n)
+           _            -> False
+
+    isSubTree :: Tree SlotDelta -> Tree SlotDelta -> Bool
+    isSubTree candidate goal = candidate == goal || (case subForest goal of
+                                                      [] -> False
+                                                      sf -> any (isSubTree candidate) sf)
+
+{-------------------------------------------------------------------------------
+ Alter a tree to make it dominated
+-------------------------------------------------------------------------------}
+
+-- | Make the tree dominated under the given genesis window length. At every
+-- intersection point, elect a candidate from the ones with highest density and
+-- for the other candidates, find the chain that is as dense as the elected one
+-- and remove a block on that one. Repeat recursively on the elected candidate.
+makeDominated :: GenesisWindowLength -> Tree SlotDelta -> Tree SlotDelta
+makeDominated _  tr@(Node _ [])  = tr
+makeDominated genLen tr@(Node _ [t]) = tr { subForest = [makeDominated genLen t] }
+makeDominated genLen tr =
+    makeItWin [genLen] $ decideByDensityOnWindow genLen tr
+  where
+    -- | Process a DecidedTree into a normal tree by removing blocks from the
+    -- competitor branches that were not elected.
+    makeItWin :: [GenesisWindowLength] -> DecidedTree -> Tree SlotDelta
+    makeItWin _         (DLeaf s)          = Node s []
+    makeItWin _         (DUndecided n)     = makeDominated genLen n
+    makeItWin mustWinAt (DNode s d others) =
+         let
+           mustWinAtWindows = genLen: map (`consumeWindow` s) mustWinAt
+           d' = makeItWin mustWinAtWindows d
+         in
+           case others of
+             [] -> Node s [d']
+             (t:ts) ->
+               let densityWinningAtEachWindow = map (\x -> (x, x `density` d')) mustWinAtWindows
+                   (okays, wrongs) =
+                     NE.partition (\x -> all (\(y, z) -> density y x < z) densityWinningAtEachWindow) (t NE.:| ts)
+               in
+                 Node s $ d' : okays ++ concatMap (removeUntilUnder densityWinningAtEachWindow) wrongs
+
+    -- | Remove blocks from this branch until it is under the given target
+    -- density.
+    removeUntilUnder :: [(GenesisWindowLength, Word64)] -> Tree SlotDelta -> [Tree SlotDelta]
+    removeUntilUnder mustLooseHereAgainst n =
+      concatMap
+      (\n' ->
+          let
+            newBranch = n' { rootLabel = deltaToSlotDelta $ nodeDelta n  + nodeDelta n'}
+          in
+            if any (\(gl, target) -> density gl newBranch>= target) mustLooseHereAgainst
+            then removeUntilUnder mustLooseHereAgainst newBranch
+            else [newBranch]
+      )
+      (subForest n)
+
+    -- | Create a DecidedTree on this GenesisWindow. This will elect one branch
+    -- if there are multiple competitors with highest density.
+    decideByDensityOnWindow :: GenesisWindowLength -> Tree SlotDelta -> DecidedTree
+    decideByDensityOnWindow _                    (Node s []) = DLeaf s
+    decideByDensityOnWindow remainingWindowAfter n@(Node s [t]) =
+      if nodeDelta t > genesisWindowLength remainingWindowAfter
+      then
+        DUndecided n
+      else
+        DNode s (decideByDensityOnWindow (consumeWindow remainingWindowAfter (rootLabel t)) t) []
+    decideByDensityOnWindow remainingWindowAfter n@(Node s ts) =
+      case   L.groupBy ((==) `on` fst)
+           $ L.sortBy (flip compare `on` fst)
+           $ map (\x -> (density remainingWindowAfter x, x))
+             ts of
+          [] -> error "can't happen because ts /= []"
+          [(0,_):_] ->
+            -- all with density 0, we are at the end of the window
+            DUndecided n
+          [(_,o)]:r ->
+            -- one with max and some others with less
+            -- (r can't be empty because ts /= [t])
+            let
+              remainingWindow = consumeWindow remainingWindowAfter (rootLabel o)
+            in
+              DNode s (decideByDensityOnWindow remainingWindow o) (concatMap (map snd) r)
+          best:r ->
+            -- multiple with same density >0
+            let
+              electedIdx = 0
+              electedBranch = snd $ best !! electedIdx
+              others = map (snd . (best !!)) ([0..electedIdx - 1] ++ [electedIdx + 1..length best - 1])
+              remainingWindow = consumeWindow remainingWindowAfter (rootLabel electedBranch)
+              electedBranch' = decideByDensityOnWindow remainingWindow electedBranch
+            in
+              DNode s electedBranch' (others ++ concatMap (map snd) r)
+
+{-------------------------------------------------------------------------------
+ Tests
+-------------------------------------------------------------------------------}
+
+prop_generator :: BlockTree -> Bool
+prop_generator BlockTree{..} = isDominated gwl tree
+
+tests :: TestTree
+tests = testGroup "Dominated tree generator"
+      [ testProperty "trees are dominated" prop_generator
+      ]

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Genesis/Paper.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Genesis/Paper.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- | A one-to-one transcript of the maxvalid-bg rule described in the report.
+module Test.Consensus.Genesis.Paper (Test.Consensus.Genesis.Paper.tests) where
+
+import           Prelude hiding (length)
+import qualified Prelude (length)
+
+import           Data.Foldable (foldl')
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Ouroboros.Consensus.Block.Abstract (Header)
+import           Ouroboros.Consensus.Config.GenesisWindowLength
+import           Ouroboros.Consensus.NodeKernel.Genesis
+import           Ouroboros.Network.AnchoredFragment hiding (HasHeader,
+                     getHeaderFields, null)
+import           Ouroboros.Network.AnchoredFragment.Completeness
+import           Ouroboros.Network.Block
+
+import           Data.Maybe (fromMaybe)
+import           Test.Consensus.Genesis.Framework
+import           Test.Util.TestBlock (TestBlock)
+
+{-------------------------------------------------------------------------------
+ Maxvalid_bg. See Definition 21.2 in the Consensus report.
+-------------------------------------------------------------------------------}
+maxvalidBg ::
+     GenesisWindowLength
+  -> [AnchoredFragment (Header TestBlock)]
+  ->  AnchoredFragment (Header TestBlock)
+maxvalidBg _ []     = error "Can't decide on empty list of chains"
+maxvalidBg s (f:fs) = res
+  where
+    res = foldl' maxvalid_bg' f fs
+    maxvalid_bg' c_max c_i =
+      let
+        (_, prev, c_max'2, c_i'2) =
+                  fromMaybe (error "Must not happen") $ intersect c_max c_i
+      in
+        if   density (genesisWindowBounds (headSlot prev) s) c_i'2
+           > density (genesisWindowBounds (headSlot prev) s) c_max'2
+        then c_i
+        else c_max
+
+{-------------------------------------------------------------------------------
+  Tests
+-------------------------------------------------------------------------------}
+
+-- | If we run prefix selection claiming that some of the fragments are
+-- incomplete, the returned fragment must be a prefix of what prefix selection
+-- returns if we claim that every fragment is complete.
+prop_contained :: AnnotatedBlockTree -> Property
+prop_contained AnnotatedBlockTree{..} =
+  let paths = pathsThroughTree bt
+      known = map (`AnnotatedAnchoredFragment` FragmentComplete) paths
+      a1 = prefixSelection GenesisPoint (gwl bt) known
+      maybeKnown = zipWith AnnotatedAnchoredFragment paths annotations
+      a2 = prefixSelection GenesisPoint (gwl bt) maybeKnown
+  in
+     counterexample (show a1 <> " /= " <> show a2) $
+     isDominated (gwl bt) (tree bt) && (Prelude.length paths > 1) ==>
+     cover 99 (Prelude.length paths > 1) "non-trivial" $
+     isPrefixOf a2 a1
+
+-- | Maxvalid_bg and prefix selection must return the same result when we claim
+-- that every fragment is complete.
+prop_all_complete :: BlockTree -> Property
+prop_all_complete b =
+  let pathsForMaxvalid = pathsThroughTree b
+      pathsForPrefixSelection =
+        map (`AnnotatedAnchoredFragment` FragmentComplete)  (pathsThroughTree b)
+  in
+    isDominated (gwl b) (tree b) && (Prelude.length pathsForMaxvalid > 1) ==>
+    cover 99 (Prelude.length pathsForMaxvalid > 1) "non-trivial" $
+        maxvalidBg                  (gwl b) pathsForMaxvalid
+    === prefixSelection GenesisPoint (gwl b) pathsForPrefixSelection
+
+tests :: TestTree
+tests = testGroup "Prefix Selection"
+      [ testProperty "Prefix Selection vs Maxvalid_bg" prop_all_complete
+      , testProperty "Unknown is always prefix of known" prop_contained
+      ]
+

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -111,8 +111,7 @@ instance Arbitrary TestSetup where
       testSetupK         <- SecurityParam   <$> choose (2, 10)
       -- TODO why does k=1 cause the nodes to only forge in the first epoch?
 
-      -- TODO @js: think about what value should be used here.
-      let testSetupS     = GenesisWindowLength $ 2 * maxRollbacks testSetupK -- TODO
+      let testSetupS     = GenesisWindowLength $ 2 * maxRollbacks testSetupK
       testSetupTxSlot    <- SlotNo          <$> choose (0, 9)
 
       testSetupSeed       <- arbitrary

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -64,6 +64,8 @@ import           Ouroboros.Network.Magic
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.GenesisWindowLength
+                     (GenesisWindowLength)
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Combinator
@@ -99,6 +101,7 @@ data ProtocolA
 
 data instance ConsensusConfig ProtocolA = CfgA {
       cfgA_k           :: SecurityParam
+    , cfgA_s           :: GenesisWindowLength
     , cfgA_leadInSlots :: Set SlotNo
     }
   deriving NoThunks via OnlyCheckWhnfNamed "CfgA" (ConsensusConfig ProtocolA)
@@ -116,7 +119,8 @@ instance ConsensusProtocol ProtocolA where
       then Just ()
       else Nothing
 
-  protocolSecurityParam = cfgA_k
+  protocolSecurityParam       = cfgA_k
+  protocolGenesisWindowLength = cfgA_s
 
   tickChainDepState     _ _ _ _ = TickedTrivial
   updateChainDepState   _ _ _ _ = return ()

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -53,6 +53,8 @@ import           Ouroboros.Network.Magic
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.GenesisWindowLength
+                     (GenesisWindowLength)
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Combinator
@@ -85,6 +87,7 @@ data ProtocolB
 
 data instance ConsensusConfig ProtocolB = CfgB {
       cfgB_k           :: SecurityParam
+    , cfgB_s           :: GenesisWindowLength
     , cfgB_leadInSlots :: Set SlotNo
     }
   deriving NoThunks via OnlyCheckWhnfNamed "CfgB" (ConsensusConfig ProtocolB)
@@ -102,7 +105,8 @@ instance ConsensusProtocol ProtocolB where
       then Just ()
       else Nothing
 
-  protocolSecurityParam = cfgB_k
+  protocolSecurityParam       = cfgB_k
+  protocolGenesisWindowLength = cfgB_s
 
   tickChainDepState     _ _ _ _ = TickedTrivial
   updateChainDepState   _ _ _ _ = return ()

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -27,6 +27,7 @@ import           Cardano.Crypto.DSIGN.Mock
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Ouroboros.Network.AnchoredFragment.Completeness as AF
 import           Ouroboros.Network.Block (getTipPoint)
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Driver
@@ -285,7 +286,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
               WithFingerprint (const Nothing) (Fingerprint 0)
           }
 
-        client :: StrictTVar m (AnchoredFragment (Header TestBlock))
+        client :: StrictTVar m (AF.AnnotatedAnchoredFragment (Header TestBlock))
                -> Consensus ChainSyncClientPipelined
                     TestBlock
                     m
@@ -381,11 +382,11 @@ runChainSync securityParam (ClientUpdates clientUpdates)
     atomically $ do
       finalClientChain       <- readTVar varClientState
       finalServerChain       <- chainState <$> readTVar varChainProducerState
-      candidateFragment <- readTVar varFinalCandidates >>= readTVar . (Map.! serverId)
+      candidateFragment      <- readTVar varFinalCandidates >>= readTVar . (Map.! serverId)
       mbResult      <- readTVar varClientResult
       return ChainSyncOutcome {
           finalServerChain = testHeader <$> finalServerChain
-        , syncedFragment   = AF.mapAnchoredFragment testHeader candidateFragment
+        , syncedFragment   = AF.mapAnchoredFragment testHeader (AF.fragment candidateFragment)
         , ..
         }
   where

--- a/ouroboros-consensus/docs/report/chapters/future/genesis.tex
+++ b/ouroboros-consensus/docs/report/chapters/future/genesis.tex
@@ -1358,7 +1358,7 @@ It is important to consider several things here:
   $2k$ slots in (P)BFT.
 \end{itemize}
 
-Because of the reasons above, we could have the following bounds:
+Because of the reasons above, we have the following bounds:
 \begin{itemize}
 \item In PBFT: $2k \le s \le 2k$
 \item In Praos: $3k/f \le s \le 3k/f$
@@ -1367,15 +1367,15 @@ Because of the reasons above, we could have the following bounds:
 \subsection{The current decision}
 
 However one can argue that in reality and with the use cases that are envisioned
-for this consensus layer, it doesn't currently provide much benefits
+for this consensus layer, it doesn't currently provide many benefits
 implementing the machinery to be able to achieve this change in the genesis
 window length.
 
 In (P)BFT, the chain was produced by a set of core nodes that were extending the
 chain in a round-robin like fashion, and when one is to bootstrap from genesis,
 only one chain will be served as only one existed. There will be no choice to
-make and therefore the genesis window will never ever be invoked. Therefore
-whatever value we use for (P)BFT is irrelevant.
+make and therefore the genesis window will never be invoked. Therefore whatever
+value we use for (P)BFT is irrelevant.
 
 Furthermore, if someone uses this consensus layer to run something different
 that the actual Cardano network, either it doesn't make sense to use (P)BFT
@@ -1386,15 +1386,16 @@ core nodes and there will be no choices to make.
 We then decided to use $3k/f$ with the values those variables have in Praos to
 define the genesis window length as up to the current protocol choices ((P)BFT -
 TPraos - Praos). The genesis window length will then be just a parameter in a
-way similar to $k$ and will be fixed during the execution.
+way similar to $k$ and will be fixed until the node is restarted with a
+different set of configuration parameters.
 
 \subsection{Future approaches}
 
 There is however a subtlety that has to be made precise here. This choice is
 correct for now and as long as $f$ doesn't change. Currently, the active slots
 coefficient is not a votable parameter so there is no current way to change it.
-However, if it was made votable or even era-dependent, further development will
-be required.
+However, if it was made votable or even era-dependent, further investigation
+will be required.
 
 This would lead to the following situation, where the chains transition from era
 $E_1$ to era $E_2$ at the dot:
@@ -1421,12 +1422,12 @@ $E_1$ to era $E_2$ at the dot:
 \end{tikzpicture}
 \end{center}
 
-In this picture, imagine we are moving from $E_1$ that uses $f_1$ to $E_2$
-that uses $f_2$ where $f_1 > f_2$. The length of the second window would be
-bigger. However, it doesn't make sense to compare the part of the chain after
+In this picture, imagine we are moving from $E_1$ that uses $f_1$ to $E_2$ that
+uses $f_2$ where $f_1 > f_2$. The length of the second window would be
+bigger. However, it does not make sense to compare the part of the chain after
 the transition point using the genesis window from before the transition point
-and conversely it doesn't make sense to compare the part of the chain before the
-transition point using the genesis window from after the transition point.
+and conversely it does not make sense to compare the part of the chain before
+the transition point using the genesis window from after the transition point.
 
 It would therefore only be sensible to provide a specific transition function
 that can decide in such situations which chain has to be preferred. Very much

--- a/ouroboros-consensus/docs/report/chapters/future/genesis.tex
+++ b/ouroboros-consensus/docs/report/chapters/future/genesis.tex
@@ -1337,6 +1337,141 @@ tiny fork that it itself created. Moreover, blocks that we produce while we are
 not up to date may in fact be helpful for an adversary. We should therefore
 disable block production while the node is not up to date.
 
+\section{Dynamic genesis window length}
+
+The genesis window length is defined to be equal to $3k/f$. However this
+definition only makes sense in Praos and beyond as such protocols actually have
+a $f$ active slot coefficient. There is no equivalent $f$ for (P)BFT.
+
+It is important to consider several things here:
+
+\begin{itemize}
+\item The $f = 0.05$ factor is actually present in (P)BFT already as slots are 20
+  seconds long.
+\item The genesis window length is bounded from the top by the forecast
+  range. It wouldn't be practical to define a genesis window length that
+  involved blocks that we possibly could not verify. Currently the forecast
+  range is $3k/f$ slots in Praos and $2k$ slots in (P)BFT.
+\item The genesis window length is bounded from the bottom by the honest chain
+  growth rate. Currently we require that the window always has at least $k$
+  blocks inside the window and this is achieved in Praos in $3k/f$ slots and in
+  $2k$ slots in (P)BFT.
+\end{itemize}
+
+Because of the reasons above, we could have the following bounds:
+\begin{itemize}
+\item In PBFT: $2k \le s \le 2k$
+\item In Praos: $3k/f \le s \le 3k/f$
+\end{itemize}
+
+\subsection{The current decision}
+
+However one can argue that in reality and with the use cases that are envisioned
+for this consensus layer, it doesn't currently provide much benefits
+implementing the machinery to be able to achieve this change in the genesis
+window length.
+
+In (P)BFT, the chain was produced by a set of core nodes that were extending the
+chain in a round-robin like fashion, and when one is to bootstrap from genesis,
+only one chain will be served as only one existed. There will be no choice to
+make and therefore the genesis window will never ever be invoked. Therefore
+whatever value we use for (P)BFT is irrelevant.
+
+Furthermore, if someone uses this consensus layer to run something different
+that the actual Cardano network, either it doesn't make sense to use (P)BFT
+because they want a decentralized network (so $s$ can be set to $3k/f$) or they
+are only going to run (P)BFT and there block production is controlled by the
+core nodes and there will be no choices to make.
+
+We then decided to use $3k/f$ with the values those variables have in Praos to
+define the genesis window length as up to the current protocol choices ((P)BFT -
+TPraos - Praos). The genesis window length will then be just a parameter in a
+way similar to $k$ and will be fixed during the execution.
+
+\subsection{Future approaches}
+
+There is however a subtlety that has to be made precise here. This choice is
+correct for now and as long as $f$ doesn't change. Currently, the active slots
+coefficient is not a votable parameter so there is no current way to change it.
+However, if it was made votable or even era-dependent, further development will
+be required.
+
+This would lead to the following situation, where the chains transition from era
+$E_1$ to era $E_2$ at the dot:
+
+\begin{center}
+\begin{tikzpicture}[yscale=0.75]
+\draw (0, 0) -- (4, 0) coordinate(i);
+\draw (i) -- ++(1,  1) -- ++(1,0) node{$\bullet$} -- ++(5,0) node[right]{$A$};
+\draw (i) -- ++(1, -1) -- ++(1,0) node{$\bullet$} -- ++(5,0) node[right]{$B$};
+\draw [dashed]
+     (i)
+  -- ++( 0,  2)
+  -- ++( 4,  0) node[pos=0.5,above]{$\overbrace{\hspace{4cm}}^{s_1}$}
+  -- ++( 0, -3.4)
+  -- ++(-4,  0)
+  -- cycle;
+  \draw [dotted]
+     (i)
+  -- ++( 0,  3)
+  -- ++( 5,  0) node[pos=0.5,above]{$\overbrace{\hspace{5cm}}^{s_2}$}
+  -- ++( 0, -5)
+  -- ++(-5,  0)
+  -- cycle;
+\end{tikzpicture}
+\end{center}
+
+In this picture, imagine we are moving from $E_1$ that uses $f_1$ to $E_2$
+that uses $f_2$ where $f_1 > f_2$. The length of the second window would be
+bigger. However, it doesn't make sense to compare the part of the chain after
+the transition point using the genesis window from before the transition point
+and conversely it doesn't make sense to compare the part of the chain before the
+transition point using the genesis window from after the transition point.
+
+It would therefore only be sensible to provide a specific transition function
+that can decide in such situations which chain has to be preferred. Very much
+like other combination functions that are relevant for era transitions, it would
+be required to introduce a new field probably in \lstinline!CanHardFork!:
+
+\begin{lstlisting}
+class (...) => CanHardFork xs where
+  ...
+  hardForkDensitiesComparisons :: InPairs AcrossEraDensities xs
+\end{lstlisting}
+
+where \lstinline!AcrossEraDensities! would be defined in a similar way to
+\lstinline!AcrossEraSelection!:
+
+\begin{lstlisting}
+data AcrossEraDensities :: Type -> Type -> Type where
+  -- Example of a default function that does no combination
+  CompareNumberOfBlocks :: AcrossEraDensities x y
+
+  -- In case we are running the same protocol in two eras (for example Shelley - Allegra)
+  CompareSameProtocol ::
+       BlockProtocol x ~ BlockProtocol y
+    => AcrossEraDensities x y
+
+  -- Rest of the cases, custom overriding function.
+  CustomDensityComparison ::
+     (    AnchoredFragment (BlockProtocol x)
+       -> AnchoredFragment (BlockProtocol y)
+       -> Ordering
+     )
+     -> AcrossEraDensities x y
+\end{lstlisting}
+
+It will then be a matter of defining the variant
+\lstinline!CustomDensityComparison! for each of the conflictive era
+transitions. Notice that even if this was to be implemented, the algorithm for
+prefix selection would just need to receive such a function and use it if there
+is an era transition, otherwise just comparing by density of the genesis window
+length as defined for the era in the given chain fragment.
+
+Currently it is unknown what mechanism would such a function use to combine two
+different genesis window lengths, and solving this would probably require some
+discussions with the researchers.
+
 \section{Implementation concerns}
 
 \subsection{Chain selection in the chain database}

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -47,6 +47,7 @@ library
                        Ouroboros.Consensus.BlockchainTime.WallClock.Types
                        Ouroboros.Consensus.BlockchainTime.WallClock.Util
                        Ouroboros.Consensus.Config
+                       Ouroboros.Consensus.Config.GenesisWindowLength
                        Ouroboros.Consensus.Config.SecurityParam
                        Ouroboros.Consensus.Config.SupportsNode
                        Ouroboros.Consensus.Forecast
@@ -143,6 +144,7 @@ library
                        Ouroboros.Consensus.Node.Exit
                        Ouroboros.Consensus.NodeId
                        Ouroboros.Consensus.NodeKernel
+                       Ouroboros.Consensus.NodeKernel.Genesis
                        Ouroboros.Consensus.Node.InitStorage
                        Ouroboros.Consensus.Node.NetworkProtocolVersion
                        Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -145,6 +145,8 @@ library
                        Ouroboros.Consensus.NodeId
                        Ouroboros.Consensus.NodeKernel
                        Ouroboros.Consensus.NodeKernel.Genesis
+                       Ouroboros.Consensus.NodeKernel.Genesis.Impl
+                       Ouroboros.Consensus.NodeKernel.Genesis.Spec                                              
                        Ouroboros.Consensus.Node.InitStorage
                        Ouroboros.Consensus.Node.NetworkProtocolVersion
                        Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/GenesisWindowLength.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/GenesisWindowLength.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Ouroboros.Consensus.Config.GenesisWindowLength (
+    GenesisWindowLength (..)
+  , genesisWindowBounds
+  ) where
+
+import           Cardano.Slotting.Slot
+import           Data.Word
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+import           Quiet
+
+-- | The Genesis window length as needed for Ouroboros Genesis.
+--
+-- The paper <https://eprint.iacr.org/2018/378.pdf Ouroboros Genesis: Composable Proof-of-Stake Blockchains with Dynamic Availability>
+-- specifies that when two chains intersect more than @k@ blocks in the past,
+-- then the best chain is the one that has more blocks in the window of length
+-- @s@.
+--
+-- After discussing what value should be used for @s@ with the researchers, it
+-- was set to @3k/f@.
+--
+-- The genesis window must be available for all eras. Ouroboros Genesis is a
+-- refinement of Praos that aims to solve the problem of nodes joining the
+-- network. Therefore it does not make sense to enable the genesis window only
+-- for certain eras or periods.
+--
+-- Although the genesis window length could potentially change among eras,
+-- there's no benefit currently for our use case or for any use case that we
+-- envision to run on this consensus layer for having a way of varying the
+-- length. See the consensus report for more details.
+newtype GenesisWindowLength = GenesisWindowLength { genesisWindowLength :: Word64 }
+  deriving (Eq, Generic, NoThunks)
+  deriving Show via Quiet GenesisWindowLength
+
+-- | Given the slot of the window's anchor and the length of the window return
+-- the bounds of the window.
+genesisWindowBounds
+  :: WithOrigin SlotNo
+  -> GenesisWindowLength
+  -> (WithOrigin SlotNo, SlotNo)
+genesisWindowBounds w (GenesisWindowLength s) =
+  (w, withOrigin (SlotNo s) (SlotNo s +) w)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -54,6 +54,7 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.SOP (fn_5)
 
+import           Ouroboros.Consensus.Config.GenesisWindowLength
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
@@ -90,7 +91,11 @@ deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock
 
 data instance ConsensusConfig (HardForkProtocol xs) = HardForkConsensusConfig {
       -- | The value of @k@ cannot change at hard fork boundaries
-      hardForkConsensusConfigK :: !(SecurityParam)
+      hardForkConsensusConfigK :: !SecurityParam
+
+      -- | The length of the genesis window @s@ cannot change. See
+      -- 'Ouroboros.Consensus.Config.GenesisWindowLength'.
+    , hardForkGenesisWindowLength :: !GenesisWindowLength
 
       -- | The shape of the hard fork
       --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
@@ -16,11 +16,14 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Node
-import           Ouroboros.Consensus.Protocol.Abstract (protocolSecurityParam)
+import           Ouroboros.Consensus.Protocol.Abstract
+                     (ConsensusProtocol (protocolGenesisWindowLength),
+                     protocolSecurityParam)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Counting (exactlyTwo)
 import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
 
+import           Ouroboros.Consensus.Config.GenesisWindowLength
 import           Ouroboros.Consensus.HardFork.Combinator
 import qualified Ouroboros.Consensus.HardFork.History as History
 
@@ -48,6 +51,7 @@ protocolInfoBinary protocolInfo1 eraParams1 toPartialConsensusConfig1 toPartialL
         pInfoConfig = TopLevelConfig {
             topLevelConfigProtocol = HardForkConsensusConfig {
                 hardForkConsensusConfigK      = k
+              , hardForkGenesisWindowLength   = s
               , hardForkConsensusConfigShape  = shape
               , hardForkConsensusConfigPerEra = PerEraConsensusConfig
                   (  WrapPartialConsensusConfig (toPartialConsensusConfig1 consensusConfig1)
@@ -120,6 +124,11 @@ protocolInfoBinary protocolInfo1 eraParams1 toPartialConsensusConfig1 toPartialL
     k1 = protocolSecurityParam consensusConfig1
     k2 = protocolSecurityParam consensusConfig2
     k = assert (k1 == k2) k1
+
+    s1, s2, s :: GenesisWindowLength
+    s1 = protocolGenesisWindowLength consensusConfig1
+    s2 = protocolGenesisWindowLength consensusConfig2
+    s = assert (s1 == s2) s1
 
     shape :: History.Shape '[blk1, blk2]
     shape = History.Shape $ exactlyTwo eraParams1 eraParams2

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -315,6 +315,7 @@ instance Isomorphic TopLevelConfig where
                    -> ConsensusConfig (BlockProtocol (HardForkBlock '[blk]))
       auxConsensus cfg = HardForkConsensusConfig {
             hardForkConsensusConfigK      = protocolSecurityParam cfg
+          , hardForkGenesisWindowLength   = protocolGenesisWindowLength cfg
           , hardForkConsensusConfigShape  = History.singletonShape eraParams
           , hardForkConsensusConfigPerEra = PerEraConsensusConfig $
                  WrapPartialConsensusConfig (toPartialConsensusConfig (Proxy @blk) cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -110,6 +110,8 @@ instance CanHardFork xs => ConsensusProtocol (HardForkProtocol xs) where
   -- Security parameter must be equal across /all/ eras
   protocolSecurityParam = hardForkConsensusConfigK
 
+  protocolGenesisWindowLength = hardForkGenesisWindowLength
+
 {-------------------------------------------------------------------------------
   BlockSupportsProtocol
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -42,7 +42,7 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Map.Strict (Map)
 import           Data.Void (Void)
 
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import           Ouroboros.Network.AnchoredFragment.Completeness
 import           Ouroboros.Network.Block (Serialised (..), decodePoint,
                      decodeTip, encodePoint, encodeTip)
 import           Ouroboros.Network.BlockFetch
@@ -109,7 +109,7 @@ data Handlers m peer blk = Handlers {
         :: peer
         -> NodeToNodeVersion
         -> ControlMessageSTM m
-        -> StrictTVar m (AnchoredFragment (Header blk))
+        -> StrictTVar m (AnnotatedAnchoredFragment (Header blk))
         -> ChainSyncClientPipelined (Header blk) (Point blk) (Tip blk) m ChainSyncClientResult
         -- TODO: we should consider either bundling these context parameters
         -- into a record, or extending the protocol handler representation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -402,7 +402,7 @@ initBlockFetchConsensusInterface cfg chainDB getCandidates blockFetchSize btime 
        currChain <- readCurrentChain
        return $ case syncMode of
          Syncing ->
-           Genesis.processWithPrefixSelection (AF.anchorPoint currChain) s fragments
+           Genesis.processWithPrefixSelectionImpl (AF.anchorPoint currChain) s fragments
          CaughtUp ->
            -- TODO @js: is this okay?
            fragments

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel/Genesis.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel/Genesis.hs
@@ -1,0 +1,287 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | An implementation of the prefix selection algorithm.
+module Ouroboros.Consensus.NodeKernel.Genesis (
+    processWithPrefixSelection
+    -- * For testing
+  , density
+  , findCommonPrefix
+  , findSuffixes
+  , prefixSelection
+  ) where
+
+import           Prelude hiding (length)
+
+import           Data.Function (on)
+import           Data.List (foldl', maximumBy)
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes)
+
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config.GenesisWindowLength
+import           Ouroboros.Network.AnchoredFragment hiding (filter)
+import           Ouroboros.Network.AnchoredFragment.Completeness
+import           Ouroboros.Network.AnchoredSeq hiding (filter, join, map,
+                     prettyPrint)
+
+{-------------------------------------------------------------------------------
+ The prefix selection algorithm
+-------------------------------------------------------------------------------}
+
+-- | Process a map of candidates as stated in the prefixSelection chapter of the
+-- report.
+processWithPrefixSelection ::
+     ( BlockSupportsProtocol blk
+     , Ord peer
+     )
+  => Point (Header blk)
+     -- ^ The current immutable tip as point
+  -> GenesisWindowLength
+     -- ^ The length of the genesis window
+  -> Map peer (AnnotatedAnchoredFragment (Header blk))
+     -- ^ The list of candidates
+  -> Map peer (AnnotatedAnchoredFragment (Header blk))
+processWithPrefixSelection immTip s m =
+    Map.fromList result
+  where
+    theList        = Map.toList m
+    selectedPrefix = prefixSelection immTip s $ map snd theList
+    headAsPoint    = headPoint selectedPrefix
+    result         =
+      catMaybes
+      [ do
+          (_, reAnchored)    <- splitAfterPoint (fragment candidate) immTip
+          (candidate', rest) <- splitAfterPoint reAnchored headAsPoint
+          return (peer, AnnotatedAnchoredFragment candidate' (case rest of
+                            Empty _ -> completeness candidate
+                            _       -> FragmentIncomplete))
+      | (peer, candidate) <- theList ]
+
+{-------------------------------------------------------------------------------
+ Internal implementation
+-------------------------------------------------------------------------------}
+
+-- | Run the prefix selection algorithm on a list of candidates.
+prefixSelection :: forall blk.
+  ( HasHeader (Header blk)
+  , HasHeader blk
+  )
+  => Point (Header blk)
+     -- ^ The current immutable tip as point
+  -> GenesisWindowLength
+     -- ^ The length of the genesis window
+  -> [AnnotatedAnchoredFragment (Header blk)]
+     -- ^ The list of candidates
+  ->   AnchoredFragment (Header blk)
+prefixSelection currentImmTip s originalCandidates =
+    go initialPrefix
+  where
+    -- | Compute a usable list of candidates
+    --
+    -- Every candidate is anchored at the block that was the tip of the
+    -- immutable database when the sync was performed. The immutable tip might
+    -- have moved and candidates that fork before it can be safely discarded as
+    -- the ChainDB will never switch to them. Therefore we will continue only
+    -- with the candidates that contain the immutable tip and we will anchor
+    -- them there.
+    --
+    -- Note that after this, *all candidates are anchored at the same point*,
+    -- namely the tip of the immutable database.
+    initialCandidates :: [AnnotatedAnchoredFragment (Header blk)]
+    initialCandidates =
+      catMaybes
+        [     flip AnnotatedAnchoredFragment (completeness candidate)
+          .   snd
+          <$> splitAfterPoint (fragment candidate) currentImmTip
+        | candidate <- originalCandidates ]
+
+    -- | First common prefix
+    initialPrefix :: AnchoredFragment (Header blk)
+    initialPrefix = findCommonPrefix (map fragment initialCandidates)
+
+    -- | Recursive algorithm
+    --
+    -- Given an anchored fragment, the algorithm will run by:
+    -- - anchoring a genesis window at the end of the fragment
+    -- - making a decision based on densities of the fragments in the window
+    -- - find the common prefix of the set of candidates that share more than
+    --   just the anchor of the window with the best candidate.
+    -- - repeat if in the previous step, multiple candidates share the prefix.
+    go :: AnchoredFragment (Header blk) -> AnchoredFragment (Header blk)
+    go thisIterationPrefix =
+        case result of
+          Just result' -> result'
+          Nothing      -> error "Fragments that should be consecutive could not be joined"
+      where
+
+        -- | The suffixes of the candidates anchored at the head of
+        -- thisIterationPrefix
+        thisIterationSuffixes ::
+          [AnnotatedAnchoredFragment (Header blk)]
+        thisIterationSuffixes =
+          findSuffixes thisIterationPrefix initialCandidates
+
+        -- | The boundaries of the genesis window
+        thisWindow :: (WithOrigin SlotNo, SlotNo)
+        thisWindow = genesisWindowBounds (headSlot thisIterationPrefix) s
+
+        -- | The best candidate in the window
+        iterationBestCandidate :: PrefixSelection (AnchoredFragment (Header blk))
+        iterationBestCandidate =
+          if all (hasKnownDensityAt (snd thisWindow)) thisIterationSuffixes
+          then
+            -- Find the densest candidate and continue
+              MoreDecisions
+            $ maximumBy (compare `on` density thisWindow) (map fragment thisIterationSuffixes)
+          else
+            case filter (not . hasKnownDensityAt (snd thisWindow)) thisIterationSuffixes of
+              [one] ->
+                if density thisWindow (fragment one)
+                   >= maximum (map (density thisWindow) (map fragment thisIterationSuffixes))
+                -- there is only one candidate with unknown density and it is
+                -- already the densest in the window.
+                then LastDecision $ fragment one
+                else Unknown
+              _ -> Unknown
+
+        -- | The common prefix for the next iteration
+        nextIterationPrefix :: PrefixSelection (AnchoredFragment (Header blk))
+        nextIterationPrefix =
+          case iterationBestCandidate of
+            MoreDecisions bestCandidate ->
+              let nextIterationFragments =
+                    [ candidate | candidate <- thisIterationSuffixes
+                                , case intersect bestCandidate (fragment candidate) of
+                                    -- discard non-intersecting
+                                    Nothing                    -> False
+                                    -- include iterationBestCandidate itself
+                                    Just (Empty _, Empty _, a, b) ->
+                                         headPoint a == headPoint b
+                                      && headPoint a == headPoint bestCandidate
+                                    -- discard those that only intersect on the
+                                    -- anchor
+                                    Just (_, Empty _, _, _) -> False
+                                    _                       -> True
+                                ]
+              in
+                case nextIterationFragments of
+                  [f] -> LastDecision $ fragment f
+                  _   -> MoreDecisions $ findCommonPrefix (map fragment nextIterationFragments)
+            l@(LastDecision ld) ->
+              let nextIterationFragments = [ candidate | candidate <- thisIterationSuffixes
+                                , case intersect ld (fragment candidate) of
+                                    -- discard non-intersecting
+                                    Nothing                    -> False
+                                    -- include iterationBestCandidate itself
+                                    Just (Empty _, Empty _, a, b) ->
+                                         headPoint a == headPoint b
+                                      && headPoint a == headPoint ld
+                                    -- discard those that only intersect on the
+                                    -- anchor
+                                    Just (_, Empty _, _, _) -> False
+                                    _                       -> True
+                                ]
+              in
+                case nextIterationFragments of
+                  [_] -> l
+                  _   -> MoreDecisions $ findCommonPrefix (map fragment nextIterationFragments)
+            _ -> iterationBestCandidate
+
+        -- | This iteration's result
+        result =
+            join thisIterationPrefix
+            $ case nextIterationPrefix of
+                LastDecision ld  -> ld
+                Unknown          -> Empty $ headAnchor thisIterationPrefix
+                MoreDecisions md -> go md
+
+-- | A result of prefix selection
+data PrefixSelection a =
+    -- | A decision has been made at a known-density point. The next
+    -- intersection point has to be resolved.
+    MoreDecisions a
+  | -- | There are no more intersection points to resolve.
+    LastDecision a
+  | -- | There was no outcome from the decision process because densities are
+    -- unknown at the intersection point.
+    Unknown
+ deriving (Show)
+
+{-------------------------------------------------------------------------------
+ Density
+-------------------------------------------------------------------------------}
+
+-- | Whether the provided fragment has known density within a window that ends
+-- at the given slot number.
+hasKnownDensityAt ::
+     HasHeader b
+  => SlotNo
+  -> AnnotatedAnchoredFragment b
+  -> Bool
+hasKnownDensityAt _  (AnnotatedAnchoredFragment _ FragmentComplete) = True
+hasKnownDensityAt to f                                              =
+  withOrigin False (>= to) (headSlot $ fragment f)
+
+-- | Compute the density of the fragment in the given window
+density ::
+     HasHeader blk
+  => (WithOrigin SlotNo, SlotNo)
+  -> AnchoredFragment blk
+  -> Int
+density (a, b) f =
+    length
+    -- To be completely precise, the density would sometimes require a +1 but as
+    -- all fragments will go through the same function, they will all be scaled.
+  . takeWhileOldest (\blk -> blockSlot blk <= b)
+  . maybe f snd
+    -- If the fragment is already anchored at the beginning of the window, split
+    -- will return nothing. This assumes that we are going to apply this
+    -- function only on fragments which actually have a block at the anchor of
+    -- the genesis window.
+  . splitBeforeMeasure a (const True)
+  $ f
+
+{-------------------------------------------------------------------------------
+ Prefixes and suffixes operations
+-------------------------------------------------------------------------------}
+
+-- | Given a list of chains, find the prefix that is common to all of them.
+--
+-- PRECONDITION: all candidates must be anchored at the same anchor.
+findCommonPrefix ::
+     HasHeader (Header blk)
+  => [AnchoredFragment (Header blk)]
+  ->  AnchoredFragment          (Header blk)
+findCommonPrefix []     = error "findCommonPrefix called with empty list"
+findCommonPrefix (f:fs) =
+  case result of
+    Just frag -> frag
+    Nothing   -> error "Precondition violated: fragments must be anchored at the same anchor."
+  where
+    result =
+      foldl'
+        (\acc candidate -> do
+            acc' <- acc
+            (acc'', _, _, _) <- intersect acc' candidate
+            return acc'')
+        (Just f)
+        fs
+
+-- | Move the anchor point of each fragment in the list to the head of the
+-- common prefix provided.
+findSuffixes ::
+     forall hblk. HasHeader hblk
+  => AnchoredFragment hblk
+  -> [AnnotatedAnchoredFragment hblk]
+  -> [AnnotatedAnchoredFragment hblk]
+findSuffixes commonPrefix l =
+   catMaybes
+     [     flip AnnotatedAnchoredFragment (completeness candidate)
+       .   snd
+       <$> splitAfterPoint (fragment candidate) (headPoint commonPrefix)
+     | candidate <- l ]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel/Genesis/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel/Genesis/Impl.hs
@@ -1,0 +1,328 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Consensus.NodeKernel.Genesis.Impl where
+
+import           Prelude hiding (last, length)
+import qualified Prelude (last)
+
+import           Control.Exception (assert)
+import           Data.Function (on)
+import           Data.List (foldl', groupBy, partition, sortBy)
+import qualified Data.List.NonEmpty as NE
+import           Data.Maybe (catMaybes)
+import           Data.Word
+
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config.GenesisWindowLength
+import           Ouroboros.Network.AnchoredFragment hiding (filter, null)
+import           Ouroboros.Network.AnchoredFragment.Completeness
+
+{-------------------------------------------------------------------------------
+ Genesis Trees
+-------------------------------------------------------------------------------}
+
+data UnfinishedBranch = IncompleteBranch | NA deriving (Show, Eq)
+
+-- | A GenesisTree is equivalent to a Data.Tree but captures the fact that the
+-- root is an @Anchor blk@.
+data GenesisTree blk =
+    GRoot (Anchor blk) [GenesisTree blk]
+  | GNode blk UnfinishedBranch (NE.NonEmpty (GenesisTree blk))
+  | GLeaf blk FragmentCompleteness
+  deriving (Show)
+
+bk :: GenesisTree blk -> blk
+bk (GRoot _ _)   = error "Can't call bk on a root"
+bk (GNode b _ _) = b
+bk (GLeaf b _)   = b
+
+-- | Given two unitary trees, concatenate the second at the end of the first
+concatTrees :: GenesisTree blk -> GenesisTree blk -> GenesisTree blk
+concatTrees (GRoot a   [])               ts = GRoot a [ts]
+concatTrees (GRoot a   [t])              ts = GRoot a [concatTrees t ts]
+concatTrees (GNode b f (t NE.:| []))     ts = GNode b f                (concatTrees t ts NE.:| [])
+concatTrees (GLeaf b FragmentComplete)   ts = GNode b NA               (ts NE.:| [])
+concatTrees (GLeaf b FragmentIncomplete) ts = GNode b IncompleteBranch (ts NE.:| [])
+concatTrees _ _ = error "Precondition violated: concatTrees on non-trivial tree"
+
+{-------------------------------------------------------------------------------
+ Genesis Paths
+-------------------------------------------------------------------------------}
+
+-- | A sequence of blocks representing a path on a tree.
+data GenesisPath blk =
+    GPathLeaf blk FragmentCompleteness
+  | GPath     blk (GenesisPath blk)
+
+hd :: GenesisPath blk -> blk
+hd (GPathLeaf b _) = b
+hd (GPath     b _) = b
+
+pathToUnitaryTree :: GenesisPath blk -> GenesisTree blk
+pathToUnitaryTree (GPathLeaf b f) = GLeaf b f
+pathToUnitaryTree (GPath     b n) = GNode b NA (pathToUnitaryTree n NE.:| [])
+
+unitaryTreeToAnchoredFragment ::
+  HasHeader blk
+  => GenesisTree blk
+  -> AnchoredFragment blk
+unitaryTreeToAnchoredFragment = unitaryTreeToAnchoredFragment' undefined
+  where
+    unitaryTreeToAnchoredFragment' _ (GRoot a [n])            = unitaryTreeToAnchoredFragment' (Empty a :>) n
+    unitaryTreeToAnchoredFragment' f (GNode b _ (n NE.:| [])) = unitaryTreeToAnchoredFragment' (f b :>) n
+    unitaryTreeToAnchoredFragment' f (GLeaf b _)              = f b
+    unitaryTreeToAnchoredFragment' _ _ =
+      error "Precondition violated: called unitaryTreeToAnchoredFragment with non-trivial tree"
+
+{-------------------------------------------------------------------------------
+ Convert a list of AnchoredFragments into a GenesisTree
+-------------------------------------------------------------------------------}
+
+-- | Convert a list of paths through a tree into a tree
+anchoredFragmentsToTree ::
+     forall blk . HasHeader blk
+  => [AnnotatedAnchoredFragment blk]
+  -> GenesisTree blk
+anchoredFragmentsToTree [] = error "Precondition violated: pathsToTree was given an empty list"
+anchoredFragmentsToTree paths@(path:_) =
+    -- Initially they all must be anchored at the same point
+    assert (all (\x -> anchor (fragment x) == anchor (fragment path)) paths) $
+    let
+      root = GRoot (anchor (fragment path)) []
+      fragmentToPath af =
+        case toOldestFirst (fragment af) of
+          [] -> Nothing
+          bs -> Just
+            $ foldr (\case
+                         (GPathLeaf zz _) -> \acc ->  GPath zz acc
+                         _                -> error "Can't happen")
+                    (GPathLeaf (Prelude.last bs) (completeness af))
+                    (map (`GPathLeaf` FragmentComplete) $ init bs)
+      rest = catMaybes $ map fragmentToPath paths
+    in
+      -- We are going to fold through the list of paths adding them to the tree
+      foldl' (\case
+                 (GRoot r c) -> addToTree (\c' _ -> GRoot r c') c
+                 _           -> error "Can't happen")
+             root
+             rest
+  where
+    addToTree ::
+         (   [GenesisTree blk]
+          -> (UnfinishedBranch -> UnfinishedBranch)
+          -> GenesisTree blk
+         ) -- ^ Update the parent node
+      ->  [GenesisTree blk]
+      ->   GenesisPath blk
+      ->   GenesisTree blk
+    addToTree upd children p =
+      case children of
+        [] ->
+          -- if the parent node doesn't have any children, then add this unitary
+          -- path.
+          upd [pathToUnitaryTree p] id
+        _ ->
+          if not $ blockPoint (hd p) `elem` map (blockPoint . bk) children
+          then
+            -- if the parent node doesn't have a children that matches this one,
+            -- then add this unitary path.
+            upd (pathToUnitaryTree p : children) id
+          else
+            case p of
+              GPathLeaf _ FragmentComplete ->
+                -- if the path ends here, then return id.
+                upd children id
+              GPathLeaf _ FragmentIncomplete ->
+                -- if the path ends here *AND* is incomplete, then tag the
+                -- parent as Incomplete.
+                upd children (\case
+                                 NA -> IncompleteBranch
+                                 f  -> f)
+              GPath i n ->
+                 -- if the path continues, find the relevant child and continue there
+                 let (found, others) = partition (\x -> blockPoint (bk x) == blockPoint i) children
+                 in
+                   case found of
+                     [GNode b f c] ->
+                       -- if we found one children that continues, keep recursing
+                       let upd' c' f' = upd (GNode b (f' f) (NE.fromList c') : others) id in
+                         addToTree upd' (NE.toList c) n
+                     [GLeaf b f] ->
+                       -- if we found one children that ends here, add this as
+                       -- unitary path. If it was already unfinished, then keep
+                       -- it. Otherwise, it will be finished trivially.
+                       -- Note: c' will be necessarily non-empty.
+                       let
+                         f' = if f == FragmentIncomplete then IncompleteBranch else NA
+                         upd' c' _ = upd (GNode b f' (NE.fromList c') : others) id
+                       in
+                         (addToTree upd' [] n)
+                     _           -> error "Can't happen"
+
+{-------------------------------------------------------------------------------
+ GenesisBlockchain
+-------------------------------------------------------------------------------}
+-- | The representation of all the information required to process a tree with
+-- maxvalid_bg or equivalent algorithms (prefixSelection).
+data GenesisBlockchain blk = GenesisBlockchain {
+     s :: GenesisWindowLength
+   , t :: GenesisTree blk
+   } deriving (Show)
+
+{-------------------------------------------------------------------------------
+ foldWithCommonPrefixStep
+-------------------------------------------------------------------------------}
+
+-- | A fold over a tree that combines results at the branching points.
+foldWithCommonPrefixStep ::
+     forall a blk b . HasHeader blk
+  => (   ([GenesisTree blk], SlotNo)
+      -> Maybe (GenesisTree blk, b)
+     ) -- ^ Picker function. Chooses a branch to continue plus some metadata
+     -- required for the update function or short-circuits on @Nothing@.
+  -> (a -> (GenesisTree blk, b) -> Either a a)
+     -- ^ Updater function. updates the state with the chosen unique
+     -- prefix. Short-circuits on @Left@.
+  -> (GenesisTree blk -> a)
+     -- ^ Initiator
+  -> GenesisTree blk
+     -- ^ Tree to fold
+  -> a
+foldWithCommonPrefixStep picker updater initial theTree =
+    let
+      (initialPrefix, sl, initialChildren) = splitAtIntersection theTree
+      initialState = initial initialPrefix
+    in
+      foldWithCommonPrefixStep' (initialChildren, sl) initialState
+  where
+    foldWithCommonPrefixStep' tr st =
+       case picker tr of
+         Nothing  -> st
+         Just (n, b)   ->
+           let (n', sl', ch) = splitAtIntersection n
+           in either id (foldWithCommonPrefixStep' (ch, sl')) $ updater st (n', b)
+
+-- | Find the next intersection and split the tree in
+-- 1) The common prefix
+-- 2) The slot number at the intersection
+-- 3) The branches at the intersection
+splitAtIntersection ::
+     HasHeader blk
+  => GenesisTree blk
+  -> (GenesisTree blk, SlotNo, [GenesisTree blk])
+
+splitAtIntersection   (GRoot rt [t]) = let (pr, sl, ch) = splitAtIntersection t in     (GRoot rt [pr], sl, ch)
+splitAtIntersection g@(GRoot b [])   = let sl = fromWithOrigin 0 $ anchorToSlotNo b in (g,             sl, [])
+splitAtIntersection   (GRoot b c)    = let sl = fromWithOrigin 0 $ anchorToSlotNo b in (GRoot b [],    sl, c)
+
+splitAtIntersection (GNode b f                (t NE.:| [])) = let (pr, sl, ch) = splitAtIntersection t in (GNode b f (pr NE.:| []),    sl,          ch)
+splitAtIntersection (GNode b IncompleteBranch c)            =                                             (GLeaf b FragmentIncomplete, blockSlot b, NE.toList c)
+splitAtIntersection (GNode b _                c)            =                                             (GLeaf b FragmentComplete,   blockSlot b, NE.toList c)
+
+splitAtIntersection g@(GLeaf b _) = (g, blockSlot b, [])
+
+{-------------------------------------------------------------------------------
+ Find the densest branches at a intersection
+-------------------------------------------------------------------------------}
+
+-- | Given a genesis window length, a slot at which to anchor the window and a
+-- list of candidates find the densest ones. The returned list might be empty in
+-- which case it means that it couldn't pick due to unknown densities.
+densestInWindow ::
+     forall blk.  HasHeader blk
+  => GenesisWindowLength
+  -> SlotNo
+  -> [GenesisTree blk]
+  -> [GenesisTree blk]
+densestInWindow window wrt candidates =
+    -- Candidates must be anchored at the same point
+    assert (not $ null candidates) $
+    let trimmed = trimToWindow candidates
+        (areComplete, nonComplete) = partition (isCompleteInWindow . fst) trimmed
+    in
+      case (areComplete, nonComplete) of
+        ([],[]) -> error "Precondition violated, empty window"
+        ([],_) -> []
+                  -- no candidates are fully complete, so we don't know which
+                  -- one to choose.
+        _ -> let densestComplete =
+                   Prelude.head
+                   $ groupBy ((==) `on` fst)
+                   $ sortBy (flip compare `on` fst)
+                   $ map (\(x,y) -> (getDensity x, y)) areComplete
+             in case nonComplete of
+                  [] ->
+                    -- Every candidate is known, so we provide the best ones.
+                    map snd densestComplete
+                  _ ->
+                    -- There are some unknown candidates, the only time when we
+                    -- can return something is if one of the unknown branches is
+                    -- already as dense as the densest of the known ones (either
+                    -- by a sub-branch which is known or even if there is an
+                    -- unknown branch that is actually already denser)
+                    let densestNonComplete =
+                            groupBy ((==) `on` fst)
+                          $ sortBy (flip compare `on` fst)
+                          $ map (\(x,y) -> (getPotentialDensity x, y)) nonComplete
+                    in
+                      case densestNonComplete of
+                        [(d,f)]:[] ->
+                          -- There is only one densest unknown candidate
+                          if d >= fst (Prelude.head densestComplete)
+                          then [f]
+                          else []
+                        d:_ ->
+                          -- If the perceived density of all the incomplete
+                          -- branches cannot win against the densest one that
+                          -- are complete ever, then we can pick the known ones.
+                          if all ((fst (Prelude.head densestComplete) >=) . fst) d
+                          then map snd densestComplete
+                          else []
+  where
+    -- | Reduce the candidates to the window that we are considering, keep the
+    -- original candidate (without trimming) for future use.
+    trimToWindow :: [GenesisTree blk] -> [(GenesisTree blk, GenesisTree blk)]
+    trimToWindow =
+        catMaybes
+        . map (\case
+                GRoot _ _ -> error "Precondition violated"
+                g@(GLeaf b _) ->
+                  if isInWindow b then Just (g, g) else Nothing
+                g@(GNode b f c) ->
+                  if isInWindow b
+                  then case trimToWindow $ NE.toList c of
+                         [] -> Just $ (GLeaf b (if f == IncompleteBranch
+                                               then FragmentIncomplete
+                                               else FragmentComplete), g)
+                         c' -> Just $ (GNode b f $ NE.fromList (map fst c'), g)
+                  else Nothing)
+
+    isInWindow :: blk -> Bool
+    isInWindow x = unSlotNo (blockSlot x - wrt) <= genesisWindowLength window
+
+    -- | Return whether a candidate is complete in the window
+    isCompleteInWindow :: GenesisTree blk -> Bool
+    isCompleteInWindow GRoot{} = error "Precondition violated"
+    isCompleteInWindow (GNode _ IncompleteBranch _) = False
+    isCompleteInWindow (GNode _ _ c) = all isCompleteInWindow c
+    isCompleteInWindow (GLeaf _ FragmentComplete) = True
+    isCompleteInWindow (GLeaf _ FragmentIncomplete) = False
+
+    -- | Get the density of a candidate in this window
+    getDensity :: GenesisTree blk -> Word64
+    getDensity GRoot{}       = error "PV"
+    getDensity GLeaf{}       = 1
+    getDensity (GNode _ _ n) = 1 + maximum (map getDensity $ NE.toList n)
+
+    getPotentialDensity :: GenesisTree blk -> Word64
+    getPotentialDensity GRoot{}       = error "PV"
+    getPotentialDensity (GLeaf b FragmentIncomplete) = genesisWindowLength window - unSlotNo (blockSlot b - wrt)
+    getPotentialDensity (GNode b IncompleteBranch n) = maximum ((genesisWindowLength window - unSlotNo (blockSlot b - wrt)) : (map ((1 +) . getDensity) $ NE.toList n))
+    getPotentialDensity (GNode b NA n) = 1 + maximum (map getDensity $ NE.toList n)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel/Genesis/Spec.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel/Genesis/Spec.hs
@@ -1,0 +1,352 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Consensus.NodeKernel.Genesis.Spec where
+
+import           Prelude hiding (last, length)
+
+import           Data.Function (on)
+import           Data.List (foldl', maximumBy)
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes)
+
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config.GenesisWindowLength
+import           Ouroboros.Network.AnchoredFragment hiding (filter, null)
+import           Ouroboros.Network.AnchoredFragment.Completeness
+import           Ouroboros.Network.AnchoredSeq hiding (filter, join, map, null,
+                     prettyPrint)
+{-------------------------------------------------------------------------------
+ The prefix selection algorithm
+-------------------------------------------------------------------------------}
+
+-- | Process a map of candidates as stated in the prefixSelection chapter of the
+-- report.
+processWithPrefixSelectionSpec ::
+     ( BlockSupportsProtocol blk
+     , Ord peer
+     )
+  => Point (Header blk)
+     -- ^ The current immutable tip as point
+  -> GenesisWindowLength
+     -- ^ The length of the genesis window
+  -> Map peer (AnnotatedAnchoredFragment (Header blk))
+     -- ^ The list of candidates
+  -> Map peer (AnnotatedAnchoredFragment (Header blk))
+processWithPrefixSelectionSpec immTip s m =
+    Map.fromList result
+  where
+    candidatesList = Map.toList m
+    selectedPrefix = prefixSelection immTip s $ map snd candidatesList
+    headAsPoint    = headPoint selectedPrefix
+    result         =
+      catMaybes
+      [ do
+          (_, reAnchored)    <- splitAfterPoint (fragment candidate) immTip
+          (candidate', rest) <- splitAfterPoint reAnchored headAsPoint
+          return (peer, AnnotatedAnchoredFragment candidate' (case rest of
+                            Empty _ -> completeness candidate
+                            _       -> FragmentIncomplete))
+      | (peer, candidate) <- candidatesList ]
+
+{-------------------------------------------------------------------------------
+ Internal implementation
+-------------------------------------------------------------------------------}
+
+-- | Run the prefix selection algorithm on a list of candidates.
+prefixSelection :: forall blk.
+  ( HasHeader (Header blk)
+  , HasHeader blk
+  )
+  => Point (Header blk)
+     -- ^ The current immutable tip as point
+  -> GenesisWindowLength
+     -- ^ The length of the genesis window
+  -> [AnnotatedAnchoredFragment (Header blk)]
+     -- ^ The list of candidates
+  ->           AnchoredFragment (Header blk)
+
+prefixSelection currentImmTip s originalCandidates =
+    go initialPrefix
+  where
+    -- | Compute a usable list of candidates
+    --
+    -- Every candidate is anchored at the block that was the tip of the
+    -- immutable database when the sync was performed. The immutable tip might
+    -- have moved and candidates that fork before it can be safely discarded as
+    -- the ChainDB will never switch to them. Therefore we will continue only
+    -- with the candidates that contain the immutable tip and we will anchor
+    -- them there.
+    --
+    -- Note that after this, *all candidates are anchored at the same point*,
+    -- namely the tip of the immutable database.
+    initialCandidates :: [AnnotatedAnchoredFragment (Header blk)]
+    initialCandidates =
+      catMaybes
+        [     flip AnnotatedAnchoredFragment (completeness candidate)
+          .   snd
+          <$> splitAfterPoint (fragment candidate) currentImmTip
+        | candidate <- originalCandidates ]
+
+    -- | First common prefix
+    initialPrefix :: AnchoredFragment (Header blk)
+    initialPrefix = findCommonPrefix (map fragment initialCandidates)
+
+    -- | Recursive algorithm
+    --
+    -- Given an anchored fragment, the algorithm will run by:
+    -- - anchoring a genesis window at the end of the fragment
+    -- - making a decision based on densities of the fragments in the window
+    -- - find the common prefix of the set of candidates that share more than
+    --   just the anchor of the window with the best candidate.
+    -- - repeat if in the previous step, multiple candidates share the prefix.
+    go :: AnchoredFragment (Header blk) -> AnchoredFragment (Header blk)
+    go thisIterationPrefix =
+        case result of
+          Just result' -> result'
+          Nothing      -> error "Fragments that should be consecutive could not be joined"
+      where
+
+        -- | The suffixes of the candidates anchored at the head of
+        -- thisIterationPrefix
+        thisIterationSuffixes ::
+          [AnnotatedAnchoredFragment (Header blk)]
+        thisIterationSuffixes =
+          findSuffixes thisIterationPrefix initialCandidates
+
+        -- | The boundaries of the genesis window
+        thisWindow :: GenesisWindow
+        thisWindow = genesisWindowBounds (headSlot thisIterationPrefix) s
+
+        -- | The best candidate in the window
+        iterationBestCandidate :: PrefixSelection (AnchoredFragment (Header blk))
+        iterationBestCandidate =
+          if all (hasKnownDensityAt (gwTo thisWindow)) thisIterationSuffixes
+          then
+            -- Find the densest candidate and continue
+              MoreDecisions
+            $ maximumBy (compare `on` density thisWindow) (map fragment thisIterationSuffixes)
+          else
+            case filter (not . hasKnownDensityAt (gwTo thisWindow)) thisIterationSuffixes of
+              [one] ->
+                if density thisWindow (fragment one)
+                   >= maximum (map (density thisWindow . fragment) thisIterationSuffixes)
+                -- there is only one candidate with unknown density and it is
+                -- already the densest in the window.
+                then LastDecision $ fragment one
+                else Unknown
+              _ -> Unknown
+
+        -- | The common prefix for the next iteration
+        nextIterationPrefix :: PrefixSelection (AnchoredFragment (Header blk))
+        nextIterationPrefix =
+          case iterationBestCandidate of
+            MoreDecisions bestCandidate ->
+              let nextIterationFragments =
+                    [ candidate | candidate <- thisIterationSuffixes
+                                , case bestCandidate `intersect` fragment candidate of
+                                    -- discard non-intersecting
+                                    Nothing                    -> False
+                                    -- include iterationBestCandidate itself
+                                    Just (Empty _, Empty _, a, b) ->
+                                         headPoint a == headPoint b
+                                      && headPoint a == headPoint bestCandidate
+                                    -- discard those that only intersect on the
+                                    -- anchor
+                                    Just (_, Empty _, _, _) -> False
+                                    _                       -> True
+                                ]
+              in
+                case nextIterationFragments of
+                  [f] -> LastDecision $ fragment f
+                  _   -> MoreDecisions $ findCommonPrefix (map fragment nextIterationFragments)
+            l@(LastDecision ld) ->
+              let nextIterationFragments = [ candidate | candidate <- thisIterationSuffixes
+                                , case ld `intersect` fragment candidate of
+                                    -- discard non-intersecting
+                                    Nothing                    -> False
+                                    -- include iterationBestCandidate itself
+                                    Just (Empty _, Empty _, a, b) ->
+                                         headPoint a == headPoint b
+                                      && headPoint a == headPoint ld
+                                    -- discard those that only intersect on the
+                                    -- anchor
+                                    Just (_, Empty _, _, _) -> False
+                                    _                       -> True
+                                ]
+              in
+                case nextIterationFragments of
+                  [_] -> l
+                  _   -> MoreDecisions $ findCommonPrefix (map fragment nextIterationFragments)
+            _ -> iterationBestCandidate
+
+        -- | This iteration's result
+        result =
+            join thisIterationPrefix
+            $ case nextIterationPrefix of
+                LastDecision ld  -> ld
+                Unknown          -> Empty $ headAnchor thisIterationPrefix
+                MoreDecisions md -> go md
+
+-- | A result of prefix selection
+data PrefixSelection a =
+    -- | A decision has been made at a known-density point. The next
+    -- intersection point has to be resolved.
+    MoreDecisions a
+  | -- | There are no more intersection points to resolve.
+    LastDecision a
+  | -- | There was no outcome from the decision process because densities are
+    -- unknown at the intersection point.
+    Unknown
+ deriving (Show)
+
+{-------------------------------------------------------------------------------
+ Density
+-------------------------------------------------------------------------------}
+
+-- | Whether the provided fragment has known density within a window that ends
+-- at the given slot number.
+hasKnownDensityAt ::
+     HasHeader b
+  => SlotNo
+  -> AnnotatedAnchoredFragment b
+  -> Bool
+hasKnownDensityAt _  (AnnotatedAnchoredFragment _ FragmentComplete) = True
+hasKnownDensityAt to f                                              =
+  withOrigin False (>= to) (headSlot $ fragment f)
+
+-- | Compute the density of the fragment in the given window
+density ::
+     HasHeader blk
+  => GenesisWindow
+  -> AnchoredFragment blk
+  -> Int
+density gw f =
+    length
+    -- To be completely precise, the density would sometimes require a +1 but as
+    -- all fragments will go through the same function, they will all be scaled.
+  . takeWhileOldest (\blk -> blockSlot blk <= gwTo gw)
+  . maybe f snd
+    -- If the fragment is already anchored at the beginning of the window, split
+    -- will return nothing. This assumes that we are going to apply this
+    -- function only on fragments which actually have a block at the anchor of
+    -- the genesis window.
+  . splitBeforeMeasure (At $ gwFrom gw) (const True)
+  $ f
+
+{-------------------------------------------------------------------------------
+ Prefixes and suffixes operations
+-------------------------------------------------------------------------------}
+
+-- | Given a list of chains, find the prefix that is common to all of them.
+--
+-- PRECONDITION: all candidates must be anchored at the same point.
+--
+-- Example:
+--
+-- >    ┆ A ┆     ┆ A ┆     ┆ A ┆
+-- >    ├───┤     ├───┤     ├───┤
+-- >    │ B │     │ B │     │ B │
+-- >    ├───┤     ├───┤     ├───┤
+-- >    │ C │     │ C │     │ C │
+-- >    ├───┤     ├───┤     ├───┤
+-- >    │ D │     │ G │     │ J │
+-- >    ├───┤     ├───┤     ├───┤
+-- >    │ E │     │ H │     │ K │
+-- >    ├───┤     ├───┤     └───┘
+-- >    │ F │     │ I │
+-- >    └───┘     └───┘
+-- >      C1        C2        C3
+-- >
+-- >           candidates
+--
+-- Will result in the prefix shared by every candidate (could be just the anchor
+-- point):
+--
+-- >    ┆ A ┆
+-- >    ├───┤
+-- >    │ B │
+-- >    ├───┤
+-- >    │ C │
+-- >    └───┘
+--
+-- Note that this will always exist because of the precondition that candidates
+-- are all anchored at the same point.
+findCommonPrefix ::
+     HasHeader (Header blk)
+  => [AnchoredFragment (Header blk)]
+  ->  AnchoredFragment          (Header blk)
+findCommonPrefix []     = error "findCommonPrefix called with empty list"
+findCommonPrefix (f:fs) =
+  case result of
+    Just frag -> frag
+    Nothing   -> error "Precondition violated: fragments must be anchored at the same point."
+  where
+    result =
+      foldl'
+        (\acc candidate -> do
+            acc' <- acc
+            (acc'', _, _, _) <-  acc' `intersect` candidate
+            return acc'')
+        (Just f)
+        fs
+
+-- | Move the anchor point of each fragment to the head of the common prefix
+-- provided.
+--
+-- Example:
+--
+-- >                                                  commonPrefix
+-- >
+-- >    ┆   ┆     ┆   ┆     ┆   ┆     ┆   ┆               ┆   ┆
+-- >    ├───┤     ├───┤     ├───┤     ├───┤               ├───┤
+-- >    │ A │     │ A │     │ A │     │ A │               │ A │
+-- >    ├───┤     ├───┤     ├───┤     ├───┤               ├───┤
+-- >    │ B │     │ B │     │ B │     │ B │               │ B │
+-- >    ├───┤     ├───┤     ├───┤     ├───┤               ├───┤
+-- >    │ X │     │ C │     │ C │     │ C │               │ C │
+-- >    ├───┤     ├───┤     ├───┤     ├───┤               └───┘
+-- >    │ Y │     │ D │     │ G │     │ J │
+-- >    └───┘     ├───┤     ├───┤     ├───┤
+-- >              │ E │     │ H │     │ K │
+-- >              ├───┤     ├───┤     └───┘
+-- >              │ F │     │ I │
+-- >              └───┘     └───┘
+-- >      C1        C2        C3        C4
+-- >
+-- >                 candidates
+--
+-- Will result in:
+--
+-- >
+-- >              ┆ C ┆     ┆ C ┆     ┆ C ┆
+-- >              ├───┤     ├───┤     ├───┤
+-- >              │ D │     │ G │     │ J │
+-- >              ├───┤     ├───┤     ├───┤
+-- >              │ E │     │ H │     │ K │
+-- >              ├───┤     ├───┤     └───┘
+-- >              │ F │     │ I │
+-- >              └───┘     └───┘
+-- >                C2        C3        C4
+-- >
+-- >                     candidates'
+--
+-- Note that as C1 couldn't be split after C, it was discarded.
+findSuffixes ::
+     forall hblk. HasHeader hblk
+  => AnchoredFragment hblk
+  -> [AnnotatedAnchoredFragment hblk]
+  -> [AnnotatedAnchoredFragment hblk]
+findSuffixes commonPrefix l =
+   catMaybes
+     [     flip AnnotatedAnchoredFragment (completeness candidate)
+       .   snd
+       <$> splitAfterPoint (fragment candidate) (headPoint commonPrefix)
+     | candidate <- l ]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -18,6 +18,7 @@ import           GHC.Stack
 import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Config.GenesisWindowLength
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ticked
 
@@ -170,6 +171,9 @@ class ( Show (ChainDepState   p)
 
   -- | We require that protocols support a @k@ security parameter
   protocolSecurityParam :: ConsensusConfig p -> SecurityParam
+
+  -- | We require that protocols support a @s@ genesis window length
+  protocolGenesisWindowLength :: ConsensusConfig p -> GenesisWindowLength
 
 -- | Compare a candidate chain to our own
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -39,6 +39,7 @@ import           NoThunks.Class (NoThunks (..))
 import           Cardano.Crypto.DSIGN
 
 import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Config.GenesisWindowLength
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -131,6 +132,9 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
   type CanBeLeader   (Bft c) = CoreNodeId
 
   protocolSecurityParam = bftSecurityParam . bftParams
+
+  protocolGenesisWindowLength =
+    GenesisWindowLength . (3 *) . maxRollbacks . protocolSecurityParam
 
   checkIsLeader BftConfig{..} (CoreNodeId i) (SlotNo n) _ =
       if n `mod` numCoreNodes == i

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -36,10 +36,11 @@ instance ( ConsensusProtocol p
     type ValidationErr (ModChainSel p s) = ValidationErr p
     type ValidateView  (ModChainSel p s) = ValidateView  p
 
-    checkIsLeader         = checkIsLeader         . mcsConfigP
-    tickChainDepState     = tickChainDepState     . mcsConfigP
-    updateChainDepState   = updateChainDepState   . mcsConfigP
-    reupdateChainDepState = reupdateChainDepState . mcsConfigP
-    protocolSecurityParam = protocolSecurityParam . mcsConfigP
+    checkIsLeader               = checkIsLeader               . mcsConfigP
+    tickChainDepState           = tickChainDepState           . mcsConfigP
+    updateChainDepState         = updateChainDepState         . mcsConfigP
+    reupdateChainDepState       = reupdateChainDepState       . mcsConfigP
+    protocolSecurityParam       = protocolSecurityParam       . mcsConfigP
+    protocolGenesisWindowLength = protocolGenesisWindowLength . mcsConfigP
 
 instance ConsensusProtocol p => NoThunks (ConsensusConfig (ModChainSel p s))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -300,8 +300,10 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
 
   protocolSecurityParam = pbftSecurityParam . pbftParams
 
+  -- See the comments on Ouroboros.Consensus.Config.GenesisWindowLength for an
+  -- explanation on why this is set to a constant (2k)
   protocolGenesisWindowLength =
-    GenesisWindowLength . (3 *) . maxRollbacks . protocolSecurityParam
+    GenesisWindowLength . (2 *) . maxRollbacks . protocolSecurityParam
 
   checkIsLeader PBftConfig{pbftParams}
                 PBftCanBeLeader{..}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -61,6 +61,7 @@ import           NoThunks.Class (NoThunks)
 import           Cardano.Crypto.DSIGN.Class
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config.GenesisWindowLength
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -298,6 +299,9 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
   type CanBeLeader   (PBft c) = PBftCanBeLeader c
 
   protocolSecurityParam = pbftSecurityParam . pbftParams
+
+  protocolGenesisWindowLength =
+    GenesisWindowLength . (3 *) . maxRollbacks . protocolSecurityParam
 
   checkIsLeader PBftConfig{pbftParams}
                 PBftCanBeLeader{..}

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -52,6 +52,7 @@ library
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:     Ouroboros.Network.AnchoredFragment
+                       Ouroboros.Network.AnchoredFragment.Completeness
                        Ouroboros.Network.AnchoredSeq
                        Ouroboros.Network.Block
                        Ouroboros.Network.BlockFetch

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -74,6 +74,7 @@ module Ouroboros.Network.AnchoredFragment (
   successorBlock,
   selectPoints,
   isPrefixOf,
+  isPrefixOfByPoints,
   splitAfterPoint,
   splitBeforePoint,
   sliceRange,
@@ -709,3 +710,12 @@ mapAnchoredFragment ::
   -> AnchoredFragment block1
   -> AnchoredFragment block2
 mapAnchoredFragment = bimap castAnchor
+
+-- | See 'AS.isPrefixOfByInjectiveFuns'.
+isPrefixOfByPoints ::
+     forall a. HasHeader a =>
+     AnchoredFragment a
+  -> AnchoredFragment a
+  -> Bool
+s1 `isPrefixOfByPoints` s2 =
+  AS.isPrefixOfByInjectiveFuns anchorToPoint blockPoint s1 s2

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment/Completeness.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment/Completeness.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Ouroboros.Network.AnchoredFragment.Completeness (
+    AnnotatedAnchoredFragment (..)
+  , FragmentCompleteness (..)
+  , emptyAnnotatedAnchoredFragment
+  , isFragmentComplete
+  ) where
+
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+
+import           Ouroboros.Network.AnchoredFragment
+import           Ouroboros.Network.Block
+import           Cardano.Slotting.Slot
+
+-- | BlockFetch and ChainSync operate with 'AnchoredFragment's when dealing with
+-- candidate chains. For Ouroboros Genesis, we need to know whether or not the
+-- fragment represents the end of the remote chain, to make judgments about
+-- whether or not our perceived density is indeed the real density.
+--
+-- Every fragment returned by ChainSync will be coupled with one of these tags,
+-- specifying if the ChainSync client thinks that the fragment is indeed
+-- complete. This flag will be used by the prefix selection algorithm to filter
+-- appropriate candidates to be provided to BlockFetch.
+--
+-- Note that completeness of a fragment is a local property, dependent on the
+-- current state of the ChainSync protocol, and based on the information
+-- provided by the ChainSync server.
+data FragmentCompleteness = FragmentComplete | FragmentIncomplete
+  deriving (Show, Generic, Eq, NoThunks)
+
+-- | Return a 'FragmentCompleteness' for the given fragment assuming the
+-- provided tip is the one announced by the remote peer.
+--
+-- This function will return 'Nothing' when the slot of the announced tip is
+-- smaller than the slot of the most recent block on the fragment. This should
+-- be interpreted in the ChainSync protocol as a misbehave of the server.
+isFragmentComplete ::
+  ( StandardHash blk
+  , HasHeader blk)
+  => Tip blk
+  -> AnchoredFragment blk
+  -> Maybe FragmentCompleteness
+isFragmentComplete TipGenesis theirFrag =
+  if pointHash (anchorPoint theirFrag) == GenesisHash
+  then Just FragmentComplete
+  else Nothing
+isFragmentComplete (Tip s tipHash _) theirFrag =
+  if headSlot theirFrag > At s
+  then
+    Nothing
+  else
+  Just $ case headHash theirFrag of
+    GenesisHash -> FragmentIncomplete
+    BlockHash theHeadHash
+      | theHeadHash == tipHash -> FragmentComplete
+      | otherwise              -> FragmentIncomplete
+
+-- | A fragment annotated with its completeness.
+data AnnotatedAnchoredFragment blk =
+  AnnotatedAnchoredFragment {
+      fragment ::     !(AnchoredFragment blk)
+    , completeness :: !FragmentCompleteness
+    }
+  deriving (Generic, NoThunks)
+
+emptyAnnotatedAnchoredFragment :: HasHeader blk => AnnotatedAnchoredFragment blk
+emptyAnnotatedAnchoredFragment =
+  AnnotatedAnchoredFragment (Empty AnchorGenesis) FragmentComplete

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredSeq.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredSeq.hs
@@ -504,7 +504,7 @@ anchorNewest n c
     linearDrop !0 c'        = c'
     linearDrop !m (_ :< c') = linearDrop (m - 1) c'
 
--- | \( O(\max(n_1, n_2)) \). Check whether the first anchored sequence is a
+-- | \( O(\min(n_1, n_2)) \). Check whether the first anchored sequence is a
 -- prefix of the second. Comparisons are done based on the 'Eq' instances.
 --
 -- The two 'AnchoredSeq's must have the same anchor, otherwise the first cannot
@@ -521,7 +521,7 @@ s1 `isPrefixOf` s2 =
     toElements :: AnchoredSeq v a b -> [b]
     toElements = L.map unMeasuredWith . Foldable.toList . unanchorSeq
 
--- | \( O(\max(n_1, n_2)) \). Check whether the first anchored sequence is a
+-- | \( O(\min(n_1, n_2)) \). Check whether the first anchored sequence is a
 -- prefix of the second. Comparisons are done based on the measure.
 --
 -- The two 'AnchoredSeq's must have the same anchor, otherwise the first cannot
@@ -538,13 +538,18 @@ s1 `isPrefixOfByMeasure` s2 =
     toMeasures :: AnchoredSeq v a b -> [v]
     toMeasures = L.map getElementMeasure . Foldable.toList . unanchorSeq
 
--- | \( O(\max(n_1, n_2)) \). Check whether the first anchored sequence is a
+-- | \( O(\min(n_1, n_2)) \). Check whether the first anchored sequence is a
 -- prefix of the second. Comparisons are done based on the result of the
 -- transformation through injective functions into @Eq@ types.
 --
 -- The first function will transform an @a@, the second function will transform
 -- a @b@ and they both have to be injective, this is: for two different
--- elements, the result of the function must be different.
+-- elements, the result of the function must be different. If the functions
+-- provided are not injective, then elements with the same image are
+-- indistinguishable and the purpose of this function is defeated.
+--
+-- This is intended to be used with some identifier of elements like the hash of
+-- a block or maybe its Point.
 --
 -- The two 'AnchoredSeq's must have the same anchor, otherwise the first cannot
 -- be a prefix of the second.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -12,6 +12,7 @@ module Ouroboros.Network.BlockFetch.Decision (
     PeerInfo,
     FetchDecision,
     FetchDecline(..),
+    SyncingMode(..),
 
     -- ** Components of the decision-making process
     filterPlausibleCandidates,
@@ -71,6 +72,10 @@ data FetchDecisionPolicy header = FetchDecisionPolicy {
        blockFetchSize          :: header -> SizeInBytes
      }
 
+-- | The current syncing mode that we are in
+data SyncingMode =
+    Syncing
+  | CaughtUp
 
 data FetchMode =
        -- | Use this mode when we are catching up on the chain but are stil

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -143,6 +143,8 @@ fetchLogicIteration decisionTracer clientStateTracer
           fetchTriggerVariables
           fetchNonTriggerVariables
           stateFingerprint
+        -- The retrieved peer chains might require some refinement such as
+        -- `prefixSelection` when running on Genesis mode.
         state' <- consensusRefinement state
         return (state', fingerprint)
 


### PR DESCRIPTION
The way I implemented prefix selection for now is as follows:
![2021-09-14-165436_1444x1459_scrot](https://user-images.githubusercontent.com/9791461/133570118-5728e1af-4abf-4bb4-b139-b66f353d2dc4.png)


Implemented:
- Currently prefix selection is just a step before BlockFetch decision logic that will provide an updated map of candidates if we are in Syncing mode. 
- Genesis window length is now a parameter of the consensus config that for now *MUST NOT* change between eras (à la `k`).

Open questions:
- How to define Caught up and Syncing?
- In CaughtUp mode, should BlockFetch receive all the candidates and download them following its own policies (network timing, then length) or should we only provide certain candidates?

Pending changes:
- property tests.
- the `TODO @js` comments here and there
