### PR TITLE
Update cabal.project to reflect the re-arranged cardano-ledger repo

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -211,26 +211,26 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ec51e4fb1b17461ab612cf427b79f1742942e8cb
-  --sha256: 05bwy7x1asyfshqsfsyv2c70qwrxp4680xlvhwdm1hz9bi0lpq41
+  tag: ac51494e151af0ad99b937a787458ce71db0aaea
+  --sha256: 1dh80kaqhq4fn0w1dixcqiir3mz5nahr7n9drds3rrjlx1nkczi4
   subdir:
-    alonzo/impl
-    alonzo/test
-    byron/chain/executable-spec
-    byron/crypto
-    byron/crypto/test
-    byron/ledger/executable-spec
-    byron/ledger/impl
-    byron/ledger/impl/test
-    cardano-ledger-core
-    cardano-protocol-tpraos
-    semantics/executable-spec
-    semantics/small-steps-test
-    shelley/chain-and-ledger/dependencies/non-integer
-    shelley/chain-and-ledger/executable-spec
-    shelley/chain-and-ledger/shelley-spec-ledger-test
-    shelley-ma/impl
-    shelley-ma/shelley-ma-test
+    eras/alonzo/impl
+    eras/alonzo/test-suite
+    eras/byron/chain/executable-spec
+    eras/byron/crypto
+    eras/byron/crypto/test
+    eras/byron/ledger/executable-spec
+    eras/byron/ledger/impl
+    eras/byron/ledger/impl/test
+    eras/shelley-ma/impl
+    eras/shelley-ma/test-suite
+    eras/shelley/impl
+    eras/shelley/test-suite
+    libs/cardano-ledger-core
+    libs/cardano-protocol-tpraos
+    libs/non-integral
+    libs/small-steps
+    libs/small-steps-test
 
 source-repository-package
   type: git

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -46,9 +46,9 @@ library
                      , cardano-ledger-alonzo-test
                      , cardano-ledger-byron
                      , cardano-ledger-core
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-test
                      , cardano-protocol-tpraos
-                     , shelley-spec-ledger
-                     , shelley-spec-ledger-test
 
                      , ouroboros-network
                      , ouroboros-consensus
@@ -95,11 +95,11 @@ test-suite test
                      , tasty
                      , tasty-quickcheck
 
-                     , cardano-ledger-core
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
+                     , cardano-ledger-core
+                     , cardano-ledger-shelley
                      , cardano-protocol-tpraos
-                     , shelley-spec-ledger
 
                      , ouroboros-network
                      , ouroboros-consensus

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
@@ -23,7 +23,7 @@ import           Ouroboros.Consensus.Shelley.Protocol (PraosCrypto)
 -- * Similarly, @HASH@ has to have the same bit size as Byron header hashes (ie
 --   256), that's why we use 'Blake2b_256' here.
 --
--- * The @shelley-spec-ledger@ package currently requires that @'DSIGN' ~
+-- * The @cardano-ledger-shelley@ package currently requires that @'DSIGN' ~
 --   'Ed25519DSIGN' in order to use Byron bootstrap witnesses.
 --
 -- * We can still use mock KES and mock VRF.

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -44,7 +44,7 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 import qualified Ouroboros.Consensus.HardFork.History as History
 
 import qualified Cardano.Ledger.Era as SL
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Mempool.TxLimits (TxLimits)
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -38,12 +38,12 @@ import           Cardano.Chain.Genesis (GeneratedSecrets (..))
 import qualified Cardano.Ledger.Address as SL (BootstrapAddress (..))
 import qualified Cardano.Ledger.Hashes as SL
 import qualified Cardano.Ledger.SafeHash as SL
-import           Cardano.Ledger.Val ((<->))
-import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.Address.Bootstrap as SL
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.Address.Bootstrap as SL
                      (makeBootstrapWitness)
-import qualified Shelley.Spec.Ledger.Tx as SL (WitnessSetHKD (..))
-import qualified Shelley.Spec.Ledger.UTxO as SL (makeWitnessVKey)
+import qualified Cardano.Ledger.Shelley.Tx as SL (WitnessSetHKD (..))
+import qualified Cardano.Ledger.Shelley.UTxO as SL (makeWitnessVKey)
+import           Cardano.Ledger.Val ((<->))
 
 import           Ouroboros.Consensus.Shelley.Ledger (GenTx, ShelleyBlock,
                      mkShelleyTx)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
