### PR TITLE
CAD-3444 handshake changes from p2p-master

### DIFF
--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -359,6 +359,7 @@ The protocol uses the following messages.
 \newcommand{\StPropose}{\state{StPropose}}
 \newcommand{\StConfirm}{\state{StConfirm}}
 \newcommand{\MsgProposeVersions}{\msg{MsgProposeVersions}}
+\newcommand{\MsgProposeVersionsX}{\msg{MsgProposeVersions'}}
 \newcommand{\MsgAcceptVersion}{\msg{MsgAcceptVersion}}
 \newcommand{\MsgRefuse}{\msg{MsgRefuse}}
 
@@ -380,6 +381,8 @@ A node, that runs the handshake protocol, must instantiate it with the set of
 supported protocol versions and callback functions for handling the protocol parameters.
 These callback functions are specific for the supported protocol versions.
 
+The handshake mini protocol is designed to handle simultantous TCP open.
+
 \subsection{State machine}
 
 \begin{figure}[h]
@@ -392,15 +395,16 @@ These callback functions are specific for the supported protocol versions.
 \end{figure}
 
 \begin{figure}[h]
-  \begin{tikzpicture}[->,shorten >=1pt,auto,node distance=6cm, semithick]
+  \begin{tikzpicture}[->,>=stealth',shorten >=1pt,auto,node distance=6cm, semithick]
     \tikzstyle{every state}=[fill=red,draw=none,text=white]
-    \node[state, mygreen, initial]                                     (Propose)    {\StPropose};
-    \node[state, myblue, right of=Propose]                             (Confirm)    {\StConfirm};
-    \node[state, right of=Confirm]                                   (Done)       {\StDone};
+    \node[state, green, initial]   (StPropose) at (0,  0) {\StPropose};
+    \node[state, blue]             (StConfirm) at (5,  0) {\StConfirm};
+    \node[state, right of=Confirm] (StDone)    at (7,  0) {\StDone};
 
-    \draw (Propose)      edge[]      node{\MsgProposeVersions}          (Confirm);
-    \draw (Confirm)      edge[above, bend left]       node{\MsgAcceptVersion}     (Done);
-    \draw (Confirm)      edge[below, bend right]      node{\MsgRefuse}            (Done);
+    \draw (StPropose) --node[above=1em]{\MsgProposeVersions} (StConfirm);
+    \draw[->] (StConfirm.10)  to [out=15,  in=150] node[above]{\MsgAcceptVersion}     (StDone.170);
+    \draw[->] (StConfirm.350) to [out=-15, in=210] node[below]{\MsgRefuse}            (StDone.190);
+    \draw[->] (StConfirm)     -- node[fill=white,above=-0.8em] {\MsgProposeVersionsX} (StDone.west);
   \end{tikzpicture}
 \end{figure}
 
@@ -408,22 +412,29 @@ Messages of the protocol:
 \begin{description}
 \item [\MsgProposeVersions{} {\boldmath $(versionTable)$}]
       The client proposes a number of possible versions and protocol parameters.
+\item [\MsgProposeVersionsX{} {\boldmath $(versionTable)$}]
+      In TCP simultanous open the client will receive \MsgProposeVersionsX{}
+      (which was sent as \MsgProposeVersions{}) as a reply to its own
+      \MsgProposeVersions{}; thus both \MsgProposeVersions{} and
+      \MsgProposeVersionsX{} have to have the same CBOR encoding.
 \item [\MsgAcceptVersion{} {\boldmath $(versionNumber,extraParameters)$}]
       The server accepts $versionNumber$ and returns possible extra protocol parameters.
 \item [\MsgRefuse{} {\boldmath $(reason)$}]
       The server refuses the proposed versions.
 \end{description}
 
+{\small
 \begin{table}[h]
   \begin{tabular}{|l|l|l|l|} \hline
   \multicolumn{4}{|c|}{Transition table} \\ \hline
-    from          & message/event         & parameters              & to                \\ \hline\hline
-    \StPropose    & \MsgProposeVersions   & $versionTable$          & \StConfirm        \\ \hline
-    \StConfirm    & \MsgAcceptVersion     & $(versionNumber,extraParameters)$ & \StDone \\ \hline
-    \StConfirm    & \MsgRefuse            & $reason$                & \StDone           \\ \hline
+    from       & message/event         & parameters                        & to \\ \hline\hline
+    \StPropose & \MsgProposeVersions   & $versionTable$                    & \StConfirm \\ \hline
+    \StConfirm & \MsgProposeVersionsX  & $versionTable$                    & \StDone \\ \hline
+    \StConfirm & \MsgAcceptVersion     & $(versionNumber,extraParameters)$ & \StDone \\ \hline
+    \StConfirm & \MsgRefuse            & $reason$                          & \StDone \\ \hline
   \end{tabular}
-  \caption{Handhsake mini-protocol messages.}
 \end{table}
+}
 
 \subsection{Client and Server Implementation}
 Section~\ref{handshake-cddl} contains the CDDL-specification of the binary format of the handshake messages.
@@ -475,6 +486,13 @@ The handshake protocol is designed,
 such that a server can always handle requests for protocol versions that it does not support.
 The server simply ignores the CBOR terms that represent the protocol parameters of unsupported
 version.
+
+In case of simultaneous open TCP connection, both handshake clients will send
+their \MsgProposeVersions{}, both will interpet the incoming message as
+\MsgProposeVersionsX{} (thus both must have the same encoding, the
+implementation can disntiguish them by the protocol state).  Both clients
+should choose the highest version of the protocol available.  If any side does
+not accept any version (or its parameters) it can reset the connection.
 
 The handshake mini protocol runs before the MUX/DEMUX itself is initialised.
 Each message is transmitted within a single MUX segment, i.e. with a proper

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -33,7 +33,7 @@ handshakeClientPeer
   -> Peer (Handshake vNumber CBOR.Term)
           AsClient StPropose m
           (Either
-            (HandshakeClientProtocolError vNumber)
+            (HandshakeProtocolError vNumber)
             (r, vNumber, vData))
 handshakeClientPeer VersionDataCodec {encodeData, decodeData} acceptVersion versions =
   -- send known versions

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
 module Ouroboros.Network.Protocol.Handshake.Client
   ( handshakeClientPeer
+  , acceptOrRefuse
   ) where
 
 import           Data.Map (Map)
@@ -26,7 +28,8 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 -- TODO: GADT encoding of the client (@Handshake.Client@ module).
 --
 handshakeClientPeer
-  :: Ord vNumber
+  :: ( Ord vNumber
+     )
   => VersionDataCodec CBOR.Term vNumber vData
   -> (vData -> vData -> Accept vData)
   -> Versions vNumber vData r
@@ -35,11 +38,18 @@ handshakeClientPeer
           (Either
             (HandshakeProtocolError vNumber)
             (r, vNumber, vData))
-handshakeClientPeer VersionDataCodec {encodeData, decodeData} acceptVersion versions =
+handshakeClientPeer codec@VersionDataCodec {encodeData, decodeData}
+                    acceptVersion versions =
   -- send known versions
   Yield (ClientAgency TokPropose) (MsgProposeVersions $ encodeVersions encodeData versions) $
 
     Await (ServerAgency TokConfirm) $ \msg -> case msg of
+      MsgProposeVersions' vMap -> 
+        -- simultanous open; 'accept' will choose version (the greatest common
+        -- version), and check if we can accept received version data.
+        Done TokDone $ case acceptOrRefuse codec acceptVersion versions vMap of
+          Right r -> Right r
+          Left vReason -> Left (HandshakeError vReason)
 
       -- the server refused common highest version
       MsgRefuse vReason ->
@@ -76,3 +86,37 @@ encodeVersions encoder (Versions vs) = go `Map.mapWithKey` vs
     where
       go :: vNumber -> Version vData r -> vParams
       go vNumber Version {versionData} = encoder vNumber versionData
+
+
+acceptOrRefuse
+  :: forall vParams vNumber vData r.
+     Ord vNumber
+  => VersionDataCodec vParams vNumber vData
+  -> (vData -> vData -> Accept vData)
+  -> Versions vNumber vData r
+  -> Map vNumber vParams
+  -- ^ proposed versions received either with `MsgProposeVersions` or
+  -- `MsgProposeVersions'`
+  -> Either (RefuseReason vNumber) (r, vNumber, vData)
+acceptOrRefuse VersionDataCodec {decodeData}
+               acceptVersion versions versionMap =
+    case lookupGreatestCommonKey versionMap (getVersions versions) of
+      Nothing ->
+        Left $ VersionMismatch (Map.keys $ getVersions versions) []
+
+      Just (vNumber, (vParams, Version app vData)) ->
+        case decodeData vNumber vParams of
+          Left err ->
+            Left (HandshakeDecodeError vNumber err)
+
+          Right vData' ->
+            case acceptVersion vData vData' of
+              Accept agreedData ->
+                Right (app agreedData, vNumber, agreedData)
+
+              Refuse err ->
+                Left (Refused vNumber err)
+
+
+lookupGreatestCommonKey :: Ord k => Map k a -> Map k b -> Maybe (k, (a, b))
+lookupGreatestCommonKey l r = Map.lookupMax $ Map.intersectionWith (,) l r

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -8,12 +8,12 @@ module Ouroboros.Network.Protocol.Handshake.Server
   ( handshakeServerPeer
   ) where
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import qualified Codec.CBOR.Term     as CBOR
 
 import           Network.TypedProtocol.Core
 
 import           Ouroboros.Network.Protocol.Handshake.Codec
+import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse)
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 
@@ -21,58 +21,24 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 -- | Server following the handshake protocol; it accepts highest version offered
 -- by the peer that also belongs to the server @versions@.
 --
--- TODO: GADT encoding of the server (@Handshake.Server@ module).
---
 handshakeServerPeer
-  :: Ord vNumber
-  => VersionDataCodec vParams vNumber vData
+  :: ( Ord vNumber
+     )
+  => VersionDataCodec CBOR.Term vNumber vData
   -> (vData -> vData -> Accept vData)
   -> Versions vNumber vData r
-  -> Peer (Handshake vNumber vParams)
+  -> Peer (Handshake vNumber CBOR.Term)
           AsServer StPropose m
           (Either (HandshakeProtocolError vNumber) (r, vNumber, vData))
-handshakeServerPeer VersionDataCodec {encodeData, decodeData} acceptVersion versions =
-    -- await for versions proposed by a client
+handshakeServerPeer codec@VersionDataCodec {encodeData} acceptVersion versions =
     Await (ClientAgency TokPropose) $ \msg -> case msg of
-
-      MsgProposeVersions vMap ->
-        -- Compute intersection of local and remote versions.
-        case lookupGreatestCommonKey vMap (getVersions versions) of
-          Nothing ->
-            let vReason = VersionMismatch (Map.keys $ getVersions versions) []
-            in Yield (ServerAgency TokConfirm)
-                     (MsgRefuse vReason)
-                     (Done TokDone (Left $ HandshakeError vReason))
-
-          Just (vNumber, (vParams, Version app vData)) ->
-              case decodeData vNumber vParams of
-                Left err ->
-                  let vReason = HandshakeDecodeError vNumber err
-                  in Yield (ServerAgency TokConfirm)
-                           (MsgRefuse vReason)
-                           (Done TokDone $ Left $ HandshakeError vReason)
-
-                Right vData' ->
-                  case acceptVersion vData vData' of
-
-                    -- We agree on the version; send back the agreed version
-                    -- number @vNumber@ and encoded data associated with our
-                    -- version.
-                    Accept agreedData ->
-                      Yield (ServerAgency TokConfirm)
-                            (MsgAcceptVersion vNumber (encodeData vNumber agreedData))
-                            (Done TokDone $ Right $
-                              ( app agreedData
-                              , vNumber
-                              , agreedData
-                              ))
-
-                    -- We disagree on the version.
-                    Refuse err ->
-                      let vReason = Refused vNumber err
-                      in Yield (ServerAgency TokConfirm)
-                               (MsgRefuse vReason)
-                               (Done TokDone $ Left $ HandshakeError vReason)
-
-lookupGreatestCommonKey :: Ord k => Map k a -> Map k b -> Maybe (k, (a, b))
-lookupGreatestCommonKey l r = Map.lookupMax $ Map.intersectionWith (,) l r
+      MsgProposeVersions vMap  ->
+        case acceptOrRefuse codec acceptVersion versions vMap of
+          (Right r@(_, vNumber, agreedData)) ->
+            Yield (ServerAgency TokConfirm)
+                  (MsgAcceptVersion vNumber (encodeData vNumber agreedData))
+                  (Done TokDone (Right r))
+          (Left vReason) ->
+            Yield (ServerAgency TokConfirm)
+                  (MsgRefuse vReason)
+                  (Done TokDone (Left (HandshakeError vReason)))

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -20,6 +20,7 @@ module Ouroboros.Network.Protocol.Handshake.Type
   , ClientHasAgency (..)
   , ServerHasAgency (..)
   , NobodyHasAgency (..)
+    -- $simultanous-open
   , RefuseReason (..)
   , HandshakeProtocolError (..)
   )
@@ -33,7 +34,6 @@ import           Data.Map (Map)
 
 import           Network.TypedProtocol.Core
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
-
 
 -- |
 -- The handshake mini-protocol is used initially to agree the version and
@@ -83,6 +83,16 @@ instance Protocol (Handshake vNumber vParams) where
         -> Message (Handshake vNumber vParams) StPropose StConfirm
 
       -- |
+      -- `MsgProposeVersions'` received as a response to 'MsgProposeVersions'.
+      -- It is not supported to explicitly send this message. It can only be
+      -- received as a copy of 'MsgProposeVersions' in a simultanous open
+      -- scenario.
+      --
+      MsgProposeVersions'
+        :: Map vNumber vParams
+        -> Message (Handshake vNumber vParams) StConfirm StDone
+
+      -- |
       -- The remote end decides which version to use and sends chosen version.
       -- The server is allowed to modify version parameters. 
       --
@@ -111,11 +121,21 @@ instance Protocol (Handshake vNumber vParams) where
     exclusionLemma_NobodyAndClientHaveAgency TokDone    tok = case tok of {}
     exclusionLemma_NobodyAndServerHaveAgency TokDone    tok = case tok of {}
 
+-- $simultanous-open
+--
+-- On simultanous open both sides will send `MsgProposeVersions`, which will be
+-- decoded as `MsgProposeVersions'` which is a terminal message of the
+-- protocol.  It is important to stress that in this case both sides will make
+-- the choice which version and parameters to pick.  Our algorithm for picking
+-- version is symmetric, which ensures that both sides will endup with the same
+-- choice.  If one side decides to refuse the version it will close the
+-- connection, without sending the reason to the other side.
+
 deriving instance (Show vNumber, Show vParams)
     => Show (Message (Handshake vNumber vParams) from to)
 
 instance Show (ClientHasAgency (st :: Handshake vNumber vParams)) where
-    show TokPropose = "TokPropose"
+    show TokPropose       = "TokPropose"
 
 instance Show (ServerHasAgency (st :: Handshake vNumber vParams)) where
     show TokConfirm = "TokConfirm"

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -21,7 +21,7 @@ module Ouroboros.Network.Protocol.Handshake.Type
   , ServerHasAgency (..)
   , NobodyHasAgency (..)
   , RefuseReason (..)
-  , HandshakeClientProtocolError (..)
+  , HandshakeProtocolError (..)
   )
   where
 
