### PR TITLE
CAD-3444: pull changes from p2p-master

### DIFF
--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -359,6 +359,7 @@ The protocol uses the following messages.
 \newcommand{\StPropose}{\state{StPropose}}
 \newcommand{\StConfirm}{\state{StConfirm}}
 \newcommand{\MsgProposeVersions}{\msg{MsgProposeVersions}}
+\newcommand{\MsgProposeVersionsX}{\msg{MsgProposeVersions'}}
 \newcommand{\MsgAcceptVersion}{\msg{MsgAcceptVersion}}
 \newcommand{\MsgRefuse}{\msg{MsgRefuse}}
 
@@ -380,6 +381,8 @@ A node, that runs the handshake protocol, must instantiate it with the set of
 supported protocol versions and callback functions for handling the protocol parameters.
 These callback functions are specific for the supported protocol versions.
 
+The handshake mini protocol is designed to handle simultantous TCP open.
+
 \subsection{State machine}
 
 \begin{figure}[h]
@@ -392,15 +395,16 @@ These callback functions are specific for the supported protocol versions.
 \end{figure}
 
 \begin{figure}[h]
-  \begin{tikzpicture}[->,shorten >=1pt,auto,node distance=6cm, semithick]
+  \begin{tikzpicture}[->,>=stealth',shorten >=1pt,auto,node distance=6cm, semithick]
     \tikzstyle{every state}=[fill=red,draw=none,text=white]
-    \node[state, mygreen, initial]                                     (Propose)    {\StPropose};
-    \node[state, myblue, right of=Propose]                             (Confirm)    {\StConfirm};
-    \node[state, right of=Confirm]                                   (Done)       {\StDone};
+    \node[state, green, initial]   (StPropose) at (0,  0) {\StPropose};
+    \node[state, blue]             (StConfirm) at (5,  0) {\StConfirm};
+    \node[state, right of=Confirm] (StDone)    at (7,  0) {\StDone};
 
-    \draw (Propose)      edge[]      node{\MsgProposeVersions}          (Confirm);
-    \draw (Confirm)      edge[above, bend left]       node{\MsgAcceptVersion}     (Done);
-    \draw (Confirm)      edge[below, bend right]      node{\MsgRefuse}            (Done);
+    \draw (StPropose) --node[above=1em]{\MsgProposeVersions} (StConfirm);
+    \draw[->] (StConfirm.10)  to [out=15,  in=150] node[above]{\MsgAcceptVersion}     (StDone.170);
+    \draw[->] (StConfirm.350) to [out=-15, in=210] node[below]{\MsgRefuse}            (StDone.190);
+    \draw[->] (StConfirm)     -- node[fill=white,above=-0.8em] {\MsgProposeVersionsX} (StDone.west);
   \end{tikzpicture}
 \end{figure}
 
@@ -408,22 +412,29 @@ Messages of the protocol:
 \begin{description}
 \item [\MsgProposeVersions{} {\boldmath $(versionTable)$}]
       The client proposes a number of possible versions and protocol parameters.
+\item [\MsgProposeVersionsX{} {\boldmath $(versionTable)$}]
+      In TCP simultanous open the client will receive \MsgProposeVersionsX{}
+      (which was sent as \MsgProposeVersions{}) as a reply to its own
+      \MsgProposeVersions{}; thus both \MsgProposeVersions{} and
+      \MsgProposeVersionsX{} have to have the same CBOR encoding.
 \item [\MsgAcceptVersion{} {\boldmath $(versionNumber,extraParameters)$}]
       The server accepts $versionNumber$ and returns possible extra protocol parameters.
 \item [\MsgRefuse{} {\boldmath $(reason)$}]
       The server refuses the proposed versions.
 \end{description}
 
+{\small
 \begin{table}[h]
   \begin{tabular}{|l|l|l|l|} \hline
   \multicolumn{4}{|c|}{Transition table} \\ \hline
-    from          & message/event         & parameters              & to                \\ \hline\hline
-    \StPropose    & \MsgProposeVersions   & $versionTable$          & \StConfirm        \\ \hline
-    \StConfirm    & \MsgAcceptVersion     & $(versionNumber,extraParameters)$ & \StDone \\ \hline
-    \StConfirm    & \MsgRefuse            & $reason$                & \StDone           \\ \hline
+    from       & message/event         & parameters                        & to \\ \hline\hline
+    \StPropose & \MsgProposeVersions   & $versionTable$                    & \StConfirm \\ \hline
+    \StConfirm & \MsgProposeVersionsX  & $versionTable$                    & \StDone \\ \hline
+    \StConfirm & \MsgAcceptVersion     & $(versionNumber,extraParameters)$ & \StDone \\ \hline
+    \StConfirm & \MsgRefuse            & $reason$                          & \StDone \\ \hline
   \end{tabular}
-  \caption{Handhsake mini-protocol messages.}
 \end{table}
+}
 
 \subsection{Client and Server Implementation}
 Section~\ref{handshake-cddl} contains the CDDL-specification of the binary format of the handshake messages.
@@ -475,6 +486,13 @@ The handshake protocol is designed,
 such that a server can always handle requests for protocol versions that it does not support.
 The server simply ignores the CBOR terms that represent the protocol parameters of unsupported
 version.
+
+In case of simultaneous open TCP connection, both handshake clients will send
+their \MsgProposeVersions{}, both will interpet the incoming message as
+\MsgProposeVersionsX{} (thus both must have the same encoding, the
+implementation can disntiguish them by the protocol state).  Both clients
+should choose the highest version of the protocol available.  If any side does
+not accept any version (or its parameters) it can reset the connection.
 
 The handshake mini protocol runs before the MUX/DEMUX itself is initialised.
 Each message is transmitted within a single MUX segment, i.e. with a proper

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -26,6 +26,7 @@ import System.Exit
 
 import Ouroboros.Network.Socket
 import Ouroboros.Network.Snocket
+import qualified Ouroboros.Network.Snocket as Snocket
 import Ouroboros.Network.Mux
 import Ouroboros.Network.ErrorPolicy
 import Ouroboros.Network.IOManager
@@ -107,7 +108,7 @@ clientPingPong :: Bool -> IO ()
 clientPingPong pipelined =
     withIOManager $ \iomgr ->
     connectToNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -145,7 +146,7 @@ serverPingPong =
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
@@ -203,9 +204,9 @@ demoProtocol1 pingPong pingPong' =
 
 clientPingPong2 :: IO ()
 clientPingPong2 =
-    withIOManager $ \iomgr ->
+    withIOManager $ \iomgr -> do
     connectToNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -256,7 +257,7 @@ serverPingPong2 =
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iomgr defaultLocalSocketAddrPath)
+      (Snocket.localSnocket iomgr)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -33,7 +33,7 @@ handshakeClientPeer
   -> Peer (Handshake vNumber CBOR.Term)
           AsClient StPropose m
           (Either
-            (HandshakeClientProtocolError vNumber)
+            (HandshakeProtocolError vNumber)
             (r, vNumber, vData))
 handshakeClientPeer VersionDataCodec {encodeData, decodeData} acceptVersion versions =
   -- send known versions

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
 module Ouroboros.Network.Protocol.Handshake.Client
   ( handshakeClientPeer
+  , acceptOrRefuse
   ) where
 
 import           Data.Map (Map)
@@ -26,7 +28,8 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 -- TODO: GADT encoding of the client (@Handshake.Client@ module).
 --
 handshakeClientPeer
-  :: Ord vNumber
+  :: ( Ord vNumber
+     )
   => VersionDataCodec CBOR.Term vNumber vData
   -> (vData -> vData -> Accept vData)
   -> Versions vNumber vData r
@@ -35,11 +38,18 @@ handshakeClientPeer
           (Either
             (HandshakeProtocolError vNumber)
             (r, vNumber, vData))
-handshakeClientPeer VersionDataCodec {encodeData, decodeData} acceptVersion versions =
+handshakeClientPeer codec@VersionDataCodec {encodeData, decodeData}
+                    acceptVersion versions =
   -- send known versions
   Yield (ClientAgency TokPropose) (MsgProposeVersions $ encodeVersions encodeData versions) $
 
     Await (ServerAgency TokConfirm) $ \msg -> case msg of
+      MsgProposeVersions' vMap -> 
+        -- simultanous open; 'accept' will choose version (the greatest common
+        -- version), and check if we can accept received version data.
+        Done TokDone $ case acceptOrRefuse codec acceptVersion versions vMap of
+          Right r -> Right r
+          Left vReason -> Left (HandshakeError vReason)
 
       -- the server refused common highest version
       MsgRefuse vReason ->
@@ -76,3 +86,37 @@ encodeVersions encoder (Versions vs) = go `Map.mapWithKey` vs
     where
       go :: vNumber -> Version vData r -> vParams
       go vNumber Version {versionData} = encoder vNumber versionData
+
+
+acceptOrRefuse
+  :: forall vParams vNumber vData r.
+     Ord vNumber
+  => VersionDataCodec vParams vNumber vData
+  -> (vData -> vData -> Accept vData)
+  -> Versions vNumber vData r
+  -> Map vNumber vParams
+  -- ^ proposed versions received either with `MsgProposeVersions` or
+  -- `MsgProposeVersions'`
+  -> Either (RefuseReason vNumber) (r, vNumber, vData)
+acceptOrRefuse VersionDataCodec {decodeData}
+               acceptVersion versions versionMap =
+    case lookupGreatestCommonKey versionMap (getVersions versions) of
+      Nothing ->
+        Left $ VersionMismatch (Map.keys $ getVersions versions) []
+
+      Just (vNumber, (vParams, Version app vData)) ->
+        case decodeData vNumber vParams of
+          Left err ->
+            Left (HandshakeDecodeError vNumber err)
+
+          Right vData' ->
+            case acceptVersion vData vData' of
+              Accept agreedData ->
+                Right (app agreedData, vNumber, agreedData)
+
+              Refuse err ->
+                Left (Refused vNumber err)
+
+
+lookupGreatestCommonKey :: Ord k => Map k a -> Map k b -> Maybe (k, (a, b))
+lookupGreatestCommonKey l r = Map.lookupMax $ Map.intersectionWith (,) l r

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -8,12 +8,12 @@ module Ouroboros.Network.Protocol.Handshake.Server
   ( handshakeServerPeer
   ) where
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import qualified Codec.CBOR.Term     as CBOR
 
 import           Network.TypedProtocol.Core
 
 import           Ouroboros.Network.Protocol.Handshake.Codec
+import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse)
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 
@@ -21,58 +21,24 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 -- | Server following the handshake protocol; it accepts highest version offered
 -- by the peer that also belongs to the server @versions@.
 --
--- TODO: GADT encoding of the server (@Handshake.Server@ module).
---
 handshakeServerPeer
-  :: Ord vNumber
-  => VersionDataCodec vParams vNumber vData
+  :: ( Ord vNumber
+     )
+  => VersionDataCodec CBOR.Term vNumber vData
   -> (vData -> vData -> Accept vData)
   -> Versions vNumber vData r
-  -> Peer (Handshake vNumber vParams)
+  -> Peer (Handshake vNumber CBOR.Term)
           AsServer StPropose m
           (Either (HandshakeProtocolError vNumber) (r, vNumber, vData))
-handshakeServerPeer VersionDataCodec {encodeData, decodeData} acceptVersion versions =
-    -- await for versions proposed by a client
+handshakeServerPeer codec@VersionDataCodec {encodeData} acceptVersion versions =
     Await (ClientAgency TokPropose) $ \msg -> case msg of
-
-      MsgProposeVersions vMap ->
-        -- Compute intersection of local and remote versions.
-        case lookupGreatestCommonKey vMap (getVersions versions) of
-          Nothing ->
-            let vReason = VersionMismatch (Map.keys $ getVersions versions) []
-            in Yield (ServerAgency TokConfirm)
-                     (MsgRefuse vReason)
-                     (Done TokDone (Left $ HandshakeError vReason))
-
-          Just (vNumber, (vParams, Version app vData)) ->
-              case decodeData vNumber vParams of
-                Left err ->
-                  let vReason = HandshakeDecodeError vNumber err
-                  in Yield (ServerAgency TokConfirm)
-                           (MsgRefuse vReason)
-                           (Done TokDone $ Left $ HandshakeError vReason)
-
-                Right vData' ->
-                  case acceptVersion vData vData' of
-
-                    -- We agree on the version; send back the agreed version
-                    -- number @vNumber@ and encoded data associated with our
-                    -- version.
-                    Accept agreedData ->
-                      Yield (ServerAgency TokConfirm)
-                            (MsgAcceptVersion vNumber (encodeData vNumber agreedData))
-                            (Done TokDone $ Right $
-                              ( app agreedData
-                              , vNumber
-                              , agreedData
-                              ))
-
-                    -- We disagree on the version.
-                    Refuse err ->
-                      let vReason = Refused vNumber err
-                      in Yield (ServerAgency TokConfirm)
-                               (MsgRefuse vReason)
-                               (Done TokDone $ Left $ HandshakeError vReason)
-
-lookupGreatestCommonKey :: Ord k => Map k a -> Map k b -> Maybe (k, (a, b))
-lookupGreatestCommonKey l r = Map.lookupMax $ Map.intersectionWith (,) l r
+      MsgProposeVersions vMap  ->
+        case acceptOrRefuse codec acceptVersion versions vMap of
+          (Right r@(_, vNumber, agreedData)) ->
+            Yield (ServerAgency TokConfirm)
+                  (MsgAcceptVersion vNumber (encodeData vNumber agreedData))
+                  (Done TokDone (Right r))
+          (Left vReason) ->
+            Yield (ServerAgency TokConfirm)
+                  (MsgRefuse vReason)
+                  (Done TokDone (Left (HandshakeError vReason)))

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -20,6 +20,7 @@ module Ouroboros.Network.Protocol.Handshake.Type
   , ClientHasAgency (..)
   , ServerHasAgency (..)
   , NobodyHasAgency (..)
+    -- $simultanous-open
   , RefuseReason (..)
   , HandshakeProtocolError (..)
   )
