### PR TITLE
Avoid needing to specify Win32 constraint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.4"]
+        ghc: ["8.10.4", "8.10.7"]
         os: [ubuntu-20.04, windows-latest]
 
     steps:
@@ -22,7 +22,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.4.0.0
+        cabal-version: 3.6.2.0
 
     - name: Show Haskell tool versions
       run: |

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -243,7 +243,10 @@ library
                        -- Strict wrapper around SOP
                        Data.SOP.Strict
   if os(windows)
-     exposed-modules:  Ouroboros.Consensus.Storage.Seek
+     exposed-modules:
+                       -- TODO Delete this module once all our projects have upgraded to at least
+                       -- ghc-8.10.7, but not before
+                       Ouroboros.Consensus.Storage.Seek
 
   default-language:    Haskell2010
   other-extensions:
@@ -326,13 +329,7 @@ library
 
 
   if os(windows)
-    if impl(ghc >= 8.10.2) && impl(ghc < 8.11)
-      -- Fix the Win32 version to be whatever is shipped with GHC.  This is important
-      -- because we have other code that uses the GHC API which requires this specific
-      -- version of the Win32 or constraint solving will fail.
-      build-depends:   Win32 == 2.6.1.0
-    else
-      build-depends:   Win32
+     build-depends:    Win32            >= 2.6.1.0
   else
      build-depends:    unix
                      , unix-bytestring


### PR DESCRIPTION
This removes the restriction `Win32 == 2.6.1.0` when compiling for `ghc-8.10.4`.

The restriction was previously in place to prevent `Ouroboros.Consensus.Storage.Seek` from being removed.  

`Ouroboros.Consensus.Storage.Seek` implements a function that exists in `Win32-2.6.2.0` onward.  The module previously removed because of that which caused issues for downstream projects.  `ouroboros-network` must not use those functions introduced in `Win32-2.6.2.0` because that would break downstream projects that rely on `ghc` package.

This is because projects that used the `ghc` package must use the same version of `Win32` that was shipped with GHC, and for `ghc-8.10.4`, that was `Win32-2.6.1.0`.

Because upgrading to `ghc-8.10.7` is expected to be soon, I'm satisfied that replacing this constraint with a comment that says remove `Ouroboros.Consensus.Storage.Seek` after we have upgraded to `ghc-8.10.7` but not before is sufficient protection against repeating this mistake.

Doing so simplifies the `cabal` file and avoids having to carefully craft complex `if/then/else`s to allow downstream projects to upgrade to `ghc-8.10.7` on their own schedule.

After upgrading to `ghc-8.10.7` in all projects, there will no longer be any gotchas to be worried about.