@@ -120,15 +120,13 @@ instance Show (ClientHasAgency (st :: Handshake vNumber vParams)) where
 instance Show (ServerHasAgency (st :: Handshake vNumber vParams)) where
     show TokConfirm = "TokConfirm"
 
--- |
--- Client errors, which extends handshake error @'RefuseReason'@ type,
--- by client specific errors.
+-- | Extends handshake error @'RefuseReason'@ type, by client specific errors.
 --
-data HandshakeClientProtocolError vNumber
+data HandshakeProtocolError vNumber
   = HandshakeError (RefuseReason vNumber)
   | NotRecognisedVersion vNumber
   | InvalidServerSelection vNumber Text
   deriving (Eq, Show)
 
 instance (Typeable vNumber, Show vNumber)
-    => Exception (HandshakeClientProtocolError vNumber)
+    => Exception (HandshakeProtocolError vNumber)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -103,7 +103,6 @@ import           Ouroboros.Network.ErrorPolicy
 import           Ouroboros.Network.Subscription.PeerState
 import           Ouroboros.Network.Protocol.Handshake
 import           Ouroboros.Network.Protocol.Handshake.Type
-import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.IOManager (IOManager)
 import           Ouroboros.Network.Snocket (Snocket)
@@ -260,10 +259,10 @@ connectToNode' sn handshakeCodec handshakeTimeLimits versionDataCodec NetworkCon
           haHandshakeTracer  = nctHandshakeTracer,
           haHandshakeCodec   = handshakeCodec,
           haVersionDataCodec = versionDataCodec,