@@ -33,7 +34,6 @@ import           Data.Map (Map)
 
 import           Network.TypedProtocol.Core
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
-
 
 -- |
 -- The handshake mini-protocol is used initially to agree the version and
@@ -83,6 +83,16 @@ instance Protocol (Handshake vNumber vParams) where
         -> Message (Handshake vNumber vParams) StPropose StConfirm
 
       -- |
+      -- `MsgProposeVersions'` received as a response to 'MsgProposeVersions'.
+      -- It is not supported to explicitly send this message. It can only be
+      -- received as a copy of 'MsgProposeVersions' in a simultanous open
+      -- scenario.
+      --
+      MsgProposeVersions'
+        :: Map vNumber vParams
+        -> Message (Handshake vNumber vParams) StConfirm StDone
+
+      -- |
       -- The remote end decides which version to use and sends chosen version.
       -- The server is allowed to modify version parameters. 
       --
@@ -111,11 +121,21 @@ instance Protocol (Handshake vNumber vParams) where
     exclusionLemma_NobodyAndClientHaveAgency TokDone    tok = case tok of {}
     exclusionLemma_NobodyAndServerHaveAgency TokDone    tok = case tok of {}
 
+-- $simultanous-open
+--
+-- On simultanous open both sides will send `MsgProposeVersions`, which will be
+-- decoded as `MsgProposeVersions'` which is a terminal message of the
+-- protocol.  It is important to stress that in this case both sides will make
+-- the choice which version and parameters to pick.  Our algorithm for picking
+-- version is symmetric, which ensures that both sides will endup with the same
+-- choice.  If one side decides to refuse the version it will close the
+-- connection, without sending the reason to the other side.
+
 deriving instance (Show vNumber, Show vParams)
     => Show (Message (Handshake vNumber vParams) from to)
 
 instance Show (ClientHasAgency (st :: Handshake vNumber vParams)) where
