### PR TITLE
Enforce sleeping at least acceptedConnectionsDelay at hard limit

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
@@ -129,7 +129,7 @@ runConnectionRateLimits tracer
           numberOfConnections' <- numberOfConnectionsSTM
           check (numberOfConnections' < fromIntegral limit)
         end <- getMonotonicTime
-        let remainingDelay = end `diffTime` start - acceptedConnectionsDelay
+        let remainingDelay = acceptedConnectionsDelay - end `diffTime` start
         when (remainingDelay > 0)
           $ threadDelay remainingDelay
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/RateLimiting.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/RateLimiting.hs
@@ -248,6 +248,8 @@ propRateLimit_SoftLimitDelay (Arb (events, policy)) =
                          delay <= acceptedConnectionsDelay policy
 
                   WithNumberOfConnections ServerTraceAcceptConnectionHardLimit {} _ ->
+                      False
+                  WithNumberOfConnections ServerTraceAcceptConnectionResume {} _ ->
                       False)
 
         . filter (\x ->


### PR DESCRIPTION
Previous logic was switched which could cause the accept thread to sleep
too long.

Thanks to @gufmar for helping with tracking down this issue.