### PR TITLE
Fix race condition in the thread tracking set

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Server/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server/Socket.hs
@@ -258,6 +258,10 @@ mainLoop errorPolicyTrace resQ threadsVar statusVar complete main =
   connectionTx :: STM (IO t)
   connectionTx = do
     result <- STM.readTQueue resQ
+    -- Make sure we don't cleanup before spawnOne has inserted the thread
+    isMember <- Set.member (resultThread result) <$> STM.readTVar threadsVar
+    STM.check isMember
+
     st <- STM.readTVar statusVar
     CompleteApplicationResult
       { carState


### PR DESCRIPTION
It was possible for threads to get "removed" before spawnOne had added
the threads. This caused those threads to never get removed which would
trigger ratelimiting and eventually the node would refuse to accept new
connections.

Change it so that if the thread isn't inserted yet we will wait for
spawnOne to do it before we remove the thread.

Thanks to @psychomb for helping troubleshoot this problem.