-    show TokPropose = "TokPropose"
+    show TokPropose       = "TokPropose"
 
 instance Show (ServerHasAgency (st :: Handshake vNumber vParams)) where
     show TokConfirm = "TokConfirm"

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -21,7 +21,7 @@ module Ouroboros.Network.Protocol.Handshake.Type
   , ServerHasAgency (..)
   , NobodyHasAgency (..)
   , RefuseReason (..)
-  , HandshakeClientProtocolError (..)
+  , HandshakeProtocolError (..)
   )
   where
 
@@ -120,15 +120,13 @@ instance Show (ClientHasAgency (st :: Handshake vNumber vParams)) where
 instance Show (ServerHasAgency (st :: Handshake vNumber vParams)) where
     show TokConfirm = "TokConfirm"
 
--- |
--- Client errors, which extends handshake error @'RefuseReason'@ type,
--- by client specific errors.
+-- | Extends handshake error @'RefuseReason'@ type, by client specific errors.
 --
-data HandshakeClientProtocolError vNumber
+data HandshakeProtocolError vNumber
   = HandshakeError (RefuseReason vNumber)
   | NotRecognisedVersion vNumber
   | InvalidServerSelection vNumber Text
   deriving (Eq, Show)
 
 instance (Typeable vNumber, Show vNumber)
