### PR TITLE
Revert "Diable nix-fmt for time being"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,3 +3,8 @@ steps:
     command: 'nix-shell --run scripts/buildkite/check-stylish.sh'
     agents:
       system: x86_64-linux
+
+  - label: 'Check nixpkgs-fmt'
+    command: 'nix-shell --run scripts/buildkite/check-nixpkgs-fmt.sh'
+    agents:
+      system: x86_64-linux


### PR DESCRIPTION
This reverts commit 125f144cd5d5077421379ccb644b8b2c0c712e76.
As it turns out buildkite failure had nothing to do with
nixpkgs-fmt. After removing this script, stylish-haskell one started
failing.