@@ -43,8 +43,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
 
 import qualified Cardano.Ledger.BaseTypes as SL
+import qualified Cardano.Ledger.Shelley.PParams as SL
 import qualified Cardano.Protocol.TPraos.OCert as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Node

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -45,7 +45,7 @@ import           Ouroboros.Consensus.Byron.Ledger.Conversions
 import           Ouroboros.Consensus.Byron.Node
 
 import qualified Cardano.Ledger.BaseTypes as SL (ActiveSlotCoeff)
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Node
 

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
@@ -41,7 +41,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
 
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Node

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -43,8 +43,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
 
 import qualified Cardano.Ledger.BaseTypes as SL
+import qualified Cardano.Ledger.Shelley.PParams as SL
 import qualified Cardano.Protocol.TPraos.OCert as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Node

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -46,10 +46,10 @@ library
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
                      , cardano-ledger-core
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-ma
                      , cardano-prelude
                      , cardano-slotting
-                     , shelley-spec-ledger
-                     , cardano-ledger-shelley-ma
 
                      , ouroboros-network
                      , ouroboros-consensus
@@ -79,12 +79,12 @@ executable db-analyser
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
                      , cardano-ledger-core
+                     , cardano-ledger-shelley
                      , cborg
                      , containers
                      , contra-tracer
                      , mtl
                      , optparse-applicative
-                     , shelley-spec-ledger
                      , strict-containers
                      , text
 

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -77,7 +77,7 @@ import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import           Cardano.Ledger.Crypto (ADDRHASH, DSIGN, HASH)
 import qualified Cardano.Ledger.Era as SL
 import           Cardano.Ledger.Mary.Translation ()
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Cardano.Block
 
@@ -249,7 +249,7 @@ type CardanoHardForkConstraints c =
   , ShelleyBasedEra (MaryEra    c)
   , ShelleyBasedEra (AlonzoEra  c)
     -- These equalities allow the transition from Byron to Shelley, since
-    -- @shelley-spec-ledger@ requires Ed25519 for Byron bootstrap addresses and
+    -- @cardano-ledger-shelley@ requires Ed25519 for Byron bootstrap addresses and
     -- the current Byron-to-Shelley translation requires a 224-bit hash for
     -- address and a 256-bit hash for header hashes.
   , HASH     c ~ Blake2b_256

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -80,7 +80,7 @@ import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Byron.Node
 
 import qualified Cardano.Ledger.Era as Core
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -23,7 +23,7 @@ import           Options.Applicative
 
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as CL
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -45,10 +45,10 @@ library
                        -- cardano-ledger-specs
                      , cardano-ledger-alonzo
                      , cardano-ledger-alonzo-test
+                     , cardano-ledger-shelley
                      , cardano-ledger-shelley-ma
                      , cardano-ledger-shelley-ma-test
-                     , shelley-spec-ledger
-                     , shelley-spec-ledger-test
+                     , cardano-ledger-shelley-test
                      , small-steps
 
                      , ouroboros-network
@@ -92,7 +92,7 @@ test-suite test
                      , cardano-ledger-alonzo
                      , cardano-ledger-alonzo-test
                      , cardano-ledger-core
-                     , shelley-spec-ledger
+                     , cardano-ledger-shelley
 
                      , ouroboros-network
                      , ouroboros-consensus

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -29,7 +29,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Storage.Serialisation
 
-import           Test.Shelley.Spec.Ledger.Orphans ()
+import           Test.Cardano.Ledger.Shelley.Orphans ()
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger
@@ -48,7 +48,7 @@ import           Test.Cardano.Ledger.Alonzo.Examples.Consensus
                      (ledgerExamplesAlonzo)
 import           Test.Cardano.Ledger.Mary.Examples.Consensus
                      (ledgerExamplesMary)
