### PR TITLE
Add --store-ledger option to db-analyser

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -79,6 +79,7 @@ executable db-analyser
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
                      , cardano-ledger-core
+                     , cborg
                      , containers
                      , contra-tracer
                      , mtl

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -114,8 +114,15 @@ parseAnalysis = asum [
           long "show-ebbs"
         , help "Show all EBBs and their predecessors"
         ]
+    , storeLedgerParser
     , pure OnlyValidation
     ]
+
+storeLedgerParser :: Parser AnalysisName
+storeLedgerParser = (StoreLedgerStateAt . SlotNo . read) <$> strOption
+  (  long "store-ledger"
+  <> metavar "SLOT NUMBER"
+  <> help "Store ledger state at specific slot number" )
 
 blockTypeParser :: Parser BlockType
 blockTypeParser = subparser $ mconcat
@@ -187,6 +194,7 @@ analyse CmdLine {..} args =
             , initLedger
             , db = Left immutableDB
             , registry
+            , ledgerDbFS = ChainDB.cdbHasFSLgrDB args'
             }
           tipPoint <- atomically $ ImmutableDB.getTipPoint immutableDB
           putStrLn $ "ImmutableDB tip: " ++ show tipPoint
@@ -198,6 +206,7 @@ analyse CmdLine {..} args =
             , initLedger
             , db = Right chainDB
             , registry
+            , ledgerDbFS = ChainDB.cdbHasFSLgrDB args'
             }
           tipPoint <- atomically $ ChainDB.getTipPoint chainDB
           putStrLn $ "ChainDB tip: " ++ show tipPoint

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -26,12 +26,13 @@ module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
     -- * Write to disk
   , takeSnapshot
   , trimSnapshots
+  , writeSnapshot
     -- * Low-level API (primarily exposed for testing)
   , deleteSnapshot
   , snapshotToFileName
   , snapshotToPath
     -- ** opaque
-  , DiskSnapshot
+  , DiskSnapshot (..)
     -- * Trace events
   , TraceEvent (..)
   , TraceReplayEvent (..)


### PR DESCRIPTION
Consider a chain downloaded by cardano-node. While getting the chain, the default disk policy created two snapshots on disk 

```
$> ls -h db_mainnet/ledger
13916582  14776127
```
Now we can ask db-analyser to also create a snapshot of ledger at slot 13916582 - while processing the chain - and store it. The name of the file will be `13916582_db-analyser`. 
(please note that by providing a suffix _db-analyser we ensure that the snapshot will not be deleted by node in the future)

```
cabal run ouroboros-consensus-cardano:db-analyser --  \
  --db db_mainnet cardano \
  --configByron dbacfg/mainnet-byron-genesis.json \ 
  --configShelley dbacfg/mainnet-shelley-genesis.json \
  --nonce 1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81 \
  --configAlonzo dbacfg/mainnet-alonzo-genesis.json \
  --store-ledger 13916582
```

Once the node is done with its work we can see that the snapshot is created.

```
ls -h db_mainnet/ledger
13916582  13916582_db-analyser  14776127
```

We can now compare if snapshot created by node is identical to the one created by db-analyser

```
&> cmp db_mainnet/ledger/13916582 db_mainnet/ledger/13916582_db-analyser \
&& echo 'success' || echo 'failure'

success
```