### PR TITLE
[CAD-3383] Bring db analyser back to life

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -85,14 +85,17 @@ executable db-analyser
                      , optparse-applicative
                      , shelley-spec-ledger
                      , strict-containers
+                     , text
 
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
                      , ouroboros-consensus-shelley
                      , ouroboros-network
+                     , plutus-ledger-api
   other-modules:
                        Analysis
+                     , Block.Alonzo
                      , Block.Byron
                      , Block.Cardano
                      , Block.Shelley

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Alonzo.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Alonzo.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Block.Alonzo () where
+
+import           Control.Applicative
+import qualified Data.Map.Strict as Map
+import           Data.Text (Text)
+import           Prelude
+
+import           Data.Aeson (FromJSON (..), (.:), (.:?))
+import qualified Data.Aeson as Aeson
+import           Data.Aeson.Types (FromJSONKey (..))
+
+import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
+import qualified Cardano.Ledger.Alonzo.Language as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.BaseTypes as Ledger
+
+import           Plutus.V1.Ledger.Api (defaultCostModelParams)
+
+instance FromJSON Alonzo.AlonzoGenesis where
+  parseJSON = Aeson.withObject "Alonzo Genesis" $ \o -> do
+    coinsPerUTxOWord     <- o .:  "lovelacePerUTxOWord"
+                        <|> o .:  "adaPerUTxOWord"
+    cModels              <- o .:? "costModels"
+    prices               <- o .:  "executionPrices"
+    maxTxExUnits         <- o .:  "maxTxExUnits"
+    maxBlockExUnits      <- o .:  "maxBlockExUnits"
+    maxValSize           <- o .:  "maxValueSize"
+    collateralPercentage <- o .:  "collateralPercentage"
+    maxCollateralInputs  <- o .:  "maxCollateralInputs"
+    case cModels of
+      Nothing -> case Alonzo.CostModel <$> defaultCostModelParams of
+        Just m -> return Alonzo.AlonzoGenesis
+          { Alonzo.coinsPerUTxOWord
+          , Alonzo.costmdls = Map.singleton Alonzo.PlutusV1 m
+          , Alonzo.prices
+          , Alonzo.maxTxExUnits
+          , Alonzo.maxBlockExUnits
+          , Alonzo.maxValSize
+          , Alonzo.collateralPercentage
+          , Alonzo.maxCollateralInputs
+          }
+        Nothing -> fail "Failed to extract the cost model params from defaultCostModel"
+      Just costmdls -> return Alonzo.AlonzoGenesis
+        { Alonzo.coinsPerUTxOWord
+        , Alonzo.costmdls
+        , Alonzo.prices
+        , Alonzo.maxTxExUnits
+        , Alonzo.maxBlockExUnits
+        , Alonzo.maxValSize
+        , Alonzo.collateralPercentage
+        , Alonzo.maxCollateralInputs
+        }
+
+deriving instance FromJSON Alonzo.ExUnits
+
+instance FromJSON Alonzo.Language where
+  parseJSON = Aeson.withText "Language" languageFromText
+
+instance FromJSONKey Alonzo.Language where
+  fromJSONKey = Aeson.FromJSONKeyTextParser languageFromText
+
+instance FromJSON Alonzo.Prices where
+  parseJSON =
+    Aeson.withObject "prices" $ \o -> do
+      steps <- o .: "prSteps"
+      mem   <- o .: "prMem"
+      prSteps <- checkBoundedRational steps
+      prMem   <- checkBoundedRational mem
+      return Alonzo.Prices { Alonzo.prSteps, Alonzo.prMem }
+    where
+      -- We cannot round-trip via NonNegativeInterval, so we go via Rational
+      checkBoundedRational r =
+        case Ledger.boundRational r of
+          Nothing -> fail ("too much precision for bounded rational: " ++ show r)
+          Just s  -> return s
+
+deriving newtype instance FromJSON Alonzo.CostModel
+
+languageFromText :: MonadFail m => Text -> m Alonzo.Language
+languageFromText "PlutusV1" = pure Alonzo.PlutusV1
+languageFromText lang       = fail $ "Error decoding Language: " ++ show lang

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Alonzo.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Alonzo.hs
@@ -1,16 +1,22 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Block.Alonzo () where
+module Block.Alonzo (
+    AlonzoBlockArgs
+  , Args (..)
+  ) where
 
 import           Control.Applicative
 import qualified Data.Map.Strict as Map
 import           Data.Text (Text)
+import           Options.Applicative
 import           Prelude
 
 import           Data.Aeson (FromJSON (..), (.:), (.:?))
@@ -21,8 +27,30 @@ import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
+import           HasAnalysis (HasProtocolInfo (..))
+import           Ouroboros.Consensus.Shelley.Eras (StandardAlonzo)
+import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 
 import           Plutus.V1.Ledger.Api (defaultCostModelParams)
