### PR TITLE
Diable nix-fmt for time being

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,3 @@ steps:
     command: 'nix-shell --run scripts/buildkite/check-stylish.sh'
     agents:
       system: x86_64-linux
-
-  - label: 'Check nixpkgs-fmt'
-    command: 'nix-shell --run scripts/buildkite/check-nixpkgs-fmt.sh'
-    agents:
-      system: x86_64-linux


### PR DESCRIPTION
All PRs are broken now because buildkite is failing on
nixpkgs-fmt. Till this gets fixed, we disabled nix-fmt.