### PR TITLE
Review of pruning

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1919,7 +1919,9 @@ withConnectionManager ConnectionManagerArguments {
 
                 -- use 'numberOfConns + 1' because we want to know if we
                 -- actually let this connection evolve if we need to make
-                -- room for them by pruning.
+                -- room for them by pruning.  This is because
+                -- 'countIncomingConnections' does not count 'OutboundDupState'
+                -- as an inbound connection, but does so for 'InboundIdleState'.
                 let numberToPrune =
                       numberOfConns + 1
                       - fromIntegral

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1869,7 +1869,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap' :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -1878,6 +1878,11 @@ withConnectionManager ConnectionManagerArguments {
                              (,) <$> getConnType cs
                                  <*> getConnThread cs)
                      <$> readTVar connVar'
+                  let choiceMap =
+                        case getConnType connState' of
+                          Nothing -> assert False choiceMap'
+                          Just a  -> Map.insert peerAddr (a, connThread)
+                                                choiceMap'
 
                   pruneSet <-
                     cmPrunePolicy
@@ -1955,7 +1960,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap' :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -1964,6 +1969,11 @@ withConnectionManager ConnectionManagerArguments {
                              (,) <$> getConnType cs
                                  <*> getConnThread cs)
                      <$> readTVar connVar'
+                  let choiceMap =
+                        case getConnType connState' of
+                          Nothing -> assert False choiceMap'
+                          Just a  -> Map.insert peerAddr (a, connThread)
+                                                choiceMap'
 
                   pruneSet <-
                     cmPrunePolicy
@@ -2151,7 +2161,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap' :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -2160,6 +2170,11 @@ withConnectionManager ConnectionManagerArguments {
                              (,) <$> getConnType cs
                                  <*> getConnThread cs)
                      <$> readTVar connVar'
+                  let choiceMap =
+                        case getConnType connState' of
+                          Nothing -> assert False choiceMap'
+                          Just a  -> Map.insert peerAddr (a, connThread)
+                                                choiceMap'
 
                   pruneSet <-
                     cmPrunePolicy
@@ -2208,7 +2223,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap' :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -2217,6 +2232,10 @@ withConnectionManager ConnectionManagerArguments {
                              (,) <$> getConnType cs
                                  <*> getConnThread cs)
                      <$> readTVar connVar'