-import           Test.Shelley.Spec.Ledger.Examples.Consensus
+import           Test.Cardano.Ledger.Shelley.Examples.Consensus
                      (ShelleyLedgerExamples (..), ShelleyResultExamples (..),
                      ledgerExamplesShelley, testShelleyGenesis)
 

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -22,7 +22,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger
@@ -39,13 +39,13 @@ import           Test.Util.Serialisation.Roundtrip (Coherent (..),
 import           Test.Cardano.Ledger.AllegraEraGen ()
 import           Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 import           Test.Cardano.Ledger.MaryEraGen ()
+import           Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes as SL
+import           Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
+import           Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators
+                     (genCoherentBlock)
+import           Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
 import           Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
 import           Test.Consensus.Shelley.MockCrypto (CanMock)
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as SL
-import           Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
-import           Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators
-                     (genCoherentBlock)
-import           Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 
 {-------------------------------------------------------------------------------
   Generators

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
@@ -20,13 +20,13 @@ import           Cardano.Crypto.KES (MockKES)
 
 import qualified Cardano.Ledger.Core as Core
 import           Cardano.Ledger.Crypto (Crypto (..))
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.Tx as SL (ValidateScript)
 import           Control.State.Transition.Extended (PredicateFailure)
-import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.Tx as SL (ValidateScript)
 
 import           Test.Cardano.Crypto.VRF.Fake (FakeVRF)
-import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as SL (Mock)
-import qualified Test.Shelley.Spec.Ledger.Generator.EraGen as SL (EraGen)
+import qualified Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes as SL (Mock)
+import qualified Test.Cardano.Ledger.Shelley.Generator.EraGen as SL (EraGen)
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto, ShelleyBasedEra,
                      ShelleyEra)

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
@@ -4,7 +4,7 @@ import qualified Data.Map as Map
 
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import           Cardano.Ledger.Alonzo.Scripts (Prices (..))
-import           Shelley.Spec.Ledger.API (Coin (..))
+import           Cardano.Ledger.Shelley.API (Coin (..))
 
 degenerateAlonzoGenesis :: AlonzoGenesis
 degenerateAlonzoGenesis = AlonzoGenesis {

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -79,14 +79,14 @@ import           Cardano.Ledger.Hashes (EraIndependentTxBody)
 import qualified Cardano.Ledger.Keys
 import           Cardano.Ledger.SafeHash (HashAnnotated (..), SafeHash,
                      hashAnnotated)
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.PParams as SL (emptyPParams,
+                     emptyPParamsUpdate)
+import qualified Cardano.Ledger.Shelley.Tx as SL (WitnessSetHKD (..))
+import qualified Cardano.Ledger.Shelley.UTxO as SL (makeWitnessesVKey)
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 import qualified Cardano.Ledger.Val as SL
 import qualified Cardano.Protocol.TPraos.OCert as SL (OCertSignable (..))
-import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.PParams as SL (emptyPParams,
-                     emptyPParamsUpdate)
-import qualified Shelley.Spec.Ledger.Tx as SL (WitnessSetHKD (..))
-import qualified Shelley.Spec.Ledger.UTxO as SL (makeWitnessesVKey)
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto, ShelleyEra)
 import           Ouroboros.Consensus.Shelley.Ledger (GenTx (..),
@@ -94,8 +94,8 @@ import           Ouroboros.Consensus.Shelley.Ledger (GenTx (..),
 import           Ouroboros.Consensus.Shelley.Node
 import           Ouroboros.Consensus.Shelley.Protocol
 
-import qualified Test.Shelley.Spec.Ledger.Generator.Core as Gen
-import           Test.Shelley.Spec.Ledger.Utils (unsafeBoundRational)
+import qualified Test.Cardano.Ledger.Shelley.Generator.Core as Gen
+import           Test.Cardano.Ledger.Shelley.Utils (unsafeBoundRational)
 
 {-------------------------------------------------------------------------------
   The decentralization parameter

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -22,7 +22,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger
 
@@ -30,13 +30,13 @@ import           Test.QuickCheck
 
 import           Test.ThreadNet.TxGen (TxGen (..))
 
-import qualified Test.Shelley.Spec.Ledger.Generator.Constants as Gen
-import qualified Test.Shelley.Spec.Ledger.Generator.Core as Gen
-import           Test.Shelley.Spec.Ledger.Generator.EraGen
+import qualified Test.Cardano.Ledger.Shelley.Generator.Constants as Gen
+import qualified Test.Cardano.Ledger.Shelley.Generator.Core as Gen
+import           Test.Cardano.Ledger.Shelley.Generator.EraGen
                      (EraGen (genEraTwoPhase2Arg, genEraTwoPhase3Arg))
-import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Gen.Presets
-import           Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
-import qualified Test.Shelley.Spec.Ledger.Generator.Utxo as Gen
+import qualified Test.Cardano.Ledger.Shelley.Generator.Presets as Gen.Presets
+import           Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
+import qualified Test.Cardano.Ledger.Shelley.Generator.Utxo as Gen
 
 import           Test.Consensus.Shelley.MockCrypto (MockCrypto, MockShelley)
 import           Test.ThreadNet.Infra.Shelley

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
@@ -34,7 +34,7 @@ import           Test.Util.Slots (NumSlots (..))
 
 import qualified Cardano.Ledger.BaseTypes as SL (UnitInterval,
                      mkNonceFromNumber, unboundRational)
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -69,8 +69,8 @@ library
 
                        -- cardano-ledger-specs
                      , cardano-ledger-alonzo
+                     , cardano-ledger-shelley
                      , cardano-ledger-shelley-ma
-                     , shelley-spec-ledger
                      , small-steps
 
                      , ouroboros-network

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
@@ -62,11 +62,11 @@ import           Cardano.Ledger.Mary (MaryEra)
 import           Cardano.Ledger.Mary.Translation ()
 import           Cardano.Ledger.Serialization
 import           Cardano.Ledger.Shelley (ShelleyEra)
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.Rules.Ledger as SL
+import qualified Cardano.Ledger.Shelley.Rules.Utxow as SL
 import           Cardano.Ledger.ShelleyMA ()
 import           Control.State.Transition (State)
-import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.STS.Ledger as SL
-import qualified Shelley.Spec.Ledger.STS.Utxow as SL
 
 import           Ouroboros.Consensus.Ledger.SupportsMempool
                      (WhetherToIntervene (..))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -53,7 +53,7 @@ import           Ouroboros.Consensus.Util.Condense
 
 import           Cardano.Ledger.Crypto (Crypto, HASH)
 import qualified Cardano.Ledger.Era as SL (hashTxSeq)
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -32,7 +32,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -26,9 +26,9 @@ import           Ouroboros.Consensus.Util.Assert
 
 import qualified Cardano.Ledger.Core as Core (Tx)
 import qualified Cardano.Ledger.Era as SL (hashTxSeq, toTxSeq)
+import qualified Cardano.Ledger.Shelley.API as SL (extractTx)
+import qualified Cardano.Ledger.Shelley.BlockChain as SL (Block (..), bBodySize)
 import qualified Cardano.Protocol.TPraos.BHeader as SL
-import qualified Shelley.Spec.Ledger.API as SL (extractTx)
-import qualified Shelley.Spec.Ledger.BlockChain as SL (Block (..), bBodySize)
 
 import           Ouroboros.Consensus.Mempool.TxLimits (TxLimits)
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Consensus.Util.Condense
 
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.Core as Core
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
@@ -13,7 +13,7 @@ import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block
 
 import qualified Cardano.Ledger.Keys as SL (verifySignedKES)
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -81,10 +81,10 @@ import           Ouroboros.Consensus.Util.Versioned
 
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Core
+import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Control.State.Transition.Extended as STS
-import qualified Shelley.Spec.Ledger.API as SL
 
-import qualified Shelley.Spec.Ledger.STS.Chain as SL (PredicateFailure)
+import qualified Cardano.Ledger.Shelley.Rules.Chain as SL (PredicateFailure)
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -58,8 +58,8 @@ import           Cardano.Ledger.Alonzo.PParams
 import           Cardano.Ledger.Alonzo.Tx (ValidatedTx (..), totExUnits)
 import qualified Cardano.Ledger.Core as Core (Tx)
 import qualified Cardano.Ledger.Era as SL (Crypto, TxSeq, fromTxSeq)
-import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.UTxO as SL (txid)
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.UTxO as SL (txid)
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
@@ -22,9 +22,9 @@ import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 
 import           Cardano.Ledger.BaseTypes
 import qualified Cardano.Ledger.Keys as SL
+import qualified Cardano.Ledger.Shelley.LedgerState as SL
+import qualified Cardano.Ledger.Shelley.TxBody as SL
 import qualified Cardano.Protocol.TPraos as SL
-import qualified Shelley.Spec.Ledger.LedgerState as SL
-import qualified Shelley.Spec.Ledger.TxBody as SL
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -50,9 +50,10 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Util (ShowProxy (..))
 
 import qualified Cardano.Ledger.Core as LC
-import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.LedgerState as SL (RewardAccounts)
-import qualified Shelley.Spec.Ledger.RewardProvenance as SL (RewardProvenance)
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.LedgerState as SL (RewardAccounts)
+import qualified Cardano.Ledger.Shelley.RewardProvenance as SL
+                     (RewardProvenance)
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
@@ -15,7 +15,7 @@ import           Cardano.Crypto.VRF (certifiedOutput)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Signed
 
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -73,11 +73,11 @@ import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
 import qualified Cardano.Ledger.Era as Core
+import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.Constraints as SL (makeTxOut)
+import qualified Cardano.Ledger.Shelley.LedgerState as SL (stakeDistr)
 import           Cardano.Ledger.Val (coin, inject, (<->))
 import qualified Cardano.Protocol.TPraos.OCert as Absolute (KESPeriod (..))
-import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.LedgerState as SL (stakeDistr)
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -22,7 +22,7 @@ import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Storage.Serialisation
 
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -68,9 +68,9 @@ import           Ouroboros.Consensus.Util.Versioned
 
 import qualified Cardano.Ledger.BaseTypes as SL (ActiveSlotCoeff, Seed)
 import           Cardano.Ledger.Crypto (StandardCrypto, VRF)
+import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL (mkSeed, seedEta, seedL)
 import qualified Cardano.Protocol.TPraos.OCert as Absolute (KESPeriod (..))
-import qualified Shelley.Spec.Ledger.API as SL
 
 import           Ouroboros.Consensus.Shelley.Protocol.HotKey (HotKey)
 import qualified Ouroboros.Consensus.Shelley.Protocol.HotKey as HotKey

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -50,7 +50,7 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.TypeFamilyWrappers
 
 import qualified Cardano.Ledger.Era as SL
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger

--- a/ouroboros-consensus/docs/AddingAnEra.md
+++ b/ouroboros-consensus/docs/AddingAnEra.md
@@ -27,7 +27,7 @@ be adding is the Alonzo era, which comes after the Mary era.
 * Locate the new tag in the ledger, e.g., `AlonzoEra`. This is an empty data
   type that is used at the type level to indicate the era. The ledger should
   have an instance of the `ShelleyBasedEra` class (the class defined in
-  `Shelley.Spec.Ledger.API`, do not confuse it with the class with the same name
+  `Cardano.Ledger.Shelley.API`, do not confuse it with the class with the same name
   in consensus) for this era. This class should provide all the instances
   consensus integration will rely on.
 

--- a/ouroboros-consensus/docs/StyleGuide.md
+++ b/ouroboros-consensus/docs/StyleGuide.md
@@ -910,7 +910,7 @@ the rules below, it is good practice to update the code's style to match them.
     import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 
     -- cardano-ledger-specs
-    import qualified Shelley.Spec.Ledger.API as SL
+    import qualified Cardano.Ledger.Shelley.API as SL
 
     -- ouroboros-consensus-shelley (or mock or byron)
     import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)

--- a/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
@@ -269,10 +269,10 @@ instance Arbitrary a => Arbitrary (LargeNonEmptyList a) where
 
 prop_txSubmission :: Positive Word16
                   -> NonEmptyList (Tx Int)
-                  -- | The delay must be smaller (<) than 5s, so that overall
+                  -> Maybe (Positive SmallDelay)
+                  -- ^ The delay must be smaller (<) than 5s, so that overall
                   -- delay is less than 10s, otherwise 'smallDelay' in
                   -- 'timeLimitsTxSubmission' will kick in.
-                  -> Maybe (Positive SmallDelay)
                   -> Property
 prop_txSubmission (Positive maxUnacked) (NonEmpty outboundTxs) delay =
     let mbDelayTime = getSmallDelay . getPositive <$> delay


### PR DESCRIPTION
Recently cardano-ledger repo underwent some reorganization in https://github.com/input-output-hk/cardano-ledger-specs/pull/2483 

Changes this PR will make the ouroboros-network buildable. However there are some module renames that will cause deprecation warnings, which still need to be accounted for, in particular these  renames:

* `Shelley.Spec.Ledger.STS` -> `Cardano.Ledger.Shelley.Rules`
* `Shelley.Spec.Ledger.*` -> `Cardano.Ledger.Shelley.*`
* and `Test.Shelley.Spec.Ledger.*` -> `Test.Cardano.Ledger.Shelley.*`
