### PR TITLE
CAD_3444 p2p-governor changes from p2p-master

### DIFF
--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -54,6 +54,7 @@ library
                      , cardano-crypto-class
                      , cardano-ledger-core
                      , cardano-protocol-tpraos
+                     , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
@@ -7,6 +7,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Ledger.PeerSelection () where
 
+import           Cardano.Prelude (forceElemsToWHNF)
+
 import           Data.Bifunctor (second)
 import           Data.Foldable (toList)
 import           Data.List (sortOn)
@@ -65,11 +67,11 @@ instance c ~ EraCrypto era
 
       relayToRelayAddress :: SL.StakePoolRelay -> Maybe RelayAddress
       relayToRelayAddress (SL.SingleHostAddr (SJust (Port port)) (SJust ipv4) _) =
-          Just $ RelayAddressAddr (IPv4 ipv4) (fromIntegral port)
+          Just $ RelayAddress (IPv4 ipv4) (fromIntegral port)
       relayToRelayAddress (SL.SingleHostAddr (SJust (Port port)) SNothing (SJust ipv6)) =
-          Just $ RelayAddressAddr (IPv6 ipv6) (fromIntegral port)
+          Just $ RelayAddress (IPv6 ipv6) (fromIntegral port)
       relayToRelayAddress (SL.SingleHostName (SJust (Port port)) dnsName) =
-          Just $ RelayAddressDomain $ DomainAddress (encodeUtf8 $ dnsToText dnsName) (fromIntegral port)
+          Just $ RelayDomain $ DomainAddress (encodeUtf8 $ dnsToText dnsName) (fromIntegral port)
       relayToRelayAddress _ =
           -- This could be an unsupported relay (SRV records) or an unusable
           -- relay such as a relay with an IP address but without a port number.
@@ -82,6 +84,7 @@ instance c ~ EraCrypto era
         -> Maybe (NonEmpty StakePoolRelay)
       pparamsRelayAddresses injStakePoolRelay =
             NE.nonEmpty
+          . forceElemsToWHNF
           . mapMaybe (fmap injStakePoolRelay . relayToRelayAddress)
           . toList
           . SL._poolRelays

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -23,6 +23,9 @@ module Ouroboros.Consensus.NodeKernel (
   , initNodeKernel
   ) where
 
+
+import           Cardano.Prelude (forceElemsToWHNF)
+
 import           Control.Monad
 import           Control.Monad.Except
 import           Data.Bifunctor (second)
@@ -743,6 +746,7 @@ getPeersFromCurrentLedger kernel p = do
       guard (p immutableLedger)
       return
         $ map (second (fmap stakePoolRelayAddress))
+        $ forceElemsToWHNF
         $ getPeers immutableLedger
 
 -- | Like 'getPeersFromCurrentLedger' but with a \"after slot number X\"

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -79,6 +79,7 @@ library
                        Ouroboros.Network.PeerSelection.LocalRootPeers
                        Ouroboros.Network.PeerSelection.RootPeersDNS
                        Ouroboros.Network.PeerSelection.Governor
+                       Ouroboros.Network.PeerSelection.Simple
                        Ouroboros.Network.Protocol.ChainSync.Client
                        Ouroboros.Network.Protocol.ChainSync.ClientPipelined
                        Ouroboros.Network.Protocol.ChainSync.Codec

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -77,6 +77,7 @@ library
                        Ouroboros.Network.PeerSelection.KnownPeers
                        Ouroboros.Network.PeerSelection.LedgerPeers
                        Ouroboros.Network.PeerSelection.LocalRootPeers
+                       Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
                        Ouroboros.Network.PeerSelection.RootPeersDNS
                        Ouroboros.Network.PeerSelection.Governor
                        Ouroboros.Network.PeerSelection.Simple

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -154,6 +154,7 @@ library
                        TypeFamilies,
                        TypeInType
   build-depends:       base              >=4.9 && <4.15,
+                       aeson,
                        async             >=2.2 && <2.3,
                        base16-bytestring,
                        bytestring        >=0.10 && <0.11,
@@ -275,6 +276,7 @@ test-suite test
                        Test.Ouroboros.Network.PeerSelection
                        Test.Ouroboros.Network.PeerSelection.Instances
                        Test.Ouroboros.Network.PeerSelection.LocalRootPeers
+                       Test.Ouroboros.Network.PeerSelection.Json
                        Test.Ouroboros.Network.PeerSelection.MockEnvironment
                        Test.Ouroboros.Network.PeerSelection.PeerGraph
                        Test.Ouroboros.Network.PeerSelection.Script
@@ -290,6 +292,7 @@ test-suite test
   default-language:    Haskell2010
   build-depends:       base,
                        QuickCheck,
+                       aeson,
                        array,
                        async,
                        bytestring,
@@ -298,6 +301,7 @@ test-suite test
                        dns,
                        deque,
                        hashable,
+                       iproute,
                        mtl,
                        network,
                        process,
@@ -307,6 +311,7 @@ test-suite test
                        tasty,
                        tasty-hunit,
                        tasty-quickcheck,
+                       text,
 
                        cardano-prelude,
                        cardano-slotting,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -284,6 +284,7 @@ test-suite test
                        Test.Socket
                        Test.PeerState
                        Test.Version
+                       Test.QuickCheck.Utils
   default-language:    Haskell2010
   build-depends:       base,
                        QuickCheck,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -277,6 +277,7 @@ test-suite test
                        Test.Ouroboros.Network.PeerSelection
                        Test.Ouroboros.Network.PeerSelection.Instances
                        Test.Ouroboros.Network.PeerSelection.LocalRootPeers
+                       Test.Ouroboros.Network.PeerSelection.RootPeersDNS
                        Test.Ouroboros.Network.PeerSelection.Json
                        Test.Ouroboros.Network.PeerSelection.MockEnvironment
                        Test.Ouroboros.Network.PeerSelection.PeerGraph
@@ -313,6 +314,7 @@ test-suite test
                        tasty-hunit,
                        tasty-quickcheck,
                        text,
+                       time,
 
                        cardano-prelude,
                        cardano-slotting,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -264,6 +264,7 @@ test-suite test
   other-modules:       Ouroboros.Network.BlockFetch.Examples
                        Ouroboros.Network.MockNode
 
+                       Data.Signal
                        Test.AnchoredFragment
                        Test.Chain
                        Test.LedgerPeers
@@ -284,6 +285,7 @@ test-suite test
                        Test.Socket
                        Test.PeerState
                        Test.Version
+                       Test.QuickCheck.Signal
                        Test.QuickCheck.Utils
   default-language:    Haskell2010
   build-depends:       base,
@@ -294,10 +296,12 @@ test-suite test
                        cborg,
                        containers,
                        dns,
+                       deque,
                        hashable,
                        mtl,
                        network,
                        process,
+                       psqueues,
                        random,
                        serialise,
                        tasty,

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -444,16 +444,17 @@ peerSelectionGovernor :: (MonadAsync m, MonadMask m, MonadTime m, MonadTimer m,
                       => Tracer m (TracePeerSelection peeraddr)
                       -> Tracer m (DebugPeerSelection peeraddr peerconn)
                       -> Tracer m PeerSelectionCounters
+                      -> StdGen
                       -> PeerSelectionActions peeraddr peerconn m
                       -> PeerSelectionPolicy  peeraddr m
                       -> m Void
-peerSelectionGovernor tracer debugTracer countersTracer actions policy =
+peerSelectionGovernor tracer debugTracer countersTracer fuzzRng actions policy =
     JobPool.withJobPool $ \jobPool ->
       peerSelectionGovernorLoop
         tracer (debugTracer <> contramap transform countersTracer)
         actions policy
         jobPool
-        emptyPeerSelectionState
+        (emptyPeerSelectionState fuzzRng)
   where
     transform :: Ord peeraddr => DebugPeerSelection peeraddr peerconn -> PeerSelectionCounters
     transform (TraceGovernorState _ _ st) = peerStateToCounters st

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -32,7 +32,9 @@ module Ouroboros.Network.PeerSelection.Governor (
     sanePeerSelectionTargets,
     establishedPeersStatus,
     PeerSelectionState(..),
-    PeerSelectionCounters(..)
+    PeerSelectionCounters(..),
+    nullPeerSelectionTargets,
+    emptyPeerSelectionState,
 ) where
 
 import           Data.Void (Void)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -28,6 +28,7 @@ module Ouroboros.Network.PeerSelection.Governor (
     peerChurnGovernor,
 
     -- * Internals exported for testing
+    assertPeerSelectionState,
     sanePeerSelectionTargets,
     establishedPeersStatus,
     PeerSelectionState(..),

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -55,6 +55,7 @@ import qualified Ouroboros.Network.PeerSelection.Governor.KnownPeers       as Kn
 import qualified Ouroboros.Network.PeerSelection.Governor.Monitor          as Monitor
 import qualified Ouroboros.Network.PeerSelection.Governor.RootPeers        as RootPeers
 import           Ouroboros.Network.PeerSelection.Governor.Types
+import           Ouroboros.Network.BlockFetch (FetchMode (..))
 
 
 -- TODO: at a later patch it will be defined in
@@ -569,43 +570,66 @@ $peer-churn-governor
 
 -- |
 --
-peerChurnGovernor :: forall m.
+peerChurnGovernor :: forall m peeraddr.
                      ( MonadSTM m
                      , MonadMonotonicTime m
                      , MonadDelay m
                      )
-                  => StdGen
+                  => Tracer m (TracePeerSelection peeraddr)
+                  -> StdGen
+                  -> STM m FetchMode
                   -> PeerSelectionTargets
                   -> StrictTVar m PeerSelectionTargets
                   -> m Void
-peerChurnGovernor inRng base peerSelectionVar = do
+peerChurnGovernor tracer inRng getFetchMode base peerSelectionVar = do
   -- Wait a while so that not only the closest peers have had the time
   -- to become warm.
   startTs0 <- getMonotonicTime
   threadDelay 3
-  atomically $ modifyTVar peerSelectionVar (\targets -> targets {
-      targetNumberOfActivePeers = targetNumberOfActivePeers base
-      })
+  atomically increaseActivePeers
   endTs0 <- getMonotonicTime
   fuzzyDelay inRng (Time $ diffTime endTs0 startTs0) >>= go
 
   where
+
+    increaseActivePeers :: STM m ()
+    increaseActivePeers =  do
+        mode <- getFetchMode
+        modifyTVar peerSelectionVar (\targets -> targets {
+          targetNumberOfActivePeers =
+              case mode of
+                   FetchModeDeadline ->
+                       targetNumberOfActivePeers base
+                   FetchModeBulkSync ->
+                       min 2 (targetNumberOfActivePeers base)
+        })
+
+    decreaseActivePeers :: STM m ()
+    decreaseActivePeers =  do
+        mode <- getFetchMode
+        modifyTVar peerSelectionVar (\targets -> targets {
+          targetNumberOfActivePeers =
+              case mode of
+                   FetchModeDeadline ->
+                       decrease $ targetNumberOfActivePeers base
+                   FetchModeBulkSync ->
+                       min 1 (targetNumberOfActivePeers base - 1)
+        })
+
+
+    go :: StdGen -> m Void
     go rng = do
       startTs <- getMonotonicTime
 
       -- Purge the worst active peer(s).
-      atomically $ modifyTVar peerSelectionVar (\targets -> targets {
-          targetNumberOfActivePeers = decrease (targetNumberOfActivePeers base)
-          })
+      atomically decreaseActivePeers
 
       -- Short delay, we may have no active peers right now
       threadDelay 1
 
       -- Pick new active peer(s) based on the best performing established
       -- peers.
-      atomically $ modifyTVar peerSelectionVar (\targets -> targets {
-          targetNumberOfActivePeers = targetNumberOfActivePeers base
-          })
+      atomically increaseActivePeers
 
       -- Give the promotion process time to start
       threadDelay 1
@@ -634,14 +658,34 @@ peerChurnGovernor inRng base peerSelectionVar = do
     -- Randomly delay between churnInterval and churnInterval + maxFuzz seconds.
     fuzzyDelay :: StdGen -> Time -> m StdGen
     fuzzyDelay rng execTime = do
-      let (fuzz, rng') = randomR (0, 600 :: Double) rng
-      threadDelay $ (realToFrac fuzz) + (diffTime churnInterval execTime)
+      mode <- atomically getFetchMode
+      case mode of
+           FetchModeDeadline -> longDelay rng execTime
+           FetchModeBulkSync -> shortDelay rng execTime
+
+    fuzzyDelay' :: Time -> Double -> StdGen -> Time -> m StdGen
+    fuzzyDelay' baseDelay maxFuzz rng execTime = do
+      let (fuzz, rng') = randomR (0, maxFuzz :: Double) rng
+          !delay = realToFrac fuzz + diffTime baseDelay execTime
+      traceWith tracer $ TraceChurnWait delay
+      threadDelay delay
       return rng'
+
+
+    longDelay :: StdGen -> Time -> m StdGen
+    longDelay = fuzzyDelay' churnInterval 600
+
+
+    shortDelay :: StdGen -> Time -> m StdGen
+    shortDelay = fuzzyDelay' churnIntervalBulk 60
 
     -- The min time between running the churn governor.
     churnInterval :: Time
     churnInterval = Time 3300
 
+
+    churnIntervalBulk :: Time
+    churnIntervalBulk = Time 300
 
     -- Replace 20% or at least on peer every churnInterval.
     decrease :: Int -> Int

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -39,13 +39,13 @@ import           Data.Semigroup (Min(..))
 import           Control.Applicative (Alternative((<|>)))
 import qualified Control.Concurrent.JobPool as JobPool
 import           Control.Concurrent.JobPool (JobPool)
-import           Control.Monad (forever)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Tracer (Tracer(..), traceWith)
+import           System.Random
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
@@ -574,10 +574,11 @@ peerChurnGovernor :: forall m.
                      , MonadMonotonicTime m
                      , MonadDelay m
                      )
-                   => PeerSelectionTargets
-                 -> StrictTVar m PeerSelectionTargets
+                  => StdGen
+                  -> PeerSelectionTargets
+                  -> StrictTVar m PeerSelectionTargets
                   -> m Void
-peerChurnGovernor base peerSelectionVar = do
+peerChurnGovernor inRng base peerSelectionVar = do
   -- Wait a while so that not only the closest peers have had the time
   -- to become warm.
   startTs0 <- getMonotonicTime
@@ -586,9 +587,10 @@ peerChurnGovernor base peerSelectionVar = do
       targetNumberOfActivePeers = targetNumberOfActivePeers base
       })
   endTs0 <- getMonotonicTime
-  threadDelay $ diffTime churnInterval $ Time $ diffTime endTs0 startTs0
+  fuzzyDelay inRng (Time $ diffTime endTs0 startTs0) >>= go
 
-  forever $ do
+  where
+    go rng = do
       startTs <- getMonotonicTime
 
       -- Purge the worst active peer(s).
@@ -626,13 +628,20 @@ peerChurnGovernor base peerSelectionVar = do
         , targetNumberOfEstablishedPeers = targetNumberOfEstablishedPeers base
         })
       endTs <- getMonotonicTime
-      threadDelay $ diffTime churnInterval $ Time $ diffTime endTs startTs
 
+      fuzzyDelay rng (Time $ diffTime endTs startTs) >>= go
 