+                  let choiceMap =
+                        case getConnType connState' of
+                          Nothing -> assert False choiceMap'
+                          Just a  -> Map.insert peerAddr (a, connThread) choiceMap'
 
                   pruneSet <-
                     cmPrunePolicy

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1869,7 +1869,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiseMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -1881,14 +1881,14 @@ withConnectionManager ConnectionManagerArguments {
 
                   pruneSet <-
                     cmPrunePolicy
-                      (fst <$> choiseMap)
+                      (fst <$> choiceMap)
                       numberToPrune
 
                   when (remoteAddress connId `Set.notMember` pruneSet)
                     $ writeTVar connVar connState'
                   return
                     ( PruneConnections connId
-                       (snd <$> choiseMap `Map.restrictKeys` pruneSet)
+                       (snd <$> choiceMap `Map.restrictKeys` pruneSet)
                        (Left connState)
                     , Nothing
                     )
@@ -1955,7 +1955,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiseMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -1967,7 +1967,7 @@ withConnectionManager ConnectionManagerArguments {
 
                   pruneSet <-
                     cmPrunePolicy
-                      (fst <$> choiseMap)
+                      (fst <$> choiceMap)
                       numberToPrune
 
                   -- If this connection is in the to-prune set we do not let it
@@ -1976,7 +1976,7 @@ withConnectionManager ConnectionManagerArguments {
                   then
                     return
                       ( PruneConnections connId
-                         (snd <$> choiseMap `Map.restrictKeys` pruneSet)
+                         (snd <$> choiceMap `Map.restrictKeys` pruneSet)
                          (Left connState)
                       , Nothing
                       )
@@ -1984,7 +1984,7 @@ withConnectionManager ConnectionManagerArguments {
                     writeTVar connVar connState'
                     return
                       ( PruneConnections connId
-                         (snd <$> choiseMap `Map.restrictKeys` pruneSet)
+                         (snd <$> choiceMap `Map.restrictKeys` pruneSet)
                          (Right tr)
                       , Nothing
                       )
@@ -2151,7 +2151,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiseMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -2163,14 +2163,14 @@ withConnectionManager ConnectionManagerArguments {
 
                   pruneSet <-
                     cmPrunePolicy
-                      (fst <$> choiseMap)
+                      (fst <$> choiceMap)
                       numberToPrune
 
                   when (remoteAddress connId `Set.notMember` pruneSet)
                     $ writeTVar connVar connState'
                   return
                     ( OperationSuccess tr
-                    , Just ( snd <$> choiseMap `Map.restrictKeys` pruneSet
+                    , Just ( snd <$> choiceMap `Map.restrictKeys` pruneSet
                            , Nothing
                            )
 
@@ -2208,7 +2208,7 @@ withConnectionManager ConnectionManagerArguments {
                   -- have 'ConnectionType' and are running (have a thread).
                   -- This excludes connections in 'ReservedOutboundState',
                   -- 'TerminatingState' and 'TerminatedState'.
-                  (choiseMap :: Map peerAddr (ConnectionType, Async m ()))
+                  (choiceMap :: Map peerAddr (ConnectionType, Async m ()))
                     <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
                          (\cs -> do
                              -- this expression returns @Maybe (connType, connThread)@;
@@ -2220,14 +2220,14 @@ withConnectionManager ConnectionManagerArguments {
 
                   pruneSet <-
                     cmPrunePolicy
-                      (fst <$> choiseMap)
+                      (fst <$> choiceMap)
                       numberToPrune
 
                   when (remoteAddress connId `Set.notMember` pruneSet)
                     $ writeTVar connVar connState'
                   return
                     ( OperationSuccess tr
-                    , Just ( snd <$> choiseMap `Map.restrictKeys` pruneSet
+                    , Just ( snd <$> choiceMap `Map.restrictKeys` pruneSet
                            , Nothing
                            )
                     , Nothing

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -39,7 +39,6 @@ import           Data.Functor (($>), void)
 import           Data.Function (on)
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
-import           Data.Set (Set)
 import           Data.Typeable (Typeable)
 import           GHC.Stack (CallStack, HasCallStack, callStack)
 
@@ -447,6 +446,8 @@ defaultResetTimeout :: DiffTime
 defaultResetTimeout = 5
 
 
+newtype PruneAction m = PruneAction { runPruneAction :: m () }
+
 -- | Instruction used internally in @unregisterOutboundConnectionImpl@, e.g. in
 -- the implementation of one of the two  @DemotedToCold^{dataFlow}_{Local}@
 -- transitions.
@@ -482,39 +483,25 @@ data DemoteToColdLocal peerAddr handlerTrace handle handleError version m
 
     -- | Duplex connection was demoted, prune connections.
     --
-    | PruneConnections        (ConnectionId peerAddr)
+    | PruneConnections       (PruneAction m)
+                             -- ^ prune action
 
-                              (Map peerAddr ( Async m ()
-                                            , StrictTVar m
-                                                (ConnectionState
-                                                  peerAddr
-                                                  handle handleError
-                                                  version m)
-                                            ))
-                              -- ^ a subset of connections to be prunned
+                            !(Either
+                               (ConnectionState
+                                 peerAddr handle
+                                 handleError version m)
+                               (Transition (ConnectionState
+                                             peerAddr handle
+                                             handleError version m))
+                             )
+                             -- ^ Left case is for when pruning tries to prune
+                             -- the connection which triggered pruning, in this
+                             -- case we do not want to trace a new transition.
+                             --
+                             -- Right case is for when the connection which
+                             -- triggered pruning isn't pruned. In this case
+                             -- we do want to trace a new transition.
 
-                              Int
-                              -- ^ number of connections to prune, just for
-                              -- logging
-
-                              (Set peerAddr)
-                              -- ^ prunning choice set, just for logging
-
-                             !(Either
-                                (ConnectionState
-                                  peerAddr handle
-                                  handleError version m)
-                                (Transition (ConnectionState
-                                              peerAddr handle
-                                              handleError version m))
-                              )
-                              -- ^ Left case is for when pruning tries to prune
-                              -- the connection which triggered pruning, in this
-                              -- case we do not want to trace a new transition.
-                              --
-                              -- Right case is for when the connection which
-                              -- triggered pruning isn't pruned. In this case
-                              -- we do want to trace a new transition.
 
     -- | Demote error.
     | DemoteToColdLocalError  (ConnectionManagerTrace peerAddr handlerTrace)
@@ -890,6 +877,62 @@ withConnectionManager ConnectionManagerArguments {
 
                   traverse_ (traceWith trTracer . TransitionTrace peerAddr) trs
                   traceCounters stateVar
+
+    -- Pruning is done in two stages:
+    -- * an STM transaction which selects which connections to prune, and sets
+    --   their state to 'TerminatedState';
+    -- * an io action which logs and cancells all the connection handler
+    --   threads.
+    mkPruneAction :: peerAddr
+                  -> Int
+                  -- ^ number of connections to prune
+                  -> ConnectionManagerState peerAddr handle handleError version m
+                  -> ConnectionState peerAddr handle handleError version  m
+                  -- ^ next connection state, if it will not be pruned.
+                  -> StrictTVar m (ConnectionState peerAddr handle handleError version m)
+                  -> Async m ()
+                  -> STM m (Bool, PruneAction m)
+                  -- ^ return if the connection was choose to be prunned and the
+                  -- 'PruneAction'
+    mkPruneAction peerAddr numberToPrune state connState' connVar connThread = do
+      (choiceMap' :: Map peerAddr ( ConnectionType
+                                  , Async m ()
+                                  , StrictTVar m
+                                      (ConnectionState
+                                        peerAddr
+                                        handle handleError
+                                        version m)
+                                  ))
+        <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
+             (\cs -> do
+                 -- this expression returns @Maybe (connType, connThread)@;
+                 -- 'traverseMaybeWithKey' collects all 'Just' cases.
+                 guard (isInboundConn cs)
+                 (,,connVar') <$> getConnType cs
+                              <*> getConnThread cs)
+         <$> readTVar connVar'
+      let choiceMap =
+            case getConnType connState' of
+              Nothing -> assert False choiceMap'
+              Just a  -> Map.insert peerAddr (a, connThread, connVar)
+                                    choiceMap'
+
+      pruneSet <-
+        cmPrunePolicy
+          ((\(a,_,_) -> a) <$> choiceMap)
+          numberToPrune
+
+      let pruneMap = choiceMap `Map.restrictKeys` pruneSet
+      forM_ pruneMap $ \(_, _, connVar') ->
+        writeTVar connVar' (TerminatedState Nothing)
+
+      return ( peerAddr `Set.member` pruneSet
+             , PruneAction $ do
+                 traceWith tracer (TrPruneConnections (Map.keysSet pruneMap)
+                                                      numberToPrune
+                                                      (Map.keysSet choiceMap))
+                 forM_ pruneMap $ \(_, connThread', _) -> cancel connThread'
+             )
 
     includeInboundConnectionImpl
         :: HasCallStack
@@ -1883,51 +1926,10 @@ withConnectionManager ConnectionManagerArguments {
                           (acceptedConnectionsHardLimit cmConnectionsLimits)
                 if numberToPrune > 0
                 then do
-                  -- traverse the state and get only the connection which
-                  -- have 'ConnectionType' and are running (have a thread).
-                  -- This excludes connections in 'ReservedOutboundState',
-                  -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap' :: Map peerAddr ( ConnectionType
-                                              , Async m ()
-                                              , StrictTVar m
-                                                  (ConnectionState
-                                                    peerAddr
-                                                    handle handleError
-                                                    version m)
-                                              ))
-                    <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
-                         (\cs -> do
-                             -- this expression returns @Maybe (connType, connThread)@;
-                             -- 'traverseMaybeWithKey' collects all 'Just' cases.
-                             guard (isInboundConn cs)
-                             (,,connVar') <$> getConnType cs
-                                          <*> getConnThread cs)
-                     <$> readTVar connVar'
-                  let choiceMap =
-                        case getConnType connState' of
-                          Nothing -> assert False choiceMap'
-                          Just a  -> Map.insert peerAddr (a, connThread, connVar)
-                                                choiceMap'
-
-                  pruneSet <-
-                    cmPrunePolicy
-                      ((\(a, _, _) -> a) <$> choiceMap)
-                      numberToPrune
-
-                  when (remoteAddress connId `Set.notMember` pruneSet)
-                    $ writeTVar connVar connState'
-
-                  let pruneMap = choiceMap `Map.restrictKeys` pruneSet
-                  forM_ pruneMap $ \(_, _, connVar') ->
-
-                    writeTVar connVar' (TerminatedState Nothing)
+                  (_, prune)
+                    <- mkPruneAction peerAddr numberToPrune state connState' connVar connThread
                   return
-                    ( PruneConnections connId
-                       ((\(_, a, b) -> (a, b))
-                         <$> pruneMap)
-                       numberToPrune
-                       (Map.keysSet choiceMap)
-                       (Left connState)
+                    ( PruneConnections prune (Left connState)
                     , Nothing
                     )
 
@@ -1988,66 +1990,21 @@ withConnectionManager ConnectionManagerArguments {
                           (acceptedConnectionsHardLimit cmConnectionsLimits)
 
                 if numberToPrune > 0
+
                 then do
-                  -- traverse the state and get only the connection which
-                  -- have 'ConnectionType' and are running (have a thread).
-                  -- This excludes connections in 'ReservedOutboundState',
-                  -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap' :: Map peerAddr ( ConnectionType
-                                              , Async m ()
-                                              , StrictTVar m
-                                                  (ConnectionState
-                                                    peerAddr
-                                                    handle handleError
-                                                    version m)
-                                              ))
-                    <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
-                         (\cs -> do
-                             -- this expression returns @Maybe (connType, connThread)@;
-                             -- 'traverseMaybeWithKey' collects all 'Just' cases.
-                             guard (isInboundConn cs)
-                             (,,connVar') <$> getConnType cs
-                                          <*> getConnThread cs)
-                     <$> readTVar connVar'
-                  let choiceMap =
-                        case getConnType connState' of
-                          Nothing -> assert False choiceMap'
-                          Just a  -> Map.insert peerAddr (a, connThread, connVar)
-                                                choiceMap'
-
-                  pruneSet <-
-                    cmPrunePolicy
-                      ((\(a,_,_) -> a) <$> choiceMap)
-                      numberToPrune
-
-                  let pruneMap = choiceMap `Map.restrictKeys` pruneSet
-                  forM_ pruneMap $ \(_, _, connVar') ->
-                    writeTVar connVar' (TerminatedState Nothing)
-
-                  -- If this connection is in the to-prune set we do not let it
-                  -- evolve to a new state. Otherwise we do.
-                  if Set.member peerAddr pruneSet
-                  then
-                    return
-                      ( PruneConnections connId
-                          ((\(_, a, b) -> (a, b))
-                            <$> pruneMap)
-                         numberToPrune
-                         (Map.keysSet choiceMap)
-                         (Left connState)
-                      , Nothing
-                      )
-                  else do
-                    writeTVar connVar connState'
-                    return
-                      ( PruneConnections connId
-                         ((\(_, a, b) -> (a, b))
-                           <$> pruneMap)
-                         numberToPrune
-                         (Map.keysSet choiceMap)
-                         (Right tr)
-                      , Nothing
-                      )
+                  (pruneSelf, prune)
+                    <- mkPruneAction peerAddr numberToPrune state connState' connVar connThread
+                  when (not pruneSelf)
+                     $ writeTVar connVar connState'
+                  if pruneSelf
+                    then return ( PruneConnections prune (Left connState)
+                                , Nothing
+                                )
+                    else do
+                      writeTVar connVar connState'
+                      return ( PruneConnections prune (Right tr)
+                             , Nothing
+                             )
 
                 else do
                   -- @
@@ -2112,15 +2069,9 @@ withConnectionManager ConnectionManagerArguments {
             Left connState ->
               return (UnsupportedState (abstractState $ Known connState))
 
-        PruneConnections _connId pruneMap numberToPrune choiceSet eTr -> do
+        PruneConnections prune eTr -> do
           traverse_ (traceWith trTracer . TransitionTrace peerAddr) eTr
-          traceWith tracer (TrPruneConnections (Map.keysSet pruneMap)
-                                               numberToPrune
-                                               choiceSet)
-          -- previous comment applies here as well.
-          forM_ pruneMap $ \(connThread', _) -> do
-            cancel connThread'
-
+          runPruneAction prune
           traceCounters stateVar
           return (OperationSuccess (abstractState (either Known fromState eTr)))
 
@@ -2210,53 +2161,15 @@ withConnectionManager ConnectionManagerArguments {
                 -- Are we above the hard limit?
                 if numberToPrune > 0
                 then do
-                  -- traverse the state and get only the connection which
-                  -- have 'ConnectionType' and are running (have a thread).
-                  -- This excludes connections in 'ReservedOutboundState',
-                  -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap' :: Map peerAddr ( ConnectionType
-                                              , Async m ()
-                                              , StrictTVar m
-                                                  (ConnectionState
-                                                    peerAddr
-                                                    handle handleError
-                                                    version m)
-                                              ))
-                    <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
-                         (\cs -> do
-                             -- this expression returns @Maybe (connType, connThread)@;
-                             -- 'traverseMaybeWithKey' collects all 'Just' cases.
-                             guard (isInboundConn cs)
-                             (,,connVar') <$> getConnType cs
-                                          <*> getConnThread cs)
-                     <$> readTVar connVar'
-                  let choiceMap =
-                        case getConnType connState' of
-                          Nothing -> assert False choiceMap'
-                          Just a  -> Map.insert peerAddr (a, connThread, connVar)
-                                                choiceMap'
+                  (pruneSelf, prune)
+                    <- mkPruneAction peerAddr numberToPrune state connState' connVar connThread
 
-                  pruneSet <-
-                    cmPrunePolicy
-                      ((\(a, _, _) -> a)
-                        <$> choiceMap)
-                      numberToPrune
-
-                  let pruneMap = choiceMap `Map.restrictKeys` pruneSet
-                  forM_ pruneMap $ \(_, _, connVar') ->
-                    writeTVar connVar' (TerminatedState Nothing)
-
-                  when (remoteAddress connId `Set.notMember` pruneSet)
+                  when (not pruneSelf)
                     $ writeTVar connVar connState'
 
                   return
                     ( OperationSuccess tr
-                    , Just ( pruneMap
-                           , numberToPrune
-                           , Map.keysSet choiceMap
-                           , Nothing
-                           )
-
+                    , Just prune
                     , Nothing
                     )
 
@@ -2287,51 +2200,14 @@ withConnectionManager ConnectionManagerArguments {
                 -- Are we above the hard limit?
                 if numberToPrune > 0
                 then do
-                  -- traverse the state and get only the connection which
-                  -- have 'ConnectionType' and are running (have a thread).
-                  -- This excludes connections in 'ReservedOutboundState',
-                  -- 'TerminatingState' and 'TerminatedState'.
-                  (choiceMap' :: Map peerAddr ( ConnectionType
-                                              , Async m ()
-                                              , StrictTVar m
-                                                  (ConnectionState
-                                                    peerAddr
-                                                    handle handleError
-                                                    version m)
-                                              ))
-                    <- flip Map.traverseMaybeWithKey state $ \_peerAddr MutableConnState { connVar = connVar' } ->
-                         (\cs -> do
-                             -- this expression returns @Maybe (connType, connThread)@;
-                             -- 'traverseMaybeWithKey' collects all 'Just' cases.
-                             guard (isInboundConn cs)
-                             (,,connVar') <$> getConnType cs
-                                          <*> getConnThread cs)
-                     <$> readTVar connVar'
-                  let choiceMap =
-                        case getConnType connState' of
-                          Nothing -> assert False choiceMap'
-                          Just a  -> Map.insert peerAddr (a, connThread, connVar)
-                                                choiceMap'
-
-                  pruneSet <-
-                    cmPrunePolicy
-                      ((\(a, _, _) -> a) <$> choiceMap)
-                      numberToPrune
-
-                  let pruneMap = choiceMap `Map.restrictKeys` pruneSet
-                  forM_ pruneMap $ \(_, _, connVar') ->
-                    writeTVar connVar' (TerminatedState Nothing)
-
-                  when (remoteAddress connId `Set.notMember` pruneSet)
-                    $ writeTVar connVar connState'
+                  (pruneSelf, prune)
+                    <- mkPruneAction peerAddr numberToPrune state connState' connVar connThread
+                  when (not pruneSelf)
+                     $ writeTVar connVar connState'
 
                   return
-                    ( OperationSuccess tr
-                    , Just ( pruneMap
-                           , numberToPrune
-                           , Map.keysSet choiceMap
-                           , Nothing
-                           )
+                    ( OperationSuccess (mkTransition connState (TerminatedState Nothing))
+                    , Just prune
                     , Nothing
                     )
 
@@ -2394,16 +2270,9 @@ withConnectionManager ConnectionManagerArguments {
           traceWith trTracer (TransitionTrace peerAddr tr)
           traceCounters stateVar
 
-        (OperationSuccess _, Just (pruneMap, numberToPrune, choiceSet, mbTr)) -> do
-          traverse_ (traceWith trTracer . TransitionTrace peerAddr) mbTr
-          traceWith tracer (TrPruneConnections (Map.keysSet pruneMap)
-                                               numberToPrune
-                                               choiceSet)
-
-          -- We relay on the `finally` handler of connection thread to
-          -- close the socket.
-          forM_ pruneMap $ \ (_, connThread', _) -> cancel connThread'
-
+        (OperationSuccess tr, Just prune) -> do
+          traceWith trTracer (TransitionTrace peerAddr tr)
+          runPruneAction prune
           traceCounters stateVar
 
         _ -> return ()

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -837,7 +837,9 @@ data ConnectionManagerTrace peerAddr handlerTrace
   | TrConnectionFailure            !(ConnectionId peerAddr)
   | TrConnectionNotFound           !Provenance !peerAddr
   | TrForbiddenOperation           !peerAddr                !AbstractState
-  | TrPruneConnections             ![peerAddr]
+  | TrPruneConnections             !(Set peerAddr) -- ^ prunning set
+                                   !Int            -- ^ number connections that must be prunned
+                                   !(Set peerAddr) -- ^ choice set
   | TrConnectionCleanup            !(ConnectionId peerAddr)
   | TrConnectionTimeWait           !(ConnectionId peerAddr)
   | TrConnectionTimeWaitDone       !(ConnectionId peerAddr)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -55,6 +55,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, fromJust, isJust)
 import           Data.Monoid (Sum (..))
 import           Data.Monoid.Synchronisation (FirstToFinish (..))
+import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
 import           Foreign.C.Error
@@ -2477,7 +2478,11 @@ prop_inbound_governor_pruning serverAcc
 -- | Property wrapping `multinodeExperiment` that has a generator optimized for triggering
 -- pruning, and random generated number of connections hard limit.
 --
--- We test that we never go above hard limit of incoming connections.
+-- We test that:
+--
+-- * we never go above hard limit of incoming connections;
+-- * the pruning set is at least as big as expected, and that
+--   the picked peers belong to the choice set.
 --
 prop_never_above_hardlimit :: Int -> MultiNodePruningScript Int -> Property
 prop_never_above_hardlimit serverAcc
@@ -2526,6 +2531,19 @@ prop_never_above_hardlimit serverAcc
                                      )
                     . property
                     $ incomingConns cmc <= fromIntegral hardlimit
+                (TrPruneConnections prunnedSet numberToPrune choiceSet) ->
+                  ( AllProperty
+                  . counterexample (concat
+                                   [ "prunned set too small: "
+                                   , show numberToPrune
+                                   , " ≰ "
+                                   , show $ length prunnedSet
+                                   ])
+                  $ numberToPrune <= length prunnedSet )
+                  <>
+                  ( AllProperty
+                  . counterexample ""
+                  $ prunnedSet `Set.isSubsetOf` choiceSet )
                 _ -> mempty
         )
    $ evsCMT

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -127,9 +127,8 @@ tests =
                  prop_connection_manager_pruning
   , testProperty "inbound_governor_pruning"
                  prop_inbound_governor_pruning
-  -- The test fails at the moment.  See issue #3487.
-  -- , testProperty "never_above_hardlimit"
-  --                prop_never_above_hardlimit
+  , testProperty "never_above_hardlimit"
+                 prop_never_above_hardlimit
   , testProperty "connection_manager_valid_transitions"
                  prop_connection_manager_valid_transitions
   , testProperty "connection_manager_no_invalid_traces"

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -2842,8 +2842,8 @@ classifyPrunings =
   . filter ( \ tr
              -> case tr of
                   x -> case x of
-                    TrPruneConnections _ -> True
-                    _                    -> False
+                    TrPruneConnections _ _ _ -> True
+                    _                        -> False
            )
 
 -- classify negotiated data flow


### PR DESCRIPTION
Fixes #3487.

- pruning: present only inbound connections to the pruning policy
- pruning: fix typos
- pruning: include current connection in the choice map
- pruning: improved logging
- pruning: set connection state to TerminatedState
- pruning: factor out pruning
- pruning: do not prune in Duplex → InboundState transition
- pruning: improved a comment
