### PR TITLE
Add block size to CompletedBlockFetch trace event

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -394,6 +394,7 @@ data TraceFetchClientState header =
           PeerFetchInFlightLimits
          (PeerFetchStatus header)
          NominalDiffTime
+         SizeInBytes
 
        -- | Mark the successful end of receiving a streaming batch of blocks
        --
@@ -567,6 +568,7 @@ completeBlockDownload tracer blockFetchSize inflightlimits header blockDelay
         inflight' inflightlimits
         currentStatus'
         blockDelay
+        (blockFetchSize header)
 
 
 completeFetchBatch :: MonadSTM m

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -258,7 +258,7 @@ tracePropertyBlocksRequestedAndRecievedPerPeer fork1 fork2 es =
       Map.fromListWith (flip (++))
         [ (peer, [pt])
         | TraceFetchClientState
-            (TraceLabelPeer peer (CompletedBlockFetch pt _ _ _ _)) <- es
+            (TraceLabelPeer peer (CompletedBlockFetch pt _ _ _ _ _)) <- es
         ]
 
 
@@ -302,7 +302,7 @@ tracePropertyBlocksRequestedAndRecievedAllPeers fork1 fork2 es =
       Set.fromList
         [ pt
         | TraceFetchClientState
-            (TraceLabelPeer _ (CompletedBlockFetch pt _ _ _ _)) <- es
+            (TraceLabelPeer _ (CompletedBlockFetch pt _ _ _ _ _)) <- es
         ]
 
 


### PR DESCRIPTION
Block size has an impact on block delay, which is already traced in this
event. It should be tracked here.