### PR TITLE
LastToFinish: derive Foldable via Ap

### DIFF
--- a/monoidal-synchronisation/src/Data/Monoid/Synchronisation.hs
+++ b/monoidal-synchronisation/src/Data/Monoid/Synchronisation.hs
@@ -81,7 +81,7 @@ newtype LastToFinish m a = LastToFinish { runLastToFinish :: m a }
                    , MonadPlus
                    , Traversable
                    )
-  deriving Foldable via (Alt m)
+  deriving Foldable via (Ap m)
 
 instance MonadPlus m => Semigroup (LastToFinish m a) where
     LastToFinish left <> LastToFinish right = LastToFinish $ do


### PR DESCRIPTION
The derived Foldable instance via `Ap` and `Alt` are the same, but it
makes more sense to use `Ap` in `LastToFinish`.