-  where
-    -- The time between running the churn governor.
+    -- Randomly delay between churnInterval and churnInterval + maxFuzz seconds.
+    fuzzyDelay :: StdGen -> Time -> m StdGen
+    fuzzyDelay rng execTime = do
+      let (fuzz, rng') = randomR (0, 600 :: Double) rng
+      threadDelay $ (realToFrac fuzz) + (diffTime churnInterval execTime)
+      return rng'
+
+    -- The min time between running the churn governor.
     churnInterval :: Time
-    churnInterval = Time 3600 -- 1h
+    churnInterval = Time 3300
+
 
     -- Replace 20% or at least on peer every churnInterval.
     decrease :: Int -> Int

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -39,9 +39,10 @@ import           Data.Semigroup (Min(..))
 import           Control.Applicative (Alternative((<|>)))
 import qualified Control.Concurrent.JobPool as JobPool
 import           Control.Concurrent.JobPool (JobPool)
+import           Control.Monad (forever)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Tracer (Tracer(..), traceWith)
@@ -54,6 +55,13 @@ import qualified Ouroboros.Network.PeerSelection.Governor.KnownPeers       as Kn
 import qualified Ouroboros.Network.PeerSelection.Governor.Monitor          as Monitor
 import qualified Ouroboros.Network.PeerSelection.Governor.RootPeers        as RootPeers
 import           Ouroboros.Network.PeerSelection.Governor.Types
+
+
+-- TODO: at a later patch it will be defined in
+-- 'Ouroboros.Network.Diffusion.Policies'
+--
+closeConnectionTimeout :: DiffTime
+closeConnectionTimeout = 120
 
 
 {- $overview
@@ -561,8 +569,73 @@ $peer-churn-governor
 
 -- |
 --
-peerChurnGovernor :: MonadSTM m
-                  => PeerSelectionTargets
-                  -> m () --Void
-peerChurnGovernor _ =
-    return ()
+peerChurnGovernor :: forall m.
+                     ( MonadSTM m
+                     , MonadMonotonicTime m
+                     , MonadDelay m
+                     )
+                   => PeerSelectionTargets
+                 -> StrictTVar m PeerSelectionTargets
+                  -> m Void
+peerChurnGovernor base peerSelectionVar = do
+  -- Wait a while so that not only the closest peers have had the time
+  -- to become warm.
+  startTs0 <- getMonotonicTime
+  threadDelay 3
+  atomically $ modifyTVar peerSelectionVar (\targets -> targets {
+      targetNumberOfActivePeers = targetNumberOfActivePeers base
+      })
+  endTs0 <- getMonotonicTime
+  threadDelay $ diffTime churnInterval $ Time $ diffTime endTs0 startTs0
+
+  forever $ do
+      startTs <- getMonotonicTime
+
+      -- Purge the worst active peer(s).
+      atomically $ modifyTVar peerSelectionVar (\targets -> targets {
+          targetNumberOfActivePeers = decrease (targetNumberOfActivePeers base)
+          })
+
+      -- Short delay, we may have no active peers right now
+      threadDelay 1
+
+      -- Pick new active peer(s) based on the best performing established
+      -- peers.
+      atomically $ modifyTVar peerSelectionVar (\targets -> targets {
+          targetNumberOfActivePeers = targetNumberOfActivePeers base
+          })
+
+      -- Give the promotion process time to start
+      threadDelay 1
+
+      -- Forget the worst performing non-active peers.
+      atomically $ modifyTVar peerSelectionVar (\targets -> targets {
+          targetNumberOfRootPeers = decrease (targetNumberOfRootPeers base)
+        , targetNumberOfKnownPeers = decrease (targetNumberOfKnownPeers base)
+        , targetNumberOfEstablishedPeers =
+              decrease (targetNumberOfEstablishedPeers base)
+        })
+
+      -- Give the governor time to properly demote them.
+      threadDelay $ 1 + closeConnectionTimeout
+
+      -- Pick new non-active peers
+      atomically $ modifyTVar peerSelectionVar (\targets -> targets {
+          targetNumberOfRootPeers = targetNumberOfRootPeers base
+        , targetNumberOfKnownPeers = targetNumberOfKnownPeers base
+        , targetNumberOfEstablishedPeers = targetNumberOfEstablishedPeers base
+        })
+      endTs <- getMonotonicTime
+      threadDelay $ diffTime churnInterval $ Time $ diffTime endTs startTs
+
+
+  where
+    -- The time between running the churn governor.
+    churnInterval :: Time
+    churnInterval = Time 3600 -- 1h
+
+    -- Replace 20% or at least on peer every churnInterval.
+    decrease :: Int -> Int
+    decrease v = v  - max 1 (v `div` 5)
+
+

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -19,6 +19,7 @@ import           Control.Concurrent.JobPool (Job(..))
 import           Control.Exception (SomeException, assert)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
+import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
 import           Ouroboros.Network.PeerSelection.Governor.Types
 
 
@@ -34,36 +35,136 @@ belowTarget :: forall peeraddr peerconn m.
                (MonadSTM m, Ord peeraddr)
             => PeerSelectionActions peeraddr peerconn m
             -> MkGuardedDecision peeraddr peerconn m
-belowTarget actions
-            PeerSelectionPolicy {
+belowTarget = belowTargetLocal <> belowTargetOther
+
+
+belowTargetLocal :: forall peeraddr peerconn m.
+                    (MonadSTM m, Ord peeraddr)
+                 => PeerSelectionActions peeraddr peerconn m
+                 -> MkGuardedDecision peeraddr peerconn m
+belowTargetLocal actions
+                 PeerSelectionPolicy {
+                   policyPickWarmPeersToPromote
+                 }
+                 st@PeerSelectionState {
+                   localRootPeers,
+                   establishedPeers,
+                   activePeers,
+                   inProgressPromoteWarm,
+                   inProgressDemoteWarm
+                 }
+    -- Are there any groups of local peers that are below target?
+  | not (null groupsBelowTarget)
+    -- We need this detailed check because it is not enough to check we are
+    -- below an aggregate target. We can be above target for some groups
+    -- and below for others.
+
+    -- Are there any groups where we can pick members to promote?
+  , let groupsAvailableToPromote =
+          [ (numMembersToPromote, membersAvailableToPromote)
+          | let availableToPromote =
+                  (LocalRootPeers.keysSet localRootPeers
+                    `Set.intersection`
+                   EstablishedPeers.readyPeers establishedPeers)
+                     Set.\\ activePeers
+                     Set.\\ inProgressPromoteWarm
+                     Set.\\ inProgressDemoteWarm
+                numPromoteInProgress = Set.size inProgressPromoteWarm
+          , not (Set.null availableToPromote)
+          , (target, members, membersActive) <- groupsBelowTarget
+          , let membersAvailableToPromote = Set.intersection
+                                              members availableToPromote
+                numMembersToPromote       = target
+                                          - Set.size membersActive
+                                          - numPromoteInProgress
+          , not (Set.null membersAvailableToPromote)
+          , numMembersToPromote > 0
+          ]
+  , not (null groupsAvailableToPromote)
+  = Guarded Nothing $ do
+      selectedToPromote <-
+        Set.unions <$> sequence
+          [ pickPeers
               policyPickWarmPeersToPromote
-            }
-            st@PeerSelectionState {
-              establishedPeers,
-              activePeers,
-              inProgressPromoteWarm,
-              inProgressDemoteWarm,
-              targets = PeerSelectionTargets {
-                          targetNumberOfActivePeers
-                        }
-            }
+              membersAvailableToPromote
+              numMembersToPromote
+          | (numMembersToPromote,
+             membersAvailableToPromote) <- groupsAvailableToPromote ]
+
+      let selectedToPromote' :: Map peeraddr peerconn
+          selectedToPromote' = EstablishedPeers.toMap establishedPeers
+                                 `Map.restrictKeys` selectedToPromote
+      return $ \_now -> Decision {
+        decisionTrace = TracePromoteWarmLocalPeers
+                          [ (target, Set.size membersActive)
+                          | (target, _, membersActive) <- groupsBelowTarget ]
+                          selectedToPromote,
+        decisionState = st {
+                          inProgressPromoteWarm = inProgressPromoteWarm
+                                               <> selectedToPromote
+                        },
+        decisionJobs  = [ jobPromoteWarmPeer actions peeraddr peerconn
+                        | (peeraddr, peerconn) <- Map.assocs selectedToPromote' ]
+      }
+
+
+    -- If we could promote except that there are no peers currently available
+    -- then we return the next wakeup time (if any)
+  | not (null groupsBelowTarget)
+  , let potentialToPromote =
+          -- These are local peers that are warm but not ready.
+          (LocalRootPeers.keysSet localRootPeers
+            `Set.intersection`
+           EstablishedPeers.toSet establishedPeers)
+             Set.\\ activePeers
+             Set.\\ EstablishedPeers.readyPeers establishedPeers
+  , not (Set.null potentialToPromote)
+  = GuardedSkip (Min <$> EstablishedPeers.minActivateTime establishedPeers)
+
+  | otherwise
+  = GuardedSkip Nothing
+  where
+    groupsBelowTarget =
+      [ (target, members, membersActive)
+      | (target, members) <- LocalRootPeers.toGroupSets localRootPeers
+      , let membersActive = members `Set.intersection` activePeers
+      , Set.size membersActive < target
+      ]
+
+belowTargetOther :: forall peeraddr peerconn m.
+                    (MonadSTM m, Ord peeraddr)
+                 => PeerSelectionActions peeraddr peerconn m
+                 -> MkGuardedDecision peeraddr peerconn m
+belowTargetOther actions
+                 PeerSelectionPolicy {
+                   policyPickWarmPeersToPromote
+                 }
+                 st@PeerSelectionState {
+                   localRootPeers,
+                   establishedPeers,
+                   activePeers,
+                   inProgressPromoteWarm,
+                   inProgressDemoteWarm,
+                   targets = PeerSelectionTargets {
+                               targetNumberOfActivePeers
+                             }
+                 }
     -- Are we below the target for number of active peers?
   | numActivePeers + numPromoteInProgress < targetNumberOfActivePeers
 
     -- Are there any warm peers we could pick to promote?
-  , numEstablishedReadyPeers - numActivePeers
-                             - numPromoteInProgress - numDemoteInProgress > 0
+  , let availableToPromote :: Set peeraddr
+        availableToPromote = EstablishedPeers.readyPeers establishedPeers
+                               Set.\\ activePeers
+                               Set.\\ inProgressPromoteWarm
+                               Set.\\ inProgressDemoteWarm
+                               Set.\\ LocalRootPeers.keysSet localRootPeers
+        numPeersToPromote = targetNumberOfActivePeers
+                          - numActivePeers
+                          - numPromoteInProgress
+  , not (Set.null availableToPromote)
+  , numPeersToPromote > 0
   = Guarded Nothing $ do
-          -- The availableToPromote is non-empty due to the second guard.
-          -- The numPeersToPromote is positive due to the first guard.
-      let availableToPromote :: Set peeraddr
-          availableToPromote = EstablishedPeers.readyPeers establishedPeers
-                                 Set.\\ activePeers
-                                 Set.\\ inProgressPromoteWarm
-                                 Set.\\ inProgressDemoteWarm
-          numPeersToPromote  = targetNumberOfActivePeers
-                             - numActivePeers
-                             - numPromoteInProgress
       selectedToPromote <- pickPeers
                              policyPickWarmPeersToPromote
                              availableToPromote
@@ -92,11 +193,8 @@ belowTarget actions
   | otherwise
   = GuardedSkip Nothing
   where
-    numEstablishedReadyPeers, numActivePeers, numPromoteInProgress :: Int
-    numEstablishedReadyPeers = EstablishedPeers.sizeReady establishedPeers
     numActivePeers       = Set.size activePeers
     numPromoteInProgress = Set.size inProgressPromoteWarm
-    numDemoteInProgress  = Set.size inProgressDemoteWarm
 
 
 jobPromoteWarmPeer :: forall peeraddr peerconn m.
@@ -161,41 +259,130 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
 -- Active peers above target
 --
 
--- | If we are above the target of /hot peers/ we demote some of the /warm
--- peers/, according to 'policyPickHotPeersToDemote'.
+-- | If we are above the target of /hot peers/ we demote some hot peers to be
+-- /warm peers/, according to 'policyPickHotPeersToDemote'.
 --
 aboveTarget :: forall peeraddr peerconn m.
                (MonadSTM m, Ord peeraddr)
             => PeerSelectionActions peeraddr peerconn m
             -> MkGuardedDecision peeraddr peerconn m
-aboveTarget actions
-            PeerSelectionPolicy {
-              policyPickHotPeersToDemote
-            }
-            st@PeerSelectionState {
-              establishedPeers,
-              activePeers,
-              inProgressDemoteHot,
-              targets = PeerSelectionTargets {
-                          targetNumberOfActivePeers
-                        }
-            }
-    -- Are we above the target for number of active peers?
-    -- Or more precisely, how many active peers could we demote?
-  | let numActivePeers, numPeersToDemote :: Int
-        numActivePeers   = Set.size activePeers
-        -- The main constraint on how many to demote is the difference in the
-        -- number we have now vs the target. We must also subtract the number
-        -- we're already demoting so we don't repeat the same work.
-        numPeersToDemote = numActivePeers
-                         - targetNumberOfActivePeers
-                         - Set.size inProgressDemoteHot
-  , numPeersToDemote > 0
-  = Guarded Nothing $ do
+aboveTarget = aboveTargetLocal <> aboveTargetOther
+  -- Start with the local root targets, then the general target. This makes
+  -- sense since we need to hit both and making progress downwards with the
+  -- local root targets makes progress for the general target too.
 
-      let availableToDemote :: Set peeraddr
-          availableToDemote = activePeers
-                                Set.\\ inProgressDemoteHot
+
+aboveTargetLocal :: forall peeraddr peerconn m.
+                    (MonadSTM m, Ord peeraddr)
+                 => PeerSelectionActions peeraddr peerconn m
+                 -> MkGuardedDecision peeraddr peerconn m
+aboveTargetLocal actions
+                 PeerSelectionPolicy {
+                   policyPickHotPeersToDemote
+                 }
+                 st@PeerSelectionState {
+                   localRootPeers,
+                   establishedPeers,
+                   activePeers,
+                   inProgressDemoteHot
+                 }
+    -- Are there any groups of local peers that are below target?
+  | let groupsAboveTarget =
+          [ (target, members, membersActive)
+          | (target, members) <- LocalRootPeers.toGroupSets localRootPeers
+          , let membersActive = members `Set.intersection` activePeers
+          , Set.size membersActive > target
+          ]
+  , not (null groupsAboveTarget)
+    -- We need this detailed check because it is not enough to check we are
+    -- above an aggregate target. We can be above target for some groups
+    -- and below for others.
+
+    -- Are there any groups where we can pick members to demote?
+  , let groupsAvailableToDemote =
+          [ (numMembersToDemote, membersAvailableToDemote)
+          | let availableToDemote = (LocalRootPeers.keysSet localRootPeers
+                                       `Set.intersection`
+                                     activePeers)
+                                       Set.\\ inProgressDemoteHot
+                numDemoteInProgress = Set.size inProgressDemoteHot
+          , not (Set.null availableToDemote)
+          , (target, members, membersActive) <- groupsAboveTarget
+          , let membersAvailableToDemote = Set.intersection
+                                             members availableToDemote
+                numMembersToDemote       = Set.size membersActive
+                                         - target
+                                         - numDemoteInProgress
+          , not (Set.null membersAvailableToDemote)
+          , numMembersToDemote > 0
+          ]
+  , not (null groupsAvailableToDemote)
+  = Guarded Nothing $ do
+      selectedToDemote <-
+        Set.unions <$> sequence
+          [ pickPeers
+              policyPickHotPeersToDemote
+              membersAvailableToDemote
+              numMembersToDemote
+          | (numMembersToDemote,
+             membersAvailableToDemote) <- groupsAvailableToDemote ]
+      let selectedToDemote' :: Map peeraddr peerconn
+          selectedToDemote' = EstablishedPeers.toMap establishedPeers
+                                `Map.restrictKeys` selectedToDemote
+
+      return $ \_now -> Decision {
+        decisionTrace = TraceDemoteLocalHotPeers
+                          [ (target, Set.size membersActive)
+                          | (target, _, membersActive) <- groupsAboveTarget ]
+                          selectedToDemote,
+        decisionState = st {
+                          inProgressDemoteHot = inProgressDemoteHot
+                                             <> selectedToDemote
+                        },
+        decisionJobs  = [ jobDemoteActivePeer actions peeraddr peerconn
+                        | (peeraddr, peerconn) <- Map.assocs selectedToDemote' ]
+      }
+
+  | otherwise
+  = GuardedSkip Nothing
+
+
+aboveTargetOther :: forall peeraddr peerconn m.
+                    (MonadSTM m, Ord peeraddr)
+                 => PeerSelectionActions peeraddr peerconn m
+                 -> MkGuardedDecision peeraddr peerconn m
+aboveTargetOther actions
+                 PeerSelectionPolicy {
+                   policyPickHotPeersToDemote
+                 }
+                 st@PeerSelectionState {
+                   localRootPeers,
+                   establishedPeers,
+                   activePeers,
+                   inProgressDemoteHot,
+                   targets = PeerSelectionTargets {
+                               targetNumberOfActivePeers
+                             }
+                 }
+    -- Are we above the general target for number of active peers?
+  | numActivePeers > targetNumberOfActivePeers
+
+    -- Would we demote any if we could?
+  , let numPeersToDemote = numActivePeers
+                         - targetNumberOfActivePeers
+                         - numDemoteInProgress
+  , numPeersToDemote > 0
+
+    -- Are there any hot peers we actually can pick to demote?
+    -- For the moment we say we cannot demote local root peers.
+    -- TODO: review this decision. If we want to be able to demote local root
+    -- peers, e.g. for churn and improved selection, then we'll need an extra
+    -- mechanism to avoid promotion/demotion loops for local peers.
+  , let availableToDemote = activePeers
+                              Set.\\ inProgressDemoteHot
+                              Set.\\ LocalRootPeers.keysSet localRootPeers
+  , not (Set.null availableToDemote)
+  = Guarded Nothing $ do
       selectedToDemote <- pickPeers
                             policyPickHotPeersToDemote
                             availableToDemote
@@ -219,6 +406,9 @@ aboveTarget actions
 
   | otherwise
   = GuardedSkip Nothing
+  where
+    numActivePeers      = Set.size activePeers
+    numDemoteInProgress = Set.size inProgressDemoteHot
 
 
 jobDemoteActivePeer :: forall peeraddr peerconn m.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -15,10 +15,12 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTime
 import           Control.Concurrent.JobPool (Job(..))
 import           Control.Exception (SomeException, assert)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
+import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
 import           Ouroboros.Network.PeerSelection.Governor.Types
 
@@ -207,31 +209,52 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                    peeraddr peerconn =
     Job job handler () "promoteWarmPeer"
   where
+    -- TODO: The delay should be randomly picked from an interval.
+    reconnectDelay :: DiffTime
+    reconnectDelay = 10
+
     handler :: SomeException -> m (Completion m peeraddr peerconn)
     handler e = return $
-      --TODO: decide what happens if promotion fails, do we stay warm or go to
-      -- cold? Will this be reported asynchronously via the state monitoring?
+      -- When promotion fails we set the peer as cold.
       Completion $ \st@PeerSelectionState {
                                activePeers,
+                               establishedPeers,
+                               knownPeers,
                                targets = PeerSelectionTargets {
                                            targetNumberOfActivePeers
                                          }
                              }
-                    _now -> Decision {
+                    now ->
+        let establishedPeers' = EstablishedPeers.delete peeraddr
+                                  establishedPeers
+            knownPeers'       = if peeraddr `KnownPeers.member` knownPeers
+                                   then KnownPeers.setConnectTime
+                                          (Set.singleton peeraddr)
+                                          (reconnectDelay `addTime` now)
+                                        $ snd $ KnownPeers.incrementFailCount
+                                          peeraddr
+                                          knownPeers
+                                   else
+                                     -- Apparently the governor can remove
+                                     -- the peer we failed to promote from the
+                                     -- set of known peers before we can process
+                                     -- the failure.
+                                     knownPeers in
+        Decision {
         decisionTrace = TracePromoteWarmFailed targetNumberOfActivePeers
-                                               (Set.size activePeers) 
+                                               (Set.size activePeers)
                                                peeraddr e,
         decisionState = st {
                           inProgressPromoteWarm = Set.delete peeraddr
-                                                    (inProgressPromoteWarm st)
+                                                    (inProgressPromoteWarm st),
+                          knownPeers            = knownPeers',
+                          establishedPeers      = establishedPeers'
                         },
         decisionJobs  = []
       }
 
     job :: m (Completion m peeraddr peerconn)
     job = do
-      --TODO: decide if we should do timeouts here or if we should make that
-      -- the responsibility of activatePeerConnection
       activatePeerConnection peerconn
       return $ Completion $ \st@PeerSelectionState {
                                activePeers,
@@ -241,6 +264,7 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                              }
                            _now ->
         assert (peeraddr `EstablishedPeers.member` establishedPeers st) $
+        assert (peeraddr `KnownPeers.member` knownPeers st) $
         let activePeers' = Set.insert peeraddr activePeers in
         Decision {
           decisionTrace = TracePromoteWarmDone targetNumberOfActivePeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -16,6 +16,7 @@ import           Control.Concurrent.JobPool (Job(..))
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Exception (SomeException)
+import           System.Random (randomR)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
@@ -239,6 +240,7 @@ jobPromoteColdPeer PeerSelectionActions {
     handler e = return $
       Completion $ \st@PeerSelectionState {
                       establishedPeers,
+                      fuzzRng,
                       targets = PeerSelectionTargets {
                                   targetNumberOfEstablishedPeers
                                 }
@@ -247,12 +249,14 @@ jobPromoteColdPeer PeerSelectionActions {
         let (failCount, knownPeers') = KnownPeers.incrementFailCount
                                          peeraddr
                                          (knownPeers st)
+            (fuzz, fuzzRng') = randomR (-2, 2 :: Double) fuzzRng
 
             -- exponential backoff: 5s, 10s, 20s, 40s, 80s, 160s.
-            delay :: DiffTime
-            delay = fromIntegral $
-                baseColdPeerRetryDiffTime
-              * 2 ^ (pred failCount `min` maxColdPeerRetryBackoff)
+            delay = realToFrac fuzz
+                  + fromIntegral
+                      ( baseColdPeerRetryDiffTime
+                      * 2 ^ (pred failCount `min` maxColdPeerRetryBackoff)
+                      )
         in
           Decision {
             decisionTrace = TracePromoteColdFailed targetNumberOfEstablishedPeers
@@ -264,7 +268,8 @@ jobPromoteColdPeer PeerSelectionActions {
                                                         (delay `addTime` now)
                                                         knownPeers',
                               inProgressPromoteCold = Set.delete peeraddr
-                                                        (inProgressPromoteCold st)
+                                                        (inProgressPromoteCold st),
+                              fuzzRng = fuzzRng'
                             },
             decisionJobs  = []
           }

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -88,11 +88,13 @@ jobs jobPool st =
 --
 reconnectDelay :: DiffTime
 reconnectDelay = 10
+--TODO: make this a policy param
 
 -- | Activation delay after a peer was asynchronously demoted to warm state.
 --
 activateDelay :: DiffTime
 activateDelay = 60
+--TODO: make this a policy param
 
 
 -- | Monitor connections.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -231,7 +231,7 @@ localRoots actions@PeerSelectionActions{readLocalRootPeers}
     Guarded Nothing $ do
       -- We have to enforce the invariant that the number of root peers is
       -- not more than the target number of known peers. It's unlikely in
-      -- practice so it's ok to resolve it arbitrarily using Map.take.
+      -- practice so it's ok to resolve it arbitrarily using clampToLimit.
       localRootPeersRaw <- readLocalRootPeers
       let localRootPeers' = LocalRootPeers.clampToLimit
                               targetNumberOfKnownPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -560,7 +560,7 @@ data TracePeerSelection peeraddr =
   deriving Show
 
 data DebugPeerSelection peeraddr peerconn =
-       TraceGovernorState Time
-                          (Maybe DiffTime)
+       TraceGovernorState Time              -- blocked time
+                          (Maybe DiffTime)  -- wait time
                           (PeerSelectionState peeraddr peerconn)
   deriving (Show, Functor)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -50,6 +50,7 @@ import           Control.Concurrent.JobPool (Job)
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Exception (assert, SomeException)
+import           System.Random (StdGen)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import           Ouroboros.Network.PeerSelection.EstablishedPeers (EstablishedPeers)
@@ -289,7 +290,10 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
        inProgressPromoteCold    :: !(Set peeraddr),
        inProgressPromoteWarm    :: !(Set peeraddr),
        inProgressDemoteWarm     :: !(Set peeraddr),
-       inProgressDemoteHot      :: !(Set peeraddr)
+       inProgressDemoteHot      :: !(Set peeraddr),
+
+       -- | Rng for fuzzy delay
+       fuzzRng                  :: !StdGen
 
 --     TODO: need something like this to distinguish between lots of bad peers
 --     and us getting disconnected from the network locally. We don't want a
@@ -315,8 +319,8 @@ peerStateToCounters st = PeerSelectionCounters { coldPeers, warmPeers, hotPeers 
     warmPeers = Set.size $ establishedPeersSet Set.\\ activePeers st
     hotPeers  = Set.size $ activePeers st
 
-emptyPeerSelectionState :: PeerSelectionState peeraddr peerconn
-emptyPeerSelectionState =
+emptyPeerSelectionState :: StdGen -> PeerSelectionState peeraddr peerconn
+emptyPeerSelectionState rng =
     PeerSelectionState {
       targets              = nullPeerSelectionTargets,
       localRootPeers       = LocalRootPeers.empty,
@@ -331,7 +335,8 @@ emptyPeerSelectionState =
       inProgressPromoteCold    = Set.empty,
       inProgressPromoteWarm    = Set.empty,
       inProgressDemoteWarm     = Set.empty,
-      inProgressDemoteHot      = Set.empty
+      inProgressDemoteHot      = Set.empty,
+      fuzzRng                  = rng
     }
 
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -531,6 +531,8 @@ data TracePeerSelection peeraddr =
      | TraceForgetColdPeers    Int Int (Set peeraddr)
      -- | target established, actual established, selected peers
      | TracePromoteColdPeers   Int Int (Set peeraddr)
+     -- | target local established, actual local established, selected peers
+     | TracePromoteColdLocalPeers Int Int (Set peeraddr)
      -- | target established, actual established, peer, delay until next
      -- promotion, reason
      | TracePromoteColdFailed  Int Int peeraddr DiffTime SomeException
@@ -538,6 +540,8 @@ data TracePeerSelection peeraddr =
      | TracePromoteColdDone    Int Int peeraddr
      -- | target active, actual active, selected peers
      | TracePromoteWarmPeers   Int Int (Set peeraddr)
+     -- | local per-group (target active, actual active), selected peers
+     | TracePromoteWarmLocalPeers [(Int, Int)] (Set peeraddr)
      -- | target active, actual active, peer, reason
      | TracePromoteWarmFailed  Int Int peeraddr SomeException
      -- | target active, actual active, peer
@@ -550,6 +554,8 @@ data TracePeerSelection peeraddr =
      | TraceDemoteWarmDone     Int Int peeraddr
      -- | target active, actual active, selected peers
      | TraceDemoteHotPeers     Int Int (Set peeraddr)
+     -- | local per-group (target active, actual active), selected peers
+     | TraceDemoteLocalHotPeers [(Int, Int)] (Set peeraddr)
      -- | target active, actual active, peer, reason
      | TraceDemoteHotFailed    Int Int peeraddr SomeException
      -- | target active, actual active, peer

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -540,6 +540,7 @@ data TracePeerSelection peeraddr =
      | TraceDemoteHotDone      Int Int peeraddr
      | TraceDemoteAsynchronous (Map peeraddr PeerStatus)
      | TraceGovernorWakeup
+     | TraceChurnWait          DiffTime
   deriving Show
 
 data DebugPeerSelection peeraddr peerconn =

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -30,6 +30,8 @@ module Ouroboros.Network.PeerSelection.Governor.Types
   , TimedDecision
   , MkGuardedDecision
   , Completion (..)
+  , PeerSelectionCounters (..)
+  , peerStateToCounters
 
   -- * Traces
   , TracePeerSelection (..)
@@ -298,6 +300,20 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
      }
   deriving (Show, Functor)
 
+data PeerSelectionCounters = PeerSelectionCounters {
+      coldPeers :: !Int,
+      warmPeers :: !Int,
+      hotPeers  :: !Int
+    } deriving Show
+
+peerStateToCounters :: Ord peeraddr => PeerSelectionState peeraddr peerconn -> PeerSelectionCounters
+peerStateToCounters st = PeerSelectionCounters { coldPeers, warmPeers, hotPeers }
+  where
+    knownPeersSet = KnownPeers.toSet (knownPeers st)
+    establishedPeersSet = EstablishedPeers.toSet (establishedPeers st)
+    coldPeers = Set.size $ knownPeersSet Set.\\ establishedPeersSet
+    warmPeers = Set.size $ establishedPeersSet Set.\\ activePeers st
+    hotPeers  = Set.size $ activePeers st
 
 emptyPeerSelectionState :: PeerSelectionState peeraddr peerconn
 emptyPeerSelectionState =

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
@@ -14,6 +14,7 @@ module Ouroboros.Network.PeerSelection.KnownPeers (
     insert,
     delete,
     toSet,
+    member,
 
     -- * Special operations
     setCurrentTime,
@@ -147,6 +148,13 @@ size = Map.size . allPeers
 -- | /O(n)/
 toSet :: KnownPeers peeraddr -> Set peeraddr
 toSet = Map.keysSet . allPeers
+
+member :: Ord peeraddr
+       => peeraddr
+       -> KnownPeers peeraddr
+       -> Bool
+member peeraddr KnownPeers {allPeers} =
+    peeraddr `Map.member` allPeers
 
 insert :: Ord peeraddr
        => Set peeraddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/KnownPeers.hs
@@ -352,7 +352,7 @@ minConnectTime KnownPeers { nextConnectTimes }
 
 
 setConnectTime :: Ord peeraddr
-               => Set peeraddr
+               => Set peeraddr --TODO: make this a single entry
                -> Time
                -> KnownPeers peeraddr
                -> KnownPeers peeraddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -103,8 +103,8 @@ instance Show TraceLedgerPeers where
 
 -- | A relay can have either an IP address and a port number or
 -- a domain with a port number
-data RelayAddress = RelayDomain DomainAddress
-                  | RelayAddress IP.IP Socket.PortNumber
+data RelayAddress = RelayDomain !DomainAddress
+                  | RelayAddress !IP.IP !Socket.PortNumber
                   deriving (Show, Eq, Ord)
 
 -- | The relative stake of a stakepool in relation to the total amount staked.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -203,19 +203,19 @@ runLedgerPeers :: forall m.
                       )
                => StdGen
                -> Tracer m TraceLedgerPeers
-               -> StrictTVar m UseLedgerAfter
+               -> STM m UseLedgerAfter
                -> LedgerPeersConsensusInterface m
                -> ([DomainAddress] -> m (Map DomainAddress (Set SockAddr)))
                -> STM m NumberOfPeers
                -> (Maybe (Set SockAddr, DiffTime) -> STM m ())
                -> m Void
-runLedgerPeers inRng tracer useLedgerAfterVar LedgerPeersConsensusInterface{..} doResolve
+runLedgerPeers inRng tracer readUseLedgerAfter LedgerPeersConsensusInterface{..} doResolve
                getReq putRsp = do
     go inRng (Time 0) Map.empty
   where
     go :: StdGen -> Time -> Map AccPoolStake (PoolStake, NonEmpty RelayAddress) -> m Void
     go rng oldTs peerMap = do
-        useLedgerAfter <- atomically $ readTVar useLedgerAfterVar
+        useLedgerAfter <- atomically readUseLedgerAfter
         traceWith tracer (TraceUseLedgerAfter useLedgerAfter)
 
         let peerListLifeTime = if Map.null peerMap && isLedgerPeersEnabled useLedgerAfter

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -111,7 +111,7 @@ data RelayAddress = RelayDomain DomainAddress
 -- A value in the [0, 1] range.
 --
 newtype PoolStake = PoolStake { unPoolStake :: Rational }
-  deriving (Eq, Fractional, Num, Ord, Show)
+  deriving (Eq, Fractional, Num, Real, Ord, Show)
 
 -- | The accumulated relative stake of a stake pool, like PoolStake but it also includes the
 -- relative stake of all preceding pools. A value in the range [0, 1].

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -45,7 +45,7 @@ import           System.Random
 
 import           Cardano.Slotting.Slot (SlotNo)
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
-                     (DomainAddress (..))
+                     (RelayAddress (..), DomainAddress (..))
 
 import           Text.Printf
 
@@ -73,6 +73,8 @@ data TraceLedgerPeers =
       -- returned.
     | DisabledLedgerPeers
       -- ^ Trace for when getting peers from the ledger is disabled, that is DontUseLedger.
+    | TraceUseLedgerAfter !UseLedgerAfter
+      -- ^ Trace UseLedgerAfter value
     | WaitingOnRequest
     | RequestForPeers !NumberOfPeers
     | ReusingLedgerState !Int !DiffTime
@@ -92,6 +94,9 @@ instance Show TraceLedgerPeers where
     show (FetchingNewLedgerState cnt) =
         printf "Fetching new ledgerstate, %d registered pools"
             cnt
+    show (TraceUseLedgerAfter ula) =
+        printf "UseLedgerAfter state %s"
+            (show ula)
     show WaitingOnRequest = "WaitingOnRequest"
     show (RequestForPeers (NumberOfPeers cnt)) = printf "RequestForPeers %d" cnt
     show (ReusingLedgerState cnt age) =
@@ -100,12 +105,6 @@ instance Show TraceLedgerPeers where
           (show age)
     show FallingBackToBootstrapPeers = "Falling back to bootstrap peers"
     show DisabledLedgerPeers = "LedgerPeers is disabled"
-
--- | A relay can have either an IP address and a port number or
--- a domain with a port number
-data RelayAddress = RelayDomain !DomainAddress
-                  | RelayAddress !IP.IP !Socket.PortNumber
-                  deriving (Show, Eq, Ord)
 
 -- | The relative stake of a stakepool in relation to the total amount staked.
 -- A value in the [0, 1] range.
@@ -187,18 +186,21 @@ runLedgerPeers :: forall m.
                       )
                => StdGen
                -> Tracer m TraceLedgerPeers
-               -> UseLedgerAfter
+               -> StrictTVar m UseLedgerAfter
                -> LedgerPeersConsensusInterface m
                -> ([DomainAddress] -> m (Map DomainAddress (Set SockAddr)))
                -> STM m NumberOfPeers
                -> (Maybe (Set SockAddr, DiffTime) -> STM m ())
                -> m Void
-runLedgerPeers inRng tracer useLedgerAfter LedgerPeersConsensusInterface{..} doResolve
+runLedgerPeers inRng tracer useLedgerAfterVar LedgerPeersConsensusInterface{..} doResolve
                getReq putRsp = do
     go inRng (Time 0) Map.empty
   where
     go :: StdGen -> Time -> Map AccPoolStake (PoolStake, NonEmpty RelayAddress) -> m Void
     go rng oldTs peerMap = do
+        useLedgerAfter <- atomically $ readTVar useLedgerAfterVar
+        traceWith tracer (TraceUseLedgerAfter useLedgerAfter)
+
         let peerListLifeTime = if Map.null peerMap && isLedgerPeersEnabled useLedgerAfter
                                   then 30
                                   else 1847 -- Close to but not exactly 30min.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -13,14 +13,19 @@ module Ouroboros.Network.PeerSelection.LedgerPeers (
     PoolStake (..),
     AccPoolStake (..),
     TraceLedgerPeers (..),
+    NumberOfPeers (..),
     pickPeers,
     accPoolStake,
+    runLedgerPeers,
+    UseLedgerAfter (..),
 
     Socket.PortNumber
     ) where
 
 
-import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer, traceWith)
 import qualified Data.IP as IP
 import           Data.List (foldl')
@@ -29,8 +34,12 @@ import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Ratio
+import qualified Data.Set as Set
+import           Data.Set (Set)
 import           Data.Word
+import           Data.Void (Void)
 import qualified Network.Socket as Socket
+import           Network.Socket (SockAddr)
 import           System.Random
 
 import           Cardano.Slotting.Slot (SlotNo)
@@ -38,6 +47,15 @@ import           Ouroboros.Network.PeerSelection.RootPeersDNS
                      (DomainAddress (..))
 
 import           Text.Printf
+
+-- | Only use the ledger after the given slot number.
+data UseLedgerAfter = DontUseLedger | UseLedgerAfter SlotNo deriving (Eq, Show)
+
+isLedgerPeersEnabled :: UseLedgerAfter -> Bool
+isLedgerPeersEnabled DontUseLedger = False
+isLedgerPeersEnabled _             = True
+
+newtype NumberOfPeers = NumberOfPeers Word16 deriving Show
 
 newtype LedgerPeersConsensusInterface m = LedgerPeersConsensusInterface {
       lpGetPeers :: SlotNo -> STM m (Maybe [(PoolStake, NonEmpty RelayAddress)])
@@ -47,11 +65,15 @@ newtype LedgerPeersConsensusInterface m = LedgerPeersConsensusInterface {
 data TraceLedgerPeers =
       PickedPeer !RelayAddress !AccPoolStake ! PoolStake
       -- ^ Trace for a peer picked with accumulated and relative stake of its pool.
-    | PickedPeers !Word16 ![RelayAddress]
+    | PickedPeers !NumberOfPeers ![RelayAddress]
       -- ^ Trace for the number of peers we wanted to pick and the list of peers picked.
     | FetchingNewLedgerState !Int
       -- ^ Trace for fetching a new list of peers from the ledger. Int is the number of peers
       -- returned.
+    | WaitingOnRequest
+    | RequestForPeers !NumberOfPeers
+    | ReusingLedgerState !Int !DiffTime
+    | FallingBackToBootstrapPeers
 
 
 instance Show TraceLedgerPeers where
@@ -62,15 +84,23 @@ instance Show TraceLedgerPeers where
             (fromRational (unAccPoolStake ackStake) :: Double)
             (show $ unPoolStake stake)
             (fromRational (unPoolStake stake) :: Double)
-    show (PickedPeers n peers) =
+    show (PickedPeers (NumberOfPeers n) peers) =
         printf "PickedPeers %d %s" n (show peers)
     show (FetchingNewLedgerState cnt) =
         printf "Fetching new ledgerstate, %d registered pools"
             cnt
+    show WaitingOnRequest = "WaitingOnRequest"
+    show (RequestForPeers (NumberOfPeers cnt)) = printf "RequestForPeers %d" cnt
+    show (ReusingLedgerState cnt age) =
+        printf "ReusingLedgerState %d peers age %s"
+          cnt
+          (show age)
+    show FallingBackToBootstrapPeers = "Falling back to bootstrap peers"
 
-
-data RelayAddress = RelayAddressDomain DomainAddress
-                  | RelayAddressAddr IP.IP Socket.PortNumber
+-- | A relay can have either an IP address and a port number or
+-- a domain with a port number
+data RelayAddress = RelayDomain DomainAddress
+                  | RelayAddress IP.IP Socket.PortNumber
                   deriving (Show, Eq, Ord)
 
 -- | The relative stake of a stakepool in relation to the total amount staked.
@@ -125,10 +155,10 @@ pickPeers :: forall m. Monad m
           => StdGen
           -> Tracer m TraceLedgerPeers
           -> Map AccPoolStake (PoolStake, NonEmpty RelayAddress)
-          -> Word16
+          -> NumberOfPeers
           -> m (StdGen, [RelayAddress])
 pickPeers inRng _ pools _ | Map.null pools = return (inRng, [])
-pickPeers inRng tracer pools cnt = go inRng cnt []
+pickPeers inRng tracer pools (NumberOfPeers cnt) = go inRng cnt []
   where
     go :: StdGen -> Word16 -> [RelayAddress] -> m (StdGen, [RelayAddress])
     go rng 0 picked = return (rng, picked)
@@ -144,3 +174,91 @@ pickPeers inRng tracer pools cnt = go inRng cnt []
                      relay = relays NonEmpty.!! ix
                  traceWith tracer $ PickedPeer relay ackStake stake
                  go rng'' (n - 1) (relay : picked)
+
+
+-- | Run the LedgerPeers worker thread.
+runLedgerPeers :: forall m.
+                      ( MonadAsync m
+                      , MonadTime m
+                      )
+               => StdGen
+               -> Tracer m TraceLedgerPeers
+               -> UseLedgerAfter
+               -> LedgerPeersConsensusInterface m
+               -> ([DomainAddress] -> m (Map DomainAddress (Set SockAddr)))
+               -> STM m NumberOfPeers
+               -> (Maybe (Set SockAddr, DiffTime) -> STM m ())
+               -> m Void
+runLedgerPeers inRng tracer useLedgerAfter LedgerPeersConsensusInterface{..} doResolve
+               getReq putRsp = do
+    go inRng (Time 0) Map.empty
+  where
+    go :: StdGen -> Time -> Map AccPoolStake (PoolStake, NonEmpty RelayAddress) -> m Void
+    go rng oldTs peerMap = do
+        let peerListLifeTime = if Map.null peerMap && isLedgerPeersEnabled useLedgerAfter
+                                  then 30
+                                  else 1847 -- Close to but not exactly 30min.
+
+        traceWith tracer WaitingOnRequest
+        numRequested <- atomically getReq
+        traceWith tracer $ RequestForPeers numRequested
+        !now <- getMonotonicTime
+        let age = diffTime now oldTs
+        (peerMap', ts) <- if age > peerListLifeTime
+                             then
+                                 case useLedgerAfter of
+                                   DontUseLedger -> do
+                                     traceWith tracer $ FetchingNewLedgerState 0
+                                     return (Map.empty, now)
+                                   UseLedgerAfter slot -> do
+                                     peers_m <- atomically $ lpGetPeers slot
+                                     let peers = maybe Map.empty accPoolStake peers_m
+                                     traceWith tracer $ FetchingNewLedgerState $ Map.size peers
+                                     return (peers, now)
+
+                             else do
+                                 traceWith tracer $ ReusingLedgerState (Map.size peerMap) age
+                                 return (peerMap, oldTs)
+
+        if Map.null peerMap'
+           then do
+               traceWith tracer FallingBackToBootstrapPeers
+               atomically $ putRsp Nothing
+               go rng ts peerMap'
+           else do
+               let ttl = 5 -- TTL, used as re-request interval by the governor.
+
+               (rng', !pickedPeers) <- pickPeers rng tracer peerMap' numRequested
+               traceWith tracer $ PickedPeers numRequested pickedPeers
+
+               let (plainAddrs, domains) = foldl' splitPeers (Set.empty, []) pickedPeers
+
+               domainAddrs <- doResolve domains
+
+               let (rng'', rngDomain) = split rng'
+                   pickedAddrs = snd $ foldl' pickDomainAddrs (rngDomain, plainAddrs)
+                                                       domainAddrs
+
+               atomically $ putRsp $ Just (pickedAddrs, ttl)
+               go rng'' ts peerMap'
+
+    -- Randomly pick one of the addresses returned in the DNS result.
+    pickDomainAddrs :: (StdGen, Set SockAddr)
+                    -> Set SockAddr
+                    -> (StdGen, Set SockAddr)
+    pickDomainAddrs (rng, pickedAddrs) addrs | Set.null addrs = (rng, pickedAddrs)
+    pickDomainAddrs (rng, pickedAddrs) addrs =
+        let (ix, rng') = randomR (0, Set.size addrs - 1) rng
+            !pickedAddr = Set.elemAt ix addrs in
+        (rng', Set.insert pickedAddr pickedAddrs)
+
+
+    -- Divide the picked peers form the ledger into addresses we can use directly and
+    -- domain names that we need to resolve.
+    splitPeers :: (Set SockAddr, [DomainAddress])
+               -> RelayAddress
+               -> (Set SockAddr, [DomainAddress])
+    splitPeers (addrs, domains) (RelayDomain domain) = (addrs, domain : domains)
+    splitPeers (addrs, domains) (RelayAddress ip port) =
+        let !addr = IP.toSockAddr (ip, port) in
+        (Set.insert addr addrs, domains)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -23,6 +23,7 @@ module Ouroboros.Network.PeerSelection.LedgerPeers (
     ) where
 
 
+import           Control.Exception (assert)
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM.Strict
@@ -147,11 +148,27 @@ accPoolStake pl =
 -- | Not all stake pools have valid \/ usable relay information. This means that we need to
 -- recalculate the relative stake for each pool.
 --
+-- The relative stake is scaled by the square root in order to increase the number
+-- of down stream peers smaller pools are likely to get.
+-- https://en.wikipedia.org/wiki/Penrose_method
+--
 reRelativeStake :: [(PoolStake, NonEmpty RelayAddress)]
                 -> [(PoolStake, NonEmpty RelayAddress)]
 reRelativeStake pl =
-    let total = sum $ map fst pl in
-    map (\(s, rls) -> (s / total, rls)) pl
+    let total = sum $ map (adjustment . fst) pl
+        pl' = map  (\(s, rls) -> (adjustment s / total, rls)) pl
+        total' = sum $ map fst pl' in
+    assert (total == 0 || (total' > (PoolStake $ 999999 % 1000000) &&
+            total' < (PoolStake $ 1000001 % 1000000))) pl'
+
+  where
+    -- We do loose some precisioun in the conversion. However we care about precision
+    -- in the order of 1 block per year and for that a Double is good enough.
+    adjustment :: PoolStake -> PoolStake
+    adjustment (PoolStake s) =
+      let d = fromRational s ::Double in
+      PoolStake $ toRational $ sqrt d
+
 
 -- | Try to pick n random peers.
 pickPeers :: forall m. Monad m

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -62,9 +62,9 @@ invariant (LocalRootPeers m gs) =
     -- The localRootPeers groups must not overlap with each other
  && Map.size m == sum [ Set.size g | (_, g) <- gs ]
 
-    -- Individual group targets must be zero or more and achievable given the
-    -- group sizes.
- && and [ 0 <= t && t <= Set.size g | (t, g) <- gs ]
+    -- Individual group targets must be greater than zero and achievable given
+    -- the group sizes.
+ && and [ 0 < t && t <= Set.size g | (t, g) <- gs ]
 
 
 empty :: LocalRootPeers peeraddr
@@ -110,11 +110,11 @@ fromGroups =
     -- The groups must not overlap; have achievable targets; and be non-empty.
     establishStructureInvariant !_ [] = []
     establishStructureInvariant !acc ((t, g): gs)
-      | not (Map.null g') = (t', g') : establishStructureInvariant acc' gs
-      | otherwise         =            establishStructureInvariant acc' gs
+      | t' > 0    = (t', g') : establishStructureInvariant acc' gs
+      | otherwise =            establishStructureInvariant acc' gs
       where
         !g'   = g `Map.withoutKeys` acc
-        !t'   = min (max 0 t) (Map.size g')
+        !t'   = min t (Map.size g')
         !acc' = acc <> Map.keysSet g
 
 -- | Inverse of 'fromGroups', for the subset of inputs to 'fromGroups' that

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -13,6 +13,7 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS (
     -- * DNS based provider for local root peers
     localRootPeersProvider,
     DomainAddress (..),
+    RelayAddress (..),
     IP.IP (..),
     TraceLocalRootPeers(..),
 
@@ -40,10 +41,12 @@ import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.Map.Strict as Map
 import           Data.Map.Strict (Map)
+import qualified Data.IntMap.Strict as IntMap
 import           Data.Void (Void)
 
+import           Control.Applicative ((<|>))
 import           Control.Exception (IOException)
-import           Control.Monad (when)
+import           Control.Monad (when, void)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
@@ -71,6 +74,11 @@ data DomainAddress = DomainAddress {
   }
   deriving (Show, Eq, Ord)
 
+-- | A relay can have either an IP address and a port number or
+-- a domain with a port number
+data RelayAddress = RelayDomain !DomainAddress
+                  | RelayAddress !IP.IP !Socket.PortNumber
+                  deriving (Show, Eq, Ord)
 
 -----------------------------------------------
 -- Resource
@@ -265,34 +273,113 @@ newResolverResource resolvConf = go
 --
 
 data TraceLocalRootPeers =
-       TraceLocalRootDomains [(DomainAddress, PeerAdvertise)]
+       TraceLocalRootDomains [(Int, Map RelayAddress PeerAdvertise)]
+       -- ^ 'Int' is the configured valency for the local producer groups
      | TraceLocalRootWaiting DomainAddress DiffTime
      | TraceLocalRootResult  DomainAddress [(IPv4, DNS.TTL)]
      | TraceLocalRootFailure DomainAddress DNSorIOError
        --TODO: classify DNS errors, config error vs transitory
   deriving Show
 
-
 -- |
 --
-localRootPeersProvider :: Tracer IO TraceLocalRootPeers
-                       -> TimeoutFn IO
-                       -> DNS.ResolvConf
-                       -> StrictTVar IO (Map DomainAddress (Map Socket.SockAddr PeerAdvertise))
-                       -> NonEmpty (DomainAddress, PeerAdvertise)
-                       -> IO Void
-localRootPeersProvider tracer timeout resolvConf rootPeersVar domains = do
-    traceWith tracer (TraceLocalRootDomains (NonEmpty.toList domains))
+localRootPeersProvider
+  :: Tracer IO TraceLocalRootPeers
+  -> TimeoutFn IO
+  -> DNS.ResolvConf
+  -> StrictTVar IO [(Int, Map Socket.SockAddr PeerAdvertise)]
+  -> StrictTVar IO [(Int, Map RelayAddress PeerAdvertise)]
+  -> IO Void
+localRootPeersProvider tracer
+                       timeout
+                       resolvConf
+                       rootPeersGroupsVar
+                       domainsGroupsVar = do
+  domainsGroups <- atomically $ readTVar domainsGroupsVar
+  traceWith tracer (TraceLocalRootDomains domainsGroups)
 #if !defined(mingw32_HOST_OS)
-    rr <- asyncResolverResource resolvConf
+  rr <- asyncResolverResource resolvConf
 #else
-    let rr = newResolverResource resolvConf
+  let rr = newResolverResource resolvConf
 #endif
-    withAsyncAll (map (monitorDomain rr) (NonEmpty.toList domains)) $ \asyncs ->
-      snd <$> waitAny asyncs
+  let
+      -- Flatten the local root peers groups and associate a group index to each
+      -- DomainAddress to be monitorized.
+      domains :: [(Int, DomainAddress, PeerAdvertise)]
+      domains = [ (group, domain, pa)
+                  | (group, (_, m)) <- zip [0..] domainsGroups
+                  , (RelayDomain domain, pa) <- Map.toList m ]
+      -- Since we want to preserve the number of groups, the targets, and
+      -- the addresses within each group, we fill the TVar with
+      -- a placeholder list, in order for each monitored DomainAddress to
+      -- be updated in the correct group.
+      rootPeersGroups :: [(Int, Map Socket.SockAddr PeerAdvertise)]
+      rootPeersGroups = map (\(target, m) -> (target, f m)) domainsGroups
+        where
+           f :: Map RelayAddress PeerAdvertise -> Map Socket.SockAddr PeerAdvertise
+           f =   Map.mapKeys
+                   (\k -> case k of
+                     RelayAddress ip port ->
+                       IP.toSockAddr (ip, port)
+                     _ ->
+                       error "localRootPeersProvider: impossible happend"
+                   )
+               . Map.filterWithKey
+                   (\k _ -> case k of
+                     RelayAddress {} -> True
+                     RelayDomain {}  -> False
+                   )
+
+  atomically $
+    writeTVar rootPeersGroupsVar rootPeersGroups
+
+  -- Launch DomainAddress monitoring threads and
+  -- wait for threads to return or for local config changes
+  withAsyncAll (map (monitorDomain rr) domains) $ \as ->
+    atomically $
+        void (waitAnySTM as) <|> waitConfigChanged domainsGroups
+
+  -- Recursive call to remonitor all new/updated local root peers
+  localRootPeersProvider tracer
+                         timeout
+                         resolvConf
+                         rootPeersGroupsVar
+                         domainsGroupsVar
+
   where
-    monitorDomain :: Resource DNSorIOError DNS.Resolver -> (DomainAddress, PeerAdvertise) -> IO Void
-    monitorDomain rr0 (domain@DomainAddress {daDomain, daPortNumber}, advertisePeer) =
+    waitConfigChanged :: [(Int, Map RelayAddress PeerAdvertise)] -> STM IO ()
+    waitConfigChanged dg = do
+      dg' <- readTVar domainsGroupsVar
+      check (dg /= dg')
+
+    resolveDomain
+      :: DNS.Resolver
+      -> DomainAddress
+      -> PeerAdvertise
+      -> IO (Either DNSError [((Socket.SockAddr, PeerAdvertise), DNS.TTL)])
+    resolveDomain resolver
+                  domain@DomainAddress {daDomain, daPortNumber}
+                  advertisePeer = do
+      reply <- lookupAWithTTL timeout resolvConf resolver daDomain
+      case reply of
+        Left  err -> do
+          traceWith tracer (TraceLocalRootFailure domain (DNSError err))
+          return $ Left err
+
+        Right results -> do
+          traceWith tracer (TraceLocalRootResult domain results)
+          return $ Right [ (( Socket.SockAddrInet
+                               daPortNumber
+                               (IP.toHostAddress addr)
+                           , advertisePeer)
+                           , _ttl)
+                         | (addr, _ttl) <- results ]
+
+    monitorDomain
+      :: Resource DNSorIOError DNS.Resolver
+      -> (Int, DomainAddress, PeerAdvertise)
+      -> IO Void
+    monitorDomain rr0 (group, domain, advertisePeer) =
         go rr0 0
       where
         go :: Resource DNSorIOError DNS.Resolver -> DiffTime -> IO Void
@@ -305,28 +392,25 @@ localRootPeersProvider tracer timeout resolvConf rootPeersVar domains = do
             withResource' (TraceLocalRootFailure domain `contramap` tracer)
                           (1 :| [3, 6, 9, 12])
                           rr
-          reply <- lookupAWithTTL timeout resolvConf resolver daDomain
+          reply <- resolveDomain resolver domain advertisePeer
           case reply of
-            Left  err -> do
-              traceWith tracer (TraceLocalRootFailure domain (DNSError err))
-              go rrNext (ttlForDnsError err ttl)
-
+            Left err -> go rrNext (ttlForDnsError err ttl)
             Right results -> do
-              traceWith tracer (TraceLocalRootResult domain results)
               atomically $ do
-                rootPeers <- readTVar rootPeersVar
-                let resultsMap :: Map Socket.SockAddr PeerAdvertise
-                    resultsMap = Map.fromList [ ( Socket.SockAddrInet
-                                                    daPortNumber
-                                                    (IP.toHostAddress addr)
-                                                , advertisePeer)
-                                              | (addr, _ttl) <- results ]
-                    rootPeers' :: Map DomainAddress (Map Socket.SockAddr PeerAdvertise)
-                    rootPeers' = Map.insert domain resultsMap rootPeers
+                rootPeersGroups <- readTVar rootPeersGroupsVar
+                let rootPeersGroups' = IntMap.fromList $ zip [0,1..] rootPeersGroups
+                    (target, entry)  = rootPeersGroups' IntMap.! group
+                    resultsMap       = Map.fromList (map fst results)
+                    entry'           = entry <> resultsMap
+                    newRootPeers     =
+                      IntMap.elems $
+                      IntMap.adjust (const (target, entry'))
+                                    group
+                                    rootPeersGroups'
 
                 -- Only overwrite if it changed:
-                when (Map.lookup domain rootPeers /= Just resultsMap) $
-                  writeTVar rootPeersVar rootPeers'
+                when (entry /= resultsMap) $
+                  writeTVar rootPeersGroupsVar newRootPeers
 
               go rrNext (ttlForResults (map snd results))
 
@@ -336,22 +420,24 @@ localRootPeersProvider tracer timeout resolvConf rootPeersVar domains = do
 --
 
 data TracePublicRootPeers =
-       TracePublicRootDomains [DomainAddress]
+       TracePublicRootRelayAddresses [RelayAddress]
+     | TracePublicRootDomains [DomainAddress]
      | TracePublicRootResult  DNS.Domain [(IPv4, DNS.TTL)]
      | TracePublicRootFailure DNS.Domain DNS.DNSError
        --TODO: classify DNS errors, config error vs transitory
   deriving Show
 
 -- |
---
+-- TODO track PeerAdvertise
 publicRootPeersProvider :: Tracer IO TracePublicRootPeers
                         -> TimeoutFn IO
                         -> DNS.ResolvConf
-                        -> [DomainAddress]
+                        -> StrictTVar IO [RelayAddress]
                         -> ((Int -> IO (Set Socket.SockAddr, DiffTime)) -> IO a)
                         -> IO a
-publicRootPeersProvider tracer timeout resolvConf domains action = do
-    traceWith tracer (TracePublicRootDomains domains)
+publicRootPeersProvider tracer timeout resolvConf domainsVar action = do
+    domains <- atomically $ readTVar domainsVar
+    traceWith tracer (TracePublicRootRelayAddresses domains)
 #if !defined(mingw32_HOST_OS)
     rr <- resolverResource resolvConf
 #else
@@ -363,6 +449,8 @@ publicRootPeersProvider tracer timeout resolvConf domains action = do
     requestPublicRootPeers :: StrictTVar IO (Resource DNSorIOError DNS.Resolver)
                            -> Int -> IO (Set Socket.SockAddr, DiffTime)
     requestPublicRootPeers resourceVar _numRequested = do
+        domains <- atomically $ readTVar domainsVar
+        traceWith tracer (TracePublicRootRelayAddresses domains)
         rr <- atomically $ readTVar resourceVar
         (er, rr') <- withResource rr
         atomically $ writeTVar resourceVar rr'
@@ -372,7 +460,7 @@ publicRootPeersProvider tracer timeout resolvConf domains action = do
           Right resolver -> do
             let lookups =
                   [ (,) domain <$> lookupAWithTTL timeout resolvConf resolver (daDomain domain)
-                  |  domain <- domains ]
+                  | RelayDomain domain <- domains ]
             -- The timeouts here are handled by the 'lookupAWithTTL'. They're
             -- configured via the DNS.ResolvConf resolvTimeout field and defaults
             -- to 3 sec.
@@ -386,7 +474,9 @@ publicRootPeersProvider tracer timeout resolvConf domains action = do
                             | (DomainAddress {daPortNumber}, Right ipttls) <- results
                             , (ip, ipttl) <- ipttls
                             ]
-                !ips      = Set.fromList  (map fst successes)
+                !domainsIps = [ IP.toSockAddr (ip, port)
+                              | RelayAddress ip port <- domains ]
+                !ips      = Set.fromList  (map fst successes ++ domainsIps)
                 !ttl      = ttlForResults (map snd successes)
             -- If all the lookups failed we'll return an empty set with a minimum
             -- TTL, and the governor will invoke its exponential backoff.
@@ -512,7 +602,6 @@ withAsyncAll xs0 action = go [] xs0
   where
     go as []     = action as
     go as (x:xs) = withAsync x (\a -> go (a:as) xs)
-
 
 ---------------------------------------------
 -- Examples

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -3,14 +3,19 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
 
---  'resolverResource' and 'asyncResolverResource' are not used when compiled
---  on @Windows@
-{-# OPTIONS_GHC -Wno-unused-top-binds #-}
-
+{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 module Ouroboros.Network.PeerSelection.RootPeersDNS (
+    -- * DNS based actions for local and public root providers
+    DNSActions (..),
+
+    -- * DNS resolver IO auxiliar functions
+    constantResource,
+    -- ** DNSActions IO
+    ioDNSActions,
+
     -- * DNS based provider for local root peers
     localRootPeersProvider,
     DomainAddress (..),
@@ -38,7 +43,6 @@ import           Data.Aeson
 import           Data.Word (Word32)
 import           Data.List (foldl')
 import           Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.Map.Strict as Map
@@ -52,7 +56,6 @@ import           Text.Read (readMaybe)
 import           Data.Void (Void)
 
 import           Control.Applicative ((<|>))
-import           Control.Exception (IOException)
 import           Control.Monad (when, void)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM.Strict
@@ -61,16 +64,22 @@ import           Control.Monad.Class.MonadTimer hiding (timeout)
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer (Tracer(..), contramap, traceWith)
 
-import           System.Directory (getModificationTime)
 
 import           Data.IP (IPv4)
 import qualified Data.IP as IP
-import           Network.DNS (DNSError)
 import qualified Network.DNS as DNS
 import qualified Network.Socket as Socket
 import           Network.Mux.Timeout
 
 import           Ouroboros.Network.PeerSelection.Types
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
+                 ( DNSorIOError (..)
+                 , DNSActions (..)
+                 , Resource (..)
+                 , ioDNSActions
+                 , constantResource
+                 , withResource'
+                 )
 
 -- | A product of a 'DNS.Domain' and 'Socket.PortNumber'.  After resolving the
 -- domain we will use the 'Socket.PortNumber' to form 'Socket.SockAddr'.
@@ -96,6 +105,7 @@ instance ToJSON DomainAddress where
 
 -- | A relay can have either an IP address and a port number or
 -- a domain with a port number
+--
 data RelayAddress = RelayDomain !DomainAddress
                   | RelayAddress !IP.IP !Socket.PortNumber
                   deriving (Show, Eq, Ord)
@@ -128,226 +138,50 @@ toRelayAddress address port =
       Just addr -> RelayAddress addr (fromIntegral port)
 
 -----------------------------------------------
--- Resource
---
-
--- | Evolving resource; We use it to reinitialise the dns library if the
--- `/etc/resolv.conf` file was modified.
---
-data Resource err a = Resource {
-    withResource :: IO (Either err a, Resource err a)
-  }
-
--- | Like 'withResource' but retries untill success.
---
-withResource' :: Tracer IO err
-              -> NonEmpty DiffTime
-              -- ^ delays between each re-try
-              -> Resource err a
-              -> IO (a, Resource err a)
-withResource' tracer delays0 = go delays0
-  where
-    dropHead :: NonEmpty a -> NonEmpty a
-    dropHead as@(_ :| [])  = as
-    dropHead (_ :| a : as) = a :| as
-
-    go !delays resource = do
-      er <- withResource resource
-      case er of
-        (Left err, resource') -> do
-          traceWith tracer err
-          threadDelay (NonEmpty.head delays)
-          withResource' tracer (dropHead delays) resource'
-        (Right r, resource') ->
-          pure (r, resource')
-
-
-constantResource :: a -> Resource err a
-constantResource a = Resource (pure (Right a, constantResource a))
-
-data DNSorIOError
-    = DNSError !DNSError
-    | IOError  !IOException
-  deriving Show
-
-instance Exception DNSorIOError where
-
-
--- | Strict version of 'Maybe' adjusted to the needs ot
--- 'asyncResolverResource'.
---
-data TimedResolver
-    = TimedResolver !DNS.Resolver !UTCTime
-    | NoResolver
-
--- |
---
--- TODO: it could be useful for `publicRootPeersProvider`.
---
-resolverResource :: DNS.ResolvConf -> IO (Resource DNSorIOError DNS.Resolver)
-resolverResource resolvConf = do
-    rs <- DNS.makeResolvSeed resolvConf
-    case DNS.resolvInfo resolvConf of
-      DNS.RCFilePath filePath ->
-        pure $ go filePath NoResolver
-
-      _ -> DNS.withResolver rs (pure . constantResource)
-
-  where
-    handlers :: FilePath
-             -> TimedResolver
-             -> [Handler IO
-                  ( Either DNSorIOError DNS.Resolver
-                  , Resource DNSorIOError DNS.Resolver)]
-    handlers filePath tr =
-      [ Handler $
-          \(err :: IOException) ->
-            pure (Left (IOError err), go filePath tr)
-      , Handler $
-          \(err :: DNS.DNSError) ->
-              pure (Left (DNSError err), go filePath tr)
-      ]
-
-    go :: FilePath
-       -> TimedResolver
-       -> Resource DNSorIOError DNS.Resolver
-    go filePath tr@NoResolver = Resource $
-      do
-        modTime <- getModificationTime filePath
-        rs <- DNS.makeResolvSeed resolvConf
-        DNS.withResolver rs
-          (\resolver ->
-            pure (Right resolver, go filePath (TimedResolver resolver modTime)))
-      `catches` handlers filePath tr
-
-    go filePath tr@(TimedResolver resolver modTime) = Resource $
-      do
-        modTime' <- getModificationTime filePath
-        if modTime' <= modTime
-          then pure (Right resolver, go filePath (TimedResolver resolver modTime))
-          else do
-            rs <- DNS.makeResolvSeed resolvConf
-            DNS.withResolver rs
-              (\resolver' ->
-                pure (Right resolver', go filePath (TimedResolver resolver' modTime')))
-      `catches` handlers filePath tr
-
-
--- | `Resource` which passes the 'DNS.Resolver' through a 'StrictTVar'.  Better
--- than 'resolverResource' when using in multiple threads.
---
-asyncResolverResource :: DNS.ResolvConf -> IO (Resource DNSorIOError DNS.Resolver)
-asyncResolverResource resolvConf =
-    case DNS.resolvInfo resolvConf of
-      DNS.RCFilePath filePath -> do
-        resourceVar <- newTVarIO NoResolver
-        pure $ go filePath resourceVar
-      _ -> do
-        rs <- DNS.makeResolvSeed resolvConf
-        DNS.withResolver rs (pure . constantResource)
-  where
-    handlers :: FilePath -> StrictTVar IO TimedResolver
-             -> [Handler IO
-                  ( Either DNSorIOError DNS.Resolver
-                  , Resource DNSorIOError DNS.Resolver)]
-    handlers filePath resourceVar =
-      [ Handler $
-          \(err :: IOException) ->
-            pure (Left (IOError err), go filePath resourceVar)
-      , Handler $
-          \(err :: DNS.DNSError) ->
-            pure (Left (DNSError err), go filePath resourceVar)
-      ]
-
-    go :: FilePath -> StrictTVar IO TimedResolver
-       -> Resource DNSorIOError DNS.Resolver
-    go filePath resourceVar = Resource $ do
-      r <- atomically (readTVar resourceVar)
-      case r of
-        NoResolver ->
-          do
-            modTime <- getModificationTime filePath
-            rs <- DNS.makeResolvSeed resolvConf
-            DNS.withResolver rs $ \resolver -> do
-              atomically (writeTVar resourceVar (TimedResolver resolver modTime))
-              pure (Right resolver, go filePath resourceVar)
-          `catches` handlers filePath resourceVar
-
-        TimedResolver resolver modTime ->
-          do
-            modTime' <- getModificationTime filePath
-            if modTime' <= modTime
-                then pure (Right resolver, go filePath resourceVar)
-                else do
-                  rs <- DNS.makeResolvSeed resolvConf
-                  DNS.withResolver rs $ \resolver' -> do
-                    atomically (writeTVar resourceVar (TimedResolver resolver' modTime'))
-                    pure (Right resolver', go filePath resourceVar)
-          `catches` handlers filePath resourceVar
-
-
-#if defined(mingw32_HOST_OS)
--- | Returns a newly intiatialised 'DNS.Resolver' at each step;  This is only
--- for Windows, where we don't have a way to check that the network
--- configuration has changed.  On /Windows/ the 'dns' library is using
--- @GetNetworkParams@ win32 api call to get the list of default dns servers.
---
-newResolverResource :: DNS.ResolvConf -> Resource DNSorIOError DNS.Resolver
-newResolverResource resolvConf = go
-    where
-      go = Resource $
-        do
-          rs <- DNS.makeResolvSeed resolvConf
-          DNS.withResolver rs $ \resolver -> pure (Right resolver, go)
-        `catches` handlers
-
-      handlers :: [Handler IO
-                    ( Either DNSorIOError DNS.Resolver
-                    , Resource DNSorIOError DNS.Resolver)]
-      handlers =
-        [ Handler $
-            \(err :: IOException) ->
-              pure (Left (IOError err), go)
-        , Handler $
-            \(err :: DNS.DNSError) ->
-              pure (Left (DNSError err), go)
-        ]
-#endif
-
-
------------------------------------------------
 -- local root peer set provider based on DNS
 --
 
-data TraceLocalRootPeers =
+data TraceLocalRootPeers exception =
        TraceLocalRootDomains [(Int, Map RelayAddress PeerAdvertise)]
        -- ^ 'Int' is the configured valency for the local producer groups
      | TraceLocalRootWaiting DomainAddress DiffTime
      | TraceLocalRootResult  DomainAddress [(IPv4, DNS.TTL)]
-     | TraceLocalRootFailure DomainAddress DNSorIOError
+     | TraceLocalRootGroups  (Seq (Int, Map Socket.SockAddr PeerAdvertise))
+       -- ^ This traces the results of the local root peer provider
+     | TraceLocalRootFailure DomainAddress (DNSorIOError exception)
        --TODO: classify DNS errors, config error vs transitory
   deriving Show
 
 -- |
 --
 localRootPeersProvider
-  :: Tracer IO TraceLocalRootPeers
-  -> TimeoutFn IO
+  :: forall m resolver exception.
+    (MonadAsync m, MonadDelay m)
+  => Tracer m (TraceLocalRootPeers exception)
+  -> TimeoutFn m
   -> DNS.ResolvConf
-  -> StrictTVar IO (Seq (Int, Map Socket.SockAddr PeerAdvertise))
-  -> STM IO [(Int, Map RelayAddress PeerAdvertise)]
-  -> IO Void
+  -> StrictTVar m (Seq (Int, Map Socket.SockAddr PeerAdvertise))
+  -> STM m [(Int, Map RelayAddress PeerAdvertise)]
+  -> DNSActions resolver exception m
+  -> m Void
 localRootPeersProvider tracer
                        timeout
                        resolvConf
                        rootPeersGroupsVar
-                       readDomainsGroups = do
+                       readDomainsGroups
+                       dnsA@DNSActions {
+                        dnsAsyncResolverResource,
+#if defined(mingw32_HOST_OS)
+                        dnsNewResolverResource,
+#endif
+                        dnsLookupAWithTTL
+                       } = do
   domainsGroups <- atomically readDomainsGroups
   traceWith tracer (TraceLocalRootDomains domainsGroups)
 #if !defined(mingw32_HOST_OS)
-  rr <- asyncResolverResource resolvConf
+  rr <- dnsAsyncResolverResource resolvConf
 #else
-  let rr = newResolverResource resolvConf
+  let rr = dnsNewResolverResource resolvConf
 #endif
   let
       -- Flatten the local root peers groups and associate its index to each
@@ -363,15 +197,18 @@ localRootPeersProvider tracer
       -- a placeholder list, in order for each monitored DomainAddress to
       -- be updated in the correct group.
       rootPeersGroups :: Seq (Int, Map Socket.SockAddr PeerAdvertise)
-      rootPeersGroups = Seq.fromList $ map (\(target, m) -> (target, f m)) domainsGroups
+      rootPeersGroups =
+        Seq.fromList
+          $ map (\(target, m) -> (target, f m)) domainsGroups
         where
-           f :: Map RelayAddress PeerAdvertise -> Map Socket.SockAddr PeerAdvertise
+           f :: Map RelayAddress PeerAdvertise
+             -> Map Socket.SockAddr PeerAdvertise
            f =   Map.mapKeys
                    (\k -> case k of
                      RelayAddress ip port ->
                        IP.toSockAddr (ip, port)
                      _ ->
-                       error "localRootPeersProvider: impossible happend"
+                       error "localRootPeersProvider: impossible happened"
                    )
                . Map.filterWithKey
                    (\k _ -> case k of
@@ -394,22 +231,23 @@ localRootPeersProvider tracer
                          resolvConf
                          rootPeersGroupsVar
                          readDomainsGroups
+                         dnsA
 
   where
-    waitConfigChanged :: [(Int, Map RelayAddress PeerAdvertise)] -> STM IO ()
+    waitConfigChanged :: [(Int, Map RelayAddress PeerAdvertise)] -> STM m ()
     waitConfigChanged dg = do
       dg' <- readDomainsGroups
       check (dg /= dg')
 
     resolveDomain
-      :: DNS.Resolver
+      :: resolver
       -> DomainAddress
       -> PeerAdvertise
-      -> IO (Either DNSError [((Socket.SockAddr, PeerAdvertise), DNS.TTL)])
+      -> m (Either DNS.DNSError [((Socket.SockAddr, PeerAdvertise), DNS.TTL)])
     resolveDomain resolver
                   domain@DomainAddress {daDomain, daPortNumber}
                   advertisePeer = do
-      reply <- lookupAWithTTL timeout resolvConf resolver daDomain
+      reply <- dnsLookupAWithTTL timeout resolvConf resolver daDomain
       case reply of
         Left  err -> do
           traceWith tracer (TraceLocalRootFailure domain (DNSError err))
@@ -425,13 +263,13 @@ localRootPeersProvider tracer
                          | (addr, _ttl) <- results ]
 
     monitorDomain
-      :: Resource DNSorIOError DNS.Resolver
+      :: Resource m (DNSorIOError exception) resolver
       -> (Int, DomainAddress, PeerAdvertise)
-      -> IO Void
+      -> m Void
     monitorDomain rr0 (index, domain, advertisePeer) =
         go rr0 0
       where
-        go :: Resource DNSorIOError DNS.Resolver -> DiffTime -> IO Void
+        go :: Resource m (DNSorIOError exception) resolver -> DiffTime -> m Void
         go !rr !ttl = do
           when (ttl > 0) $ do
             traceWith tracer (TraceLocalRootWaiting domain ttl)
@@ -455,6 +293,12 @@ localRootPeersProvider tracer
                                  (target, entry')
                                  rootPeersGroups
 
+                    -- | Return temporary tracer to trace LocalRootGroups
+                    -- result, since we can not use our 'tracer' inside the
+                    -- 'STM m' action.
+                    tmpTracer =
+                      contramap (const $ TraceLocalRootGroups rootPeersGroups')
+                                tracer
                 -- Only overwrite if it changed:
                 when (entry /= resultsMap) $
                   writeTVar rootPeersGroupsVar rootPeersGroups'
@@ -476,25 +320,43 @@ data TracePublicRootPeers =
 
 -- |
 -- TODO track PeerAdvertise
-publicRootPeersProvider :: Tracer IO TracePublicRootPeers
-                        -> TimeoutFn IO
-                        -> DNS.ResolvConf
-                        -> STM IO [RelayAddress]
-                        -> ((Int -> IO (Set Socket.SockAddr, DiffTime)) -> IO a)
-                        -> IO a
-publicRootPeersProvider tracer timeout resolvConf readDomains action = do
+--
+publicRootPeersProvider
+  :: forall resolver exception a m.
+     (MonadThrow m, MonadAsync m, Exception exception)
+  => Tracer m TracePublicRootPeers
+  -> TimeoutFn m
+  -> DNS.ResolvConf
+  -> STM m [RelayAddress]
+  -> DNSActions resolver exception m
+  -> ((Int -> m (Set Socket.SockAddr, DiffTime)) -> m a)
+  -> m a
+publicRootPeersProvider tracer
+                        timeout
+                        resolvConf
+                        readDomains
+                        DNSActions {
+                          dnsResolverResource,
+#if defined(mingw32_HOST_OS)
+                          dnsNewResolverResource,
+#endif
+                          dnsLookupAWithTTL
+                        }
+                        action = do
     domains <- atomically readDomains
     traceWith tracer (TracePublicRootRelayAddresses domains)
 #if !defined(mingw32_HOST_OS)
-    rr <- resolverResource resolvConf
+    rr <- dnsResolverResource resolvConf
 #else
-    let rr = newResolverResource resolvConf
+    let rr = dnsNewResolverResource resolvConf
 #endif
     resourceVar <- newTVarIO rr
     action (requestPublicRootPeers resourceVar)
   where
-    requestPublicRootPeers :: StrictTVar IO (Resource DNSorIOError DNS.Resolver)
-                           -> Int -> IO (Set Socket.SockAddr, DiffTime)
+    requestPublicRootPeers
+      :: StrictTVar m (Resource m (DNSorIOError exception) resolver)
+      -> Int
+      -> m (Set Socket.SockAddr, DiffTime)
     requestPublicRootPeers resourceVar _numRequested = do
         domains <- atomically readDomains
         traceWith tracer (TracePublicRootRelayAddresses domains)
@@ -506,7 +368,12 @@ publicRootPeersProvider tracer timeout resolvConf readDomains action = do
           Left (IOError  err) -> throwIO err
           Right resolver -> do
             let lookups =
-                  [ (,) domain <$> lookupAWithTTL timeout resolvConf resolver (daDomain domain)
+                  [ (,) domain
+                      <$> dnsLookupAWithTTL
+                            timeout
+                            resolvConf
+                            resolver
+                            (daDomain domain)
                   | RelayDomain domain <- domains ]
             -- The timeouts here are handled by the 'lookupAWithTTL'. They're
             -- configured via the DNS.ResolvConf resolvTimeout field and defaults
@@ -517,8 +384,11 @@ publicRootPeersProvider tracer timeout resolvConf readDomains action = do
                   Left  dnserr -> TracePublicRootFailure daDomain dnserr
                   Right ipttls -> TracePublicRootResult  daDomain ipttls
               | (DomainAddress {daDomain}, result) <- results ]
-            let successes = [ (Socket.SockAddrInet daPortNumber (IP.toHostAddress ip), ipttl)
-                            | (DomainAddress {daPortNumber}, Right ipttls) <- results
+            let successes = [ ( Socket.SockAddrInet daPortNumber
+                                                    (IP.toHostAddress ip)
+                              , ipttl)
+                            | ( DomainAddress {daPortNumber}
+                              , Right ipttls) <- results
                             , (ip, ipttl) <- ipttls
                             ]
                 !domainsIps = [ IP.toSockAddr (ip, port)
@@ -529,25 +399,41 @@ publicRootPeersProvider tracer timeout resolvConf readDomains action = do
             -- TTL, and the governor will invoke its exponential backoff.
             return (ips, ttl)
 
--- | Provides DNS resulution functionality.
+-- | Provides DNS resolution functionality.
 --
-resolveDomainAddresses :: Tracer IO TracePublicRootPeers
-                       -> TimeoutFn IO
-                       -> DNS.ResolvConf
-                       -> [DomainAddress]
-                       -> IO (Map DomainAddress (Set Socket.SockAddr))
-resolveDomainAddresses tracer timeout resolvConf domains = do
+resolveDomainAddresses
+  :: forall exception resolver m.
+  (MonadThrow m, MonadAsync m, Exception exception)
+  => Tracer m TracePublicRootPeers
+  -> TimeoutFn m
+  -> DNS.ResolvConf
+  -> DNSActions resolver exception m
+  -> [DomainAddress]
+  -> m (Map DomainAddress (Set Socket.SockAddr))
+resolveDomainAddresses tracer
+                       timeout
+                       resolvConf
+                       DNSActions {
+                          dnsResolverResource,
+#if defined(mingw32_HOST_OS)
+                          dnsNewResolverResource,
+#endif
+                          dnsLookupAWithTTL
+                        }
+                       domains
+                       = do
     traceWith tracer (TracePublicRootDomains domains)
 #if !defined(mingw32_HOST_OS)
-    rr <- resolverResource resolvConf
+    rr <- dnsResolverResource resolvConf
 #else
-    let rr = newResolverResource resolvConf
+    let rr = dnsNewResolverResource resolvConf
 #endif
     resourceVar <- newTVarIO rr
     requestPublicRootPeers resourceVar
   where
-    requestPublicRootPeers :: StrictTVar IO (Resource DNSorIOError DNS.Resolver)
-                           -> IO (Map DomainAddress (Set Socket.SockAddr))
+    requestPublicRootPeers
+      :: StrictTVar m (Resource m (DNSorIOError exception) resolver)
+      -> m (Map DomainAddress (Set Socket.SockAddr))
     requestPublicRootPeers resourceVar = do
         rr <- atomically $ readTVar resourceVar
         (er, rr') <- withResource rr
@@ -557,7 +443,12 @@ resolveDomainAddresses tracer timeout resolvConf domains = do
           Left (IOError  err) -> throwIO err
           Right resolver -> do
             let lookups =
-                  [ (,) domain <$> lookupAWithTTL timeout resolvConf resolver (daDomain domain)
+                  [ (,) domain
+                      <$> dnsLookupAWithTTL
+                            timeout
+                            resolvConf
+                            resolver
+                            (daDomain domain)
                   | domain <- domains ]
             -- The timeouts here are handled by the 'lookupAWithTTL'. They're
             -- configured via the DNS.ResolvConf resolvTimeout field and defaults
@@ -580,45 +471,24 @@ resolveDomainAddresses tracer timeout resolvConf domains = do
         addFn :: Maybe (Set Socket.SockAddr) -> Maybe (Set Socket.SockAddr)
         addFn Nothing =
             let ips = map fst ipsttls
-                !addrs = map (Socket.SockAddrInet (daPortNumber domain) . IP.toHostAddress) ips
+                !addrs =
+                  map ( Socket.SockAddrInet (daPortNumber domain)
+                      . IP.toHostAddress)
+                      ips
                 !addrSet = Set.fromList addrs in
             Just addrSet
         addFn (Just addrSet) =
             let ips = map fst ipsttls
-                !addrs = map (Socket.SockAddrInet (daPortNumber domain) . IP.toHostAddress) ips
+                !addrs =
+                  map ( Socket.SockAddrInet (daPortNumber domain)
+                      . IP.toHostAddress)
+                      ips
                 !addrSet' = Set.union addrSet (Set.fromList addrs) in
             Just addrSet'
-
 
 ---------------------------------------------
 -- Shared utils
 --
-
--- | Like 'DNS.lookupA' but also return the TTL for the results.
---
--- DNS library timeouts do not work reliably on Windows (#1873), hende the
--- additional timeout.
---
-lookupAWithTTL :: TimeoutFn IO
-               -> DNS.ResolvConf
-               -> DNS.Resolver
-               -> DNS.Domain
-               -> IO (Either DNS.DNSError [(IPv4, DNS.TTL)])
-lookupAWithTTL timeout resolvConf resolver domain = do
-    reply <- timeout (microsecondsAsIntToDiffTime $ DNS.resolvTimeout resolvConf)  $ DNS.lookupRaw resolver domain DNS.A
-    case reply of
-      Nothing -> return (Left DNS.TimeoutExpired)
-      Just (Left  err) -> return (Left err)
-      Just (Right ans) -> return (DNS.fromDNSMessage ans selectA)
-      --TODO: we can get the SOA TTL on NXDOMAIN here if we want to
-  where
-    selectA DNS.DNSMessage { DNS.answer } =
-      [ (addr, ttl)
-      | DNS.ResourceRecord {
-          DNS.rdata = DNS.RD_A addr,
-          DNS.rrttl = ttl
-        } <- answer
-      ]
 
 -- | Policy for TTL for positive results
 ttlForResults :: [DNS.TTL] -> DiffTime
@@ -644,7 +514,7 @@ clipTTLAbove, clipTTLBelow :: DiffTime -> DiffTime
 clipTTLBelow = max 60     -- between 1min
 clipTTLAbove = min 86400  -- and 24hrs
 
-withAsyncAll :: [IO a] -> ([Async IO a] -> IO b) -> IO b
+withAsyncAll :: MonadAsync m => [m a] -> ([Async m a] -> m b) -> m b
 withAsyncAll xs0 action = go [] xs0
   where
     go as []     = action as

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSActions.hs
@@ -1,0 +1,317 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
+  (
+    -- * DNS based actions for local and public root providers
+    DNSActions (..),
+
+    -- * DNSActions IO
+    ioDNSActions,
+
+    -- * Utils
+    -- ** Resource
+    Resource (..),
+    withResource',
+    constantResource,
+
+    -- ** Error type
+    DNSorIOError (..)
+  )
+  where
+
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
+
+import           Control.Exception (IOException)
+import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer hiding (timeout)
+import           Control.Monad.Class.MonadThrow
+import           Control.Tracer (Tracer(..), traceWith)
+
+import           System.Directory (getModificationTime)
+
+import           Data.IP (IPv4)
+import           Network.DNS (DNSError)
+import qualified Network.DNS as DNS
+import           Network.Mux.Timeout
+
+
+data DNSorIOError exception
+    = DNSError !DNSError
+    | IOError  !exception
+  deriving Show
+
+instance Exception exception => Exception (DNSorIOError exception) where
+
+-----------------------------------------------
+-- Resource
+--
+
+-- | Evolving resource; We use it to reinitialise the dns library if the
+-- `/etc/resolv.conf` file was modified.
+--
+newtype Resource m err a = Resource {
+    withResource :: m (Either err a, Resource m err a)
+  }
+
+-- | Like 'withResource' but retries untill success.
+--
+withResource' :: MonadDelay m
+              => Tracer m err
+              -> NonEmpty DiffTime
+              -- ^ delays between each re-try
+              -> Resource m err a
+              -> m (a, Resource m err a)
+withResource' tracer = go
+  where
+    dropHead :: NonEmpty a -> NonEmpty a
+    dropHead as@(_ :| [])  = as
+    dropHead (_ :| a : as) = a :| as
+
+    go !delays resource = do
+      er <- withResource resource
+      case er of
+        (Left err, resource') -> do
+          traceWith tracer err
+          threadDelay (NonEmpty.head delays)
+          withResource' tracer (dropHead delays) resource'
+        (Right r, resource') ->
+          pure (r, resource')
+
+constantResource :: Applicative m => a -> Resource m err a
+constantResource a = Resource (pure (Right a, constantResource a))
+
+-- | Strict version of 'Maybe' adjusted to the needs ot
+-- 'asyncResolverResource'.
+--
+data TimedResolver
+    = TimedResolver !DNS.Resolver !UTCTime
+    | NoResolver
+
+-- | Dictionary of DNS actions vocabulary
+--
+data DNSActions resolver exception m = DNSActions {
+
+    -- |
+    --
+    -- TODO: it could be useful for `publicRootPeersProvider`.
+    --
+    dnsResolverResource      :: DNS.ResolvConf
+                             -> m (Resource m (DNSorIOError exception) resolver),
+
+    -- | `Resource` which passes the 'DNS.Resolver' (or abstract resolver type)
+    -- through a 'StrictTVar'. Better than 'resolverResource' when using in
+    -- multiple threads.
+    --
+    dnsAsyncResolverResource :: DNS.ResolvConf
+                             -> m (Resource m (DNSorIOError exception) resolver),
+
+#if defined(mingw32_HOST_OS)
+    -- | Returns a newly intiatialised 'DNS.Resolver' (or abstract resolver type)
+    -- at each step;  This is only
+    -- for Windows, where we don't have a way to check that the network
+    -- configuration has changed.  On /Windows/ the 'dns' library is using
+    -- @GetNetworkParams@ win32 api call to get the list of default dns servers.
+    --
+    dnsNewResolverResource   :: DNS.ResolvConf
+                             -> Resource m (DNSorIOError exception) resolver,
+#endif
+
+    -- | Like 'DNS.lookupA' but also return the TTL for the results.
+    --
+    -- DNS library timeouts do not work reliably on Windows (#1873), hence the
+    -- additional timeout.
+    --
+    dnsLookupAWithTTL        :: TimeoutFn m
+                             -> DNS.ResolvConf
+                             -> resolver
+                             -> DNS.Domain
+                             -> m (Either DNS.DNSError [(IPv4, DNS.TTL)])
+  }
+
+
+
+
+-- |
+--
+-- TODO: it could be useful for `publicRootPeersProvider`.
+--
+resolverResource :: DNS.ResolvConf
+                 -> IO (Resource IO (DNSorIOError IOException) DNS.Resolver)
+resolverResource resolvConf = do
+    rs <- DNS.makeResolvSeed resolvConf
+    case DNS.resolvInfo resolvConf of
+      DNS.RCFilePath filePath ->
+        pure $ go filePath NoResolver
+
+      _ -> DNS.withResolver rs (pure . constantResource)
+
+  where
+    handlers :: FilePath
+             -> TimedResolver
+             -> [Handler IO
+                  ( Either (DNSorIOError IOException) DNS.Resolver
+                  , Resource IO (DNSorIOError IOException) DNS.Resolver)]
+    handlers filePath tr =
+      [ Handler $
+          \(err :: IOException) ->
+            pure (Left (IOError err), go filePath tr)
+      , Handler $
+          \(err :: DNS.DNSError) ->
+              pure (Left (DNSError err), go filePath tr)
+      ]
+
+    go :: FilePath
+       -> TimedResolver
+       -> Resource IO (DNSorIOError IOException) DNS.Resolver
+    go filePath tr@NoResolver = Resource $
+      do
+        modTime <- getModificationTime filePath
+        rs <- DNS.makeResolvSeed resolvConf
+        DNS.withResolver rs
+          (\resolver ->
+            pure (Right resolver, go filePath (TimedResolver resolver modTime)))
+      `catches` handlers filePath tr
+
+    go filePath tr@(TimedResolver resolver modTime) = Resource $
+      do
+        modTime' <- getModificationTime filePath
+        if modTime' <= modTime
+          then pure (Right resolver, go filePath (TimedResolver resolver modTime))
+          else do
+            rs <- DNS.makeResolvSeed resolvConf
+            DNS.withResolver rs
+              (\resolver' ->
+                pure (Right resolver', go filePath (TimedResolver resolver' modTime')))
+      `catches` handlers filePath tr
+
+
+-- | `Resource` which passes the 'DNS.Resolver' through a 'StrictTVar'.  Better
+-- than 'resolverResource' when using in multiple threads.
+--
+asyncResolverResource :: DNS.ResolvConf
+                      -> IO (Resource IO (DNSorIOError IOException)
+                                         DNS.Resolver)
+asyncResolverResource resolvConf =
+    case DNS.resolvInfo resolvConf of
+      DNS.RCFilePath filePath -> do
+        resourceVar <- newTVarIO NoResolver
+        pure $ go filePath resourceVar
+      _ -> do
+        rs <- DNS.makeResolvSeed resolvConf
+        DNS.withResolver rs (pure . constantResource)
+  where
+    handlers :: FilePath -> StrictTVar IO TimedResolver
+             -> [Handler IO
+                  ( Either (DNSorIOError IOException) DNS.Resolver
+                  , Resource IO (DNSorIOError IOException) DNS.Resolver)]
+    handlers filePath resourceVar =
+      [ Handler $
+          \(err :: IOException) ->
+            pure (Left (IOError err), go filePath resourceVar)
+      , Handler $
+          \(err :: DNS.DNSError) ->
+            pure (Left (DNSError err), go filePath resourceVar)
+      ]
+
+    go :: FilePath -> StrictTVar IO TimedResolver
+       -> Resource IO (DNSorIOError IOException) DNS.Resolver
+    go filePath resourceVar = Resource $ do
+      r <- atomically (readTVar resourceVar)
+      case r of
+        NoResolver ->
+          do
+            modTime <- getModificationTime filePath
+            rs <- DNS.makeResolvSeed resolvConf
+            DNS.withResolver rs $ \resolver -> do
+              atomically (writeTVar resourceVar (TimedResolver resolver modTime))
+              pure (Right resolver, go filePath resourceVar)
+          `catches` handlers filePath resourceVar
+
+        TimedResolver resolver modTime ->
+          do
+            modTime' <- getModificationTime filePath
+            if modTime' <= modTime
+                then pure (Right resolver, go filePath resourceVar)
+                else do
+                  rs <- DNS.makeResolvSeed resolvConf
+                  DNS.withResolver rs $ \resolver' -> do
+                    atomically (writeTVar resourceVar (TimedResolver resolver' modTime'))
+                    pure (Right resolver', go filePath resourceVar)
+          `catches` handlers filePath resourceVar
+
+
+#if defined(mingw32_HOST_OS)
+-- | Returns a newly intiatialised 'DNS.Resolver' at each step;  This is only
+-- for Windows, where we don't have a way to check that the network
+-- configuration has changed.  On /Windows/ the 'dns' library is using
+-- @GetNetworkParams@ win32 api call to get the list of default dns servers.
+--
+newResolverResource :: DNS.ResolvConf
+                    -> Resource IO (DNSorIOError IOException) DNS.Resolver
+newResolverResource resolvConf = go
+    where
+      go = Resource $
+        do
+          rs <- DNS.makeResolvSeed resolvConf
+          DNS.withResolver rs $ \resolver -> pure (Right resolver, go)
+        `catches` handlers
+
+      handlers :: [Handler IO
+                    ( Either (DNSorIOError IOException) DNS.Resolver
+                    , Resource IO (DNSorIOError IOException) DNS.Resolver)]
+      handlers =
+        [ Handler $
+            \(err :: IOException) ->
+              pure (Left (IOError err), go)
+        , Handler $
+            \(err :: DNS.DNSError) ->
+              pure (Left (DNSError err), go)
+        ]
+#endif
+
+-- | Like 'DNS.lookupA' but also return the TTL for the results.
+--
+-- DNS library timeouts do not work reliably on Windows (#1873), hence the
+-- additional timeout.
+--
+lookupAWithTTL :: TimeoutFn IO
+               -> DNS.ResolvConf
+               -> DNS.Resolver
+               -> DNS.Domain
+               -> IO (Either DNS.DNSError [(IPv4, DNS.TTL)])
+lookupAWithTTL timeout resolvConf resolver domain = do
+    reply <- timeout (microsecondsAsIntToDiffTime
+                      $ DNS.resolvTimeout resolvConf)
+                    (DNS.lookupRaw resolver domain DNS.A)
+    case reply of
+      Nothing -> return (Left DNS.TimeoutExpired)
+      Just (Left  err) -> return (Left err)
+      Just (Right ans) -> return (DNS.fromDNSMessage ans selectA)
+      --TODO: we can get the SOA TTL on NXDOMAIN here if we want to
+  where
+    selectA DNS.DNSMessage { DNS.answer } =
+      [ (addr, ttl)
+      | DNS.ResourceRecord {
+          DNS.rdata = DNS.RD_A addr,
+          DNS.rrttl = ttl
+        } <- answer
+      ]
+
+-- | Bundle of DNS Actions that runs in IO
+--
+ioDNSActions :: DNSActions DNS.Resolver IOException IO
+ioDNSActions = DNSActions {
+  dnsResolverResource = resolverResource,
+  dnsAsyncResolverResource = asyncResolverResource,
+#if defined(mingw32_HOST_OS)
+  dnsNewResolverResource = newResolverResource,
+#endif
+  dnsLookupAWithTTL = lookupAWithTTL
+  }
+

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RankNTypes       #-}
@@ -28,6 +27,7 @@ import           Network.Mux.Timeout
 
 import           Ouroboros.Network.PeerSelection.Types (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.Governor.Types
+import           Ouroboros.Network.PeerSelection.LedgerPeers
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
 
 
@@ -43,16 +43,19 @@ withPeerSelectionActions
   -> [DomainAddress]
   -- ^ public root peers
   -> PeerStateActions Socket.SockAddr peerconn IO
+  -> (NumberOfPeers -> STM IO ())
+  -> STM IO (Maybe (Set Socket.SockAddr, DiffTime))
   -> (Maybe (Async IO Void) -> PeerSelectionActions Socket.SockAddr peerconn IO -> IO a)
   -- ^ continuation, recieves a handle to the local roots peer provider thread
   -- (only if local root peers where non-empty).
   -> IO a
-withPeerSelectionActions localRootTracer publicRootTracer timeout targets _staticLocalRootPeers localRootPeers publicRootPeers peerStateActions k = do
+withPeerSelectionActions localRootTracer publicRootTracer timeout targets _staticLocalRootPeers
+  localRootPeers publicRootPeers peerStateActions reqLedgerPeers getLedgerPeers k = do
     localRootsVar <- newTVarIO Map.empty
     let peerSelectionActions = PeerSelectionActions {
             readPeerSelectionTargets = pure targets,
             readLocalRootPeers = pure [],
-            requestPublicRootPeers,
+            requestPublicRootPeers = requestLedgerPeers,
             requestPeerGossip = \_ -> pure [],
             peerStateActions
           }
@@ -68,6 +71,17 @@ withPeerSelectionActions localRootTracer publicRootTracer timeout targets _stati
             (a :| as))
           (\thread -> k (Just thread) peerSelectionActions)
   where
+    -- We first try to get poublic root peers from the ledger, but if it fails
+    -- (for example because the node hasn't synced far enough) we fall back
+    -- to using the manually configured bootstrap root peers.
+    requestLedgerPeers :: Int -> IO (Set Socket.SockAddr, DiffTime)
+    requestLedgerPeers n = do
+        atomically $ reqLedgerPeers $ NumberOfPeers $ fromIntegral n
+        peers_m <- atomically getLedgerPeers
+        case peers_m of
+             Nothing -> requestPublicRootPeers n
+             Just peers -> return peers
+
     -- For each call we re-initialise the dns library which forces reading
     -- `/etc/resolv.conf`:
     -- https://github.com/input-output-hk/cardano-node/issues/731

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RankNTypes       #-}
@@ -15,6 +16,7 @@ import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Tracer (Tracer)
+import           Control.Exception (IOException)
 
 import           Data.Map (Map)
 import           Data.Set (Set)
@@ -31,7 +33,7 @@ import           Ouroboros.Network.PeerSelection.RootPeersDNS
 
 
 withPeerSelectionActions
-  :: Tracer IO TraceLocalRootPeers
+  :: Tracer IO (TraceLocalRootPeers IOException)
   -> Tracer IO TracePublicRootPeers
   -> TimeoutFn IO
   -> STM IO PeerSelectionTargets
@@ -42,17 +44,28 @@ withPeerSelectionActions
   -> PeerStateActions Socket.SockAddr peerconn IO
   -> (NumberOfPeers -> STM IO ())
   -> STM IO (Maybe (Set Socket.SockAddr, DiffTime))
-  -> (Maybe (Async IO Void) -> PeerSelectionActions Socket.SockAddr peerconn IO -> IO a)
+  -> (Maybe (Async IO Void)
+      -> PeerSelectionActions Socket.SockAddr peerconn IO
+      -> IO a)
   -- ^ continuation, recieves a handle to the local roots peer provider thread
   -- (only if local root peers where non-empty).
   -> IO a
-withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets
-  readLocalRootPeers readPublicRootPeers peerStateActions reqLedgerPeers getLedgerPeers k = do
+withPeerSelectionActions
+  localRootTracer
+  publicRootTracer
+  timeout
+  readTargets
+  readLocalRootPeers
+  readPublicRootPeers
+  peerStateActions
+  reqLedgerPeers
+  getLedgerPeers
+  k = do
     localRootsVar <- newTVarIO mempty
     let peerSelectionActions = PeerSelectionActions {
             readPeerSelectionTargets = readTargets,
             readLocalRootPeers = toList <$> readTVar localRootsVar,
-            requestPublicRootPeers = requestLedgerPeers,
+            requestPublicRootPeers = requestLedgerPeers ioDNSActions,
             requestPeerGossip = \_ -> pure [],
             peerStateActions
           }
@@ -62,24 +75,31 @@ withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets
         timeout
         DNS.defaultResolvConf
         localRootsVar
-        readLocalRootPeers)
+        readLocalRootPeers
+        ioDNSActions)
       (\thread -> k (Just thread) peerSelectionActions)
   where
     -- We first try to get poublic root peers from the ledger, but if it fails
     -- (for example because the node hasn't synced far enough) we fall back
     -- to using the manually configured bootstrap root peers.
-    requestLedgerPeers :: Int -> IO (Set Socket.SockAddr, DiffTime)
-    requestLedgerPeers n = do
+    requestLedgerPeers :: DNSActions DNS.Resolver IOException IO
+                       -> Int -> IO (Set Socket.SockAddr, DiffTime)
+    requestLedgerPeers dnsActions n = do
         atomically $ reqLedgerPeers $ NumberOfPeers $ fromIntegral n
         peers_m <- atomically getLedgerPeers
         case peers_m of
-             Nothing -> requestPublicRootPeers n
+             Nothing -> requestPublicRootPeers dnsActions n
              Just peers -> return peers
 
     -- For each call we re-initialise the dns library which forces reading
     -- `/etc/resolv.conf`:
     -- https://github.com/input-output-hk/cardano-node/issues/731
-    requestPublicRootPeers :: Int -> IO (Set Socket.SockAddr, DiffTime)
-    requestPublicRootPeers n =
-      publicRootPeersProvider publicRootTracer timeout DNS.defaultResolvConf readPublicRootPeers ($ n)
-
+    requestPublicRootPeers :: DNSActions DNS.Resolver IOException IO
+                           -> Int -> IO (Set Socket.SockAddr, DiffTime)
+    requestPublicRootPeers dnsActions n =
+      publicRootPeersProvider publicRootTracer
+                              timeout
+                              DNS.defaultResolvConf
+                              readPublicRootPeers
+                              dnsActions
+                              ($ n)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -35,7 +35,7 @@ withPeerSelectionActions
   :: Tracer IO TraceLocalRootPeers
   -> Tracer IO TracePublicRootPeers
   -> TimeoutFn IO
-  -> PeerSelectionTargets
+  -> STM IO PeerSelectionTargets
   -> [(Int, Map RelayAddress PeerAdvertise)]
   -- ^ static local root peers
   -> [(DomainAddress, PeerAdvertise)]
@@ -49,11 +49,11 @@ withPeerSelectionActions
   -- ^ continuation, recieves a handle to the local roots peer provider thread
   -- (only if local root peers where non-empty).
   -> IO a
-withPeerSelectionActions localRootTracer publicRootTracer timeout targets _staticLocalRootPeers
+withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets _staticLocalRootPeers
   localRootPeers publicRootPeers peerStateActions reqLedgerPeers getLedgerPeers k = do
     localRootsVar <- newTVarIO Map.empty
     let peerSelectionActions = PeerSelectionActions {
-            readPeerSelectionTargets = pure targets,
+            readPeerSelectionTargets = readTargets,
             readLocalRootPeers = pure [],
             requestPublicRootPeers = requestLedgerPeers,
             requestPeerGossip = \_ -> pure [],

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -15,9 +15,7 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Tracer (Tracer)
 
-import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map (Map)
-import qualified Data.Map as Map
 import           Data.Set (Set)
 import           Data.Void (Void)
 
@@ -38,9 +36,9 @@ withPeerSelectionActions
   -> STM IO PeerSelectionTargets
   -> [(Int, Map RelayAddress PeerAdvertise)]
   -- ^ static local root peers
-  -> [(DomainAddress, PeerAdvertise)]
+  -> StrictTVar IO [(Int, Map RelayAddress PeerAdvertise)]
   -- ^ local root peers
-  -> [DomainAddress]
+  -> StrictTVar IO [RelayAddress]
   -- ^ public root peers
   -> PeerStateActions Socket.SockAddr peerconn IO
   -> (NumberOfPeers -> STM IO ())
@@ -50,8 +48,8 @@ withPeerSelectionActions
   -- (only if local root peers where non-empty).
   -> IO a
 withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets _staticLocalRootPeers
-  localRootPeers publicRootPeers peerStateActions reqLedgerPeers getLedgerPeers k = do
-    localRootsVar <- newTVarIO Map.empty
+  localRootPeersVar publicRootPeersVar peerStateActions reqLedgerPeers getLedgerPeers k = do
+    localRootsVar <- newTVarIO []
     let peerSelectionActions = PeerSelectionActions {
             readPeerSelectionTargets = readTargets,
             readLocalRootPeers = pure [],
@@ -59,17 +57,14 @@ withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets _s
             requestPeerGossip = \_ -> pure [],
             peerStateActions
           }
-    case localRootPeers of
-      []       -> k Nothing peerSelectionActions
-      (a : as) ->
-        withAsync
-          (localRootPeersProvider
-            localRootTracer
-            timeout
-            DNS.defaultResolvConf
-            localRootsVar
-            (a :| as))
-          (\thread -> k (Just thread) peerSelectionActions)
+    withAsync
+      (localRootPeersProvider
+        localRootTracer
+        timeout
+        DNS.defaultResolvConf
+        localRootsVar
+        localRootPeersVar)
+      (\thread -> k (Just thread) peerSelectionActions)
   where
     -- We first try to get poublic root peers from the ledger, but if it fails
     -- (for example because the node hasn't synced far enough) we fall back
@@ -87,5 +82,5 @@ withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets _s
     -- https://github.com/input-output-hk/cardano-node/issues/731
     requestPublicRootPeers :: Int -> IO (Set Socket.SockAddr, DiffTime)
     requestPublicRootPeers n =
-      publicRootPeersProvider publicRootTracer timeout DNS.defaultResolvConf publicRootPeers ($ n)
+      publicRootPeersProvider publicRootTracer timeout DNS.defaultResolvConf publicRootPeersVar ($ n)
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE RankNTypes       #-}
+
+module Ouroboros.Network.PeerSelection.Simple
+  ( withPeerSelectionActions
+  -- * Re-exports
+  , PeerSelectionTargets (..)
+  , PeerAdvertise (..)
+  ) where
+
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Tracer (Tracer)
+
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Set (Set)
+
+import qualified Network.DNS as DNS
+import qualified Network.Socket as Socket
+import           Network.Mux.Timeout
+
+import           Ouroboros.Network.PeerSelection.Types (PeerAdvertise (..))
+import           Ouroboros.Network.PeerSelection.Governor.Types
+import           Ouroboros.Network.PeerSelection.RootPeersDNS
+
+
+withPeerSelectionActions
+  :: Tracer IO TraceLocalRootPeers
+  -> Tracer IO TracePublicRootPeers
+  -> PeerSelectionTargets
+  -> Map Socket.SockAddr PeerAdvertise
+  -- ^ static local root peers
+  -> [(DomainAddress, PeerAdvertise)]
+  -- ^ local root peers
+  -> [DomainAddress]
+  -- ^ public root peers
+  -> PeerStateActions Socket.SockAddr peerconn IO
+  -> (Async IO () -> PeerSelectionActions Socket.SockAddr peerconn IO -> IO a)
+  -- ^ continuation, which allows to tra
+  -> IO a
+withPeerSelectionActions localRootTracer publicRootTracer targets staticLocalRootPeers localRootPeers publicRootPeers peerStateActions k = do
+    localRootsVar <- newTVarIO mempty
+    withTimeoutSerial $ \timeout ->
+      withAsync
+        (localRootPeersProvider
+          localRootTracer
+          timeout
+          DNS.defaultResolvConf
+          localRootsVar
+          localRootPeers)
+        $ \thread ->
+          k thread
+            PeerSelectionActions {
+                readPeerSelectionTargets = pure targets,
+                readLocalRootPeers = do
+                  localRoots <- readTVar localRootsVar
+                  pure [(0, foldr Map.union staticLocalRootPeers localRoots)],
+                requestPublicRootPeers = requestPublicRootPeers timeout,
+                requestPeerGossip = \_ -> pure [],
+                peerStateActions
+              }
+  where
+    -- For each call we re-initialise the dns library which forces reading
+    -- `/etc/resolv.conf`:
+    -- https://github.com/input-output-hk/cardano-node/issues/731
+    requestPublicRootPeers :: TimeoutFn IO -> Int -> IO (Set Socket.SockAddr, DiffTime)
+    requestPublicRootPeers timeout n =
+      publicRootPeersProvider publicRootTracer timeout DNS.defaultResolvConf publicRootPeers ($ n)
+

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -10,6 +10,7 @@ module Ouroboros.Network.PeerSelection.Simple
   ) where
 
 
+import           Data.Foldable (toList)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadSTM.Strict
@@ -34,11 +35,9 @@ withPeerSelectionActions
   -> Tracer IO TracePublicRootPeers
   -> TimeoutFn IO
   -> STM IO PeerSelectionTargets
-  -> [(Int, Map RelayAddress PeerAdvertise)]
-  -- ^ static local root peers
-  -> StrictTVar IO [(Int, Map RelayAddress PeerAdvertise)]
+  -> STM IO [(Int, Map RelayAddress PeerAdvertise)]
   -- ^ local root peers
-  -> StrictTVar IO [RelayAddress]
+  -> STM IO [RelayAddress]
   -- ^ public root peers
   -> PeerStateActions Socket.SockAddr peerconn IO
   -> (NumberOfPeers -> STM IO ())
@@ -47,12 +46,12 @@ withPeerSelectionActions
   -- ^ continuation, recieves a handle to the local roots peer provider thread
   -- (only if local root peers where non-empty).
   -> IO a
-withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets _staticLocalRootPeers
-  localRootPeersVar publicRootPeersVar peerStateActions reqLedgerPeers getLedgerPeers k = do
-    localRootsVar <- newTVarIO []
+withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets
+  readLocalRootPeers readPublicRootPeers peerStateActions reqLedgerPeers getLedgerPeers k = do
+    localRootsVar <- newTVarIO mempty
     let peerSelectionActions = PeerSelectionActions {
             readPeerSelectionTargets = readTargets,
-            readLocalRootPeers = pure [],
+            readLocalRootPeers = toList <$> readTVar localRootsVar,
             requestPublicRootPeers = requestLedgerPeers,
             requestPeerGossip = \_ -> pure [],
             peerStateActions
@@ -63,7 +62,7 @@ withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets _s
         timeout
         DNS.defaultResolvConf
         localRootsVar
-        localRootPeersVar)
+        readLocalRootPeers)
       (\thread -> k (Just thread) peerSelectionActions)
   where
     -- We first try to get poublic root peers from the ledger, but if it fails
@@ -82,5 +81,5 @@ withPeerSelectionActions localRootTracer publicRootTracer timeout readTargets _s
     -- https://github.com/input-output-hk/cardano-node/issues/731
     requestPublicRootPeers :: Int -> IO (Set Socket.SockAddr, DiffTime)
     requestPublicRootPeers n =
-      publicRootPeersProvider publicRootTracer timeout DNS.defaultResolvConf publicRootPeersVar ($ n)
+      publicRootPeersProvider publicRootTracer timeout DNS.defaultResolvConf readPublicRootPeers ($ n)
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -16,9 +16,11 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Tracer (Tracer)
 
+import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Set (Set)
+import           Data.Void (Void)
 
 import qualified Network.DNS as DNS
 import qualified Network.Socket as Socket
@@ -32,43 +34,44 @@ import           Ouroboros.Network.PeerSelection.RootPeersDNS
 withPeerSelectionActions
   :: Tracer IO TraceLocalRootPeers
   -> Tracer IO TracePublicRootPeers
+  -> TimeoutFn IO
   -> PeerSelectionTargets
-  -> Map Socket.SockAddr PeerAdvertise
+  -> [(Int, Map RelayAddress PeerAdvertise)]
   -- ^ static local root peers
   -> [(DomainAddress, PeerAdvertise)]
   -- ^ local root peers
   -> [DomainAddress]
   -- ^ public root peers
   -> PeerStateActions Socket.SockAddr peerconn IO
-  -> (Async IO () -> PeerSelectionActions Socket.SockAddr peerconn IO -> IO a)
-  -- ^ continuation, which allows to tra
+  -> (Maybe (Async IO Void) -> PeerSelectionActions Socket.SockAddr peerconn IO -> IO a)
+  -- ^ continuation, recieves a handle to the local roots peer provider thread
+  -- (only if local root peers where non-empty).
   -> IO a
-withPeerSelectionActions localRootTracer publicRootTracer targets staticLocalRootPeers localRootPeers publicRootPeers peerStateActions k = do
-    localRootsVar <- newTVarIO mempty
-    withTimeoutSerial $ \timeout ->
-      withAsync
-        (localRootPeersProvider
-          localRootTracer
-          timeout
-          DNS.defaultResolvConf
-          localRootsVar
-          localRootPeers)
-        $ \thread ->
-          k thread
-            PeerSelectionActions {
-                readPeerSelectionTargets = pure targets,
-                readLocalRootPeers = do
-                  localRoots <- readTVar localRootsVar
-                  pure [(0, foldr Map.union staticLocalRootPeers localRoots)],
-                requestPublicRootPeers = requestPublicRootPeers timeout,
-                requestPeerGossip = \_ -> pure [],
-                peerStateActions
-              }
+withPeerSelectionActions localRootTracer publicRootTracer timeout targets _staticLocalRootPeers localRootPeers publicRootPeers peerStateActions k = do
+    localRootsVar <- newTVarIO Map.empty
+    let peerSelectionActions = PeerSelectionActions {
+            readPeerSelectionTargets = pure targets,
+            readLocalRootPeers = pure [],
+            requestPublicRootPeers,
+            requestPeerGossip = \_ -> pure [],
+            peerStateActions
+          }
+    case localRootPeers of
+      []       -> k Nothing peerSelectionActions
+      (a : as) ->
+        withAsync
+          (localRootPeersProvider
+            localRootTracer
+            timeout
+            DNS.defaultResolvConf
+            localRootsVar
+            (a :| as))
+          (\thread -> k (Just thread) peerSelectionActions)
   where
     -- For each call we re-initialise the dns library which forces reading
     -- `/etc/resolv.conf`:
     -- https://github.com/input-output-hk/cardano-node/issues/731
-    requestPublicRootPeers :: TimeoutFn IO -> Int -> IO (Set Socket.SockAddr, DiffTime)
-    requestPublicRootPeers timeout n =
+    requestPublicRootPeers :: Int -> IO (Set Socket.SockAddr, DiffTime)
+    requestPublicRootPeers n =
       publicRootPeersProvider publicRootTracer timeout DNS.defaultResolvConf publicRootPeers ($ n)
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Ouroboros.Network.PeerSelection.Types (
     PeerSource(..),
@@ -7,6 +8,8 @@ module Ouroboros.Network.PeerSelection.Types (
   ) where
 
 import           GHC.Generics (Generic)
+import           Data.Aeson
+import           Data.Bool (bool)
 
 
 -- | Where did this peer come from? Policy functions can choose to treat
@@ -28,6 +31,13 @@ data PeerAdvertise = DoAdvertisePeer
                    | DoNotAdvertisePeer
   deriving (Eq, Show, Generic)
 
+instance FromJSON PeerAdvertise where
+  parseJSON = withBool "PeerAdvertise" $
+      return . bool DoNotAdvertisePeer DoAdvertisePeer
+
+instance ToJSON PeerAdvertise where
+  toJSON DoAdvertisePeer    = Bool True
+  toJSON DoNotAdvertisePeer = Bool False
 
 data PeerStatus =
        PeerCold

--- a/ouroboros-network/test/Data/Signal.hs
+++ b/ouroboros-network/test/Data/Signal.hs
@@ -1,0 +1,424 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.Signal (
+  -- * Events
+  Events,
+  eventsFromList,
+  eventsFromListUpToTime,
+  eventsToList,
+  selectEvents,
+
+  -- * Low level access
+  primitiveTransformEvents,
+  TS(..),
+  E(..),
+
+  -- * Signals
+  Signal,
+  -- ** Construction and conversion
+  fromChangeEvents,
+  toChangeEvents,
+  fromEvents,
+
+  -- * Simple signal transformations
+  truncateAt,
+  stable,
+  nub,
+
+  -- * Temporal operations
+  linger,
+  timeout,
+  until,
+  difference,
+
+  -- * Set-based temporal operations
+  keyedTimeout,
+  keyedLinger,
+  keyedUntil,
+
+  ) where
+
+import           Prelude hiding (until)
+
+import           Data.Maybe (maybeToList)
+import           Data.List (groupBy)
+import qualified Data.Set as Set
+import           Data.Set (Set)
+import qualified Data.OrdPSQ as PSQ
+import           Data.OrdPSQ (OrdPSQ)
+
+import           Control.Monad.Class.MonadTime (Time(..), DiffTime, addTime)
+
+
+--
+-- Time stamps and events
+--
+
+-- The instance Applicative Signal relies on merging event streams.
+-- The IO simulator's treatment of time means that we can have many
+-- events that occur at the same virtual time, though they are stil
+-- causually ordered.
+--
+-- We need these compound time stamps to be able to resolve the order
+-- of the events that have the same Time when merging event streams.
+-- The compound time stamp records the event number from the original
+-- trace, for events derivied from the original trace. For artificially
+-- constructed events, they can use small or big counters to be ordered
+-- before or after other events at the same time. Negative counters are
+-- permitted for this purpose.
+
+data TS = TS !Time !Int
+  deriving (Eq, Ord, Show)
+
+-- A single event or entry in a time series, annotated with its timestamp.
+--
+data E a = E {-# UNPACK #-} !TS a
+  deriving (Show, Functor)
+
+
+--
+-- Events
+--
+
+-- | A time-ordered trace of discrete events that occur at specific times.
+--
+-- This corresponds for example to a trace of events or observations from a
+-- simulation.
+--
+newtype Events a = Events [E a]
+  deriving (Show, Functor)
+
+-- | Construct 'Events' from a time series.
+--
+eventsFromList :: [(Time, a)] -> Events a
+eventsFromList txs =
+    Events [ E (TS t i) x
+           | ((t, x), i) <- zip txs [100, 102..] ]
+
+
+-- | Construct 'Events' from a time series.
+--
+-- The time series is truncated at (but not including) the given time. This is
+-- necessary to check properties over finite prefixes of infinite time series.
+--
+eventsFromListUpToTime :: Time -> [(Time, a)] -> Events a
+eventsFromListUpToTime horizon txs =
+    Events [ E (TS t i) x
+           | let txs' = takeWhile (\(t,_) -> t < horizon) txs
+           , ((t, x), i) <- zip txs' [100, 102..] ]
+
+
+eventsToList :: Events a -> [(Time, a)]
+eventsToList (Events txs) = [ (t, x) | E (TS t _i) x <- txs ]
+
+selectEvents :: (a -> Maybe b) -> Events a -> Events b
+selectEvents select (Events txs) =
+    Events [ E t y | E t x <- txs, y <- maybeToList (select x) ]
+
+primitiveTransformEvents :: ([E a] -> [E b]) -> Events a -> Events b
+primitiveTransformEvents f (Events txs) = Events (f txs)
+
+
+--
+-- Signals
+--
+
+-- | A signal is a time-varying value. It has a value at all times. It changes
+-- value at discrete times, i.e. it is not continuous.
+--
+data Signal a = Signal a [E a]
+  deriving (Show, Functor)
+
+instance Applicative Signal where
+    pure  x = Signal x []
+    f <*> x = mergeSignals f x
+
+mergeSignals :: Signal (a -> b) -> Signal a -> Signal b
+mergeSignals (Signal f0 fs0) (Signal x0 xs0) =
+    Signal (f0 x0) (go f0 x0 (mergeBy compareTimestamp fs0 xs0))
+  where
+    go :: (a -> b) -> a -> [MergeResult (E (a -> b)) (E a)] -> [E b]
+    go _ _ [] = []
+    go _ x (OnlyInLeft   (E t f)         : rs) = E t (f x) : go f x rs
+    go f _ (OnlyInRight          (E t x) : rs) = E t (f x) : go f x rs
+    go _ _ (InBoth       (E t f) (E _ x) : rs) = E t (f x) : go f x rs
+
+compareTimestamp :: E a -> E b -> Ordering
+compareTimestamp (E ts _) (E ts' _) = compare ts ts'
+
+
+-- | Construct a 'Signal' from an initial value and a time series of events
+-- that represent new values of the signal.
+--
+-- This only makes sense for events that sample a single time-varying value.
+--
+fromChangeEvents :: a -> Events a -> Signal a
+fromChangeEvents x (Events xs) = Signal x xs
+
+
+-- | Convert a 'Signal' into a time series of events when the signal value
+-- changes.
+--
+toChangeEvents :: Signal a -> Events a
+toChangeEvents = Events . toTimeSeries
+
+toTimeSeries :: Signal a -> [E a]
+toTimeSeries (Signal x xs) = E (TS (Time 0) 0) x : xs
+
+
+-- | Construct a 'Signal' that represents a time series of discrete events. The
+-- signal is @Just@ the event value at the time of the event, and is @Nothing@
+-- at all other times.
+--
+-- Note that this signal \"instantaneously\" takes the event value and reverts
+-- to @Nothing@ before time moves on. Therefore this kind of signal is not
+-- \"stable\" in the sense of 'stableSignal'.
+--
+fromEvents :: Events a -> Signal (Maybe a)
+fromEvents (Events txs) =
+    Signal Nothing
+           [ E (TS t i') s
+           | E (TS t i) x <- txs
+           , (i', s) <- [(i, Just x), (i+1, Nothing)]
+           ]
+
+
+-- | A signal can change value more than once at a single point of time.
+--
+-- Sometimes we are interested only in the final \"stable\" value of the signal
+-- before time moves on. This function discards the other values, keeping only
+-- the final value at each time.
+--
+stable :: Signal a -> Signal a
+stable (Signal x xs) =
+    Signal x ((map last . groupBy sameTime) xs)
+  where
+    sameTime (E (TS t _) _) (E (TS t' _) _) = t == t'
+
+-- Truncate a 'Signal' after a given time. This is typically necessary to
+-- check properties over finite prefixes of infinite signals.
+--
+truncateAt :: Time -> Signal a -> Signal a
+truncateAt horizon (Signal x txs) =
+    Signal x (takeWhile (\(E (TS t _) _) -> t < horizon) txs)
+
+
+-- | Sometimes the way a signal is constructed leads to duplicate signal values
+-- which can slow down signal processing. This tidies up the signal by
+-- eliminating the duplicates. This does not change the meaning (provided the
+-- 'Eq' instance is true equality).
+--
+nub :: Eq a => Signal a -> Signal a
+nub (Signal x0 xs0) =
+    Signal x0 (go x0 xs0)
+  where
+    go _ [] = []
+    go x (E t x' : xs)
+      | x == x'   = go x xs
+      | otherwise = E t x' : go x' xs
+
+
+-- | A linger signal remains @True@ for the given time after the underlying
+-- signal is @True@.
+--
+linger :: DiffTime
+       -> (a -> Bool)
+       -> Signal a
+       -> Signal Bool
+linger = error "TODO: Signal.linger"
+
+
+-- | Make a timeout signal, based on observing an underlying signal.
+--
+-- The timeout signal takes the value @True@ when the timeout has occurred, and
+-- @False@ otherwise.
+--
+-- The timeout is controlled by an \"arming\" function on the underlying signal.
+-- The arming function should return @True@ when the timeout should be started,
+-- and it returns the time to wait before the timeout fires. The arming function
+-- should return @False@ when the timeout should be cancelled or not started.
+--
+-- The output signal becomes @True@ when the arming function has been
+-- continuously active (i.e. returning @True@) for the given duration.
+--
+timeout :: forall a.
+           DiffTime    -- ^ timeout duration
+        -> (a -> Bool) -- ^ the arming function
+        -> Signal a
+        -> Signal Bool
+timeout d arm =
+    Signal False
+  . disarmed
+  . toTimeSeries
+  where
+    disarmed :: [E a] -> [E Bool]
+    disarmed []          = []
+    disarmed (E ts@(TS t _) x : txs)
+      | arm x     = armed (d `addTime` t) (E ts x : txs)
+      | otherwise = E ts False : disarmed txs
+
+    armed :: Time -> [E a] -> [E Bool]
+    armed !expiry [] = [E expiryTS True] where expiryTS = TS expiry 0
+
+    armed !expiry (E ts@(TS t _) x : txs)
+      | t > expiry  = E expiryTS True  : expired (E ts x : txs)
+      | not (arm x) = E ts       False : disarmed txs 
+      | t < expiry  = E ts       False : armed expiry txs
+      | otherwise   = E expiryTS True  : expired txs
+      where
+        expiryTS = TS expiry 0
+
+    expired :: [E a] -> [E Bool]
+    expired [] = []
+    expired (E t x : txs)
+      | arm x      = E t True  : expired  txs
+      | otherwise  = E t False : disarmed txs
+
+
+until :: (a -> Bool) -- ^ Start
+      -> (a -> Bool) -- ^ Stop
+      -> Signal a
+      -> Signal Bool
+until _ = error "TODO: Signal.until"
+
+
+-- | Make a signal that keeps track of recent activity, based on observing an
+-- underlying signal.
+--
+-- The underlying signal is scrutinised with the provided \"activity interest\"
+-- function that tells us if the signal value is activity of interest to track.
+-- If it is, the given key is entered into the result signal set for the given
+-- time duration. If the same activity occurs again before the duration expires
+-- then the expiry will be extended to the new deadline (it is not cumulative).
+-- The key will be removed from the result signal set when it expires.
+--
+keyedLinger :: forall a b. Ord b
+            => DiffTime
+            -> (a -> Set b)  -- ^ The activity set signal
+            -> Signal a
+            -> Signal (Set b)
+keyedLinger d activity =
+    Signal Set.empty
+  . go Set.empty PSQ.empty
+  . toTimeSeries
+  where
+    go :: Set b
+       -> OrdPSQ b Time ()
+       -> [E a]
+       -> [E (Set b)]
+    go _ _ [] = []
+
+    go lingerSet lingerPSQ (E ts@(TS t _) xs : txs)
+      | Just (x, t', _, lingerPSQ') <- PSQ.minView lingerPSQ
+      , t' < t
+      , let lingerSet' = Set.delete x lingerSet
+      = E (TS t' 0) lingerSet' : go lingerSet' lingerPSQ' (E ts xs : txs)
+
+    go lingerSet lingerPSQ (E ts@(TS t _) x : txs) =
+      let ys         = activity x
+          lingerSet' = lingerSet <> ys
+          lingerPSQ' = Set.foldl' (\s y -> PSQ.insert y t' () s) lingerPSQ ys
+          t'         = addTime d t
+       in if lingerSet' /= lingerSet
+            then E ts lingerSet' : go lingerSet' lingerPSQ' txs
+            else                   go lingerSet' lingerPSQ' txs
+
+
+keyedTimeout :: forall a b. Ord b
+             => DiffTime
+             -> (a -> Set b)  -- ^ The timeout arming set signal
+             -> Signal a
+             -> Signal (Set b)
+keyedTimeout d arm =
+    Signal Set.empty
+  . go Set.empty PSQ.empty Set.empty
+  . toTimeSeries
+  where
+    go :: Set b
+       -> OrdPSQ b Time ()
+       -> Set b
+       -> [E a]
+       -> [E (Set b)]
+    go _ _ _ [] = []
+
+    go armedSet armedPSQ timedout (E ts@(TS t _) x : txs)
+      | Just (y, t', _, armedPSQ') <- PSQ.minView armedPSQ
+      , t' < t
+      , let armedSet' = Set.delete y armedSet
+            timedout' = Set.insert y timedout
+      = E (TS t' 0) timedout' : go armedSet' armedPSQ' timedout' (E ts x : txs)
+
+    go armedSet armedPSQ timedout (E ts@(TS t _) x : txs) =
+      let armedSet' = arm x
+          armedAdd  = armedSet' Set.\\ armedSet
+          armedDel  = armedSet  Set.\\ armedSet'
+          armedPSQ' = flip (Set.foldl' (\s y -> PSQ.insert y t' () s)) armedAdd
+                    . flip (Set.foldl' (\s y -> PSQ.delete y       s)) armedDel
+                    $ armedPSQ
+          t'        = addTime d t
+          timedout' = timedout `Set.intersection` armedSet'
+       in if timedout' /= timedout
+            then E ts timedout' : go armedSet' armedPSQ' timedout' txs
+            else                  go armedSet' armedPSQ' timedout' txs
+
+
+keyedUntil :: forall a b. Ord b
+           => (a -> Set b)   -- ^ Start set signal
+           -> (a -> Set b)   -- ^ Stop set signal
+           -> (a -> Bool)    -- ^ Stop all signal
+           -> Signal a
+           -> Signal (Set b)
+keyedUntil start stop stopAll =
+    Signal Set.empty
+  . go Set.empty
+  . toTimeSeries
+  where
+
+    go :: Set b
+       -> [E a]
+       -> [E (Set b)]
+    go _ [] = []
+    go active (E t x : txs)
+       | active' /= active = E t active' : go active' txs
+       | otherwise         =               go active' txs
+      where
+        active'
+          | stopAll x = Set.empty
+          | otherwise = (active <> start x) Set.\\ stop x
+
+
+difference :: (a -> a -> b)
+           -> Signal a
+           -> Signal (Maybe b)
+difference diff (Signal x0 txs0) =
+    Signal Nothing (go x0 txs0)
+  where
+    go _ []                    = []
+    go x (E (TS t i) x' : txs) = E (TS t i)    (Just (diff x x'))
+                               : E (TS t (i+1)) Nothing
+                               : go x' txs
+
+
+
+--
+-- Utils
+--
+
+-- | Generic merging utility. For sorted input lists this is a full outer join.
+--
+mergeBy :: (a -> b -> Ordering) -> [a] -> [b] -> [MergeResult a b]
+mergeBy cmp = merge
+  where
+    merge []     ys     = [ OnlyInRight y | y <- ys]
+    merge xs     []     = [ OnlyInLeft  x | x <- xs]
+    merge (x:xs) (y:ys) =
+      case x `cmp` y of
+        GT -> OnlyInRight   y : merge (x:xs) ys
+        EQ -> InBoth      x y : merge xs     ys
+        LT -> OnlyInLeft  x   : merge xs  (y:ys)
+
+data MergeResult a b = OnlyInLeft a | InBoth a b | OnlyInRight b
+  deriving (Eq, Show)
+

--- a/ouroboros-network/test/Test/LedgerPeers.hs
+++ b/ouroboros-network/test/Test/LedgerPeers.hs
@@ -36,8 +36,8 @@ newtype ArbitraryRelayAddress = ArbitraryRelayAddress RelayAddress
 
 instance Arbitrary ArbitraryRelayAddress where
     arbitrary = do
-      ArbitraryRelayAddress <$> elements [ RelayAddressAddr (read "1.1.1.1") 1234
-               , RelayAddressDomain (DomainAddress "relay.iohk.example" 1234)
+      ArbitraryRelayAddress <$> elements [ RelayAddress (read "1.1.1.1") 1234
+               , RelayDomain (DomainAddress "relay.iohk.example" 1234)
                ]
 
 data StakePool = StakePool {
@@ -73,11 +73,11 @@ prop_pick100 :: Word16
              -> Property
 prop_pick100 seed =
     let rng = mkStdGen $ fromIntegral seed
-        sps = [ (1, RelayAddressAddr (read "1.1.1.1") 1  :| [])
-              , (0, RelayAddressAddr (read "0.0.0.0") 0  :| [])
+        sps = [ (1, RelayAddress (read "1.1.1.1") 1  :| [])
+              , (0, RelayAddress (read "0.0.0.0") 0  :| [])
               ]
         peerMap = accPoolStake sps
-        tr = (runSimTrace $ pickPeers rng verboseTracer peerMap 1) in
+        tr = (runSimTrace $ pickPeers rng verboseTracer peerMap $ NumberOfPeers 1) in
     ioProperty $ do
         tr' <- evaluateTrace tr
         case tr' of
@@ -87,7 +87,7 @@ prop_pick100 seed =
                  return $ counterexample (intercalate "\n" $ "Deadlock" : trace) False
              SimReturn (_, peers) _trace -> do
                  -- printf "Log: %s\n" (intercalate "\n" _trace)
-                 return $ peers === [ RelayAddressAddr (read "1.1.1.1") 1 ]
+                 return $ peers === [ RelayAddress (read "1.1.1.1") 1 ]
 
 -- | Veify that given at least one peer we manage to pick `count` peers.
 prop_pick :: LedgerPools
@@ -97,7 +97,7 @@ prop_pick :: LedgerPools
 prop_pick (LedgerPools lps) count seed =
     let rng = mkStdGen $ fromIntegral seed
         peerMap = accPoolStake lps
-        tr = runSimTrace (pickPeers rng verboseTracer peerMap count) in
+        tr = runSimTrace (pickPeers rng verboseTracer peerMap $ NumberOfPeers count) in
     ioProperty $ do
         tr' <- evaluateTrace tr
         case tr' of

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -297,7 +297,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers domains =
       domains $ \requestPublicRootPeers ->
 
         peerSelectionGovernor
-          tracer tracer
+          tracer tracer tracer
           actions { requestPublicRootPeers }
           policy
   where

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1591,6 +1591,12 @@ selectEnvTargets f =
 -- Live examples
 --
 
+-- | Run the 'publicRootPeersProvider' in IO with a stdout tracer to observe
+-- what it does.
+--
+-- This is a manual test that runs in IO and has to be observed to see that it
+-- is doing something sensible. It is not run automatically.
+--
 _governorFindingPublicRoots :: Int -> [DomainAddress] -> IO Void
 _governorFindingPublicRoots targetNumberOfRootPeers domains =
     withTimeoutSerial $ \timeout ->

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -381,7 +381,13 @@ envEventCredits (TraceEnvSetTargets PeerSelectionTargets {
 envEventCredits (TraceEnvPeersDemote Noop   _) = 10
 envEventCredits (TraceEnvPeersDemote ToWarm _) = 30
 envEventCredits (TraceEnvPeersDemote ToCold _) = 30
-envEventCredits (TraceEnvPeersStatus _)        = 0
+
+envEventCredits  TraceEnvPeersStatus{}         = 0
+-- These events are visible in the environment but are the result of actions
+-- initiated by the governor, hence the get no credit.
+envEventCredits  TraceEnvRootsResult{}         = 0
+envEventCredits  TraceEnvGossipRequest{}       = 0
+envEventCredits  TraceEnvGossipResult{}        = 0
 
 
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -475,13 +475,13 @@ allTraceNames =
 -- must find all the reachable ones, or if the target for the number of known
 -- peers to find is too low then it should at least find the target number.
 --
-prop_governor_gossip_1hr :: GovernorMockEnvironmentWithoutAsyncDemotion -> Property
-prop_governor_gossip_1hr (GovernorMockEnvironmentWAD env@GovernorMockEnvironment{
-                              peerGraph,
-                              localRootPeers,
-                              publicRootPeers,
-                              targets
-                            }) =
+prop_governor_gossip_1hr :: GovernorMockEnvironment -> Property
+prop_governor_gossip_1hr env@GovernorMockEnvironment {
+                               peerGraph,
+                               localRootPeers,
+                               publicRootPeers,
+                               targets
+                             } =
     let trace      = selectPeerSelectionTraceEvents $
                        runGovernorInMockEnvironment env {
                          targets = singletonScript (targets', NoDelay)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE NumericUnderscores         #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -17,12 +18,16 @@ module Test.Ouroboros.Network.PeerSelection (tests) where
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function (on)
 import           Data.List (groupBy, foldl')
-import           Data.Maybe (listToMaybe)
+import           Data.Maybe (listToMaybe, isNothing, fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Void (Void)
+
+import qualified Data.Signal as Signal
+import           Data.Signal (Signal, Events, E(E), TS(TS))
+import qualified Data.OrdPSQ as PSQ
 
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer (..))
@@ -36,6 +41,7 @@ import           Ouroboros.Network.PeerSelection.Governor hiding
 import qualified Ouroboros.Network.PeerSelection.Governor as Governor
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
+import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
 
 import           Test.Ouroboros.Network.PeerSelection.Instances
@@ -45,6 +51,7 @@ import qualified Test.Ouroboros.Network.PeerSelection.MockEnvironment
 import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Signal
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
@@ -54,14 +61,37 @@ tests =
   testGroup "Ouroboros.Network.PeerSelection"
   [ Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
-  , testGroup "governor"
+  , testGroup "safety"
     [ testProperty "has output"         prop_governor_hasoutput
     , testProperty "no failure"         prop_governor_nofail
     , testProperty "no livelock"        prop_governor_nolivelock
     , testProperty "no excess busyness" prop_governor_nobusyness
     , testProperty "event coverage"     prop_governor_trace_coverage
-    , testProperty "gossip reachable"   prop_governor_gossip_1hr
     , testProperty "connection status"  prop_governor_connstatus
+    ]
+  , testGroup "progress"
+    [ testProperty "gossip reachable"    prop_governor_gossip_1hr
+
+--  , testProperty "progresses towards public root peers target (from below)"
+--                 prop_governor_target_publicroots
+
+    , testProperty "progresses towards known peers target (from below)"
+                   prop_governor_target_known_below
+    , testProperty "progresses towards known peers target (from above)"
+                   (expectFailure prop_governor_target_known_above)
+                   --TODO: for the moment this correctly fails because it finds
+                   -- a nice corner case in the space, that we've not yet
+                   -- decided how we wish to resolve.
+
+    , testProperty "progresses towards established peers target (from below)"
+                   prop_governor_target_established_below
+    , testProperty "progresses towards established peers target (from above)"
+                   prop_governor_target_established_above
+
+    , testProperty "progresses towards active peers target (from below)"
+                   prop_governor_target_active_below
+    , testProperty "progresses towards active peers target (from above)"
+                   prop_governor_target_active_above
     ]
   ]
 
@@ -583,12 +613,979 @@ prop_governor_connstatus env =
 
 
 --
+-- Progress properties
+--
+
+-- | The main progress property for known peers: that we make progress towards
+-- the target for known peers from below. See 'prop_governor_target_known_above'
+-- for the (simpler) corresponding property for hitting the target from above.
+--
+-- Intuitively the property we want is that the governor either hits its target
+-- for the number of known peers, or gets as close as reasonably possible. The
+-- environment may be such that it prevents the governor from reaching its
+-- target, e.g. because the target is too high, or not all peers may be
+-- reachable by the gossip graph.
+--
+-- We approach this property as the conjunction of several simpler properties.
+-- We take this approach for three main reasons.
+--
+-- 1. Firstly modularity help us break down a complex problem into simpler
+--    problems. Overall this progress idea turns out to be quite subtle and
+--    tricky to express precisely in a way that actually works.
+-- 2. Secondly, modularity can give us opportunities to reuse code in other
+--    properties and we want to have progress properties for all the governor
+--    targets.
+-- 3. Thirdly, it turns out to be hard to dictate in a universal way precisely
+--    what the governor can be expected to do. It is simpler to specify looser
+--    constraints on what it must and must not do. We can then argue informally
+--    that the combination of properties must lead to the kinds of outcomes we
+--    intend.
+--
+-- We decompose the progress property into the following (informally stated)
+-- properties:
+--
+-- 1. The set of peers the governor knows about is a subset of the peers the
+--    environment has told the governor about.
+--
+--    This is a weak property since it simply says that the governor does not
+--    invent things out of thin air. We might expect that we could strengthen
+--    this property to require that the subset be maximal in some sense however
+--    such a property is violated by dynamic targets. There are also timing
+--    issues which would complicate such a strengthened property: the governor
+--    has legitimate reasons to update its internal state some time after the
+--    environment informs it about new peers.
+--
+-- 2. If the governor is below target and has the opportunity to gossip then
+--    within a bounded time it should perform a gossip with one of its known
+--    peers.
+--
+--    This is the primary progress property. It is a relatively weak property:
+--    we do not require that progress is actually made, just that opportunities
+--    for progress are taken when available. We cannot always demand actual
+--    progress since there are environments where it is not possible to make
+--    progress, even though opportunities for gossip remain available. Examples
+--    include environments where the total set of peers in the graph is less
+--    than the target for known peers.
+--
+-- 3. The governor should not gossip too frequently with any individual peer,
+--    except when the governor forgets known peers.
+--
+--    This is both useful in its own right, but it also helps to strengthen the
+--    primary property by helping to ensure that the choices of which peers to
+--    gossip with are reasonable. In the primary property we do not require that
+--    the peer the  the governor chooses to gossip with is one of the
+--    opportunities as defined by the property. We do not require this because
+--    the set of opportunities is a lower bound not an upper bound, and trying
+--    to make it a tight bound becomes complex and over-specifies behaviour.
+--    There is the danger however that the governor could appear to try to make
+--    progress by gossiping but always picking useless choices that avoid making
+--    actual progress. By requiring that the governor not gossip with any
+--    individual peer too often we can shrink the set of peers the governor can
+--    choose and thus force the governor to eventually pick other peers to
+--    gossip with, which should mean the governor eventually picks peers that
+--    can enable progress.
+--
+-- 4. When the governor does perform a gossip, within a bounded time it should
+--    include the results into its known peer set, or the known peer set should
+--    reach its target size.
+--
+--    This helps to strengthen the primary progress property by ensuring the
+--    results of gossip are used to make progress when that is possible.
+--
+-- 5. The governor should not shrink its known peer set except when it is above
+--    the target size.
+--
+--    This also helps to strengthen the second property by ensuring monotonic
+--    progress, except when we overshoot targets or when targets are reduced.
+--
+-- The overall progress argument is then an semi-formal argument, structured
+-- much like classic proofs about loops. A classic loop proof has two parts: 1.
+-- if the loop does terminate it gets the right result, and 2. it must
+-- eventually terminate because it makes progress in some measure that is
+-- bounded.
+--
+-- Of course in our setting there is no termination, but we can reach a goal
+-- and remain in a steady state until the environment changes. Our argument is
+-- that the governor makes progress to increase the size of its set of known
+-- peers until either it hits its target number of known peers, or it reaches a
+-- maximal possible set. As a corollary if the targets do not change too
+-- frequently then it will eventually hit the target or reach a maximal set.
+--
+-- Property number 1 above tells us that if we do reach our goal condition that
+-- we will have a correct result, as property 1 tells us that all the governors'
+-- known peers are ones supplied by the environment.
+--
+-- Progress from below relies on the combination of property 2, 3, 4 and 5.
+-- Property 2 tells us that we eventually do some gossip with some peer, but
+-- does not by itself establish that we make progress in a bounded measure.
+-- Property 3 gives us the bounded measure. Property 3 gives us a set of peers
+-- that we have not gossiped with recently. When the governor does gossip with
+-- a peer then it is removed from this set (but scheduled to be added back some
+-- time later). So the measure is the size of this set of peers. It is clearly
+-- bounded below by the empty set. So the combination of 2 and 3 tells us we
+-- make progress in this bounded measure, but that does not directly translate
+-- into increasing the size of the known peers set. Properties 4 and 5 tell us
+-- that progress with gossiping will eventually translate into increasing the
+-- size of the known peers set if that is possible.
+--
+-- There is one known wrinkle to this argument to do with property 3 that when
+-- the governor gossips with a peer it is removed from the tracking set however
+-- it gets added back some time later. If they get added back too soon then it
+-- would undermine the progress argument because it would break the argument
+-- about decreasing the bounded measure. This is readily solved however: we
+-- simply need to make sure the time scale for gossip frequency is relatively
+-- long, and the other progress bounds are relatively short.
+--
+prop_governor_target_known_below :: GovernorMockEnvironment -> Property
+prop_governor_target_known_below env =
+      prop_governor_target_known_1_valid_subset      env
+ .&&. prop_governor_target_known_2_opportunity_taken env
+ .&&. prop_governor_target_known_3_not_too_chatty    env
+ .&&. prop_governor_target_known_4_results_used      env
+ .&&. prop_governor_target_known_5_no_shrink_below   env
+
+
+-- | The set of peers the governor knows about is a subset of the peers the
+-- environment has told the governor about.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the accumulation of all the peers the environment has ever
+--    told the governor about, based on the environment trace.
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- Based on these signals we check:
+--
+-- * That the governor known peers is a subset of the accumulated environment
+--   known peers.
+--
+prop_governor_target_known_1_valid_subset :: GovernorMockEnvironment
+                                          -> Property
+prop_governor_target_known_1_valid_subset env =
+    let events = Signal.eventsFromListUpToTime (Time (60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envKnownPeersSig :: Signal (Set PeerAddr)
+        envKnownPeersSig =
+            environmentAllKnownPeers
+              (LocalRootPeers.keysSet (localRootPeers env))
+          . selectEnvEvents
+          $ events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        validState :: Set PeerAddr -> Set PeerAddr -> Bool
+        validState knownPeersEnv knownPeersGov =
+          knownPeersGov `Set.isSubsetOf` knownPeersEnv
+
+     in signalProperty 20 show (uncurry validState) $
+          (,) <$> envKnownPeersSig
+              <*> govKnownPeersSig
+
+
+-- | Look at the trace of events from the mock environment and produce a
+-- derived trace of the set of peers that could in principle be known by the
+-- governor at any point in time. It is maximal in the sense it is all such
+-- peers, without respect for any governor targets as limits.
+--
+-- This trace depends on what the governor actually does, it is not about what
+-- it could do. The set starts with the root peers and is extended each time
+-- the governor successfully gossips with a peer and finds new peers.
+--
+-- This trace transformer assumes the root peers do not change. It will need
+-- to be adjusted when the the mock environment is extended with dynamic root
+-- peers.
+--
+environmentAllKnownPeers :: Set PeerAddr
+                         -> Events TraceMockEnv
+                         -> Signal (Set PeerAddr)
+environmentAllKnownPeers localRootPeers =
+  --TODO: implement this as a generic signalScanl style combinator
+    Signal.stable
+  . Signal.fromChangeEvents localRootPeers
+  . Signal.primitiveTransformEvents (go localRootPeers)
+  where
+    go :: Set PeerAddr -> [E TraceMockEnv] -> [E (Set PeerAddr)]
+    go !_ [] = []
+
+    go !known (E t (TraceEnvRootsResult peeraddrs) : es)
+      | let known' = Set.union known (Set.fromList peeraddrs)
+      , Set.size known' > Set.size known
+      = E t known' : go known' es
+
+    go !known (E t (TraceEnvGossipResult _ peeraddrs) : es)
+      | let known' = Set.union known (Set.fromList peeraddrs)
+      , Set.size known' > Set.size known
+      = E t known' : go known' es
+
+    go !known (_ : es) = go known es
+
+
+-- | If the governor is below target and has the opportunity to gossip then
+-- within a bounded time it should perform a gossip with one of its known peers.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the target for known peers from the environment
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. A signal of the set of peers with which the governor has gossiped
+--    recently, based on the requests to the environment
+--
+-- 4. Based on 2 and 3, a signal of the set of gossip opportunities: the
+--    current known peers that are not in the recent gossip set.
+--
+-- 5. A signal of the environment gossip request events.
+--
+-- 6. Based on 1, 2, 4 and 5, a signal that becomes False if for 30 seconds:
+--    the number of known peers is below target; the set of opportunities is
+--    non empty; and no gossip request event has occurred.
+--
+-- Based on these signals we check:
+--
+-- * That the signal 6 remains True at all times.
+--
+prop_governor_target_known_2_opportunity_taken :: GovernorMockEnvironment
+                                               -> Property
+prop_governor_target_known_2_opportunity_taken env =
+
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfKnownPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        envGossipUnavailableSig :: Signal (Set PeerAddr)
+        envGossipUnavailableSig =
+            Signal.keyedLinger
+              -- peers are unavailable for gossip for at least an
+              -- hour after each gossip interaction
+              (60 * 60)
+              (maybe Set.empty Set.singleton)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TraceEnvGossipRequest peer _ -> Just peer
+                     _                            -> Nothing)
+          . selectEnvEvents
+          $ events
+
+        -- We define the governor's gossip opportunities at any point in time
+        -- to be the governor's set of known peers, less the ones we can see
+        -- that it has gossiped with recently.
+        --
+        gossipOpportunitiesSig :: Signal (Set PeerAddr)
+        gossipOpportunitiesSig =
+          (Set.\\) <$> govKnownPeersSig <*> envGossipUnavailableSig
+
+        -- Note that we only require that the governor try to gossip, it does
+        -- not have to succeed.
+        envGossipsEventsAsSig :: Signal (Maybe PeerAddr)
+        envGossipsEventsAsSig =
+            Signal.fromEvents
+          . Signal.selectEvents
+              (\case TraceEnvGossipRequest addr _ -> Just addr
+                     _                            -> Nothing)
+          . selectEnvEvents
+          $ events
+
+        -- The signal of all the things of interest for this property.
+        -- This is used to compute the final predicate, and is also what
+        -- we want to report if there is a property violation.
+        combinedSig :: Signal (Int,
+                               Set PeerAddr,
+                               Set PeerAddr,
+                               Maybe PeerAddr)
+        combinedSig =
+          (,,,) <$> envTargetsSig
+                <*> govKnownPeersSig
+                <*> gossipOpportunitiesSig
+                <*> envGossipsEventsAsSig
+
+        -- This is the ultimate predicate signal
+        gossipOpportunitiesOkSig :: Signal Bool
+        gossipOpportunitiesOkSig =
+          Signal.truncateAt (Time (60 * 60 * 10)) $
+          governorEventuallyTakesGossipOpportunities combinedSig
+
+     in counterexample
+          "Signal key: (target, known peers, opportunities, gossip event)" $
+
+        -- Check the predicate signal but for failures report the input signal
+        signalProperty 20 (show . snd) fst $
+          (,) <$> gossipOpportunitiesOkSig
+              <*> combinedSig
+
+
+governorEventuallyTakesGossipOpportunities
+  :: Signal (Int, Set PeerAddr, Set PeerAddr, Maybe PeerAddr)
+  -> Signal Bool
+
+governorEventuallyTakesGossipOpportunities =
+    -- Time out and fail after 30 seconds if we enter and remain in a bad state
+    fmap not
+  . Signal.timeout timeLimit badState
+  where
+    timeLimit :: DiffTime
+    timeLimit = 30
+
+    badState (target, govKnownPeers, gossipOpportunities, gossipEvent) =
+
+        -- A bad state is one where we are below target;
+        Set.size govKnownPeers < target
+
+        -- where we do have opportunities; and
+     && not (Set.null gossipOpportunities)
+
+        -- are not performing an action to take the opportunity.
+     && isNothing gossipEvent
+
+        -- Note that if a gossip does take place, we do /not/ require the gossip
+        -- target to be a member of the gossipOpportunities. This is because
+        -- the gossip opportunities set is a lower bound not an upper bound.
+        -- There is a separate property to check that we do not gossip too
+        -- frequently with any individual peer.
+
+
+
+-- | The governor should not gossip too frequently with any individual peer,
+-- except when the governor forgets known peers.
+--
+-- We derive a number of signals:
+--
+-- Based on these signals we check:
+--
+prop_governor_target_known_3_not_too_chatty :: GovernorMockEnvironment
+                                            -> Property
+prop_governor_target_known_3_not_too_chatty env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        gossipOk Nothing      _           = True
+        gossipOk (Just peers) unavailable =
+          Set.null (peers `Set.intersection` unavailable)
+
+     in signalProperty 20 show (uncurry gossipOk) $
+          recentGossipActivity 3600 events
+
+
+recentGossipActivity :: DiffTime
+                     -> Events TestTraceEvent
+                     -> Signal (Maybe (Set PeerAddr), Set PeerAddr)
+recentGossipActivity d =
+    Signal.fromChangeEvents (Nothing, Set.empty)
+  . Signal.primitiveTransformEvents (go Set.empty PSQ.empty)
+  where
+    go :: Set PeerAddr
+       -> PSQ.OrdPSQ PeerAddr Time ()
+       -> [E TestTraceEvent]
+       -> [E (Maybe (Set PeerAddr), Set PeerAddr)]
+    go !recentSet !recentPSQ txs@(E (TS t _) _ : _)
+      | Just (k, t', _, recentPSQ') <- PSQ.minView recentPSQ
+      , t' <= t
+      , let recentSet' = Set.delete k recentSet
+      = E (TS t' 0) (Nothing, recentSet')
+      : go recentSet' recentPSQ' txs
+
+    -- When we see a gossip request we add it to the recent set and schedule
+    -- it to be removed again at time d+t. We arrange for the change in the
+    -- recent set to happen after the gossip event.
+    go !recentSet !recentPSQ
+        (E (TS t i) (GovernorEvent (TraceGossipRequests _ _ _ addrs)) : txs) =
+      let recentSet' = recentSet <> addrs
+          recentPSQ' = foldl' (\q a -> PSQ.insert a t' () q) recentPSQ addrs
+          t'         = d `addTime` t
+       in E (TS t i)     (Just addrs, recentSet)
+        : E (TS t (i+1)) (Nothing, recentSet') -- updated in next change at same time
+        : go recentSet' recentPSQ' txs
+
+    -- When the governor is forced to forget known peers, we drop it from
+    -- the recent activity tracking, which means if it is added back again
+    -- later then we can gossip with it again earlier than the normal limit.
+    --
+    -- Alternatively we could track this more coarsely by dropping all tracking
+    -- when the targets are adjusted downwards, but we use small target
+    -- adjustments to perform churn.
+    --
+    -- There is a separate property to check that the governor does not forget
+    -- peers unnecessarily.
+    --
+    go !recentSet !recentPSQ
+        (E t (GovernorEvent (TraceForgetColdPeers _ _ addrs)) : txs) =
+      let recentSet' = foldl' (flip Set.delete) recentSet addrs
+          recentPSQ' = foldl' (flip PSQ.delete) recentPSQ addrs
+       in E t (Nothing, recentSet')
+        : go recentSet' recentPSQ' txs
+
+    go !recentSet !recentPSQ (_ : txs) =
+      go recentSet recentPSQ txs
+
+    go !_ !_ [] = []
+
+
+-- | When the governor does perform a gossip, within a bounded time it should
+-- include the results into its known peer set, or the known peer set should
+-- reach its target size.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the target for known peers from the environment
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. A signal of the environment gossip result events, as the set of results
+--    at any point in time.
+--
+-- 4. Based on 1, 2 and 3, a signal that tracks a set of peers that we have
+--    gossiped with, such that the peers remain in the set until either they
+--    appear in the governor known peers set or until the known peer set
+--    reaches its target size.
+--
+-- 5. Based on 4, a signal of the subset of elements that have been a member
+--    continuously for at least X seconds duration.
+--
+-- Based on these signals we assert:
+--
+-- * That the signal 4 above is always empty.
+--
+prop_governor_target_known_4_results_used :: GovernorMockEnvironment -> Property
+prop_governor_target_known_4_results_used env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfKnownPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        envGossipResultsSig :: Signal (Set PeerAddr)
+        envGossipResultsSig =
+            fmap (maybe Set.empty Set.fromList)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TraceEnvGossipResult _ addrs -> Just addrs
+                     _                            -> Nothing)
+          . selectEnvEvents
+          $ events
+
+        gossipResultsUntilKnown :: Signal (Set PeerAddr)
+        gossipResultsUntilKnown =
+          Signal.keyedUntil
+            (\(_, _, gossips)    -> gossips) -- start set
+            (\(_, known, _)      -> known)   -- stop set
+            (\(target, known, _) -> Set.size known <= target) -- reset condition
+            ((,,) <$> envTargetsSig
+                  <*> govKnownPeersSig
+                  <*> envGossipResultsSig)
+
+        gossipResultsUnknownTooLong :: Signal (Set PeerAddr)
+        gossipResultsUnknownTooLong =
+          Signal.keyedTimeout
+            (10 + 1) -- policyGossipOverallTimeout
+            id
+            gossipResultsUntilKnown
+
+     in counterexample
+          ("\nSignal key: (known peers, gossip result, results unknown, " ++
+           "results unknown too long)") $
+
+        signalProperty 20 show
+          (\(_,_,_,_,x) -> Set.null x) $
+          (,,,,) <$> envTargetsSig
+                 <*> govKnownPeersSig
+                 <*> envGossipResultsSig
+                 <*> gossipResultsUntilKnown
+                 <*> gossipResultsUnknownTooLong
+
+
+-- | The governor should not shrink its known peer set except when it is above
+-- the target size.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the target for known peers from the environment
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. Based on 2, a signal of change events when the set of known peers shrinks.
+--
+-- 4. Based on 1, 2 and 3, a signal of unexpected shrink events: a signal that
+--    is True when there is a shrink event and the new size of the set of known
+--    peers is below the target.
+--
+-- Based on these signals we assert:
+--
+-- * That the signal 4 above is always False.
+--
+prop_governor_target_known_5_no_shrink_below :: GovernorMockEnvironment -> Property
+prop_governor_target_known_5_no_shrink_below env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfKnownPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        knownPeersShrinksSig :: Signal (Set PeerAddr)
+        knownPeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govKnownPeersSig
+
+        unexpectedShrink :: Signal Bool
+        unexpectedShrink =
+          -- Note that when we observe a shrink, the known peers set at the
+          -- same time is the new shrunk value. This means our test has to be
+          -- Set.size known < target rather than Set.size known <= target
+          -- It also has the bonus of checking that we are checking that the
+          -- size of the known peer set after the shrink is not strictly
+          -- smaller than the target, which means we're checking that we do
+          -- not undershoot the target: from above we hit the target exactly.
+          (\target known shrinks ->
+                not (Set.null shrinks)
+             && Set.size known < target
+          ) <$> envTargetsSig
+            <*> govKnownPeersSig
+            <*> knownPeersShrinksSig
+
+     in counterexample
+          "\nSignal key: (target, known peers, shrinks, unexpected)" $
+
+        signalProperty 20 show
+          (\(_,_,_,unexpected) -> not unexpected)
+          ((,,,) <$> envTargetsSig
+                 <*> govKnownPeersSig
+                 <*> knownPeersShrinksSig
+                 <*> unexpectedShrink)
+
+
+
+-- | The governor should shrink its known peer set within a bounded time when
+-- it is above the target size.
+--
+-- This deals with hitting the target from above. We have to allow some bounded
+-- time rather than demand instant shrinking because in some situation the
+-- governor must demote active or established peers before it can forget known
+-- peers.
+--
+-- We derive a number of signals:
+--
+-- 1. A signal of the effective target for known peers from the environment,
+--    based on both the given target and the local root peers.
+--
+-- 2. A signal of the set of known peers in the governor state.
+--
+-- 3. Based on 2, a signal of change events when the set of known peers shrinks.
+--
+-- 5. Based on 1, 2 and 3, a signal that becomes True if for X seconds, the
+--    known peers is above target and there is no shrink event.
+--
+-- Based on these signals we check:
+--
+-- * That the signal 5 above is always False.
+--
+prop_governor_target_known_above :: GovernorMockEnvironment -> Property
+prop_governor_target_known_above env =
+    --TODO: this property is currently not true. There are cases involving
+    -- local root peers where we are over target for known peers, but the only
+    -- known peer that is not established is a local root peer, which we are
+    -- not allowed to forget. The established peer in this case is not a local
+    -- root, and if it were to be demoted then we would be able to forget it
+    -- instead. Alternatively if we promoted the local root peer to established
+    -- then things would also resolve (but promoting is of course something that
+    -- can fail so that's not a full solution).
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          max <$> selectEnvTargets targetNumberOfKnownPeers events
+              <*> (Signal.fromChangeEvents 0
+                 . fmap LocalRootPeers.size
+                 . Signal.selectEvents (\case TraceEnvSetLocalRoots l -> Just l
+                                              _                       -> Nothing)
+                 . selectEnvEvents
+                 $ events)
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        knownPeersShrinksSig :: Signal (Set PeerAddr)
+        knownPeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govKnownPeersSig
+
+        aboveTargetTooLong :: Signal Bool
+        aboveTargetTooLong =
+          Signal.timeout 15
+            (\(target, known, shrinks) ->
+                  Set.size known > target
+               && Set.null shrinks)
+            ((,,) <$> envTargetsSig
+                  <*> govKnownPeersSig
+                  <*> knownPeersShrinksSig)
+
+     in counterexample
+          "\nSignal key: (target, known peers, shrinks, above target too long)" $
+
+        signalProperty 20 show
+          (\(_,_,_,toolong) -> not toolong)
+          ((,,,) <$> envTargetsSig
+                 <*> govKnownPeersSig
+                 <*> knownPeersShrinksSig
+                 <*> aboveTargetTooLong)
+
+
+-- | Check that the governor can hit (but not overshoot) its target for the
+-- number of warm peers. This has to be bounded by what is possible: we cannot
+-- always find enough peers, and when we can, some of them fail.
+--
+-- This is a somewhat tricky property to express because it is non-trivial to
+-- find the maximum number of possible established connections by inspecting
+-- the mock environment.
+--
+-- We approach it in three parts: from above, from below and statistically.
+--
+-- The simplest is from above: the environment knows how many established
+-- connections there are at any point in (virtual) time, and what the targets
+-- are. So we can easily compare the two. This can be a tight bound above.
+-- When the target is stable, the governor should never overshoot the target.
+-- When the target changes to be smaller, the governor should shrink the number
+-- of established connections to be within the target within a relatively short
+-- period of time.
+--
+--
+--
+-- Tracking very precisely the maximum number of peers we could reasonably
+-- establish connections to is tricky and hence prone to mistakes in the test
+-- definition. So as an extra sanity check we take a simpler but fuzzy approach.
+-- In some fraction of test runs, the environment should be such that it is
+-- possible to actually hit the target for the number of established peers. So
+-- we label the cases where this happens, and then we can use a statistical
+-- test to assert that this happens in some fraction of test cases.
+--
+prop_governor_target_established_below :: GovernorMockEnvironment -> Property
+prop_governor_target_established_below env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfEstablishedPeers events
+
+        govKnownPeersSig :: Signal (Set PeerAddr)
+        govKnownPeersSig =
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+
+        govEstablishedPeersSig :: Signal (Set PeerAddr)
+        govEstablishedPeersSig =
+          selectGovState
+            (EstablishedPeers.toSet . Governor.establishedPeers)
+            events
+
+        govEstablishedFailuresSig :: Signal (Set PeerAddr)
+        govEstablishedFailuresSig =
+            Signal.keyedLinger
+              180 -- 3 minutes  -- TODO: too eager to reconnect?
+              (fromMaybe Set.empty)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TracePromoteColdFailed _ _ peer _ _ ->
+                       --TODO: the environment does not yet cause this to happen
+                       -- it requires synchronous failure in the establish action
+                       Just (Set.singleton peer)
+                     --TODO: what about TraceDemoteWarmDone ?
+                     -- these are also not immediate candidates
+                     -- why does the property not fail for not tracking these?
+                     TraceDemoteAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerCold) status)
+                     _ -> Nothing
+              )
+          . selectGovEvents
+          $ events
+
+        promotionOpportunities :: Signal (Set PeerAddr)
+        promotionOpportunities =
+          (\target known established recentFailures ->
+              -- There are no opportunities if we're at or above target
+              if Set.size established >= target
+                then Set.empty
+                else known Set.\\ established
+                           Set.\\ recentFailures
+          ) <$> envTargetsSig
+            <*> govKnownPeersSig
+            <*> govEstablishedPeersSig
+            <*> govEstablishedFailuresSig
+
+        promotionOpportunitiesIgnoredTooLong :: Signal (Set PeerAddr)
+        promotionOpportunitiesIgnoredTooLong =
+          Signal.keyedTimeout
+            10 -- seconds
+            id
+            promotionOpportunities
+
+     in counterexample
+          ("\nSignal key: (target, known peers, established peers, recent failures, " ++
+           "opportunities, ignored too long)") $
+
+        signalProperty 20 show
+          (\(_,_,_,_,_,toolong) -> Set.null toolong)
+          ((,,,,,) <$> envTargetsSig
+                   <*> govKnownPeersSig
+                   <*> govEstablishedPeersSig
+                   <*> govEstablishedFailuresSig
+                   <*> promotionOpportunities
+                   <*> promotionOpportunitiesIgnoredTooLong)
+
+
+
+prop_governor_target_active_below :: GovernorMockEnvironment -> Property
+prop_governor_target_active_below env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfActivePeers events
+
+        govEstablishedPeersSig :: Signal (Set PeerAddr)
+        govEstablishedPeersSig =
+          selectGovState
+            (EstablishedPeers.toSet . Governor.establishedPeers)
+            events
+
+        govActivePeersSig :: Signal (Set PeerAddr)
+        govActivePeersSig =
+          selectGovState Governor.activePeers events
+
+        govActiveFailuresSig :: Signal (Set PeerAddr)
+        govActiveFailuresSig =
+            Signal.keyedLinger
+              180 -- 3 minutes  -- TODO: too eager to reconnect?
+              (fromMaybe Set.empty)
+          . Signal.fromEvents
+          . Signal.selectEvents
+              (\case TracePromoteWarmFailed _ _ peer _ ->
+                       --TODO: the environment does not yet cause this to happen
+                       -- it requires synchronous failure in the establish action
+                       Just (Set.singleton peer)
+                     --TODO
+                     TraceDemoteAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerWarm) status)
+                     _ -> Nothing
+              )
+          . selectGovEvents
+          $ events
+
+        promotionOpportunities :: Signal (Set PeerAddr)
+        promotionOpportunities =
+          (\target established active recentFailures ->
+              -- There are no opportunities if we're at or above target
+              if Set.size active >= target
+                then Set.empty
+                else established Set.\\ active
+                                 Set.\\ recentFailures
+          ) <$> envTargetsSig
+            <*> govEstablishedPeersSig
+            <*> govActivePeersSig
+            <*> govActiveFailuresSig
+
+        promotionOpportunitiesIgnoredTooLong :: Signal (Set PeerAddr)
+        promotionOpportunitiesIgnoredTooLong =
+          Signal.keyedTimeout
+            10 -- seconds
+            id
+            promotionOpportunities
+
+     in counterexample
+          ("\nSignal key: (target, known peers, active peers, recent failures, " ++
+           "opportunities, ignored too long)") $
+
+        signalProperty 20 show
+          (\(_,_,_,_,_,toolong) -> Set.null toolong)
+          ((,,,,,) <$> envTargetsSig
+                   <*> govEstablishedPeersSig
+                   <*> govActivePeersSig
+                   <*> govActiveFailuresSig
+                   <*> promotionOpportunities
+                   <*> promotionOpportunitiesIgnoredTooLong)
+
+
+prop_governor_target_established_above :: GovernorMockEnvironment -> Property
+prop_governor_target_established_above env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfEstablishedPeers events
+
+        govEstablishedPeersSig :: Signal (Set PeerAddr)
+        govEstablishedPeersSig =
+          selectGovState
+            (EstablishedPeers.toSet . Governor.establishedPeers)
+            events
+
+        establishedPeersShrinksSig :: Signal (Set PeerAddr)
+        establishedPeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govEstablishedPeersSig
+
+        aboveTargetTooLong :: Signal Bool
+        aboveTargetTooLong =
+          Signal.timeout 15
+            (\(target, established, shrinks) ->
+                  Set.size established > target
+               && Set.null shrinks)
+            ((,,) <$> envTargetsSig
+                  <*> govEstablishedPeersSig
+                  <*> establishedPeersShrinksSig)
+
+     in counterexample
+          "\nSignal key: (target, established peers, shrinks, above target too long)" $
+
+        signalProperty 20 show
+          (\(_,_,_,toolong) -> not toolong)
+          ((,,,) <$> envTargetsSig
+                 <*> govEstablishedPeersSig
+                 <*> establishedPeersShrinksSig
+                 <*> aboveTargetTooLong)
+
+
+prop_governor_target_active_above :: GovernorMockEnvironment -> Property
+prop_governor_target_active_above env =
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
+               . selectPeerSelectionTraceEvents
+               . runGovernorInMockEnvironment
+               $ env
+
+        envTargetsSig :: Signal Int
+        envTargetsSig =
+          selectEnvTargets targetNumberOfActivePeers events
+
+        govActivePeersSig :: Signal (Set PeerAddr)
+        govActivePeersSig =
+          selectGovState Governor.activePeers events
+
+        activePeersShrinksSig :: Signal (Set PeerAddr)
+        activePeersShrinksSig =
+            Signal.nub
+          . fmap (fromMaybe Set.empty)
+          $ Signal.difference
+              (\x x' -> x Set.\\ x')
+              govActivePeersSig
+
+        aboveTargetTooLong :: Signal Bool
+        aboveTargetTooLong =
+          Signal.timeout 15
+            (\(target, active, shrinks) ->
+                  Set.size active > target
+               && Set.null shrinks)
+            ((,,) <$> envTargetsSig
+                  <*> govActivePeersSig
+                  <*> activePeersShrinksSig)
+
+     in counterexample
+          "\nSignal key: (target, active peers, shrinks, above target too long)" $
+
+        signalProperty 20 show
+          (\(_,_,_,toolong) -> not toolong)
+          ((,,,) <$> envTargetsSig
+                 <*> govActivePeersSig
+                 <*> activePeersShrinksSig
+                 <*> aboveTargetTooLong)
+
+
+--
 -- Utils for properties
 --
 
 takeFirstNHours :: DiffTime -> [(Time, a)] -> [(Time, a)]
 takeFirstNHours h = takeWhile (\(t,_) -> t < Time (60*60*h))
 
+selectEnvEvents :: Events TestTraceEvent -> Events TraceMockEnv
+selectEnvEvents = Signal.selectEvents
+                    (\case MockEnvEvent e -> Just e
+                           _              -> Nothing)
+
+selectGovEvents :: Events TestTraceEvent
+                -> Events (TracePeerSelection PeerAddr)
+selectGovEvents = Signal.selectEvents
+                    (\case GovernorEvent e -> Just e
+                           _               -> Nothing)
+
+selectGovState :: Eq a
+               => (Governor.PeerSelectionState PeerAddr () -> a)
+               -> Events TestTraceEvent
+               -> Signal a
+selectGovState f =
+    Signal.nub
+  . fmap f
+  . Signal.fromChangeEvents Governor.emptyPeerSelectionState
+  . Signal.selectEvents
+      (\case GovernorDebug (TraceGovernorState _ _ st) -> Just st
+             _                                         -> Nothing)
+
+selectEnvTargets :: Eq a
+                 => (PeerSelectionTargets -> a)
+                 -> Events TestTraceEvent
+                 -> Signal a
+selectEnvTargets f =
+    Signal.nub
+  . fmap f
+  . Signal.fromChangeEvents nullPeerSelectionTargets
+  . Signal.selectEvents
+      (\case TraceEnvSetTargets targets -> Just targets
+             _                          -> Nothing)
+  . selectEnvEvents
 
 --
 -- Live examples

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -793,7 +793,10 @@ prop_governor_target_known_1_valid_subset env =
         validState knownPeersEnv knownPeersGov =
           knownPeersGov `Set.isSubsetOf` knownPeersEnv
 
-     in signalProperty 20 show (uncurry validState) $
+     in counterexample
+          "Signal key: (environment known peers, governor known peers)" $
+
+        signalProperty 20 show (uncurry validState) $
           (,) <$> envKnownPeersSig
               <*> govKnownPeersSig
 
@@ -816,8 +819,7 @@ environmentAllKnownPeers :: Set PeerAddr
                          -> Signal (Set PeerAddr)
 environmentAllKnownPeers localRootPeers =
   --TODO: implement this as a generic signalScanl style combinator
-    Signal.stable
-  . Signal.fromChangeEvents localRootPeers
+    Signal.fromChangeEvents localRootPeers
   . Signal.primitiveTransformEvents (go localRootPeers)
   where
     go :: Set PeerAddr -> [E TraceMockEnv] -> [E (Set PeerAddr)]

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -52,7 +52,7 @@ import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Signal
-import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup, after, DependencyType(..))
 import           Test.Tasty.QuickCheck (testProperty)
 
 
@@ -61,15 +61,23 @@ tests =
   testGroup "Ouroboros.Network.PeerSelection"
   [ Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
-  , testGroup "safety"
+  , testGroup "basic"
     [ testProperty "has output"         prop_governor_hasoutput
     , testProperty "no failure"         prop_governor_nofail
     , testProperty "no livelock"        prop_governor_nolivelock
-    , testProperty "no excess busyness" prop_governor_nobusyness
+    ]
+
+    -- The no livelock property is needed to ensure other tests terminate
+  , after AllSucceed "Ouroboros.Network.PeerSelection.basic" $
+    testGroup "safety"
+    [ testProperty "no excess busyness" prop_governor_nobusyness
     , testProperty "event coverage"     prop_governor_trace_coverage
     , testProperty "connection status"  prop_governor_connstatus
     ]
-  , testGroup "progress"
+
+    -- The no livelock property is needed to ensure other tests terminate
+  , after AllSucceed "Ouroboros.Network.PeerSelection.basic" $
+    testGroup "progress"
     [ testProperty "gossip reachable"    prop_governor_gossip_1hr
 
 --  , testProperty "progresses towards public root peers target (from below)"

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -152,10 +152,10 @@ tests =
 --
 -- * A public root peers target property: that the governor hits its target for
 --   for the number of public root peers (or as near as possible), and does
---   note "grossly" overshoot. Since the public roots is a one sided target, but
+--   not "grossly" overshoot. Since the public roots is a one sided target, but
 --   we don't want to overshoot excessively.
 --
--- * A local root peers target property: that the governor hits it target for
+-- * A local root peers target property: that the governor hits its target for
 --   getting all its local root peers into the established state, and a target
 --   number of them into the active state (or as near as possible).
 --
@@ -445,6 +445,8 @@ prop_governor_trace_coverage env =
      in coverTable "trace events" [ (n, 1) | n <- Map.elems allTraceNames ] $
         tabulate   "trace events" (Map.elems traceNamesSeen)
         True
+        --TODO: use cover to check we do indeed get them all. There are a few
+        -- cases we do not cover yet. These should be fixed first.
 
 collectTraces :: [(Time, TestTraceEvent)] -> Set Int
 collectTraces trace =

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -125,6 +125,10 @@ tests =
 --   into a busy cycle. See also the "no excessive busyness" property for a
 --   more advanced version.
 --
+-- * A "no excessive busyness" property. This checks that the governor does not
+--   remain too busy for too long. It's quite easy to write bugs that don't
+--   cause the governor to fail, but cause it to go into fairly-busy cycles.
+--
 -- * A state consistency property that the governor's view of part of the state
 --   and the "true" state of the mock environment are maintained in an
 --   appropriate correspondence.
@@ -136,22 +140,20 @@ tests =
 -- * A cold peer gossip "reachable" property: that the governor either hits
 --   its target for the number of cold peers, or finds all the reachable peers.
 --
--- Properties that we would like to have:
+-- * A known peer target progress property: that the governor makes progress
+--   within a bounded time towards its known peers target, from below and above.
 --
--- * A "no excessive busyness" property. This checks that the governor does not
---   remain too busy for too long. It's quite easy to write bugs that don't
---   cause the governor to fail, but cause it to go into fairly-busy cycles.
+-- * An established peer target property: the same as above but for established
+--   peers.
+--
+-- * An active peer target property: the same as above but for active peers.
+--
+-- Properties that we would like to have:
 --
 -- * A public root peers target property: that the governor hits its target for
 --   for the number of public root peers (or as near as possible), and does
 --   note "grossly" overshoot. Since the public roots is a one sided target, but
 --   we don't want to overshoot excessively.
---
--- * A warm peer target property: that the governor hits its established peers
---   target (or as near as possible).
---
--- * A hot peer target property: that the governor hits its active peers
---   target (or as near as possible).
 --
 -- * A local root peers target property: that the governor hits it target for
 --   getting all its local root peers into the established state, and a target
@@ -159,8 +161,6 @@ tests =
 --
 -- Other properties we might like to think about
 --
--- * for vaguely stable envs, we do stablise at our target number of cold peers
--- * time to stabilise after a change is not crazy
 -- * time to find new nodes after a graph change is ok
 -- * targets or root peer set dynamic
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -32,8 +32,9 @@ import qualified Data.OrdPSQ as PSQ
 import           Control.Monad.Class.MonadSTM.Strict (STM)
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer (..))
+import           Control.Exception (IOException)
 
-import qualified Network.DNS as DNS (defaultResolvConf)
+import qualified Network.DNS as DNS (defaultResolvConf, Resolver)
 import           Network.Socket (SockAddr)
 import           Network.Mux.Timeout
 
@@ -1905,7 +1906,8 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains =
       tracer
       timeout
       DNS.defaultResolvConf
-      readDomains $ \requestPublicRootPeers ->
+      readDomains
+      dnsActions $ \requestPublicRootPeers ->
 
         peerSelectionGovernor
           tracer tracer tracer
@@ -1914,6 +1916,13 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains =
   where
     tracer :: Show a => Tracer IO a
     tracer  = Tracer (BS.putStrLn . BS.pack . show)
+
+    dnsActions :: DNSActions ResolvConf DNS.Resolver IOException IO
+    dnsActions = DNSActions {
+            dnsResolverResource = resolverResource,
+            dnsAsyncResolverResource = asyncResolverResource,
+            dnsLookupAWithTTL = lookupAWithTTL
+    }
 
     actions :: PeerSelectionActions SockAddr () IO
     actions = PeerSelectionActions {

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1230,6 +1230,7 @@ prop_governor_target_known_above env =
         -- There are no demotion opportunities if we're at or below target.
         -- Otherwise, the opportunities for demotion are known peers that
         -- are not currently established and are not local.
+        --
         demotionOpportunity targets local public known established
           | Set.size known <= targetNumberOfKnownPeers targets
           = Set.empty
@@ -1249,8 +1250,8 @@ prop_governor_target_known_above env =
               | otherwise
               = Set.empty
 
-        deomotionOpportunities :: Signal (Set PeerAddr)
-        deomotionOpportunities =
+        demotionOpportunities :: Signal (Set PeerAddr)
+        demotionOpportunities =
           demotionOpportunity
             <$> envTargetsSig
             <*> govLocalRootPeersSig
@@ -1263,7 +1264,7 @@ prop_governor_target_known_above env =
           Signal.keyedTimeout
             10 -- seconds
             id
-            deomotionOpportunities
+            demotionOpportunities
 
      in counterexample
           ("\nSignal key: (target (root, known), local peers, public peers, known peers, " ++
@@ -1277,7 +1278,7 @@ prop_governor_target_known_above env =
                     <*> govPublicRootPeersSig
                     <*> govKnownPeersSig
                     <*> govEstablishedPeersSig
-                    <*> deomotionOpportunities
+                    <*> demotionOpportunities
                     <*> demotionOpportunitiesIgnoredTooLong)
 
 
@@ -1354,15 +1355,20 @@ prop_governor_target_established_below env =
           . selectGovEvents
           $ events
 
+        -- There are no opportunities if we're at or above target
+        --
+        promotionOpportunity target known established recentFailures
+          | Set.size established >= target
+          = Set.empty
+
+          | otherwise
+          = known Set.\\ established
+                  Set.\\ recentFailures
+
         promotionOpportunities :: Signal (Set PeerAddr)
         promotionOpportunities =
-          (\target known established recentFailures ->
-              -- There are no opportunities if we're at or above target
-              if Set.size established >= target
-                then Set.empty
-                else known Set.\\ established
-                           Set.\\ recentFailures
-          ) <$> envTargetsSig
+          promotionOpportunity
+            <$> envTargetsSig
             <*> govKnownPeersSig
             <*> govEstablishedPeersSig
             <*> govEstablishedFailuresSig
@@ -1400,6 +1406,10 @@ prop_governor_target_active_below env =
         envTargetsSig =
           selectEnvTargets targetNumberOfActivePeers events
 
+        govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
+        govLocalRootPeersSig =
+          selectGovState Governor.localRootPeers events
+
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
@@ -1432,15 +1442,31 @@ prop_governor_target_active_below env =
           . selectGovEvents
           $ events
 
+        -- There are no opportunities if we're at or above target.
+        --
+        -- We define local root peers not to be promotion opportunities for
+        -- the purpose of the general target of active peers.
+        -- The local root peers have a separate target with a separate property.
+        -- And we cannot count local peers since we can have corner cases where
+        -- the only choices are local roots in a group that is already at target
+        -- but the general target is still higher. In such situations we do not
+        -- want to promote any, since we'd then be above target for the local
+        -- root peer group.
+        --
+        promotionOpportunity target local established active recentFailures
+          | Set.size active >= target
+          = Set.empty
+
+          | otherwise
+          = established Set.\\ active
+                        Set.\\ LocalRootPeers.keysSet local
+                        Set.\\ recentFailures
+
         promotionOpportunities :: Signal (Set PeerAddr)
         promotionOpportunities =
-          (\target established active recentFailures ->
-              -- There are no opportunities if we're at or above target
-              if Set.size active >= target
-                then Set.empty
-                else established Set.\\ active
-                                 Set.\\ recentFailures
-          ) <$> envTargetsSig
+          promotionOpportunity
+            <$> envTargetsSig
+            <*> govLocalRootPeersSig
             <*> govEstablishedPeersSig
             <*> govActivePeersSig
             <*> govActiveFailuresSig
@@ -1453,17 +1479,18 @@ prop_governor_target_active_below env =
             promotionOpportunities
 
      in counterexample
-          ("\nSignal key: (target, known peers, active peers, recent failures, " ++
-           "opportunities, ignored too long)") $
+          ("\nSignal key: (target, local peers, established peers, " ++
+           "active peers, recent failures, opportunities, ignored too long)") $
 
         signalProperty 20 show
-          (\(_,_,_,_,_,toolong) -> Set.null toolong)
-          ((,,,,,) <$> envTargetsSig
-                   <*> govEstablishedPeersSig
-                   <*> govActivePeersSig
-                   <*> govActiveFailuresSig
-                   <*> promotionOpportunities
-                   <*> promotionOpportunitiesIgnoredTooLong)
+          (\(_,_,_,_,_,_,toolong) -> Set.null toolong)
+          ((,,,,,,) <$> envTargetsSig
+                    <*> govLocalRootPeersSig
+                    <*> govEstablishedPeersSig
+                    <*> govActivePeersSig
+                    <*> govActiveFailuresSig
+                    <*> promotionOpportunities
+                    <*> promotionOpportunitiesIgnoredTooLong)
 
 
 prop_governor_target_established_above :: GovernorMockEnvironment -> Property
@@ -1477,39 +1504,58 @@ prop_governor_target_established_above env =
         envTargetsSig =
           selectEnvTargets targetNumberOfEstablishedPeers events
 
+        govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
+        govLocalRootPeersSig =
+          selectGovState Governor.localRootPeers events
+
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (EstablishedPeers.toSet . Governor.establishedPeers)
             events
 
-        establishedPeersShrinksSig :: Signal (Set PeerAddr)
-        establishedPeersShrinksSig =
-            Signal.nub
-          . fmap (fromMaybe Set.empty)
-          $ Signal.difference
-              (\x x' -> x Set.\\ x')
-              govEstablishedPeersSig
+        govActivePeersSig :: Signal (Set PeerAddr)
+        govActivePeersSig =
+          selectGovState Governor.activePeers events
 
-        aboveTargetTooLong :: Signal Bool
-        aboveTargetTooLong =
-          Signal.timeout 15
-            (\(target, established, shrinks) ->
-                  Set.size established > target
-               && Set.null shrinks)
-            ((,,) <$> envTargetsSig
-                  <*> govEstablishedPeersSig
-                  <*> establishedPeersShrinksSig)
+        -- There are no demotion opportunities if we're at or below target.
+        -- Otherwise the demotion opportunities are the established peers that
+        -- are not active and not local root peers.
+        --
+        demotionOpportunity target local established active
+          | Set.size established <= target
+          = Set.empty
+
+          | otherwise
+          = established Set.\\ active
+                        Set.\\ LocalRootPeers.keysSet local
+        demotionOpportunities :: Signal (Set PeerAddr)
+        demotionOpportunities =
+          demotionOpportunity
+            <$> envTargetsSig
+            <*> govLocalRootPeersSig
+            <*> govEstablishedPeersSig
+            <*> govActivePeersSig
+
+        demotionOpportunitiesIgnoredTooLong :: Signal (Set PeerAddr)
+        demotionOpportunitiesIgnoredTooLong =
+          Signal.keyedTimeout
+            10 -- seconds
+            id
+            demotionOpportunities
 
      in counterexample
-          "\nSignal key: (target, established peers, shrinks, above target too long)" $
+          ("\nSignal key: (target, local peers, established peers, active peers, " ++
+           "demotion opportunities, ignored too long)") $
 
         signalProperty 20 show
-          (\(_,_,_,toolong) -> not toolong)
-          ((,,,) <$> envTargetsSig
-                 <*> govEstablishedPeersSig
-                 <*> establishedPeersShrinksSig
-                 <*> aboveTargetTooLong)
+          (\(_,_,_,_,_,toolong) -> Set.null toolong)
+          ((,,,,,) <$> envTargetsSig
+                   <*> (LocalRootPeers.toGroupSets <$> govLocalRootPeersSig)
+                   <*> govEstablishedPeersSig
+                   <*> govActivePeersSig
+                   <*> demotionOpportunities
+                   <*> demotionOpportunitiesIgnoredTooLong)
 
 
 prop_governor_target_active_above :: GovernorMockEnvironment -> Property
@@ -1523,37 +1569,46 @@ prop_governor_target_active_above env =
         envTargetsSig =
           selectEnvTargets targetNumberOfActivePeers events
 
+        govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
+        govLocalRootPeersSig =
+          selectGovState Governor.localRootPeers events
+
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
           selectGovState Governor.activePeers events
 
-        activePeersShrinksSig :: Signal (Set PeerAddr)
-        activePeersShrinksSig =
-            Signal.nub
-          . fmap (fromMaybe Set.empty)
-          $ Signal.difference
-              (\x x' -> x Set.\\ x')
-              govActivePeersSig
+        demotionOpportunity target local active
+          | Set.size active <= target
+          = Set.empty
 
-        aboveTargetTooLong :: Signal Bool
-        aboveTargetTooLong =
-          Signal.timeout 15
-            (\(target, active, shrinks) ->
-                  Set.size active > target
-               && Set.null shrinks)
-            ((,,) <$> envTargetsSig
-                  <*> govActivePeersSig
-                  <*> activePeersShrinksSig)
+          | otherwise
+          = active Set.\\ LocalRootPeers.keysSet local
+
+        demotionOpportunities :: Signal (Set PeerAddr)
+        demotionOpportunities =
+          demotionOpportunity
+            <$> envTargetsSig
+            <*> govLocalRootPeersSig
+            <*> govActivePeersSig
+
+        demotionOpportunitiesIgnoredTooLong :: Signal (Set PeerAddr)
+        demotionOpportunitiesIgnoredTooLong =
+          Signal.keyedTimeout
+            10 -- seconds
+            id
+            demotionOpportunities
 
      in counterexample
-          "\nSignal key: (target, active peers, shrinks, above target too long)" $
+          ("\nSignal key: (target, local peers, active peers, " ++
+           "demotion opportunities, ignored too long)") $
 
         signalProperty 20 show
-          (\(_,_,_,toolong) -> not toolong)
-          ((,,,) <$> envTargetsSig
-                 <*> govActivePeersSig
-                 <*> activePeersShrinksSig
-                 <*> aboveTargetTooLong)
+          (\(_,_,_,_,toolong) -> Set.null toolong)
+          ((,,,,) <$> envTargetsSig
+                  <*> (LocalRootPeers.toGroupSets <$> govLocalRootPeersSig)
+                  <*> govActivePeersSig
+                  <*> demotionOpportunities
+                  <*> demotionOpportunitiesIgnoredTooLong)
 
 
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -29,6 +29,7 @@ import qualified Data.Signal as Signal
 import           Data.Signal (Signal, Events, E(E), TS(TS))
 import qualified Data.OrdPSQ as PSQ
 
+import           Control.Monad.Class.MonadSTM.Strict (StrictTVar)
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer (..))
 
@@ -1892,14 +1893,14 @@ selectEnvTargets f =
 -- This is a manual test that runs in IO and has to be observed to see that it
 -- is doing something sensible. It is not run automatically.
 --
-_governorFindingPublicRoots :: Int -> [DomainAddress] -> IO Void
-_governorFindingPublicRoots targetNumberOfRootPeers domains =
+_governorFindingPublicRoots :: Int -> StrictTVar IO [RelayAddress] -> IO Void
+_governorFindingPublicRoots targetNumberOfRootPeers domainsVar =
     withTimeoutSerial $ \timeout ->
     publicRootPeersProvider
       tracer
       timeout
       DNS.defaultResolvConf
-      domains $ \requestPublicRootPeers ->
+      domainsVar $ \requestPublicRootPeers ->
 
         peerSelectionGovernor
           tracer tracer tracer

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -32,9 +32,8 @@ import qualified Data.OrdPSQ as PSQ
 import           Control.Monad.Class.MonadSTM.Strict (STM)
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer (..))
-import           Control.Exception (IOException)
 
-import qualified Network.DNS as DNS (defaultResolvConf, Resolver)
+import qualified Network.DNS as DNS (defaultResolvConf)
 import           Network.Socket (SockAddr)
 import           Network.Mux.Timeout
 
@@ -48,6 +47,7 @@ import           Ouroboros.Network.PeerSelection.RootPeersDNS
 
 import           Test.Ouroboros.Network.PeerSelection.Instances
 import qualified Test.Ouroboros.Network.PeerSelection.LocalRootPeers
+import qualified Test.Ouroboros.Network.PeerSelection.RootPeersDNS
 import qualified Test.Ouroboros.Network.PeerSelection.Json
 import           Test.Ouroboros.Network.PeerSelection.MockEnvironment hiding (tests)
 import qualified Test.Ouroboros.Network.PeerSelection.MockEnvironment
@@ -63,6 +63,7 @@ tests :: TestTree
 tests =
   testGroup "Ouroboros.Network.PeerSelection"
   [ Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
+  , Test.Ouroboros.Network.PeerSelection.RootPeersDNS.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
   , testGroup "basic"
     [ testProperty "has output"         prop_governor_hasoutput
@@ -609,7 +610,8 @@ prop_governor_connstatus env =
     let trace = takeFirstNHours 1
               . selectPeerSelectionTraceEvents $
                   runGovernorInMockEnvironment env
-        --TODO: check any actually get a true status output and try some deliberate bugs
+        --TODO: check any actually get a true status output and try some
+        --      deliberate bugs
      in conjoin (map ok (groupBy ((==) `on` fst) trace))
   where
     -- We look at events when the environment's view of the state of all the
@@ -933,7 +935,6 @@ prop_governor_target_known_2_opportunity_taken env =
 governorEventuallyTakesGossipOpportunities
   :: Signal (Int, Set PeerAddr, Set PeerAddr, Maybe PeerAddr)
   -> Signal Bool
-
 governorEventuallyTakesGossipOpportunities =
     -- Time out and fail after 30 seconds if we enter and remain in a bad state
     fmap not
@@ -1188,8 +1189,6 @@ prop_governor_target_known_5_no_shrink_below env =
                  <*> knownPeersShrinksSig
                  <*> unexpectedShrink)
 
-
-
 -- | The governor should shrink its known peer set within a bounded time when
 -- it is above the target size.
 --
@@ -1409,8 +1408,6 @@ prop_governor_target_established_below env =
                    <*> promotionOpportunities
                    <*> promotionOpportunitiesIgnoredTooLong)
 
-
-
 prop_governor_target_active_below :: GovernorMockEnvironment -> Property
 prop_governor_target_active_below env =
     let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
@@ -1508,7 +1505,6 @@ prop_governor_target_active_below env =
                     <*> promotionOpportunities
                     <*> promotionOpportunitiesIgnoredTooLong)
 
-
 prop_governor_target_established_above :: GovernorMockEnvironment -> Property
 prop_governor_target_established_above env =
     let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
@@ -1573,7 +1569,6 @@ prop_governor_target_established_above env =
                    <*> demotionOpportunities
                    <*> demotionOpportunitiesIgnoredTooLong)
 
-
 prop_governor_target_active_above :: GovernorMockEnvironment -> Property
 prop_governor_target_active_above env =
     let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
@@ -1625,7 +1620,6 @@ prop_governor_target_active_above env =
                   <*> govActivePeersSig
                   <*> demotionOpportunities
                   <*> demotionOpportunitiesIgnoredTooLong)
-
 
 -- | A variant of 'prop_governor_target_established_below' but for the target
 -- that all local root peers should become established.
@@ -1797,7 +1791,6 @@ prop_governor_target_active_local_below env =
                    <*> promotionOpportunities
                    <*> promotionOpportunitiesIgnoredTooLong)
 
-
 prop_governor_target_active_local_above :: GovernorMockEnvironment -> Property
 prop_governor_target_active_local_above env =
     let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
@@ -1844,7 +1837,6 @@ prop_governor_target_active_local_above env =
                  <*> govActivePeersSig
                  <*> deomotionOpportunities
                  <*> demotionOpportunitiesIgnoredTooLong)
-
 
 --
 -- Utils for properties
@@ -1907,7 +1899,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains =
       timeout
       DNS.defaultResolvConf
       readDomains
-      dnsActions $ \requestPublicRootPeers ->
+      ioDNSActions $ \requestPublicRootPeers ->
 
         peerSelectionGovernor
           tracer tracer tracer
@@ -1916,13 +1908,6 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains =
   where
     tracer :: Show a => Tracer IO a
     tracer  = Tracer (BS.putStrLn . BS.pack . show)
-
-    dnsActions :: DNSActions ResolvConf DNS.Resolver IOException IO
-    dnsActions = DNSActions {
-            dnsResolverResource = resolverResource,
-            dnsAsyncResolverResource = asyncResolverResource,
-            dnsLookupAWithTTL = lookupAWithTTL
-    }
 
     actions :: PeerSelectionActions SockAddr () IO
     actions = PeerSelectionActions {

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1365,6 +1365,8 @@ prop_governor_target_established_below env =
                        | otherwise         -> Just failures
                        where
                          failures = Map.keysSet (Map.filter (==PeerCold) status)
+                     TracePromoteWarmFailed _ _ peer _ ->
+                       Just (Set.singleton peer)
                      _ -> Nothing
               )
           . selectGovEvents
@@ -1664,6 +1666,8 @@ prop_governor_target_established_local env =
                        | otherwise         -> Just failures
                        where
                          failures = Map.keysSet (Map.filter (==PeerCold) status)
+                     TracePromoteWarmFailed _ _ peer _ ->
+                       Just (Set.singleton peer)
                      _ -> Nothing
               )
           . selectGovEvents

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -28,6 +28,7 @@ import           Data.Void (Void)
 import qualified Data.Signal as Signal
 import           Data.Signal (Signal, Events, E(E), TS(TS))
 import qualified Data.OrdPSQ as PSQ
+import           System.Random (mkStdGen)
 
 import           Control.Monad.Class.MonadSTM.Strict (STM)
 import           Control.Monad.Class.MonadTime
@@ -1867,7 +1868,8 @@ selectGovState :: Eq a
 selectGovState f =
     Signal.nub
   . fmap f
-  . Signal.fromChangeEvents Governor.emptyPeerSelectionState
+  -- TODO: #3182 Rng seed should come from quickcheck.
+  . Signal.fromChangeEvents (Governor.emptyPeerSelectionState $ mkStdGen 42)
   . Signal.selectEvents
       (\case GovernorDebug (TraceGovernorState _ _ st) -> Just st
              _                                         -> Nothing)
@@ -1907,6 +1909,8 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains =
 
         peerSelectionGovernor
           tracer tracer tracer
+          -- TODO: #3182 Rng seed should come from quickcheck.
+          (mkStdGen 42)
           actions { requestPublicRootPeers }
           policy
   where

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -7,9 +7,6 @@ module Test.Ouroboros.Network.PeerSelection.Instances (
     -- test types
     PeerAddr(..),
 
-    -- test utils
-    renderRanges,
-
     -- generator tests
     prop_arbitrary_PeerSelectionTargets,
     prop_shrink_PeerSelectionTargets,
@@ -89,15 +86,4 @@ prop_arbitrary_PeerSelectionTargets =
 prop_shrink_PeerSelectionTargets :: PeerSelectionTargets -> Bool
 prop_shrink_PeerSelectionTargets =
     all sanePeerSelectionTargets . shrink
-
-
---
--- QuickCheck utils
---
-
-renderRanges :: Int -> Int -> String
-renderRanges r n = show lower ++ " -- " ++ show upper
-  where
-    lower = n - n `mod` r
-    upper = lower + (r-1)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -34,7 +34,7 @@ newtype PeerAddr = PeerAddr Int
 -- here for the few cases that need it, and it is used for (lack-of) shrinking.
 --
 instance Arbitrary PeerAddr where
-  arbitrary = PeerAddr . getNonNegative <$> arbitrary
+  arbitrary = PeerAddr <$> arbitrarySizedNatural
   shrink _  = []
 
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -18,6 +18,7 @@ import           Ouroboros.Network.PeerSelection.Governor
 import           Ouroboros.Network.PeerSelection.Types
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Utils
 
 
 --
@@ -70,7 +71,8 @@ prop_arbitrary_PeerSelectionTargets :: PeerSelectionTargets -> Bool
 prop_arbitrary_PeerSelectionTargets =
     sanePeerSelectionTargets
 
-prop_shrink_PeerSelectionTargets :: PeerSelectionTargets -> Bool
-prop_shrink_PeerSelectionTargets =
-    all sanePeerSelectionTargets . shrink
+prop_shrink_PeerSelectionTargets :: Fixed PeerSelectionTargets -> Property
+prop_shrink_PeerSelectionTargets x =
+      prop_shrink_valid sanePeerSelectionTargets x
+ .&&. prop_shrink_nonequal x
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -13,8 +13,6 @@ module Test.Ouroboros.Network.PeerSelection.Instances (
 
   ) where
 
-import           Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NonEmpty
 
 import           Ouroboros.Network.PeerSelection.Governor
 import           Ouroboros.Network.PeerSelection.Types
@@ -39,17 +37,6 @@ instance Arbitrary PeerAddr where
   arbitrary = PeerAddr . getNonNegative <$> arbitrary
   shrink _  = []
 
-
-instance Arbitrary a => Arbitrary (NonEmpty a) where
-  arbitrary = NonEmpty.fromList <$> listOf1 arbitrary
-
-  shrink = shrinkMap from to
-    where
-      to :: NonEmpty a -> NonEmptyList a
-      to xs = NonEmpty (NonEmpty.toList xs)
-
-      from :: NonEmptyList a -> NonEmpty a
-      from (NonEmpty xs) = NonEmpty.fromList xs
 
 
 instance Arbitrary PeerAdvertise where

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Json.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Json.hs
@@ -1,0 +1,38 @@
+module Test.Ouroboros.Network.PeerSelection.Json
+  ( tests ) where
+
+import           Data.Aeson (decode, encode, fromJSON, toJSON)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS (DomainAddress(..), RelayAddress(..))
+import           Ouroboros.Network.PeerSelection.Types (PeerAdvertise)
+import           Test.Ouroboros.Network.PeerSelection.Instances()
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+  testGroup "PeerSelection Types JSON instances"
+  [ testProperty "DomainAddress roundtrip" prop_roundtrip_DomainAddress_JSON
+  , testProperty "RelayAddress roundtrip"  prop_roundtrip_RelayAddress_JSON
+  , testProperty "PeerAdvertise roundtrip" prop_roundtrip_PeerAdvertise_JSON
+  ]
+
+prop_roundtrip_DomainAddress_JSON :: DomainAddress -> Property
+prop_roundtrip_DomainAddress_JSON da =
+    decode (encode da) === Just da
+    .&.
+    fromJSON (toJSON da) === pure da
+
+prop_roundtrip_RelayAddress_JSON :: RelayAddress -> Property
+prop_roundtrip_RelayAddress_JSON ra =
+    decode (encode ra) === Just ra
+    .&.
+    fromJSON (toJSON ra) === pure ra
+
+prop_roundtrip_PeerAdvertise_JSON :: PeerAdvertise -> Property
+prop_roundtrip_PeerAdvertise_JSON pa =
+    decode (encode pa) === Just pa
+    .&.
+    fromJSON (toJSON pa) === pure pa
+

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -24,6 +24,7 @@ import           Test.Ouroboros.Network.PeerSelection.Instances
 
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Utils
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -59,7 +58,8 @@ prop_clampToLimit localRootPeers targets =
                  (LocalRootPeers.size localRootPeers)
 
 
-arbitraryLocalRootPeers :: Set PeerAddr -> Gen (LocalRootPeers PeerAddr)
+arbitraryLocalRootPeers :: Ord peeraddr
+                        => Set peeraddr -> Gen (LocalRootPeers peeraddr)
 arbitraryLocalRootPeers peeraddrs = do
     -- divide into a few disjoint groups
     ngroups     <- choose (1, 5 :: Int)
@@ -77,10 +77,10 @@ arbitraryLocalRootPeers peeraddrs = do
     return (LocalRootPeers.fromGroups (zip targets groups))
 
 
-instance Arbitrary (LocalRootPeers PeerAddr) where
+instance (Arbitrary peeraddr, Ord peeraddr) =>
+         Arbitrary (LocalRootPeers peeraddr) where
     arbitrary = do
-        peeraddrs <- Set.map (PeerAddr . getNonNegative)
-                 <$> scale (`div` 4) arbitrary
+        peeraddrs <- scale (`div` 4) arbitrary
         arbitraryLocalRootPeers peeraddrs
 
     shrink lrps =

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -115,9 +115,10 @@ prop_arbitrary_LocalRootPeers lrps =
                  | (t, g) <- LocalRootPeers.toGroupSets lrps ]
 
 
-prop_shrink_LocalRootPeers :: LocalRootPeers PeerAddr -> Bool
-prop_shrink_LocalRootPeers =
-    all LocalRootPeers.invariant . shrink
+prop_shrink_LocalRootPeers :: Fixed (LocalRootPeers PeerAddr) -> Property
+prop_shrink_LocalRootPeers x =
+      prop_shrink_valid LocalRootPeers.invariant x
+ .&&. prop_shrink_nonequal x
 
 prop_fromGroups :: [(Int, Map PeerAddr PeerAdvertise)] -> Bool
 prop_fromGroups = LocalRootPeers.invariant . LocalRootPeers.fromGroups

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -284,6 +284,7 @@ mockPeerSelectionActions' tracer
         traceWith tracer (TraceEnvGossipTTL addr)
       case mgossip of
         Nothing                -> do
+          threadDelay 1
           traceWith tracer (TraceEnvGossipResult addr [])
           fail "no peers"
         Just (peeraddrs, time) -> do
@@ -293,6 +294,7 @@ mockPeerSelectionActions' tracer
 
     establishPeerConnection :: PeerAddr -> m (PeerConn m)
     establishPeerConnection peeraddr = do
+      --TODO: add support for variable delays and synchronous failure
       threadDelay 1
       (conn@(PeerConn _ v), snapshot) <- atomically $ do
         conn  <- newTVar PeerWarm

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -452,6 +452,13 @@ data TestTraceEvent = GovernorDebug    (DebugPeerSelection PeerAddr ())
                     | GovernorEvent    (TracePeerSelection PeerAddr)
                     | GovernorCounters PeerSelectionCounters
                     | MockEnvEvent     TraceMockEnv
+                   -- Warning: be careful with writing properties that rely
+                   -- on trace events from both the governor and from the
+                   -- environment. These events typically occur in separate
+                   -- threads and so are not casually ordered. It is ok to use
+                   -- them for timeout/eventually properties, but not for
+                   -- properties that check conditions synchronously.
+                   -- The governor debug vs other events are fully ordered.
   deriving Show
 
 tracerTracePeerSelection :: Tracer (IOSim s) (TracePeerSelection PeerAddr)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -223,7 +223,7 @@ mockPeerSelectionActions' tracer
                           targetsVar
                           connsVar =
     PeerSelectionActions {
-      readLocalRootPeers       = return (LocalRootPeers.toGroups' localRootPeers),
+      readLocalRootPeers       = return (LocalRootPeers.toGroups localRootPeers),
       requestPublicRootPeers   = \_ -> return (publicRootPeers, 60),
       readPeerSelectionTargets = readTVar targetsVar,
       requestPeerGossip,

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -168,6 +168,7 @@ runGovernorInMockEnvironment mockEnv =
       peerSelectionGovernor
         tracerTracePeerSelection
         tracerDebugPeerSelection
+        tracerTracePeerSelectionCounters
         actions
         policy
 
@@ -382,9 +383,10 @@ mockPeerSelectionPolicy GovernorMockEnvironment {
 -- Utils for properties
 --
 
-data TestTraceEvent = GovernorDebug (DebugPeerSelection PeerAddr ())
-                    | GovernorEvent (TracePeerSelection PeerAddr)
-                    | MockEnvEvent   TraceMockEnv
+data TestTraceEvent = GovernorDebug    (DebugPeerSelection PeerAddr ())
+                    | GovernorEvent    (TracePeerSelection PeerAddr)
+                    | GovernorCounters PeerSelectionCounters
+                    | MockEnvEvent     TraceMockEnv
   deriving Show
 
 tracerTracePeerSelection :: Tracer (IOSim s) (TracePeerSelection PeerAddr)
@@ -393,6 +395,9 @@ tracerTracePeerSelection = contramap GovernorEvent tracerTestTraceEvent
 tracerDebugPeerSelection :: Tracer (IOSim s) (DebugPeerSelection PeerAddr peerconn)
 tracerDebugPeerSelection = contramap (GovernorDebug . fmap (const ()))
                                      tracerTestTraceEvent
+
+tracerTracePeerSelectionCounters :: Tracer (IOSim s) PeerSelectionCounters
+tracerTracePeerSelectionCounters = contramap GovernorCounters tracerTestTraceEvent
 
 tracerMockEnv :: Tracer (IOSim s) TraceMockEnv
 tracerMockEnv = contramap MockEnvEvent tracerTestTraceEvent

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -73,7 +73,9 @@ import           Test.Tasty.QuickCheck (QuickCheckMaxSize (..), testProperty)
 tests :: TestTree
 tests =
   testGroup "Mock environment"
-    [ testProperty "arbitrary for PeerSelectionTargets"    prop_arbitrary_PeerSelectionTargets
+    [ testProperty "shrink for Script"                     prop_shrink_Script
+    , testProperty "shrink for GovernorScripts"            prop_shrink_GovernorScripts
+    , testProperty "arbitrary for PeerSelectionTargets"    prop_arbitrary_PeerSelectionTargets
     , testProperty "shrink for PeerSelectionTargets"       prop_shrink_PeerSelectionTargets
     , testProperty "arbitrary for PeerGraph"               prop_arbitrary_PeerGraph
     , localOption (QuickCheckMaxSize 30) $
@@ -107,7 +109,7 @@ data GovernorMockEnvironment = GovernorMockEnvironment {
        pickWarmPeersToDemote   :: PickScript PeerAddr,
        pickColdPeersToForget   :: PickScript PeerAddr
      }
-  deriving Show
+  deriving (Show, Eq)
 
 data PeerConn m = PeerConn !PeerAddr !(TVar m PeerStatus)
 
@@ -554,7 +556,8 @@ prop_arbitrary_GovernorMockEnvironment env =
           (LocalRootPeers.keysSet (localRootPeers env))
           (publicRootPeers env)
 
-prop_shrink_GovernorMockEnvironment :: GovernorMockEnvironment -> Bool
-prop_shrink_GovernorMockEnvironment =
-    all validGovernorMockEnvironment . shrink
+prop_shrink_GovernorMockEnvironment :: Fixed GovernorMockEnvironment -> Property
+prop_shrink_GovernorMockEnvironment x =
+      prop_shrink_valid validGovernorMockEnvironment x
+ .&&. prop_shrink_nonequal x
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -35,6 +35,7 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
+import           System.Random (mkStdGen)
 
 import           Control.Exception (throw)
 import           Control.Monad (forM_)
@@ -168,6 +169,7 @@ runGovernorInMockEnvironment mockEnv =
         tracerTracePeerSelection
         tracerDebugPeerSelection
         tracerTracePeerSelectionCounters
+        (mkStdGen 42)
         actions
         policy
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -205,8 +205,11 @@ instance Arbitrary GovernorScripts where
       | gossipScript' <- shrink gossipScript
       ]
       ++
-      [ GovernorScripts gossipScript (fixConnectionScript connectionScript')
-      | connectionScript' <- shrink connectionScript
+      [ GovernorScripts gossipScript connectionScript'
+      | connectionScript' <- map fixConnectionScript (shrink connectionScript)
+        -- fixConnectionScript can result in re-creating the same script
+        -- which would cause shrinking to loop. Filter out such cases.
+      , connectionScript' /= connectionScript
       ]
 
 -- | We ensure that eventually the connection script will allow to connect to

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -14,7 +14,7 @@ module Test.Ouroboros.Network.PeerSelection.PeerGraph (
     GossipScript,
     ConnectionScript,
     AsyncDemotion(..),
-    GossipTime,
+    GossipTime(..),
     interpretGossipTime,
 
     prop_shrink_GovernorScripts,
@@ -25,7 +25,6 @@ module Test.Ouroboros.Network.PeerSelection.PeerGraph (
 
 import           Data.Graph (Graph)
 import qualified Data.Graph as Graph
-import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -17,6 +17,7 @@ module Test.Ouroboros.Network.PeerSelection.PeerGraph (
     GossipTime,
     interpretGossipTime,
 
+    prop_shrink_GovernorScripts,
     prop_arbitrary_PeerGraph,
     prop_shrink_PeerGraph,
 
@@ -313,6 +314,10 @@ instance Arbitrary GossipTime where
 -- Tests for the QC Arbitrary instances
 --
 
+prop_shrink_GovernorScripts :: Fixed GovernorScripts -> Property
+prop_shrink_GovernorScripts =
+    prop_shrink_nonequal
+
 prop_arbitrary_PeerGraph :: PeerGraph -> Property
 prop_arbitrary_PeerGraph pg =
     -- We are interested in the distribution of the graph size (in nodes)
@@ -341,7 +346,8 @@ peerGraphNumStronglyConnectedComponents pg =
   where
     (g,_,_) = peerGraphAsGraph pg
 
-prop_shrink_PeerGraph :: PeerGraph -> Bool
-prop_shrink_PeerGraph =
-    all validPeerGraph . shrink
+prop_shrink_PeerGraph :: Fixed PeerGraph -> Property
+prop_shrink_PeerGraph x =
+      prop_shrink_valid validPeerGraph x
+ .&&. prop_shrink_nonequal x
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -37,6 +37,7 @@ import           Test.Ouroboros.Network.PeerSelection.Instances
 import           Test.Ouroboros.Network.PeerSelection.Script
 
 import           Test.QuickCheck
+import           Test.QuickCheck.Utils
 
 
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -255,7 +255,8 @@ instance Arbitrary PeerGraph where
 
 arbitraryGossipScript :: [PeerAddr] -> Gen GossipScript
 arbitraryGossipScript peers =
-    arbitraryShortScriptOf gossipResult
+    sized $ \sz ->
+      arbitraryScriptOf (isqrt sz) gossipResult
   where
     gossipResult :: Gen (Maybe ([PeerAddr], GossipTime))
     gossipResult =
@@ -267,6 +268,9 @@ arbitraryGossipScript peers =
     selectHalfRandomly xs = do
         picked <- vectorOf (length xs) arbitrary
         return [ x | (x, True) <- zip xs picked ]
+
+isqrt :: Int -> Int
+isqrt = floor . sqrt . (fromIntegral :: Int -> Double)
 
 -- | Remove dangling graph edges and gossip results.
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -1,0 +1,505 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+ module Test.Ouroboros.Network.PeerSelection.RootPeersDNS (
+  tests
+  ) where
+
+import           Ouroboros.Network.PeerSelection.RootPeersDNS
+import           Ouroboros.Network.PeerSelection.Types (PeerAdvertise (..))
+
+import           Data.Dynamic (fromDynamic, Typeable)
+import           Data.Foldable (toList, foldl')
+import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import           Data.Sequence (Seq)
+import           Data.Void (Void)
+import           Data.IP (IPv4, toIPv4w, fromHostAddress)
+import           Data.Time.Clock (picosecondsToDiffTime)
+import           Data.ByteString.Char8 (pack)
+import           Data.Set (Set)
+import           Data.Time (DiffTime)
+import           Network.Mux.Timeout (TimeoutFn)
+import qualified Network.DNS.Resolver as DNSResolver
+import           Network.DNS (DNSError(NameError, TimeoutExpired))
+import           Network.Socket (SockAddr (..))
+
+import           Control.Exception (throw)
+import           Control.Monad.IOSim
+import qualified Control.Monad.Class.MonadTimer as MonadTimer
+import           Control.Tracer (Tracer(Tracer), contramap)
+import           Control.Monad.Class.MonadSTM.Strict (newTVarIO, readTVar,
+                                                      MonadSTM (atomically),
+                                                      writeTVar, StrictTVar)
+import           Control.Monad.Class.MonadTime (Time)
+
+import           Test.Ouroboros.Network.PeerSelection.Instances()
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           System.Random (StdGen, split, uniformR, mkStdGen)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+tests :: TestTree
+tests =
+  testGroup "Ouroboros.Network.PeerSelection.RootPeersDNS"
+  [ testGroup "localRootPeersProvider"
+     [ testProperty "preserves groups and targets"
+                    prop_local_preservesGroupNumberAndTargets
+     , testProperty "resolves domains correctly"
+                    prop_local_resolvesDomainsCorrectly
+     , testProperty "updates domains correctly"
+                    prop_local_updatesDomainsCorrectly
+     ]
+  , testGroup "publicRootPeersProvider"
+     [ testProperty "resolves domains correctly"
+                    prop_public_resolvesDomainsCorrectly
+     ]
+  , testGroup "resolveDomainAddresses"
+     [ testProperty "resolves domains correctly"
+                    prop_resolveDomainAddresses_resolvesDomainsCorrectly
+     ]
+  ]
+
+--
+-- Mock Environment and Utils
+--
+
+data MockRoots = MockRoots {
+  mockLocalRootPeers :: [(Int, Map RelayAddress PeerAdvertise)],
+  mockDNSMap :: Map Domain [IPv4],
+  mockStdGen :: StdGen
+} deriving Show
+
+-- | Generates MockRoots environments
+--
+genMockRoots :: Gen MockRoots
+genMockRoots = sized $ \relaysNumber -> do
+    relaysPerGroup <- chooseEnum (1, relaysNumber)
+
+    relays <- vectorOf relaysNumber arbitrary
+    targets <- vectorOf relaysNumber (chooseEnum (1, 5))
+
+    peerAdvertise <- blocks relaysPerGroup
+                      <$> vectorOf relaysNumber (arbitrary @PeerAdvertise)
+
+        -- concat unique identifier to DNS domains to simplify tests
+    let taggedRelays =
+          zipWith
+            (\tag rel
+              -> case rel of
+                   RelayDomain (DomainAddress domain port)
+                     -> RelayDomain
+                        (DomainAddress (domain <> (pack . show) tag)
+                                       port)
+                   x -> x
+            )
+            [(0 :: Int), 1 .. ]
+            relays
+        relaysBlocks = blocks relaysPerGroup taggedRelays
+        relaysMap    = map Map.fromList $ zipWith zip relaysBlocks peerAdvertise
+
+        localRootPeers = zip targets relaysMap
+
+        domains = [ domain | RelayDomain (DomainAddress domain _) <- taggedRelays ]
+
+        ipsPerDomain = 2
+
+    ips <- blocks ipsPerDomain
+            <$> vectorOf (ipsPerDomain * length domains) (toIPv4w <$> arbitrary)
+    gen <- mkStdGen <$> arbitrary
+
+    let dnsMap = Map.fromList $ zip domains ips
+
+    return (MockRoots {
+      mockLocalRootPeers = localRootPeers,
+      mockDNSMap         = dnsMap,
+      mockStdGen         = gen
+    })
+  where
+    blocks _ [] = []
+    blocks s l  = take s l : blocks s (drop s l)
+
+instance Arbitrary MockRoots where
+    arbitrary = genMockRoots
+
+-- | Used for debugging in GHCI
+--
+simpleMockRoots :: MockRoots
+simpleMockRoots = MockRoots localRootPeers dnsMap (mkStdGen 60)
+  where
+    localRootPeers =
+      [ ( 2
+        , Map.fromList
+          [ ( RelayAddress (read "192.0.2.1")           (read "3333")
+            , DoAdvertisePeer
+            )
+          , ( RelayDomain  (DomainAddress "test.domain" (read "4444"))
+            , DoNotAdvertisePeer
+            )
+          ]
+        )
+      ]
+    dnsMap = Map.fromList [ ("test.domain", [read "192.1.1.1", read "192.2.2.2"])
+                          ]
+
+-- | Mock DNSActions data structure for testing purposes.
+-- Adds DNS Lookup function for IOSim with different timeout and lookup
+-- delays for every attempt.
+mockDNSActions :: forall exception s.
+               Map Domain [IPv4]
+               -> StrictTVar (IOSim s) StdGen
+               -> DNSActions () exception (IOSim s)
+mockDNSActions dnsMap stdGenVar =
+    DNSActions {
+      dnsResolverResource,
+      dnsAsyncResolverResource,
+#if defined(mingw32_HOST_OS)
+      dnsNewResolverResource,
+#endif
+      dnsLookupAWithTTL
+    }
+ where
+   genDiffTime :: Integer -> Integer -> StdGen -> DiffTime
+   genDiffTime lo hi =
+    picosecondsToDiffTime
+    . fst
+    . uniformR (lo * 1000000000, hi * 1000000000)
+
+   dnsResolverResource      _ = return (constantResource ())
+   dnsAsyncResolverResource _ = return (constantResource ())
+#if defined(mingw32_HOST_OS)
+   dnsNewResolverResource   _ = constantResource ()
+#endif
+
+   dnsLookupAWithTTL :: TimeoutFn (IOSim s)
+                     -> resolvConf
+                     -> resolver
+                     -> Domain
+                     -> IOSim s (Either DNSError [(IPv4, TTL)])
+   dnsLookupAWithTTL timeout _ _ domain = do
+     gen <- atomically $ readTVar stdGenVar
+
+         -- Small probability of timeout
+     let (_, (g', g'')) = split <$> split gen
+         dtTimeout      = genDiffTime 110 300 g'
+         dtDelay        = genDiffTime 20 120 g''
+
+     atomically $ writeTVar stdGenVar g'
+
+     dnsLookup <-
+        timeout dtTimeout $ do
+          MonadTimer.threadDelay dtDelay
+          case Map.lookup domain dnsMap of
+            Nothing -> return (Left NameError)
+            Just x  -> return (Right (map (\a -> (a, 0)) x))
+
+     case dnsLookup of
+       Nothing -> return (Left TimeoutExpired)
+       Just a  -> return a
+
+-- | 'localRootPeersProvider' running with a given MockRoots env
+--
+mockLocalRootPeersProvider :: forall s. MockRoots -> IOSim s Void
+mockLocalRootPeersProvider (MockRoots localRootPeers dnsMap stdGen) = do
+      localRootPeersVar <- newTVarIO localRootPeers
+      resultVar <- newTVarIO mempty
+      genVar <- newTVarIO stdGen
+
+      localRootPeersProvider tracerTraceLocalRoots
+                             MonadTimer.timeout
+                             DNSResolver.defaultResolvConf
+                             resultVar
+                             (readTVar localRootPeersVar)
+                             (mockDNSActions dnsMap genVar)
+
+-- | 'publicRootPeersProvider' running with a given MockRoots env
+--
+mockPublicRootPeersProvider :: forall s. MockRoots
+                            -> Int
+                            -> IOSim s (Set SockAddr, DiffTime)
+mockPublicRootPeersProvider (MockRoots localRootPeers dnsMap stdGen) n = do
+      localRootPeersVar <- newTVarIO (concatMap (Map.keys . snd) localRootPeers)
+      genVar <- newTVarIO stdGen
+
+      publicRootPeersProvider tracerTracePublicRoots
+                              MonadTimer.timeout
+                              DNSResolver.defaultResolvConf
+                              (readTVar localRootPeersVar)
+                              (mockDNSActions @Failure dnsMap genVar)
+                              ($ n)
+
+-- | 'resolveDomainAddresses' running with a given MockRoots env
+--
+mockResolveDomainAddresses :: forall s. MockRoots
+                           -> IOSim s (Map DomainAddress (Set SockAddr))
+mockResolveDomainAddresses (MockRoots localRootPeers dnsMap stdGen) = do
+      genVar <- newTVarIO stdGen
+
+      resolveDomainAddresses tracerTracePublicRoots
+                             MonadTimer.timeout
+                             DNSResolver.defaultResolvConf
+                             (mockDNSActions @Failure dnsMap genVar)
+                             [ domain
+                             | (_, m) <- localRootPeers
+                             , RelayDomain domain <- Map.keys m ]
+
+--
+-- Utils for properties
+--
+
+data TestTraceEvent exception = RootPeerDNSLocal  (TraceLocalRootPeers exception)
+                              | RootPeerDNSPublic TracePublicRootPeers
+  deriving Show
+
+tracerTraceLocalRoots :: Tracer (IOSim s) (TraceLocalRootPeers Failure)
+tracerTraceLocalRoots = contramap RootPeerDNSLocal tracerTestTraceEvent
+
+tracerTracePublicRoots :: Tracer (IOSim s) TracePublicRootPeers
+tracerTracePublicRoots = contramap RootPeerDNSPublic tracerTestTraceEvent
+
+tracerTestTraceEvent :: Tracer (IOSim s) (TestTraceEvent Failure)
+tracerTestTraceEvent = dynamicTracer
+
+dynamicTracer :: Typeable a => Tracer (IOSim s) a
+dynamicTracer = Tracer traceM
+
+selectRootPeerDNSTraceEvents :: Trace a -> [(Time, TestTraceEvent Failure)]
+selectRootPeerDNSTraceEvents = go
+  where
+    go (Trace t _ _ (EventLog e) trace)
+     | Just x <- fromDynamic e    = (t,x) : go trace
+    go (Trace _ _ _ _ trace)      =         go trace
+    go (TraceMainException _ e _) = throw e
+    go (TraceDeadlock      _   _) = [] -- expected result in many cases
+    go (TraceMainReturn    _ _ _) = []
+
+selectLocalRootPeersEvents :: [(Time, TestTraceEvent Failure)]
+                           -> [(Time, TraceLocalRootPeers Failure)]
+selectLocalRootPeersEvents trace = [ (t, e) | (t, RootPeerDNSLocal e) <- trace ]
+
+selectLocalRootGroupsEvents :: [(Time, TraceLocalRootPeers Failure)]
+                            -> [(Time, Seq (Int, Map SockAddr PeerAdvertise))]
+selectLocalRootGroupsEvents trace = [ (t, e) | (t, TraceLocalRootGroups e) <- trace ]
+
+selectLocalRootResultEvents :: [(Time, TraceLocalRootPeers Failure)]
+                            -> [(Time, (Domain, [IPv4]))]
+selectLocalRootResultEvents trace = [ (t, (domain, map fst r))
+                                    | (t, TraceLocalRootResult (DomainAddress domain _) r) <- trace ]
+
+selectPublicRootPeersEvents :: [(Time, TestTraceEvent Failure)]
+                            -> [(Time, TracePublicRootPeers)]
+selectPublicRootPeersEvents trace = [ (t, e) | (t, RootPeerDNSPublic e) <- trace ]
+
+selectPublicRootFailureEvents :: [(Time, TracePublicRootPeers)]
+                              -> [(Time, Domain)]
+selectPublicRootFailureEvents trace = [ (t, domain)
+                                      | (t, TracePublicRootFailure domain _) <- trace ]
+
+selectPublicRootResultEvents :: [(Time, TracePublicRootPeers)]
+                             -> [(Time, (Domain, [IPv4]))]
+selectPublicRootResultEvents trace = [ (t, (domain, map fst r))
+                                     | (t, TracePublicRootResult domain r) <- trace ]
+
+--
+-- Local Root Peers Provider Tests
+--
+
+-- | The 'localRootPeersProvider' should preserve the local root peers
+-- group number and respective targets. This property tests whether local
+-- root peer groups update due to DNS resolution results, does not alter
+-- the initial groups configuration.
+--
+prop_local_preservesGroupNumberAndTargets :: MockRoots -> Property
+prop_local_preservesGroupNumberAndTargets mockRoots@(MockRoots lrp _ _) =
+    let tr = take 1000
+              $ selectLocalRootGroupsEvents
+              $ selectLocalRootPeersEvents
+              $ selectRootPeerDNSTraceEvents
+              $ runSimTrace
+              $ mockLocalRootPeersProvider mockRoots
+
+        -- For all LocalRootGroup results, the number of groups should be
+        -- preserved, i.e. no new groups are added nor deleted along the
+        -- trace by localRootPeersProvider.
+        preservesGroupNumber = all ((== length lrp) . length . snd) tr
+
+        -- For all LocalRootGroup results, the targets for each group
+        -- should be preserved, i.e. targets are not modified along the
+        -- trace by localRootPeersProvider.
+        preservesTargets     = all (all (\(a, b) -> fst a == fst b))
+                                   [ zip lrp (toList r) | r <- map snd tr ]
+
+     in preservesGroupNumber .&&. preservesTargets
+
+-- | The 'localRootPeersProvider' should be able to resolve DNS domains
+-- correctly, assuming the domain maps to any IP address. This property
+-- tests whether 'localRootPeersProvider' is capable of eventually resolving
+-- domain addresses even after having failed to do so in the first attempt.
+--
+prop_local_resolvesDomainsCorrectly :: MockRoots -> Property
+prop_local_resolvesDomainsCorrectly mockRoots@(MockRoots _ dnsMap _) =
+    let tr = take 1000
+              $ selectLocalRootResultEvents
+              $ selectLocalRootPeersEvents
+              $ selectRootPeerDNSTraceEvents
+              $ runSimTrace
+              $ mockLocalRootPeersProvider mockRoots
+
+        finalResultMap = Map.fromList $ map snd tr
+
+     in finalResultMap === dnsMap
+
+-- | The 'localRootPeersProvider' after resolving a DNS domain address
+-- should update the local result group list correctly, i.e. add the
+-- resolved ip addresses to the correct group where the domain address was
+-- (in the initial configuration specification). This property tests whether
+-- after a successful DNS lookup the result list is updated correctly.
+prop_local_updatesDomainsCorrectly :: MockRoots -> Property
+prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _) =
+    let tr = take 1000
+              $ selectLocalRootPeersEvents
+              $ selectRootPeerDNSTraceEvents
+              $ runSimTrace
+              $ mockLocalRootPeersProvider mockRoots
+        r = foldl' (\(b, (t, x)) (t', y) ->
+                    case (x, y) of
+                      -- Last DNS lookup result   , Current result groups value
+                      (TraceLocalRootResult da res, TraceLocalRootGroups lrpg) ->
+                            -- create and index db for each group
+                        let db = zip [0,1..] lrp
+                            -- since our MockRoots generator generates
+                            -- unique domain addresses we can look for
+                            -- which group index does a particular domain
+                            -- address belongs
+                            index = foldr (\(i, (_, m)) prev ->
+                                            case Map.lookup (RelayDomain da) m of
+                                              Nothing -> prev
+                                              Just _  -> i
+                                          ) (-1) db
+                            -- Get all IPv4 present in group at position
+                            -- 'index'
+                            ipsAtIndex = map (\sockAddr ->
+                                             case sockAddr of
+                                               SockAddrInet _ hostAddr
+                                                 -> fromHostAddress hostAddr
+                                               _ -> error "Impossible happened!"
+
+                                         ) $ Map.keys
+                                           $ snd
+                                           $ lrpg `Seq.index` index
+                            -- Check if all ips from the previous DNS
+                            -- lookup result are present in the current
+                            -- result group at the correct index
+                            arePresent = all ((`elem` ipsAtIndex) . fst) res
+                         in (arePresent && b, (t', y))
+
+                      (TraceLocalRootResult _ _, _) -> (b, (t, x))
+                      (_, _)                        -> (b, (t', y))
+                   )
+              (True, head tr)
+              (tail tr)
+     in property (fst r)
+
+
+--
+-- Public Root Peers Provider Tests
+--
+
+-- | The 'publicRootPeersProvider' should be able to resolve DNS domains
+-- correctly, assuming the domain maps to any IP address. This property
+-- tests whether 'publicRootPeersProvider' is capable of eventually resolving domain
+-- addresses even after having failed to do so in the first attempt, in
+-- a bounded amount of time.
+--
+prop_public_resolvesDomainsCorrectly :: MockRoots -> Int -> Property
+prop_public_resolvesDomainsCorrectly mockRoots@(MockRoots _ dnsMap _) n =
+    within 1_000_000 $
+      lookupLoop mockRoots dnsMap === dnsMap
+  where
+    -- Perform public root DNS lookup until no failures
+    lookupLoop :: MockRoots -> Map Domain [IPv4] -> Map Domain [IPv4]
+    lookupLoop mr res =
+      let successes = selectPublicRootResultEvents
+                        $ selectPublicRootPeersEvents
+                        $ selectRootPeerDNSTraceEvents
+                        $ runSimTrace
+                        $ mockPublicRootPeersProvider mr n
+
+          failures = selectPublicRootFailureEvents
+                      $ selectPublicRootPeersEvents
+                      $ selectRootPeerDNSTraceEvents
+                      $ runSimTrace
+                      $ mockPublicRootPeersProvider mr n
+
+          successesMap = Map.fromList $ map snd successes
+
+          -- Update MockRoots with only the RelayAddresses that failed the
+          -- DNS timeouts
+          failuresMap  =
+            [ ( i
+              , Map.fromList [ (RelayDomain domain, pa)
+                             | (RelayDomain domain, pa) <- Map.toList m
+                             , daDomain domain `elem` map snd failures
+                             ]
+              )
+            | (i, m) <- mockLocalRootPeers mr
+            ]
+          newMR = mr { mockLocalRootPeers = failuresMap }
+
+       in if null failures
+            then res
+            else lookupLoop newMR (res <> successesMap)
+
+-- | The 'resolveDomainAddresses' should be able to resolve DNS domains
+-- correctly, assuming the domain maps to any IP address. This property
+-- tests whether 'resolveDomainAddresses' is capable of eventually resolving domain
+-- addresses even after having failed to do so in the first attempt, in
+-- a bounded amount of time.
+--
+prop_resolveDomainAddresses_resolvesDomainsCorrectly :: MockRoots -> Property
+prop_resolveDomainAddresses_resolvesDomainsCorrectly
+  mockRoots@(MockRoots _ dnsMap _) =
+    within 1000000 $
+      lookupLoop mockRoots dnsMap === dnsMap
+  where
+    -- Perform public root DNS lookup until no failures
+    lookupLoop :: MockRoots -> Map Domain [IPv4] -> Map Domain [IPv4]
+    lookupLoop mr res =
+      let successes = selectPublicRootResultEvents
+                        $ selectPublicRootPeersEvents
+                        $ selectRootPeerDNSTraceEvents
+                        $ runSimTrace
+                        $ mockResolveDomainAddresses mr
+
+          failures = selectPublicRootFailureEvents
+                      $ selectPublicRootPeersEvents
+                      $ selectRootPeerDNSTraceEvents
+                      $ runSimTrace
+                      $ mockResolveDomainAddresses mr
+
+          successesMap = Map.fromList $ map snd successes
+
+          -- Update MockRoots with only the RelayAddresses that failed the
+          -- DNS timeouts
+          failuresMap  =
+            [ ( i
+              , Map.fromList [ (RelayDomain domain, pa)
+                             | (RelayDomain domain, pa) <- Map.toList m
+                             , daDomain domain `elem` map snd failures
+                             ]
+              )
+            | (i, m) <- mockLocalRootPeers mr
+            ]
+          newMR = mr { mockLocalRootPeers = failuresMap }
+
+       in if null failures
+            then res
+            else lookupLoop newMR (res <> successesMap)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
@@ -112,6 +112,7 @@ playTimedScript :: (MonadAsync m, MonadTimer m)
                 => Tracer m a -> TimedScript a -> m (TVar m a)
 playTimedScript tracer (Script ((x0,d0) :| script)) = do
     v <- newTVarIO x0
+    traceWith tracer x0
     _ <- async $ do
            threadDelay (interpretScriptDelay d0)
            sequence_ [ do atomically (writeTVar v x)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
@@ -11,6 +11,7 @@ module Test.Ouroboros.Network.PeerSelection.Script (
     stepScript,
     stepScriptSTM,
     arbitraryScriptOf,
+    prop_shrink_Script,
 
     -- * Timed scripts
     ScriptDelay(..),
@@ -189,4 +190,12 @@ interpretPickMembers (PickSome as) ps n
   | otherwise    = Set.take n ps'
   where
     ps' = Set.intersection ps as
+
+
+--
+-- Tests for the QC Arbitrary instances
+--
+
+prop_shrink_Script :: Fixed (Script Int) -> Property
+prop_shrink_Script = prop_shrink_nonequal
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/Script.hs
@@ -176,9 +176,6 @@ interpretPickScript scriptVar available pickNum
   | pickNum <= 0
   = error "interpretPickScript: given invalid pickNum"
 
-  | Set.size available <= pickNum
-  = return available
-
   | otherwise
   = do pickmembers <- stepScriptSTM scriptVar
        return (interpretPickMembers pickmembers available pickNum)

--- a/ouroboros-network/test/Test/QuickCheck/Signal.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Signal.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.QuickCheck.Signal where
+
+import qualified Deque.Lazy as Deque
+import           Deque.Lazy (Deque)
+import qualified Data.Foldable as Deque (toList)
+import qualified Data.Signal as Signal
+import           Data.Signal (Signal)
+
+import           Control.Monad.Class.MonadTime (Time)
+
+import           Test.QuickCheck
+
+
+-- | Check a property over a 'Signal'. The property should be true at all times.
+--
+-- On failure it shows the @n@ most recent signal values.
+--
+signalProperty :: forall a. Int -> (a -> String)
+               -> (a -> Bool) -> Signal a -> Property
+signalProperty atMost showSignalValue p =
+    go 0 mempty . Signal.eventsToList . Signal.toChangeEvents
+  where
+    go :: Int -> Deque (Time, a) -> [(Time, a)] -> Property
+    go !_ !_ []                   = property True
+    go !n !q ((t, x) : txs) | p x = next
+      where
+        next
+          | n < atMost = go (n+1) (              Deque.snoc (t,x)  q) txs
+          | otherwise  = go n     ((Deque.tail . Deque.snoc (t,x)) q) txs
+
+    go !_ !recent ((t, x) : _) = counterexample details (property False)
+      where
+        details =
+          unlines [ "Last " ++ show atMost ++ " signal values:"
+                  , unlines [ show t' ++ "\t: " ++ showSignalValue x'
+                            | (t',x') <- Deque.toList recent ]
+                  , "Property violated at: " ++ show t
+                  , "Invalid signal value:"
+                  , showSignalValue x
+                  ]

--- a/ouroboros-network/test/Test/QuickCheck/Utils.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Utils.hs
@@ -1,0 +1,18 @@
+
+-- | QuickCheck utils
+--
+module Test.QuickCheck.Utils (
+
+    -- * Reporting utils
+    renderRanges,
+
+  ) where
+
+
+-- | Use in 'tabulate' to help summarise data into buckets.
+--
+renderRanges :: Int -> Int -> String
+renderRanges r n = show lower ++ " -- " ++ show upper
+  where
+    lower = n - n `mod` r
+    upper = lower + (r-1)

--- a/ouroboros-network/test/Test/QuickCheck/Utils.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Utils.hs
@@ -4,12 +4,31 @@
 module Test.QuickCheck.Utils (
 
     -- * Generator and shrinker utils
+    arbitrarySubset,
     shrinkListElems,
 
     -- * Reporting utils
     renderRanges,
 
   ) where
+
+import           Data.Set (Set)
+import qualified Data.Set as Set
+
+import           Test.QuickCheck
+
+-- | Pick a subset of a set, using a 50:50 chance for each set element.
+--
+arbitrarySubset :: Ord a => Set a -> Gen (Set a)
+arbitrarySubset s = do
+    picks <- vectorOf (Set.size s) (arbitrary :: Gen Bool)
+    let s' = Set.fromList
+           . map snd
+           . filter fst
+           . zip picks
+           . Set.toList
+           $ s
+    return s'
 
 
 -- | Like 'shrinkList' but only shrink the elems, don't drop elements.

--- a/ouroboros-network/test/Test/QuickCheck/Utils.hs
+++ b/ouroboros-network/test/Test/QuickCheck/Utils.hs
@@ -3,10 +3,23 @@
 --
 module Test.QuickCheck.Utils (
 
+    -- * Generator and shrinker utils
+    shrinkListElems,
+
     -- * Reporting utils
     renderRanges,
 
   ) where
+
+
+-- | Like 'shrinkList' but only shrink the elems, don't drop elements.
+--
+-- Useful when you want a custom strategy for dropping elements.
+--
+shrinkListElems :: (a -> [a]) -> [a] -> [[a]]
+shrinkListElems _   []     = []
+shrinkListElems shr (x:xs) = [ x':xs | x'  <- shr x ]
+                          ++ [ x:xs' | xs' <- shrinkListElems shr xs ]
 
 
 -- | Use in 'tabulate' to help summarise data into buckets.


### PR DESCRIPTION
- p2p-governor: peer selection without gossip
- p2p-governor: localRootPersProvider
- p2p-governor: use ledger as a source for publicRootPeers
- p2p-governor: improved tracing when ledger peers is disabled
- p2p-governor: PoolStake: derive Real instance
- p2p-governor: force the list of ledger peers to WHNF
- p2p-governor: keep lookup results for different domains separate
- p2p-governor: basic churnGovernor based on random selection only
- p2p-governor: sleep between 3300s and 3900s between churns
- p2p-governor: Adjust number of active peers based on fetchmode
- p2p-governor: added PeerSelectionCounters and respective tracers.
- p2p-governor: change LocalRootPeers.toGroups to match fromGroups, and use in Show
- p2p-governor: fix a bug in the QC shrinker for the p2p governor mock environment
- p2p-governor: move QC utils to their own module
- p2p-governor: improve the Script shrinker
- p2p-governor: Restructure the p2p governor tests a bit: split, add and reorder
- p2p-governor: Slightly simplify the Arbitrary instance for PeerAddr
- p2p-governor: Make the arbitraryScriptOf generator more general and use it more
- p2p-governor: Generalise the LocalRootPeers instance for Arbitrary
- p2p-governor: Change the PickScript to pick elements not offsets.
- p2p-governor: Extend the shrinker tests: test that the shrinkers shrink!
- p2p-governor: Add a "no excessive busyness" test for the p2p governor
- p2p-governor: Adjust prop_governor_gossip_1hr to allow demotions
- p2p-governor: Adjust prop_governor_connstatus to allow demotions
- p2p-governor: Improve counterexamples for +prop_governor_connstatus
- p2p-governor: Improve the mock env pick script interpretation
- p2p-governor: Adjust playTimedScript to trace the initial value
- p2p-governor: Add new env tracers for public roots and gossips
- p2p-governor: Make gossip failure results take non-zero time
- p2p-governor: Add a new signal-based abstraction for expressing properties
- p2p-governor: New governor properties for making progress towards targets
- p2p-governor: Add a few misc comments and TODOs
- p2p-governor: Order p2p governor tests after the livelock test
- p2p-governor: Update the comment on the list of properties
- p2p-governor: Add review feedback
- p2p-governor: Fix prop_governor_target_known_1_valid_subset
- p2p-governor: Add more Signal primitives
- p2p-governor: Replace one use of Signal.primitiveTransformEvents
- p2p-governor: Adjust LocalRootPeers to require targets > 0
- p2p-governor: Minor correction in a comment
- p2p-governor: Fix the prop_governor_target_known_above property
- p2p-governor: Adjust established and active target properties for local roots
- p2p-governor: Add support for hitting the local root peer targets
- p2p-governor: Refactored localRootPeersProvider
- p2p-governor: Scale pool's stake by sqrt
- p2p-governor: new root peers configuration (#3079)
- p2p-governor: Refactored DNS resolution to use io-sim-classes
- p2p-governor: Added dns resolution tests
- p2p-governor: Process synchronous hot promotion errors
- p2p-governor: add some randomness to the reconnection delay
