### PR TITLE
New get header state tip query

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -25,7 +25,8 @@ library
                        ouroboros-consensus,
                        ouroboros-network,
                        ouroboros-network-framework,
-                       network-mux
+                       network-mux,
+                       serialise
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors

--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
@@ -38,10 +39,10 @@ import           Ouroboros.Network.NodeToClient (ClientSubscriptionParams (..),
                      ConnectionId, LocalAddress,
                      NetworkClientSubcriptionTracers,
                      NodeToClientProtocols (..),
+                     NodeToClientVersion,
                      NodeToClientVersionData (NodeToClientVersionData),
                      ncSubscriptionWorker, newNetworkMutableState,
                      versionedNodeToClientProtocols)
-import           Ouroboros.Network.NodeToClient (NodeToClientVersion)
 import           Ouroboros.Network.Protocol.Handshake.Version (Versions,
                    foldMapVersions)
 import qualified Ouroboros.Network.Snocket as Snocket

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -374,18 +374,19 @@ instance CardanoHardForkConstraints c
       ]
 
   supportedNodeToClientVersions _ = Map.fromList $
-      [ (NodeToClientV_1, CardanoNodeToClientVersion1)
-      , (NodeToClientV_2, CardanoNodeToClientVersion1)
-      , (NodeToClientV_3, CardanoNodeToClientVersion2)
-      , (NodeToClientV_4, CardanoNodeToClientVersion3)
-      , (NodeToClientV_5, CardanoNodeToClientVersion4)
-      , (NodeToClientV_6, CardanoNodeToClientVersion5)
-      , (NodeToClientV_7, CardanoNodeToClientVersion6)
-      , (NodeToClientV_8, CardanoNodeToClientVersion6)
-      , (NodeToClientV_9, CardanoNodeToClientVersion7)
+      [ (NodeToClientV_1 , CardanoNodeToClientVersion1)
+      , (NodeToClientV_2 , CardanoNodeToClientVersion1)
+      , (NodeToClientV_3 , CardanoNodeToClientVersion2)
+      , (NodeToClientV_4 , CardanoNodeToClientVersion3)
+      , (NodeToClientV_5 , CardanoNodeToClientVersion4)
+      , (NodeToClientV_6 , CardanoNodeToClientVersion5)
+      , (NodeToClientV_7 , CardanoNodeToClientVersion6)
+      , (NodeToClientV_8 , CardanoNodeToClientVersion6)
+      , (NodeToClientV_9 , CardanoNodeToClientVersion7)
+      , (NodeToClientV_10, CardanoNodeToClientVersion7)
       ]
 
-  latestReleasedNodeVersion _prx = (Just NodeToNodeV_7, Just NodeToClientV_9)
+  latestReleasedNodeVersion _prx = (Just NodeToNodeV_7, Just NodeToClientV_10)
 
 {-------------------------------------------------------------------------------
   ProtocolInfo

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -237,6 +237,9 @@ instance ( blockVersion ~ BlockNodeToClientVersion blk
           , (1,  do blockV <- arbitrary
                     return (WithVersion (queryVersion, blockV)
                                         (SomeSecond GetSystemStart)))
+          , (1,  do blockV <- arbitrary
+                    return (WithVersion (queryVersion, blockV)
+                                        (SomeSecond GetHeaderStateTip)))
           ]
     where
       arbitraryBlockQuery :: QueryVersion

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -81,7 +81,7 @@ data Query blk result where
 
   -- | Get the 'GetHeaderStateTip' time.
   --
-  -- Supported by 'QueryVersion' >= 'QueryVersionX'. -- TODO jky what version?
+  -- Supported by 'QueryVersion' >= 'QueryVersion2'.
   GetHeaderStateTip :: Query blk (WithOrigin (HeaderStateTip blk))
 
 
@@ -120,6 +120,7 @@ data QueryEncoderException blk =
 deriving instance Show (SomeSecond BlockQuery blk) => Show (QueryEncoderException blk)
 instance (Typeable blk, Show (SomeSecond BlockQuery blk)) => Exception (QueryEncoderException blk)
 
+
 queryEncodeNodeToClient ::
      forall blk.
      Typeable blk
@@ -143,19 +144,34 @@ queryEncodeNodeToClient codecConfig queryVersion blockVersion (SomeSecond query)
           throw $ QueryEncoderUnsupportedQuery (SomeSecond query) queryVersion
 
     -- From version 1 onwards, we use normal constructor tags
-    QueryVersion1 ->
+    _ ->
       case query of
         BlockQuery blockQuery ->
-            encodeListLen 2
-         <> encodeWord8 0
-         <> encodeBlockQuery blockQuery
+          requireVersion QueryVersion1 queryVersion $ mconcat
+            [ encodeListLen 2
+            , encodeWord8 0
+            , encodeBlockQuery blockQuery
+            ]
+
         GetSystemStart ->
-            encodeListLen 1
-         <> encodeWord8 1
+          requireVersion QueryVersion1 queryVersion $ mconcat
+            [ encodeListLen 1
+            , encodeWord8 1
+            ]
+
         GetHeaderStateTip ->
-            encodeListLen 1
-         <> encodeWord8 2
+          requireVersion QueryVersion2 queryVersion $ mconcat
+            [ encodeListLen 1
+            , encodeWord8 2
+            ]
+
   where
+    requireVersion :: QueryVersion -> QueryVersion -> a -> a
+    requireVersion expectedVersion actualVersion a =
+      if actualVersion >= expectedVersion
+        then a
+        else throw $ QueryEncoderUnsupportedQuery (SomeSecond query) actualVersion
+
     encodeBlockQuery blockQuery =
       encodeNodeToClient
         @blk
@@ -174,15 +190,26 @@ queryDecodeNodeToClient ::
 queryDecodeNodeToClient codecConfig queryVersion blockVersion
   = case queryVersion of
       TopLevelQueryDisabled -> decodeBlockQuery
-      QueryVersion1 -> do
+      QueryVersion1         -> handleTopLevelQuery
+      QueryVersion2         -> handleTopLevelQuery
+  where
+    handleTopLevelQuery :: Decoder s (SomeSecond Query blk)
+    handleTopLevelQuery = do
         size <- decodeListLen
         tag  <- decodeWord8
         case (size, tag) of
-          (2, 0) -> decodeBlockQuery
-          (1, 1) -> return (SomeSecond GetSystemStart)
-          (1, 2) -> return (SomeSecond GetHeaderStateTip)
+          (2, 0) -> requireVersion "BlockQuery"        QueryVersion1   decodeBlockQuery
+          (1, 1) -> requireVersion "GetSystemStart"    QueryVersion1 $ return (SomeSecond GetSystemStart)
+          (1, 2) -> requireVersion "GetHeaderStateTip" QueryVersion2 $ return (SomeSecond GetHeaderStateTip)
           _      -> fail $ "Query: invalid size and tag" <> show (size, tag)
-  where
+
+    requireVersion :: String -> QueryVersion -> Decoder s (SomeSecond Query blk) -> Decoder s (SomeSecond Query blk)
+    requireVersion name expectedVersion f =
+      if queryVersion >= expectedVersion
+        then f
+        else fail $ "Query: " <> name <> " requires at least " <> show expectedVersion
+
+    decodeBlockQuery :: Decoder s (SomeSecond Query blk)
     decodeBlockQuery = do
       SomeSecond blockQuery <- decodeNodeToClient
         @blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query/Version.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query/Version.hs
@@ -7,27 +7,32 @@ module Ouroboros.Consensus.Ledger.Query.Version (
 import           Ouroboros.Network.NodeToClient.Version
 
 -- | Version of the `Query blk` type.
+--
+-- Multiple top level queries are now supported. The encoding now has
+-- constructor tags for the different top level queries for QueryVersion1 onwards.
 data QueryVersion
     -- | Only the 'BlockQuery' constructor of 'Query' is supported. The binary
     -- encoding is backwards compatible: it does not introduce any constructor
     -- tag around the 'BlockQuery'.
   = TopLevelQueryDisabled
 
-    -- | Multiple top level queries are now supported. The encoding now has
-    -- constructor tags for the different top level queries. Specifically V1
-    -- adds support for 'GetSystemStart'.
+  -- Adds support for 'GetSystemStart'.
   | QueryVersion1
+
+  -- Adds support for 'GetHeaderStateTip'.
+  | QueryVersion2
   deriving (Eq, Ord, Enum, Bounded, Show)
 
 -- | Get the @QueryVersion@ supported by this @NodeToClientVersion@.
 nodeToClientVersionToQueryVersion :: NodeToClientVersion -> QueryVersion
 nodeToClientVersionToQueryVersion x = case x of
-  NodeToClientV_1 -> TopLevelQueryDisabled
-  NodeToClientV_2 -> TopLevelQueryDisabled
-  NodeToClientV_3 -> TopLevelQueryDisabled
-  NodeToClientV_4 -> TopLevelQueryDisabled
-  NodeToClientV_5 -> TopLevelQueryDisabled
-  NodeToClientV_6 -> TopLevelQueryDisabled
-  NodeToClientV_7 -> TopLevelQueryDisabled
-  NodeToClientV_8 -> TopLevelQueryDisabled
-  NodeToClientV_9 -> QueryVersion1
+  NodeToClientV_1  -> TopLevelQueryDisabled
+  NodeToClientV_2  -> TopLevelQueryDisabled
+  NodeToClientV_3  -> TopLevelQueryDisabled
+  NodeToClientV_4  -> TopLevelQueryDisabled
+  NodeToClientV_5  -> TopLevelQueryDisabled
+  NodeToClientV_6  -> TopLevelQueryDisabled
+  NodeToClientV_7  -> TopLevelQueryDisabled
+  NodeToClientV_8  -> TopLevelQueryDisabled
+  NodeToClientV_9  -> QueryVersion1
+  NodeToClientV_10 -> QueryVersion2

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -12,8 +12,10 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Util.IOLike
 
+import           Ouroboros.Consensus.HeaderValidation (HasAnnTip (..))
+
 localStateQueryServer ::
-     forall m blk. (IOLike m, QueryLedger blk, ConfigSupportsNode blk)
+     forall m blk. (IOLike m, QueryLedger blk, ConfigSupportsNode blk, HasAnnTip blk)
   => ExtLedgerCfg blk
   -> STM m (Point blk)
      -- ^ Get tip point

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -35,6 +35,8 @@ module Ouroboros.Consensus.Network.NodeToClient (
 
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
+import           Codec.Serialise (Serialise (..))
+
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Void (Void)
@@ -164,6 +166,8 @@ defaultCodecs :: forall m blk.
                  ( MonadST m
                  , SerialiseNodeToClientConstraints blk
                  , ShowQuery (BlockQuery blk)
+                 , Show (HeaderHash blk)
+                 , Serialise (HeaderHash blk)
                  )
               => CodecConfig blk
               -> BlockNodeToClientVersion blk
@@ -216,6 +220,8 @@ clientCodecs :: forall m blk.
                 ( MonadST m
                 , SerialiseNodeToClientConstraints blk
                 , ShowQuery (BlockQuery blk)
+                , Serialise (HeaderHash blk)
+                , Show (HeaderHash blk)
                 )
              => CodecConfig blk
              -> BlockNodeToClientVersion blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE NamedFieldPuns      #-}
@@ -5,6 +6,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+
 -- | Run the whole Node
 --
 -- Intended for qualified import.
@@ -51,6 +53,7 @@ module Ouroboros.Consensus.Node (
   ) where
 
 import           Codec.Serialise (DeserialiseFailure)
+
 import           Control.Monad (when)
 import           Control.Tracer (Tracer, contramap)
 import           Data.ByteString.Lazy (ByteString)
@@ -230,8 +233,7 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk = L
 -------------------------------------------------------------------------------}
 
 -- | Combination of 'runWith' and 'stdLowLevelRunArgsIO'
-run :: forall blk.
-     RunNode blk
+run :: forall blk. RunNode blk
   => RunNodeArgs IO RemoteAddress LocalAddress blk
   -> StdRunNodeArgs IO blk
   -> IO ()

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -41,6 +41,8 @@ data NodeToClientVersion
     -- ^ 'LocalStateQuery' protocol codec change, allows to acquire tip point.
     | NodeToClientV_9
     -- ^ enabled @CardanoNodeToClientVersion7@, i.e., Alonzo
+    | NodeToClientV_10
+    -- ^ enabled @CardanoNodeToClientVersion7@, i.e., Alonzo
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
@@ -53,15 +55,16 @@ data NodeToClientVersion
 nodeToClientVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToClientVersion
 nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     where
-      encodeTerm NodeToClientV_1 = CBOR.TInt 1
-      encodeTerm NodeToClientV_2 = CBOR.TInt (2 `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_3 = CBOR.TInt (3 `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_4 = CBOR.TInt (4 `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_5 = CBOR.TInt (5 `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_6 = CBOR.TInt (6 `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_7 = CBOR.TInt (7 `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_8 = CBOR.TInt (8 `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_9 = CBOR.TInt (9 `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_1  = CBOR.TInt 1
+      encodeTerm NodeToClientV_2  = CBOR.TInt (2  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_3  = CBOR.TInt (3  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_4  = CBOR.TInt (4  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_5  = CBOR.TInt (5  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_6  = CBOR.TInt (6  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_7  = CBOR.TInt (7  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_8  = CBOR.TInt (8  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_9  = CBOR.TInt (9  `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_10 = CBOR.TInt (10 `setBit` nodeToClientVersionBit)
 
       decodeTerm (CBOR.TInt tag) =
        case ( tag `clearBit` nodeToClientVersionBit
@@ -76,6 +79,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
         (7, True)  -> Right NodeToClientV_7
         (8, True)  -> Right NodeToClientV_8
         (9, True)  -> Right NodeToClientV_9
+        (10, True) -> Right NodeToClientV_10
         (n, _)     -> Left ( T.pack "decode NodeToClientVersion: unknown tag: " <> T.pack (show tag)
                             , Just n)
       decodeTerm _  = Left ( T.pack "decode NodeToClientVersion: unexpected term"

--- a/ouroboros-network/test-cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network/test-cddl/specs/handshake-node-to-client.cddl
@@ -14,7 +14,7 @@ msgRefuse          = [2, refuseReason]
 versionTable = { * versionNumber => nodeToClientVersionData }
 
 ; from version 2 we set 15th bit to 1
-versionNumber = 1 / 32770 / 32771 / 32772 / 32773 / 32774 / 32775 / 32776 / 32777
+versionNumber = 1 / 32770 / 32771 / 32772 / 32773 / 32774 / 32775 / 32776 / 32777 / 32778
 
 nodeToClientVersionData = networkMagic
 


### PR DESCRIPTION
I was able to query the local state tip and observe that it matches the chain sync result.

```
CARDANO_NODE_SOCKET_PATH=example/node-bft1/node.sock  $(./scripts/bin-path.sh cardano-cli) query tip --testnet-magic 42 --cardano-mode
headerStateTip At HeaderStateTip {queriedTipSlotNo = SlotNo 57, queriedTipBlockNo = BlockNo 4, queriedTipInfo = e7013470b0d6f915005e27a735c5abc6ad99416801819c1c9ef72fdf29784bc7}
{
    "epoch": 0,
    "hash": "e7013470b0d6f915005e27a735c5abc6ad99416801819c1c9ef72fdf29784bc7",
    "slot": 57,
    "block": 4,
    "era": "Alonzo",
    "syncProgress": "100.00"
}
```