+
+instance HasProtocolInfo (ShelleyBlock StandardAlonzo) where
+  data Args (ShelleyBlock StandardAlonzo) = AlonzoBlockArgs {
+        configFileAlonzo :: FilePath
+      }
+    deriving (Show)
+
+  argsParser _ = AlonzoBlockArgs
+    <$> strOption (mconcat [
+            long "configAlonzo"
+          , help "Path to config file"
+          , metavar "PATH"
+          ])
+
+  -- | Not implemented because we don't anticipate running
+  -- an 'Alonzo only' chain.
+  mkProtocolInfo _ = undefined
+
+type AlonzoBlockArgs = Args (ShelleyBlock StandardAlonzo)
 
 instance FromJSON Alonzo.AlonzoGenesis where
   parseJSON = Aeson.withObject "Alonzo Genesis" $ \o -> do

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Alonzo.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Alonzo.hs
@@ -46,9 +46,11 @@ instance HasProtocolInfo (ShelleyBlock StandardAlonzo) where
           , metavar "PATH"
           ])
 
-  -- | Not implemented because we don't anticipate running
-  -- an 'Alonzo only' chain.
-  mkProtocolInfo _ = undefined
+  -- | This function would only be used if we run an
+  -- Alonzo only chain. This should be dead code really.
+  mkProtocolInfo _ =
+    error $ "Not implemented because we don't "
+         <> "anticipate running an 'Alonzo only' chain."
 
 type AlonzoBlockArgs = Args (ShelleyBlock StandardAlonzo)
 

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -39,6 +39,7 @@ import           Ouroboros.Consensus.Cardano
 import           Ouroboros.Consensus.Cardano.Node (TriggerHardFork (..),
                      protocolInfoCardano)
 
+import           Block.Alonzo ()
 import           Block.Byron (Args (..), openGenesisByron)
 import           Block.Shelley (Args (..))
 import           HasAnalysis
@@ -58,9 +59,9 @@ analyseBlock f =
 instance HasProtocolInfo (CardanoBlock StandardCrypto) where
   data Args (CardanoBlock StandardCrypto) =
     CardanoBlockArgs {
-        byronArgs   :: Args ByronBlock
-      , shelleyArgs :: Args (ShelleyBlock StandardShelley)
-      , alonzoArgs  :: FilePath
+        byronArgs        :: Args ByronBlock
+      , shelleyArgs      :: Args (ShelleyBlock StandardShelley)
+      , configFileAlonzo :: FilePath
       }
   argsParser _ = parseCardanoArgs
   mkProtocolInfo CardanoBlockArgs {..} = do
@@ -69,7 +70,8 @@ instance HasProtocolInfo (CardanoBlock StandardCrypto) where
     genesisByron <- openGenesisByron configFileByron genesisHash requiresNetworkMagic
     genesisShelley <- either (error . show) return =<<
       Aeson.eitherDecodeFileStrict' configFileShelley
-    genesisAlonzo <- undefined alonzoArgs
+    genesisAlonzo <- either (error . show) return =<<
+      Aeson.eitherDecodeFileStrict' configFileAlonzo
     return $ mkCardanoProtocolInfo genesisByron threshold genesisShelley genesisAlonzo initialNonce
 
 instance HasAnalysis (CardanoBlock StandardCrypto) where

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -113,15 +113,15 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         , shelleyBasedLeaderCredentials = []
         }
       ProtocolParamsShelley {
-          shelleyProtVer                = ProtVer 2 0
+          shelleyProtVer                = ProtVer 3 0
         , shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsAllegra {
-          allegraProtVer                = ProtVer 3 0
+          allegraProtVer                = ProtVer 4 0
         , allegraMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsMary {
-          maryProtVer                   = ProtVer 4 0
+          maryProtVer                   = ProtVer 5 0
         , maryMaxTxCapacityOverrides    = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsAlonzo {


### PR DESCRIPTION
* Add FromJSON instance to AlonzoGenesis
This instances was copied from node. But it should really live in
ledger spec. Same as ShelleyGenesis does. This should be addressed in
the near future. Issue was created https://github.com/input-output-hk/cardano-ledger-specs/issues/2452

* Bring db-analyser back to life
Once we have AlonzoGenesis FromJSON, providing it to
mkCardanoProtocolInfo is just a matter of reading the configuration
file provided by the user


Examples usage:

```
λ cabal run ouroboros-consensus-cardano:db-analyser -- \
   --db db_mainnet cardano \
   --configByron dbacfg/mainnet-byron-genesis.json \
   --configShelley dbacfg/mainnet-shelley-genesis.json \
   --configAlonzo dbacfg/mainnet-alonzo-genesis.json \
   --show-slot-block-no

(...)
BlockNo 73752	SlotNo 73780
BlockNo 73753	SlotNo 73781
BlockNo 73754	SlotNo 73782
BlockNo 73755	SlotNo 73783
BlockNo 73756	SlotNo 73784
(...)
```

Not tested with Alonzo yet, because the mainnet chain (that this tool was tested with) does not yet hold alonzo blocks. 