-    => Exception (HandshakeClientProtocolError vNumber)
+    => Exception (HandshakeProtocolError vNumber)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
 
 module Ouroboros.Network.Snocket
   ( -- * Snocket Interface
@@ -187,20 +188,19 @@ instance Hashable LocalAddress where
 
 -- | We support either sockets or named pipes.
 --
+-- 'LocalFamily' requires 'LocalAddress', this is needed to provide path of the
+-- openned Win32 'HANDLE'.
+--
 data AddressFamily addr where
 
     SocketFamily :: !Socket.Family
                  -> AddressFamily Socket.SockAddr
 
-    LocalFamily  :: AddressFamily LocalAddress
+    LocalFamily  :: !LocalAddress -> AddressFamily LocalAddress
 
-instance Eq (AddressFamily addr) where
-    SocketFamily fam0 == SocketFamily fam1 = fam0 == fam1
-    LocalFamily       == LocalFamily       = True
+deriving instance Eq   addr => Eq   (AddressFamily addr)
+deriving instance Show addr => Show (AddressFamily addr)
 
-instance Show (AddressFamily addr) where
-    show (SocketFamily fam) = show fam
-    show LocalFamily        = "LocalFamily"
 
 -- | Abstract communication interface that can be used by more than
 -- 'Socket'.  Snockets are polymorphic over monad which is used, this feature
@@ -213,7 +213,7 @@ data Snocket m fd addr = Snocket {
   , addrFamily :: addr -> AddressFamily addr
 
   -- | Open a file descriptor  (socket / namedPipe).  For named pipes this is
-  -- using 'CreateNamedPipe' syscall, for Berkeley sockets 'socket' is used..
+  -- using 'CreateNamedPipe' syscall, for Berkeley sockets 'socket' is used.
   --
   , open          :: AddressFamily addr -> m fd
 
@@ -223,7 +223,7 @@ data Snocket m fd addr = Snocket {
     -- For named pipes we need full 'addr' rather than just address family as
     -- it is for sockets.
     --
-  , openToConnect :: addr ->  m fd
+  , openToConnect :: addr -> m fd
 
     -- | `connect` is only needed for Berkeley sockets, for named pipes this is
     -- no-op.
@@ -342,25 +342,41 @@ type LocalHandle = Socket
 #endif
 
 -- | System dependent LocalSnocket type
+--
+#if defined(mingw32_HOST_OS)
+data LocalSocket = LocalSocket { getLocalHandle :: LocalHandle
+                               , getLocalPath   :: LocalAddress
+                               }
+    deriving (Eq, Generic)
+    deriving Show via Quiet LocalSocket
+#else
 newtype LocalSocket  = LocalSocket { getLocalHandle :: LocalHandle }
     deriving (Eq, Generic)
     deriving Show via Quiet LocalSocket
+#endif
 
 -- | System dependent LocalSnocket
 type    LocalSnocket = Snocket IO LocalSocket LocalAddress
 
-localSnocket :: IOManager -> FilePath -> LocalSnocket
-#if defined(mingw32_HOST_OS)
-localSnocket ioManager path = Snocket {
-      getLocalAddr  = \_ -> return localAddress
-    , getRemoteAddr = \_ -> return localAddress
-    , addrFamily  = \_ -> LocalFamily
 
-    , open = \_addrFamily -> do
+-- | Create a 'LocalSnocket'.
+--
+-- On /Windows/, there is no way to get path associated to a named pipe.  To go
+-- around this, the address passed to 'open' via 'LocalFamily' will be
+-- referenced by 'LocalSocket'.
+--
+localSnocket :: IOManager -> LocalSnocket
+#if defined(mingw32_HOST_OS)
+localSnocket ioManager = Snocket {
+      getLocalAddr  = return . getLocalPath
+    , getRemoteAddr = return . getLocalPath
+    , addrFamily    = LocalFamily
+
+    , open = \(LocalFamily addr) -> do
         hpipe <- Win32.createNamedPipe
-                   path
+                   (getFilePath addr)
                    (Win32.pIPE_ACCESS_DUPLEX .|. Win32.fILE_FLAG_OVERLAPPED)
-                   (Win32.pIPE_TYPE_BYTE .|. Win32.pIPE_READMODE_BYTE)
+                   (Win32.pIPE_TYPE_BYTE     .|. Win32.pIPE_READMODE_BYTE)
                    Win32.pIPE_UNLIMITED_INSTANCES
                    65536   -- outbound pipe size
                    16384   -- inbound pipe size
@@ -373,7 +389,7 @@ localSnocket ioManager path = Snocket {
           `catch` \(SomeAsyncException _) -> do
             Win32.closeHandle hpipe
             throwIO e
-        pure (LocalSocket hpipe)
+        pure (LocalSocket hpipe addr)
 
     -- To connect, simply create a file whose name is the named pipe name.
     , openToConnect  = \(LocalAddress pipeName) -> do
@@ -391,16 +407,16 @@ localSnocket ioManager path = Snocket {
           `catch` \(SomeAsyncException _) -> do
             Win32.closeHandle hpipe
             throwIO e
-        return (LocalSocket hpipe)
+        return (LocalSocket hpipe (LocalAddress pipeName))
     , connect  = \_ _ -> pure ()
 
     -- Bind and listen are no-op.
     , bind     = \_ _ -> pure ()
     , listen   = \_ -> pure ()
 
-    , accept   = \sock@(LocalSocket hpipe) -> Accept $ do
+    , accept   = \sock@(LocalSocket hpipe addr) -> Accept $ do
           Win32.Async.connectNamedPipe hpipe
-          return (Accepted sock localAddress, acceptNext)
+          return (Accepted sock addr, acceptNext 0 addr)
 
       -- Win32.closeHandle is not interrupible
     , close    = Win32.closeHandle . getLocalHandle
@@ -408,36 +424,29 @@ localSnocket ioManager path = Snocket {
     , toBearer = \_sduTimeout tr -> pure . namedPipeAsBearer tr . getLocalHandle
     }
   where
-    localAddress :: LocalAddress
-    localAddress = LocalAddress path
-
-    acceptNext :: Accept IO LocalSocket LocalAddress
-    acceptNext = go 0
+    acceptNext :: Word64 -> LocalAddress -> Accept IO LocalSocket LocalAddress
+    acceptNext !cnt addr = Accept (acceptOne `catch` handleIOException)
       where
-        go cnt = Accept (acceptOne cnt `catch` handleIOException cnt)
-
         handleIOException
-          :: Word64
-          -> IOException
+          :: IOException
           -> IO ( Accepted  LocalSocket LocalAddress
                 , Accept IO LocalSocket LocalAddress
                 )
-        handleIOException !cnt err =
+        handleIOException err =
           pure ( AcceptFailure (toException err)
-               , go cnt
+               , acceptNext (succ cnt) addr
                )
 
         acceptOne
-          :: Word64
-          -> IO ( Accepted  LocalSocket LocalAddress
+          :: IO ( Accepted  LocalSocket LocalAddress
                 , Accept IO LocalSocket LocalAddress
                 )
-        acceptOne !cnt =
+        acceptOne =
           bracketOnError
             (Win32.createNamedPipe
-                 path
+                 (getFilePath addr)
                  (Win32.pIPE_ACCESS_DUPLEX .|. Win32.fILE_FLAG_OVERLAPPED)
-                 (Win32.pIPE_TYPE_BYTE .|. Win32.pIPE_READMODE_BYTE)
+                 (Win32.pIPE_TYPE_BYTE     .|. Win32.pIPE_READMODE_BYTE)
                  Win32.pIPE_UNLIMITED_INSTANCES
                  65536    -- outbound pipe size
                  16384    -- inbound pipe size
@@ -452,17 +461,17 @@ localSnocket ioManager path = Snocket {
               -- So to differentiate clients we use a simple counter as the
               -- remote end's address.
               --
-              let addr = localAddressFromPath $ "temp-" ++ show cnt
-              return (Accepted (LocalSocket hpipe) addr, go $ succ cnt )
+              let addr' = LocalAddress $ "\\\\.\\pipe\\ouroboros-network-temp-" ++ show cnt
+              return (Accepted (LocalSocket hpipe addr') addr', acceptNext (succ cnt) addr)
 
 -- local snocket on unix
 #else
 
-localSnocket ioManager _ =
+localSnocket ioManager =
     Snocket {
         getLocalAddr  = fmap toLocalAddress . Socket.getSocketName . getLocalHandle
       , getRemoteAddr = fmap toLocalAddress . Socket.getPeerName . getLocalHandle
-      , addrFamily    = const LocalFamily
+      , addrFamily    = LocalFamily
       , connect       = \(LocalSocket s) addr ->
           Socket.connect s (fromLocalAddress addr)
       , bind          = \(LocalSocket fd) addr -> Socket.bind fd (fromLocalAddress addr)
@@ -471,7 +480,7 @@ localSnocket ioManager _ =
                       . berkeleyAccept ioManager
                       . getLocalHandle
       , open          = openSocket
-      , openToConnect = \_addr -> openSocket LocalFamily
+      , openToConnect = \addr -> openSocket (LocalFamily addr)
       , close         = uninterruptibleMask_ . Socket.close . getLocalHandle
       , toBearer      = \df tr (LocalSocket sd) -> pure (Mx.socketAsMuxBearer df tr sd)
       }
@@ -484,7 +493,7 @@ localSnocket ioManager _ =
     fromLocalAddress = SockAddrUnix . getFilePath
 
     openSocket :: AddressFamily LocalAddress -> IO LocalSocket
-    openSocket LocalFamily = do
+    openSocket (LocalFamily _addr) = do
       sd <- Socket.socket AF_UNIX Socket.Stream Socket.defaultProtocol
       associateWithIOManager ioManager (Right sd)
         -- open is designed to be used in `bracket`, and thus it's called with
@@ -518,7 +527,7 @@ socketFileDescriptor = fmap (FileDescriptor . fromIntegral) . Socket.unsafeFdSoc
 localSocketFileDescriptor :: LocalSocket -> IO FileDescriptor
 #if defined(mingw32_HOST_OS)
 localSocketFileDescriptor =
-  \(LocalSocket fd) -> case ptrToIntPtr fd of
+  \(LocalSocket fd _) -> case ptrToIntPtr fd of
     IntPtr i -> return (FileDescriptor i)
 #else
 localSocketFileDescriptor = socketFileDescriptor . getLocalHandle

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -250,9 +250,10 @@ connectToNode' sn handshakeCodec handshakeTimeLimits versionDataCodec NetworkCon
     muxTracer <- initDeltaQTracer' $ Mx.WithMuxBearer connectionId `contramap` nctMuxTracer
     ts_start <- getMonotonicTime
  
+    handshakeBearer <- Snocket.toBearer sn sduHandshakeTimeout muxTracer sd
     app_e <-
       runHandshakeClient
-        (Snocket.toBearer sn sduHandshakeTimeout muxTracer sd)
+        handshakeBearer
         connectionId
         -- TODO: push 'HandshakeArguments' up the call stack.
         HandshakeArguments {
@@ -275,10 +276,11 @@ connectToNode' sn handshakeCodec handshakeTimeLimits versionDataCodec NetworkCon
 
          Right (app, _versionNumber, _agreedOptions) -> do
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
+             bearer <- Snocket.toBearer sn sduTimeout muxTracer sd
              Mx.muxStart
                muxTracer
                (toApplication connectionId (continueForever (Proxy :: Proxy IO)) app)
-               (Snocket.toBearer sn sduTimeout muxTracer sd)
+               bearer
 
 
 -- Wraps a Socket inside a Snocket and calls connectToNode'
@@ -374,9 +376,12 @@ beginConnection sn muxTracer handshakeTracer handshakeCodec handshakeTimeLimits 
 
         traceWith muxTracer' $ Mx.MuxTraceHandshakeStart
 
+        handshakeBearer <- Snocket.toBearer sn
+                                            sduHandshakeTimeout
+                                            muxTracer' sd
         app_e <-
           runHandshakeServer
-            (Snocket.toBearer sn sduHandshakeTimeout muxTracer' sd)
+            handshakeBearer
             connectionId
             HandshakeArguments {
               haHandshakeTracer  = handshakeTracer,
@@ -398,10 +403,11 @@ beginConnection sn muxTracer handshakeTracer handshakeCodec handshakeTimeLimits 
 
              Right (SomeResponderApplication app, _versionNumber, _agreedOptions) -> do
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
+                 bearer <- Snocket.toBearer sn sduTimeout muxTracer' sd
                  Mx.muxStart
                    muxTracer'
                    (toApplication connectionId (continueForever (Proxy :: Proxy IO)) app)
-                   (Snocket.toBearer sn sduTimeout muxTracer' sd)
+                   bearer
 
       RejectConnection st' _peerid -> pure $ Server.Reject st'
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -433,11 +433,16 @@ fromSnocket tblVar sn sd = go (Snocket.accept sn sd)
   where
     go :: Snocket.Accept IO fd addr -> Server.Socket addr fd
     go (Snocket.Accept accept) = Server.Socket $ do
-      (sd', remoteAddr, next) <- accept
-      -- TOOD: we don't need to that on each accept
-      localAddr <- Snocket.getLocalAddr sn sd'
-      atomically $ addConnection tblVar remoteAddr localAddr Nothing
-      pure (remoteAddr, sd', close remoteAddr localAddr sd', go next)
+      (result, next) <- accept
+      case result of
+        Snocket.Accepted sd' remoteAddr -> do
+          -- TOOD: we don't need to that on each accept
+          localAddr <- Snocket.getLocalAddr sn sd'
+          atomically $ addConnection tblVar remoteAddr localAddr Nothing
+          pure (remoteAddr, sd', close remoteAddr localAddr sd', go next)
+        Snocket.AcceptFailure err ->
+          -- the is no way to construct 'Server.Socket'; This will be removed in a later commit!
+          throwIO err
 
     close remoteAddr localAddr sd' = do
         removeConnection tblVar remoteAddr localAddr

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/Utils.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/Utils.hs
@@ -1,10 +1,14 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE DerivingStrategies         #-}
 
 module Ouroboros.Network.Testing.Utils where
 
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadSay
 import           Control.Tracer (Tracer (..))
+
+import           Data.Ratio
 
 import           Test.QuickCheck
 
@@ -13,18 +17,33 @@ import           Debug.Trace (traceShowM)
 
 newtype Delay = Delay { getDelay :: DiffTime }
   deriving Show
+  deriving newtype (Eq, Ord, Num)
 
+
+genDelayWithPrecision :: Integer -> Gen DiffTime
+genDelayWithPrecision precision = 
+    sized $ \n -> do
+      b <- chooseInteger (1, precision)
+      a <- chooseInteger (0, toInteger n * b)
+      return (fromRational (a % b))
 
 -- | This needs to be small, as we are using real time limits in block-fetch
 -- examples.
 --
 instance Arbitrary Delay where
-    arbitrary = do
-      Positive (delay :: Float) <- resize 5 arbitrary
-      return (Delay (realToFrac delay))
+    arbitrary = Delay <$> genDelayWithPrecision 10
     shrink (Delay delay) | delay >= 0.1 = [ Delay (delay - 0.1) ]
                          | otherwise    = []
 
+
+newtype SmallDelay = SmallDelay { getSmallDelay :: DiffTime }
+  deriving Show
+  deriving newtype (Eq, Ord, Num)
+
+instance Arbitrary SmallDelay where
+    arbitrary = resize 5 $ SmallDelay . getDelay <$> suchThat arbitrary (\(Delay d ) -> d < 5)
+    shrink (SmallDelay delay) | delay >= 0.1 = [ SmallDelay (delay - 0.1) ]
+                              | otherwise    = []
 
 --
 -- Debugging tools

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -152,7 +152,7 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
     forConcurrently_ (zip [0..] sockPaths) $ \(index, sockPath) -> do
       threadDelay (50000 * index)
       connectToNode
-        (localSnocket iocp sockPath)
+        (localSnocket iocp)
         unversionedHandshakeCodec
         noTimeLimitsHandshake
         (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -182,7 +182,7 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iocp defaultLocalSocketAddrPath)
+      (localSnocket iocp)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
@@ -365,7 +365,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
     peerAsyncs <- sequence
                     [ async $
                         connectToNode
-                          (localSnocket iocp defaultLocalSocketAddrPath)
+                          (localSnocket iocp)
                           unversionedHandshakeCodec
                           noTimeLimitsHandshake
                           (cborTermVersionDataCodec unversionedProtocolDataCodec)
@@ -417,7 +417,7 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
     networkState <- newNetworkMutableState
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
-      (localSnocket iocp defaultLocalSocketAddrPath)
+      (localSnocket iocp)
       nullNetworkServerTracers
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -547,6 +547,9 @@ instance Eq (AnyMessage (Handshake VersionNumber CBOR.Term)) where
   AnyMessage (MsgProposeVersions vs) == AnyMessage (MsgProposeVersions vs')
     = vs == vs'
 
+  AnyMessage (MsgProposeVersions' vs) == AnyMessage (MsgProposeVersions' vs')
+    = vs == vs'
+
   AnyMessage (MsgAcceptVersion vNumber vParams) == AnyMessage (MsgAcceptVersion vNumber' vParams')
     = vNumber == vNumber' && vParams == vParams'
 
@@ -559,6 +562,12 @@ instance Arbitrary (AnyMessageAndAgency (Handshake VersionNumber CBOR.Term)) whe
   arbitrary = oneof
     [     AnyMessageAndAgency (ClientAgency TokPropose)
         . MsgProposeVersions
+        . Map.mapWithKey (\v -> encodeTerm (dataCodecCBORTerm v) . versionData)
+        . getVersions
+      <$> genVersions
+
+    ,     AnyMessageAndAgency (ServerAgency TokConfirm)
+        . MsgProposeVersions'
         . Map.mapWithKey (\v -> encodeTerm (dataCodecCBORTerm v) . versionData)
         . getVersions
       <$> genVersions

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
@@ -20,13 +22,14 @@ import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Term as CBOR
 
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Control.Monad.Class.MonadAsync (MonadAsync)
+import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow ( MonadCatch
                                                 , MonadThrow
                                                 )
 import           Control.Tracer (nullTracer)
 
+import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Proofs
 
 import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
@@ -35,7 +38,8 @@ import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.CodecCBORTerm
-import           Ouroboros.Network.Driver.Simple ( runConnectedPeers
+import           Ouroboros.Network.Driver.Simple ( runPeer
+                                                 , runConnectedPeers
                                                  , runConnectedPeersAsymmetric
                                                  )
 
@@ -62,6 +66,8 @@ tests =
         , testProperty "pipe IO"               prop_pipe_IO
         , testProperty "channel asymmetric ST" prop_channel_asymmetric_ST
         , testProperty "channel asymmetric IO" prop_channel_asymmetric_IO
+        , testProperty "simultaneous open ST"  prop_channel_simultaneous_open_ST
+        , testProperty "simultaneous open IO"  prop_channel_simultaneous_open_IO
         , testProperty "pipe asymmetric IO"    prop_pipe_asymmetric_IO
         , testProperty "codec RefuseReason"    prop_codec_RefuseReason
         , testProperty "codec"                 prop_codec_Handshake
@@ -538,6 +544,72 @@ prop_pipe_asymmetric_IO :: ArbitraryVersions -> Property
 prop_pipe_asymmetric_IO (ArbitraryVersions clientVersions _serverVersions) =
     ioProperty (prop_channel_asymmetric createPipeConnectedChannels clientVersions)
 
+
+-- | Run two handshake clients against each other, which simulates a TCP
+-- simultaneous open.
+--
+prop_channel_simultaneous_open
+    :: ( MonadAsync m
+       , MonadCatch m
+       , MonadST m
+       )
+    => m (Channel m ByteString, Channel m ByteString)
+    -> Versions VersionNumber VersionData Bool
+    -> Versions VersionNumber VersionData Bool
+    -> m Property
+prop_channel_simultaneous_open createChannels clientVersions serverVersions =
+  let (serverRes, clientRes) =
+        pureHandshake
+          ((maybeAccept .) . acceptableVersion)
+          serverVersions
+          clientVersions
+  in do
+    (clientChannel, serverChannel) <- createChannels
+    let client  = handshakeClientPeer
+                    (cborTermVersionDataCodec dataCodecCBORTerm)
+                    acceptableVersion
+                    clientVersions
+        client' = handshakeClientPeer
+                    (cborTermVersionDataCodec dataCodecCBORTerm)
+                    acceptableVersion
+                    serverVersions
+    (clientRes', serverRes') <-
+      (fst <$> runPeer nullTracer versionNumberHandshakeCodec clientChannel client)
+        `concurrently`
+      (fst <$> runPeer nullTracer versionNumberHandshakeCodec serverChannel client')
+    pure $
+      case (clientRes', serverRes') of
+        -- both succeeded, we just check that the application (which is
+        -- a boolean value) is the one that was put inside 'Version'
+        (Right (c,_,_), Right (s,_,_)) ->
+          label "both-succeed" $
+               Just c === clientRes
+          .&&. Just s === serverRes
+
+        -- both failed
+        (Left{}, Left{})   -> label "both-failed" True
+
+        -- it should not happen that one protocol succeeds and the other end
+        -- fails
+        _                  -> property False
+
+-- | Run 'prop_channel_simultaneous_open' in the simulation monad.
+--
+prop_channel_simultaneous_open_ST :: ArbitraryVersions -> Property
+prop_channel_simultaneous_open_ST (ArbitraryVersions clientVersions serverVersions) =
+  runSimOrThrow $ prop_channel_simultaneous_open
+                    createConnectedChannels
+                    clientVersions
+                    serverVersions
+
+-- | Run 'prop_channel_simultaneous_open' in the IO monad.
+--
+prop_channel_simultaneous_open_IO :: ArbitraryVersions -> Property
+prop_channel_simultaneous_open_IO (ArbitraryVersions clientVersions serverVersions) =
+  ioProperty $ prop_channel_simultaneous_open
+                 createConnectedChannels
+                 clientVersions
+                 serverVersions
 
 --
 -- Codec tests

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -349,13 +349,13 @@ runDataDiffusion tracers
                    case a of
                         (Socket.SockAddrUnix path) -> do
                           traceWith dtDiffusionInitializationTracer $ UsingSystemdSocket path
-                          return (LocalSocket sd, Snocket.localSnocket iocp path)
+                          return (LocalSocket sd, Snocket.localSnocket iocp)
                         unsupportedAddr -> do
                           traceWith dtDiffusionInitializationTracer $ UnsupportedLocalSystemdSocket unsupportedAddr
                           throwIO UnsupportedLocalSocketType
 #endif
                Right addr -> do
-                   let sn = Snocket.localSnocket iocp addr
+                   let sn = Snocket.localSnocket iocp
                    traceWith dtDiffusionInitializationTracer $ CreateSystemdSocketForSnocketPath addr
                    sd <- Snocket.open sn (Snocket.addrFamily sn $ Snocket.localAddressFromPath addr)
                    traceWith dtDiffusionInitializationTracer $ CreatedLocalSocket addr

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -342,7 +342,7 @@ networkErrorPolicies = ErrorPolicies
         -- version or we refused it.  This is only for outbound connections to
         -- a local node, thus we throw the exception.
         ErrorPolicy
-          $ \(_ :: HandshakeClientProtocolError NodeToClientVersion)
+          $ \(_ :: HandshakeProtocolError NodeToClientVersion)
                 -> Just ourBug
 
         -- exception thrown by `runPeerWithLimits`

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -538,7 +538,7 @@ remoteNetworkErrorPolicy = ErrorPolicies {
           -- version or we refused it.  This is only for outbound connections,
           -- thus we suspend the consumer.
           ErrorPolicy
-            $ \(_ :: HandshakeClientProtocolError NodeToNodeVersion)
+            $ \(_ :: HandshakeProtocolError NodeToNodeVersion)
                   -> Just misconfiguredPeer
 
           -- deserialisation failure; this means that the remote peer is either

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -617,8 +617,8 @@ _unit_bracketSyncWithFetchClient step = do
 -- make a proper calucation what should it be.  At the moment this test shows
 -- that the block fetch protocol can exit within some large time limit.
 --
-prop_terminate :: TestChainFork -> Delay -> Property
-prop_terminate (TestChainFork _commonChain forkChain _forkChain) (Delay delay) =
+prop_terminate :: TestChainFork -> Positive SmallDelay -> Property
+prop_terminate (TestChainFork _commonChain forkChain _forkChain) (Positive (SmallDelay delay)) =
     let tr = runSimTrace simulation
         trace :: [FetchRequestTrace]
         trace  = selectTraceEventsDynamic tr

--- a/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
@@ -269,10 +269,13 @@ instance Arbitrary a => Arbitrary (LargeNonEmptyList a) where
 
 prop_txSubmission :: Positive Word16
                   -> NonEmptyList (Tx Int)
-                  -> Maybe Delay
+                  -- | The delay must be smaller (<) than 5s, so that overall
+                  -- delay is less than 10s, otherwise 'smallDelay' in
+                  -- 'timeLimitsTxSubmission' will kick in.
+                  -> Maybe (Positive SmallDelay)
                   -> Property
 prop_txSubmission (Positive maxUnacked) (NonEmpty outboundTxs) delay =
-    let mbDelayTime = getDelay <$> delay
+    let mbDelayTime = getSmallDelay . getPositive <$> delay
         tr = (runSimTrace $ do
             controlMessageVar <- newTVarIO Continue
             _ <-

--- a/typed-protocols/src/Network/TypedProtocol/Core.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Core.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE PolyKinds #-}
@@ -26,6 +27,7 @@ module Network.TypedProtocol.Core (
   -- * Engaging in protocols
   -- $using
   PeerRole(..),
+  TokPeerRole(..),
   FlipAgency,
   PeerHasAgency(..),
   WeHaveAgency,
@@ -319,6 +321,14 @@ class Protocol ps where
 -- This definition is only used as promoted types and kinds, never as values.
 --
 data PeerRole = AsClient | AsServer
+
+-- | Singletons for the promoted 'PeerRole' types.  Not directly used by the
+-- framework, however some times useful when writing code that is shared between
+-- client and server.
+--
+data TokPeerRole (peerRole :: PeerRole) where
+    TokAsClient :: TokPeerRole AsClient
+    TokAsServer :: TokPeerRole AsServer
 
 -- | This data type is used to hold state tokens for states with either client
 -- or server agency. This GADT shows up when writing protocol peers, when


### PR DESCRIPTION
- Snocket.Accept
- ouroboros-network-testing: generate delay with a given precision
- handshake codec
- typed-protocols: added TokPeerRole
- handshake: simplify types of client / server
- handshake: resiliant for simultanous open
- handshake: refactor the codec
- handshake: added test for a simultaneous open connections
- handshake: updated network-spec
- Use a counter to provide a unique remote addr
- snockets - monadic toBearer
- snocket: support getLocalName for named pipes (Windows)