-          haVersions         = versions,
           haAcceptVersion    = acceptVersion,
           haTimeLimits       = handshakeTimeLimits
         }
+        versions
     ts_end <- getMonotonicTime
     case app_e of
          Left (HandshakeProtocolLimit err) -> do
@@ -387,10 +386,10 @@ beginConnection sn muxTracer handshakeTracer handshakeCodec handshakeTimeLimits 
               haHandshakeTracer  = handshakeTracer,
               haHandshakeCodec   = handshakeCodec,
               haVersionDataCodec = versionDataCodec,
-              haVersions         = versions,
               haAcceptVersion    = acceptVersion,
               haTimeLimits       = handshakeTimeLimits
             }
+           versions
 
         case app_e of
              Left (HandshakeProtocolLimit err) -> do

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -547,6 +547,9 @@ instance Eq (AnyMessage (Handshake VersionNumber CBOR.Term)) where
   AnyMessage (MsgProposeVersions vs) == AnyMessage (MsgProposeVersions vs')
     = vs == vs'
 
+  AnyMessage (MsgProposeVersions' vs) == AnyMessage (MsgProposeVersions' vs')
+    = vs == vs'
+
   AnyMessage (MsgAcceptVersion vNumber vParams) == AnyMessage (MsgAcceptVersion vNumber' vParams')
     = vNumber == vNumber' && vParams == vParams'
 
@@ -559,6 +562,12 @@ instance Arbitrary (AnyMessageAndAgency (Handshake VersionNumber CBOR.Term)) whe
   arbitrary = oneof
     [     AnyMessageAndAgency (ClientAgency TokPropose)
         . MsgProposeVersions
+        . Map.mapWithKey (\v -> encodeTerm (dataCodecCBORTerm v) . versionData)
+        . getVersions
+      <$> genVersions
+
+    ,     AnyMessageAndAgency (ServerAgency TokConfirm)
+        . MsgProposeVersions'
         . Map.mapWithKey (\v -> encodeTerm (dataCodecCBORTerm v) . versionData)
         . getVersions
       <$> genVersions

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
@@ -20,13 +22,14 @@ import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Term as CBOR
 
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Control.Monad.Class.MonadAsync (MonadAsync)
+import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow ( MonadCatch
                                                 , MonadThrow
                                                 )
 import           Control.Tracer (nullTracer)
 
+import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Proofs
 
 import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
@@ -35,7 +38,8 @@ import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.CodecCBORTerm
-import           Ouroboros.Network.Driver.Simple ( runConnectedPeers
+import           Ouroboros.Network.Driver.Simple ( runPeer
+                                                 , runConnectedPeers
                                                  , runConnectedPeersAsymmetric
                                                  )
 
@@ -62,6 +66,8 @@ tests =
         , testProperty "pipe IO"               prop_pipe_IO
         , testProperty "channel asymmetric ST" prop_channel_asymmetric_ST
         , testProperty "channel asymmetric IO" prop_channel_asymmetric_IO
+        , testProperty "simultaneous open ST"  prop_channel_simultaneous_open_ST
+        , testProperty "simultaneous open IO"  prop_channel_simultaneous_open_IO
         , testProperty "pipe asymmetric IO"    prop_pipe_asymmetric_IO
         , testProperty "codec RefuseReason"    prop_codec_RefuseReason
         , testProperty "codec"                 prop_codec_Handshake
@@ -538,6 +544,72 @@ prop_pipe_asymmetric_IO :: ArbitraryVersions -> Property
 prop_pipe_asymmetric_IO (ArbitraryVersions clientVersions _serverVersions) =
     ioProperty (prop_channel_asymmetric createPipeConnectedChannels clientVersions)
 
+
+-- | Run two handshake clients against each other, which simulates a TCP
+-- simultaneous open.
+--
+prop_channel_simultaneous_open
+    :: ( MonadAsync m
+       , MonadCatch m
+       , MonadST m
+       )
+    => m (Channel m ByteString, Channel m ByteString)
+    -> Versions VersionNumber VersionData Bool
+    -> Versions VersionNumber VersionData Bool
+    -> m Property
+prop_channel_simultaneous_open createChannels clientVersions serverVersions =
+  let (serverRes, clientRes) =
+        pureHandshake
+          ((maybeAccept .) . acceptableVersion)
+          serverVersions
+          clientVersions
+  in do
+    (clientChannel, serverChannel) <- createChannels
+    let client  = handshakeClientPeer
+                    (cborTermVersionDataCodec dataCodecCBORTerm)
+                    acceptableVersion
+                    clientVersions
+        client' = handshakeClientPeer
+                    (cborTermVersionDataCodec dataCodecCBORTerm)
+                    acceptableVersion
+                    serverVersions
+    (clientRes', serverRes') <-
+      (fst <$> runPeer nullTracer versionNumberHandshakeCodec clientChannel client)
+        `concurrently`
+      (fst <$> runPeer nullTracer versionNumberHandshakeCodec serverChannel client')
+    pure $
+      case (clientRes', serverRes') of
+        -- both succeeded, we just check that the application (which is
+        -- a boolean value) is the one that was put inside 'Version'
+        (Right (c,_,_), Right (s,_,_)) ->
+          label "both-succeed" $
+               Just c === clientRes
+          .&&. Just s === serverRes
+
+        -- both failed
+        (Left{}, Left{})   -> label "both-failed" True
+
+        -- it should not happen that one protocol succeeds and the other end
+        -- fails
+        _                  -> property False
+
+-- | Run 'prop_channel_simultaneous_open' in the simulation monad.
+--
+prop_channel_simultaneous_open_ST :: ArbitraryVersions -> Property
+prop_channel_simultaneous_open_ST (ArbitraryVersions clientVersions serverVersions) =
+  runSimOrThrow $ prop_channel_simultaneous_open
+                    createConnectedChannels
+                    clientVersions
+                    serverVersions
+
+-- | Run 'prop_channel_simultaneous_open' in the IO monad.
+--
+prop_channel_simultaneous_open_IO :: ArbitraryVersions -> Property
+prop_channel_simultaneous_open_IO (ArbitraryVersions clientVersions serverVersions) =
+  ioProperty $ prop_channel_simultaneous_open
+                 createConnectedChannels
+                 clientVersions
+                 serverVersions
 
 --
 -- Codec tests

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -343,7 +343,7 @@ networkErrorPolicies = ErrorPolicies
         -- version or we refused it.  This is only for outbound connections to
         -- a local node, thus we throw the exception.
         ErrorPolicy
-          $ \(_ :: HandshakeClientProtocolError NodeToClientVersion)
+          $ \(_ :: HandshakeProtocolError NodeToClientVersion)
                 -> Just ourBug
 
         -- exception thrown by `runPeerWithLimits`

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -539,7 +539,7 @@ remoteNetworkErrorPolicy = ErrorPolicies {
           -- version or we refused it.  This is only for outbound connections,
           -- thus we suspend the consumer.
           ErrorPolicy
-            $ \(_ :: HandshakeClientProtocolError NodeToNodeVersion)
+            $ \(_ :: HandshakeProtocolError NodeToNodeVersion)
                   -> Just misconfiguredPeer
 
           -- deserialisation failure; this means that the remote peer is either


### PR DESCRIPTION
- handshake codec
- handshake: simplify types of client / server
- handshake: resiliant for simultanous open
- handshake: refactor the codec
- handshake: added test for a simultaneous open connections
- handshake: updated network-spec
- handshake: remove versioned application from HandshakeArguments
