### PR TITLE
Add new analysis --count-blocks

### DIFF
--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -61,6 +61,7 @@ data AnalysisName =
   | ShowEBBs
   | OnlyValidation
   | StoreLedgerStateAt SlotNo
+  | CountBlocks
   deriving Show
 
 runAnalysis ::
@@ -77,6 +78,7 @@ runAnalysis ShowBlockTxsSize            = showBlockTxsSize
 runAnalysis ShowEBBs                    = showEBBs
 runAnalysis OnlyValidation              = \_ -> return ()
 runAnalysis (StoreLedgerStateAt slotNo) = storeLedgerStateAt slotNo
+runAnalysis CountBlocks                 = countBlocks
 
 type Analysis blk = AnalysisEnv blk -> IO ()
 
@@ -253,6 +255,18 @@ storeLedgerStateAt slotNo (AnalysisEnv { db, registry, initLedger, cfg, limit, l
            (encodeDisk ccfg)
            (encodeDisk ccfg)
 
+countBlocks ::
+     forall blk .
+     ( HasAnalysis blk
+     )
+  => Analysis blk
+countBlocks (AnalysisEnv { db, registry, initLedger, limit }) = do
+    putStrLn $ "About to count number of blocks ..."
+    counted <- processAll db registry (GetPure ()) initLedger limit 0 process
+    putStrLn $ "Counted: " <> show counted <> " blocks."
+  where
+    process :: Int -> () -> IO Int
+    process count _ = pure $ count + 1
 {-------------------------------------------------------------------------------
   Auxiliary: processing all blocks in the DB
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -145,6 +145,10 @@ parseAnalysis = asum [
         , help "Show all EBBs and their predecessors"
         ]
     , storeLedgerParser
+    , flag' CountBlocks $ mconcat [
+          long "count-blocks"
+        , help "Count number of blocks processed"
+        ]
     , pure OnlyValidation
     ]
 


### PR DESCRIPTION
```
cabal run ouroboros-consensus-cardano:db-analyser --\
  --db db_mainnet_with_alonzo_40217333 cardano \
  --configByron dbacfg/mainnet-byron-genesis.json \
  --configShelley dbacfg/mainnet-shelley-genesis.json \
  --nonce 1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81 \
  --configAlonzo dbacfg/mainnet-alonzo-genesis.json \
  --only-immutable-db \
  --analyse-from 39842441 \
  --count-blocks

About to count number of blocks processed...
Counted: 16378
```