### PR TITLE
inbound-governor & connection-manger: improved validation

### DIFF
--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -264,6 +264,7 @@ withBidirectionalConnectionManager snocket socket
                     serverSockets = socket :| [],
                     serverSnocket = snocket,
                     serverTracer = ("server",) `contramap` debugTracer, -- ServerTrace
+                    serverTrTracer = nullTracer,
                     serverInboundGovernorTracer = ("inbound-governor",) `contramap` debugTracer,
                     serverConnectionLimits = AcceptedConnectionsLimit maxBound maxBound 0,
                     serverConnectionManager = connectionManager,

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1640,14 +1640,14 @@ withConnectionManager ConnectionManagerArguments {
                 return (UnsupportedState (UnnegotiatedSt provenance))
               OutboundUniState _connId _connThread _handle ->
                 return (UnsupportedState OutboundUniSt)
-              OutboundDupState _connId _connThread _handle expired ->
-                return (UnsupportedState (OutboundDupSt expired))
+              OutboundDupState _connId _connThread _handle _expired ->
+                return (OperationSuccess (mkTransition connState connState))
               -- one can only enter 'OutboundIdleState' if remote state is
               -- already cold.
-              OutboundIdleState _connId _connThread _handle dataFlow ->
-                return (UnsupportedState (OutboundIdleSt dataFlow))
-              InboundIdleState _connId _connThread _handle dataFlow ->
-                return (UnsupportedState (InboundIdleSt dataFlow))
+              OutboundIdleState _connId _connThread _handle _dataFlow ->
+                return (OperationSuccess (mkTransition connState connState))
+              InboundIdleState _connId _connThread _handle _dataFlow ->
+                return (OperationSuccess (mkTransition connState connState))
 
               -- @
               --   DemotedToCold^{dataFlow}_{Remote}

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1639,6 +1639,7 @@ withConnectionManager ConnectionManagerArguments {
                 assert False $
                 return (UnsupportedState (UnnegotiatedSt provenance))
               OutboundUniState _connId _connThread _handle ->
+                assert False $
                 return (UnsupportedState OutboundUniSt)
               OutboundDupState _connId _connThread _handle _expired ->
                 return (OperationSuccess (mkTransition connState connState))

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -577,6 +577,9 @@ promotedToWarmRemote =
 -- This executes:
 --
 -- * \(DemotedToCold^{*}_{Remote}\) transition.
+--
+-- This method is idempotent.
+--
 demotedToColdRemote
     :: HasResponder muxMode ~ True
     => ConnectionManager muxMode socket peerAddr handle handleError m

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -839,7 +840,15 @@ data Transition' state = Transition
     { fromState :: !state
     , toState   :: !state
     }
-  deriving (Eq, Functor, Show)
+  deriving (Eq, Functor)
+
+instance Show state
+      => Show (Transition' state) where
+    show Transition { fromState, toState } =
+      concat [ show fromState
+             , " → "
+             , show toState
+             ]
 
 type Transition state   = Transition' (MaybeUnknown state)
 type AbstractTransition = Transition' AbstractState
@@ -854,6 +863,16 @@ data TransitionTrace' peerAddr state = TransitionTrace
     { ttPeerAddr   :: peerAddr
     , ttTransition :: Transition' state
     }
-  deriving (Show, Functor)
+  deriving Functor
+
+instance (Show peerAddr, Show state)
+      =>  Show (TransitionTrace' peerAddr state) where
+    show (TransitionTrace addr tr) =
+      concat [ "TranstionTrace @("
+             , show addr
+             , ") ("
+             , show tr
+             , ")"
+             ]
 
 type TransitionTrace peerAddr state = TransitionTrace' peerAddr (MaybeUnknown state)

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -439,10 +439,6 @@ data DemotedToColdRemoteTr =
     --
     CommitTr
 
-    -- | @DemotedToCold^{Remote}@ transition from @'InboundState' dataFlow@
-    --
-  | DemotedToColdRemoteTr
-
     -- | Either @DemotedToCold^{Remote}@ transition from @'DuplexState'@, or
     -- a level triggered @Awake^{Duplex}_{Local}@ transition.  In both cases
     -- the server must keep the responder side of all protocols ready.

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -366,14 +366,6 @@ inboundGovernor tracer serverControlChannel inboundIdleTimeout
                   let state' = unregisterConnection connId state
                   inboundGovernorLoop state'
 
-                DemotedToColdRemoteTr -> do
-                  -- @
-                  --    Commit^{dataFlow}_{Remote} : InboundIdleState dataFlow
-                  --                               → TerminatingState
-                  -- @
-                  let state' = unregisterConnection connId state
-                  inboundGovernorLoop state'
-
                 -- the connection is still used by p2p-governor, carry on but put
                 -- it in 'RemoteCold' state.  This will ensure we keep ready to
                 -- serve the peer.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
@@ -29,6 +29,9 @@ module Ouroboros.Network.Server2
   -- * Trace
   , ServerTrace (..)
   , AcceptConnectionsPolicyTrace (..)
+  , RemoteSt (..)
+  , RemoteTransition
+  , RemoteTransitionTrace
   -- * ControlChannel
   , module ControlChannel
   ) where
@@ -69,6 +72,7 @@ data ServerArguments (muxMode  :: MuxMode) socket peerAddr versionNumber bytes m
       serverSockets               :: NonEmpty socket,
       serverSnocket               :: Snocket m socket peerAddr,
       serverTracer                :: Tracer m (ServerTrace peerAddr),
+      serverTrTracer              :: Tracer m (RemoteTransitionTrace peerAddr),
       serverInboundGovernorTracer :: Tracer m (InboundGovernorTrace peerAddr),
       serverConnectionLimits      :: AcceptedConnectionsLimit,
       serverConnectionManager     :: MuxConnectionManager muxMode socket peerAddr
@@ -123,6 +127,7 @@ run :: forall muxMode socket peerAddr versionNumber m a b.
 run ServerArguments {
       serverSockets,
       serverSnocket,
+      serverTrTracer,
       serverTracer = tracer,
       serverInboundGovernorTracer = inboundGovernorTracer,
       serverConnectionLimits,
@@ -141,7 +146,8 @@ run ServerArguments {
       let threads = (  labelThisThread (  "inbound-governor-"
                                        ++ intercalate "-" (show <$> localAddresses)
                                        )
-                    >> inboundGovernor inboundGovernorTracer
+                    >> inboundGovernor serverTrTracer
+                                       inboundGovernorTracer
                                        serverControlChannel
                                        serverInboundIdleTimeout
                                        serverConnectionManager

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
@@ -1736,6 +1736,8 @@ verifyAbstractTransition Transition { fromState, toState } =
       (OutboundDupSt Ticking, OutboundDupSt Expired) -> True
       -- @DemotedToCold^{Duplex}_{Local}@
       (OutboundDupSt Expired, OutboundIdleSt Duplex) -> True
+      -- identity transition executed by 'demotedToColdRemote'
+      (OutboundIdleSt dataFlow, OutboundIdleSt dataFlow') -> dataFlow == dataFlow'
 
       --
       -- Outbound ↔ Inbound
@@ -1748,6 +1750,9 @@ verifyAbstractTransition Transition { fromState, toState } =
       -- @PromotedToWarm^{Duplex}_{Remote}@
       (OutboundDupSt Ticking, DuplexSt) -> True
       (OutboundDupSt Expired, DuplexSt) -> True
+      -- can be executed by 'demotedToColdRemote'
+      (OutboundDupSt expired, OutboundDupSt expired')
+                                        -> expired == expired'
       -- @PromotedToWarm^{Duplex}_{Local}@
       (InboundSt Duplex, DuplexSt) -> True
       -- @DemotedToCold^{Duplex}_{Remote}@
@@ -1769,7 +1774,7 @@ verifyAbstractTransition Transition { fromState, toState } =
       -- @Negotiated^{Unidirectional}_{Inbound}
       (UnnegotiatedSt Inbound, InboundIdleSt Unidirectional) -> True
 
-      -- 'unregisterOutboundConnection' might perfrom
+      -- 'unregisterOutboundConnection' and 'demotedToColdRemote' might perfrom
       (InboundIdleSt Duplex, InboundIdleSt Duplex) -> True
       -- @Awake^{Duplex}_{Remote}
       (InboundIdleSt Duplex, InboundSt Duplex) -> True

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -78,7 +78,8 @@ import           Ouroboros.Network.ConnectionHandler
 import           Ouroboros.Network.ConnectionManager.Core
 import           Ouroboros.Network.ConnectionManager.Types
 import           Ouroboros.Network.IOManager
-import           Ouroboros.Network.InboundGovernor (RemoteSt (..))
+import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..),
+                   RemoteSt (..))
 import qualified Ouroboros.Network.InboundGovernor.ControlChannel as Server
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.MuxMode
@@ -459,6 +460,7 @@ withBidirectionalConnectionManager
     -- ^ identifier (for logging)
     -> Tracer m (WithName name (RemoteTransitionTrace peerAddr))
     -> Tracer m (WithName name (AbstractTransitionTrace peerAddr))
+    -> Tracer m (WithName name (InboundGovernorTrace peerAddr))
     -> Snocket m socket peerAddr
     -> socket
     -- ^ listening socket
@@ -476,7 +478,9 @@ withBidirectionalConnectionManager
        -> Async m Void
        -> m a)
     -> m a
-withBidirectionalConnectionManager name timeouts inboundTrTracer cmTrTracer snocket socket localAddress
+withBidirectionalConnectionManager name timeouts
+                                   inboundTrTracer cmTrTracer inboundTracer
+                                   snocket socket localAddress
                                    accumulatorInit nextRequests k = do
     mainThreadId <- myThreadId
     inbgovControlChannel      <- Server.newControlChannel
@@ -539,7 +543,7 @@ withBidirectionalConnectionManager name timeouts inboundTrTracer cmTrTracer snoc
                     serverTracer =
                       WithName name `contramap` nullTracer, -- ServerTrace
                     serverInboundGovernorTracer =
-                      WithName name `contramap` nullTracer, -- InboundGovernorTrace
+                      WithName name `contramap` inboundTracer, -- InboundGovernorTrace
                     serverConnectionLimits = AcceptedConnectionsLimit maxBound maxBound 0,
                     serverConnectionManager = connectionManager,
                     serverInboundIdleTimeout = tProtocolIdleTimeout timeouts,
@@ -729,7 +733,8 @@ unidirectionalExperiment timeouts snocket socket clientAndServerData = do
     withInitiatorOnlyConnectionManager
       "client" timeouts nullTracer snocket Nothing nextReqs
       $ \connectionManager ->
-        withBidirectionalConnectionManager "server" timeouts nullTracer nullTracer
+        withBidirectionalConnectionManager "server" timeouts
+                                           nullTracer nullTracer nullTracer
                                            snocket socket Nothing
                                            [accumulatorInit clientAndServerData]
                                            noNextRequests
@@ -832,14 +837,14 @@ bidirectionalExperiment
       nextRequests0 <- oneshotNextRequests clientAndServerData0
       nextRequests1 <- oneshotNextRequests clientAndServerData1
       withBidirectionalConnectionManager "node-0" timeouts
-                                         nullTracer nullTracer
+                                         nullTracer nullTracer nullTracer
                                          snocket socket0
                                          (Just localAddr0)
                                          [accumulatorInit clientAndServerData0]
                                          nextRequests0
         (\connectionManager0 _serverAddr0 _serverAsync0 ->
           withBidirectionalConnectionManager "node-1" timeouts
-                                             nullTracer nullTracer
+                                             nullTracer nullTracer nullTracer
                                              snocket socket1
                                              (Just localAddr1)
                                              [accumulatorInit clientAndServerData1]
@@ -1221,6 +1226,8 @@ multinodeExperiment
                           (RemoteTransitionTrace peerAddr))
     -> Tracer m (WithName (Name peerAddr)
                           (AbstractTransitionTrace peerAddr))
+    -> Tracer m (WithName (Name peerAddr)
+                          (InboundGovernorTrace peerAddr))
     -> Snocket m socket peerAddr
     -> Snocket.AddressFamily peerAddr
     -- ^ either run the main node in 'Duplex' or 'Unidirectional' mode.
@@ -1229,7 +1236,7 @@ multinodeExperiment
     -> DataFlow
     -> MultiNodeScript req peerAddr
     -> m ()
-multinodeExperiment inboundTrTracer cmTrTracer
+multinodeExperiment inboundTrTracer cmTrTracer inboundTracer
                     snocket addrFamily serverAddr accInit
                     dataFlow0 (MultiNodeScript script) =
   withJobPool $ \jobpool -> do
@@ -1352,7 +1359,7 @@ multinodeExperiment inboundTrTracer cmTrTracer
                 Duplex ->
                   Job ( withBidirectionalConnectionManager
                           name simTimeouts
-                          inboundTrTracer cmTrTracer
+                          inboundTrTracer cmTrTracer inboundTracer
                           snocket fd (Just localAddr) serverAcc
                           (mkNextRequests connVar)
                           ( \ connectionManager _ _serverAsync -> do
@@ -1635,6 +1642,14 @@ verifyRemoteTransition Transition {fromState, toState} =
 
 
 
+data Three a b c
+    = First  a
+    | Second b
+    | Third  c
+  deriving Show
+
+
+
 -- | Property wrapping `multinodeExperiment`.
 --
 -- Note: this test validates both connection manager and inbound governor state
@@ -1645,21 +1660,26 @@ verifyRemoteTransition Transition {fromState, toState} =
 prop_multinode_Sim :: Int -> ArbDataFlow -> MultiNodeScript Int TestAddr -> Property
 prop_multinode_Sim serverAcc (ArbDataFlow dataFlow) script =
   let evs :: Octopus (Value ())
-                     (Either (RemoteTransitionTrace SimAddr)
-                             (AbstractTransitionTrace SimAddr))
+                     (Three (RemoteTransitionTrace SimAddr)
+                            (AbstractTransitionTrace SimAddr)
+                            (InboundGovernorTrace SimAddr))
       evs = fmap wnEvent
           . Octopus.filter ((MainServer ==) . wnName)
           . octoSelectTraceEvents
               (\ev ->
                 case ev of
                   EventLog dyn ->
-                        fmap Left
+                        fmap First
                         <$> fromDynamic
                               @(WithName (Name SimAddr) (RemoteTransitionTrace   SimAddr))
                               dyn
-                    <|> fmap Right
+                    <|> fmap Second
                         <$> fromDynamic
                               @(WithName (Name SimAddr) (AbstractTransitionTrace SimAddr))
+                              dyn
+                    <|> fmap Third
+                        <$> fromDynamic
+                              @(WithName (Name SimAddr) (InboundGovernorTrace SimAddr))
                               dyn
                   _ ->
                        Nothing
@@ -1674,6 +1694,7 @@ prop_multinode_Sim serverAcc (ArbDataFlow dataFlow) script =
                     $ \snocket ->
                        multinodeExperiment (Tracer traceM)
                                            (Tracer traceM)
+                                           (Tracer traceM)
                                            snocket
                                            Snocket.TestFamily
                                            (Snocket.TestAddress 0)
@@ -1687,10 +1708,37 @@ prop_multinode_Sim serverAcc (ArbDataFlow dataFlow) script =
 
   in counterexample (ppScript script)
     . counterexample (ppOctopus show show evs)
-    . (\ ( l :: Octopus (Value ()) (RemoteTransitionTrace   SimAddr)
-         , r :: Octopus (Value ()) (AbstractTransitionTrace SimAddr)
+    . (\ ( tr1 :: Octopus (Value ()) (RemoteTransitionTrace   SimAddr)
+         , tr2 :: Octopus (Value ()) (AbstractTransitionTrace SimAddr)
+         , tr3 :: Octopus (Value ()) (InboundGovernorTrace    SimAddr)
          )
        ->
+        ( getAllProperty
+        . bifoldMap
+            ( \ _ -> AllProperty (property True))
+            ( \ tr -> case tr of
+                -- verify that 'unregisterInboundConnection' does not return
+                -- 'UnsupportedState'.
+                TrDemotedToColdRemote _ res ->
+                  case res of
+                    UnsupportedState {}
+                      -> AllProperty (counterexample (show tr) False)
+                    _ -> AllProperty (property True)
+
+                -- verify that 'demotedToColdRemote' does not return
+                -- 'UnsupportedState'
+                TrWaitIdleRemote _ res ->
+                  case res of
+                    UnsupportedState {}
+                      -> AllProperty (counterexample (show tr) False)
+                    _ -> AllProperty (property True)
+
+                _     -> AllProperty (property True)
+            )
+
+        $ tr3
+        )
+        .&&.
         ( mkProperty
         . bifoldMap
            ( \ case
@@ -1725,7 +1773,7 @@ prop_multinode_Sim serverAcc (ArbDataFlow dataFlow) script =
               }
            )
          . splitConns
-         $ r
+         $ tr2
          )
          .&&.
          ( getAllProperty
@@ -1741,7 +1789,7 @@ prop_multinode_Sim serverAcc (ArbDataFlow dataFlow) script =
                 . verifyRemoteTransition
                 $ tr
             )
-         $ l
+         $ tr1
          )
 
      )
@@ -1804,15 +1852,21 @@ prop_multinode_Sim serverAcc (ArbDataFlow dataFlow) script =
 
 -- Right fold of the 'Octopus' which splits its results.
 --
-octoSplit :: Octopus a (Either b c) -> (Octopus a b, Octopus a c)
-octoSplit = go [] []
+octoSplit :: Octopus a (Three b c d) -> (Octopus a b, Octopus a c, Octopus a d)
+octoSplit = go [] [] []
   where
     -- this version seems the fastest one (faster than a strict version, DList
     -- style or a coinductive definition).
-    go :: [b] -> [c] -> Octopus a (Either b c) -> (Octopus a b, Octopus a c)
-    go bs cs (Nil a) = (foldl' (flip Cons) (Nil a) bs, foldl' (flip Cons) (Nil a) cs)
-    go bs cs (Cons (Left  b) o) = go (b : bs)      cs  o
-    go bs cs (Cons (Right c) o) = go      bs  (c : cs) o
+    go :: [b] -> [c] -> [d]
+       -> Octopus a (Three b c d)
+       -> (Octopus a b, Octopus a c, Octopus a d)
+    go bs cs ds (Nil a) = ( foldl' (flip Cons) (Nil a) bs
+                          , foldl' (flip Cons) (Nil a) cs
+                          , foldl' (flip Cons) (Nil a) ds
+                          )
+    go bs cs ds (Cons (First  b) o) = go (b : bs)      cs       ds o
+    go bs cs ds (Cons (Second c) o) = go      bs  (c : cs)      ds o
+    go bs cs ds (Cons (Third d) o) = go       bs       cs  (d : ds) o
 
 
 splitConns :: Octopus (Value ()) (AbstractTransitionTrace SimAddr)

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -789,7 +789,7 @@ runM Interfaces
                     localConnectionManagerArguments =
                       ConnectionManagerArguments {
                           cmTracer              = dtLocalConnectionManagerTracer,
-                          cmTrTracer            = nullTracer, -- TODO
+                          cmTrTracer            = nullTracer, -- TODO: issue #3320
                           cmMuxTracer           = dtLocalMuxTracer,
                           cmIPv4Address         = Nothing,
                           cmIPv6Address         = Nothing,
@@ -826,6 +826,7 @@ runM Interfaces
                           serverSockets               = localSocket :| [],
                           serverSnocket               = diNtcSnocket,
                           serverTracer                = dtLocalServerTracer,
+                          serverTrTracer              = nullTracer, -- TODO: issue #3320
                           serverInboundGovernorTracer = dtLocalInboundGovernorTracer,
                           serverInboundIdleTimeout    = local_PROTOCOL_IDLE_TIMEOUT,
                           serverConnectionLimits      = localConnectionLimits,
@@ -1101,6 +1102,7 @@ runM Interfaces
                                   serverSockets               = sockets,
                                   serverSnocket               = diNtnSnocket,
                                   serverTracer                = dtServerTracer,
+                                  serverTrTracer              = nullTracer, -- TODO: issue #3320
                                   serverInboundGovernorTracer = dtInboundGovernorTracer,
                                   serverConnectionLimits      = daAcceptedConnectionsLimit,
                                   serverConnectionManager     = connectionManager,


### PR DESCRIPTION
Fixes #3288

- connection-manager: removed DemotedToColdRemoteTr constructor
- connection-manager: pretty print Transition' and TransitionTrace'.
- inbound-governor: test inbound governor state changes
- inbound-governor: verify demotedToColdRemote & unregisterInboundConnection
- connection-manager: demotedToColdRemote in OutboundUniState
