### PR TITLE
Connection manager refactoring

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -272,17 +272,19 @@ connectionStateToCounters state =
       InboundState _ _ _ Duplex             -> duplexConn
                                             <> inboundConn
 
-      DuplexState _ _ _                     -> duplexConn
+      DuplexState _ _ _                     -> fullDuplexConn
+                                            <> duplexConn
                                             <> inboundConn
                                             <> outboundConn
 
       TerminatingState _ _ _                -> mempty
       TerminatedState _                     -> mempty
   where
-    duplexConn         = ConnectionManagerCounters 1 0 0 0
-    unidirectionalConn = ConnectionManagerCounters 0 1 0 0
-    inboundConn        = ConnectionManagerCounters 0 0 1 0
-    outboundConn       = ConnectionManagerCounters 0 0 0 1
+    fullDuplexConn     = ConnectionManagerCounters 1 0 0 0 0
+    duplexConn         = ConnectionManagerCounters 0 1 0 0 0
+    unidirectionalConn = ConnectionManagerCounters 0 0 1 0 0
+    inboundConn        = ConnectionManagerCounters 0 0 0 1 0
+    outboundConn       = ConnectionManagerCounters 0 0 0 0 1
 
 
 instance ( Show peerAddr

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -244,54 +244,45 @@ connectionStateToCounters state =
     case state of
       ReservedOutboundState                 -> mempty
 
-      UnnegotiatedState Inbound _ _         -> prunableConn
-                                            <> incomingConn
+      UnnegotiatedState Inbound _ _         -> incomingConn
 
       UnnegotiatedState Outbound _ _        -> outgoingConn
 
       OutboundUniState _ _ _                -> uniConn
                                             <> outgoingConn
 
-      OutboundDupState  _ _ _ _             -> prunableConn
-                                            <> duplexConn
+      OutboundDupState  _ _ _ _             -> duplexConn
                                             <> outgoingConn
 
       OutboundIdleState _ _ _ Unidirectional -> uniConn
                                              <> outgoingConn
 
-      OutboundIdleState _ _ _ Duplex         -> prunableConn
-                                             <> duplexConn
+      OutboundIdleState _ _ _ Duplex         -> duplexConn
                                              <> outgoingConn
 
-      InboundIdleState _ _ _ Unidirectional -> prunableConn
-                                            <> uniConn
+      InboundIdleState _ _ _ Unidirectional -> uniConn
                                             <> incomingConn
 
-      InboundIdleState _ _ _ Duplex         -> prunableConn
-                                            <> duplexConn
+      InboundIdleState _ _ _ Duplex         -> duplexConn
                                             <> incomingConn
 
-      InboundState _ _ _ Unidirectional     -> prunableConn
-                                            <> uniConn
+      InboundState _ _ _ Unidirectional     -> uniConn
                                             <> incomingConn
 
-      InboundState _ _ _ Duplex             -> prunableConn
-                                            <> duplexConn
+      InboundState _ _ _ Duplex             -> duplexConn
                                             <> incomingConn
 
-      DuplexState _ _ _                     -> prunableConn
-                                            <> duplexConn
+      DuplexState _ _ _                     -> duplexConn
                                             <> incomingConn
                                             <> outgoingConn
 
       TerminatingState _ _ _                -> mempty
       TerminatedState _                     -> mempty
   where
-    prunableConn  = ConnectionManagerCounters 1 0 0 0 0
-    duplexConn    = ConnectionManagerCounters 0 1 0 0 0
-    uniConn       = ConnectionManagerCounters 0 0 1 0 0
-    incomingConn  = ConnectionManagerCounters 0 0 0 1 0
-    outgoingConn  = ConnectionManagerCounters 0 0 0 0 1
+    duplexConn    = ConnectionManagerCounters 1 0 0 0
+    uniConn       = ConnectionManagerCounters 0 1 0 0
+    incomingConn  = ConnectionManagerCounters 0 0 1 0
+    outgoingConn  = ConnectionManagerCounters 0 0 0 1
 
 
 instance ( Show peerAddr

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -244,45 +244,45 @@ connectionStateToCounters state =
     case state of
       ReservedOutboundState                 -> mempty
 
-      UnnegotiatedState Inbound _ _         -> incomingConn
+      UnnegotiatedState Inbound _ _         -> inboundConn
 
-      UnnegotiatedState Outbound _ _        -> outgoingConn
+      UnnegotiatedState Outbound _ _        -> outboundConn
 
-      OutboundUniState _ _ _                -> uniConn
-                                            <> outgoingConn
+      OutboundUniState _ _ _                -> unidirectionalConn
+                                            <> outboundConn
 
       OutboundDupState  _ _ _ _             -> duplexConn
-                                            <> outgoingConn
+                                            <> outboundConn
 
-      OutboundIdleState _ _ _ Unidirectional -> uniConn
-                                             <> outgoingConn
+      OutboundIdleState _ _ _ Unidirectional -> unidirectionalConn
+                                             <> outboundConn
 
       OutboundIdleState _ _ _ Duplex         -> duplexConn
-                                             <> outgoingConn
+                                             <> outboundConn
 
-      InboundIdleState _ _ _ Unidirectional -> uniConn
-                                            <> incomingConn
+      InboundIdleState _ _ _ Unidirectional -> unidirectionalConn
+                                            <> inboundConn
 
       InboundIdleState _ _ _ Duplex         -> duplexConn
-                                            <> incomingConn
+                                            <> inboundConn
 
-      InboundState _ _ _ Unidirectional     -> uniConn
-                                            <> incomingConn
+      InboundState _ _ _ Unidirectional     -> unidirectionalConn
+                                            <> inboundConn
 
       InboundState _ _ _ Duplex             -> duplexConn
-                                            <> incomingConn
+                                            <> inboundConn
 
       DuplexState _ _ _                     -> duplexConn
-                                            <> incomingConn
-                                            <> outgoingConn
+                                            <> inboundConn
+                                            <> outboundConn
 
       TerminatingState _ _ _                -> mempty
       TerminatedState _                     -> mempty
   where
-    duplexConn    = ConnectionManagerCounters 1 0 0 0
-    uniConn       = ConnectionManagerCounters 0 1 0 0
-    incomingConn  = ConnectionManagerCounters 0 0 1 0
-    outgoingConn  = ConnectionManagerCounters 0 0 0 1
+    duplexConn         = ConnectionManagerCounters 1 0 0 0
+    unidirectionalConn = ConnectionManagerCounters 0 1 0 0
+    inboundConn        = ConnectionManagerCounters 0 0 1 0
+    outboundConn       = ConnectionManagerCounters 0 0 0 1
 
 
 instance ( Show peerAddr
@@ -685,7 +685,7 @@ withConnectionManager ConnectionManagerArguments {
         :: ConnectionManagerState peerAddr handle handleError version m
         -> STM m Int
     countIncomingConnections st =
-          incomingConns
+          inboundConns
         . connectionManagerStateToCounters
       <$> traverse (readTVar . connVar) st
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -658,6 +658,7 @@ data AbstractState
 -- | Counters for tracing and analysis purposes
 --
 data ConnectionManagerCounters = ConnectionManagerCounters {
+      fullDuplexConns     :: !Int, -- ^ number of full duplex connections
       duplexConns         :: !Int, -- ^ number of negotiated duplex connections
                                    --   (including DuplexState connections)
       unidirectionalConns :: !Int, -- ^ number of negotiated unidirectional connections
@@ -667,11 +668,11 @@ data ConnectionManagerCounters = ConnectionManagerCounters {
   deriving (Show, Eq, Ord)
 
 instance Semigroup ConnectionManagerCounters where
-    ConnectionManagerCounters d1 s1 i1 o1 <> ConnectionManagerCounters d2 s2 i2 o2 =
-      ConnectionManagerCounters (d1 + d2) (s1 + s2) (i1 + i2) (o1 + o2)
+    ConnectionManagerCounters fd1 d1 s1 i1 o1 <> ConnectionManagerCounters fd2 d2 s2 i2 o2 =
+      ConnectionManagerCounters (fd1 + fd2) (d1 + d2) (s1 + s2) (i1 + i2) (o1 + o2)
 
 instance Monoid ConnectionManagerCounters where
-    mempty = ConnectionManagerCounters 0 0 0 0
+    mempty = ConnectionManagerCounters 0 0 0 0 0
 
 -- | Exceptions used by 'ConnectionManager'.
 --

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -658,11 +658,11 @@ data AbstractState
 -- | Counters for tracing and analysis purposes
 --
 data ConnectionManagerCounters = ConnectionManagerCounters {
-      duplexConns   :: !Int, -- ^ number of negotiated duplex connections
-                             -- (including DuplexState connections)
-      uniConns      :: !Int, -- ^ number of negotiated unidirectional connections
-      incomingConns :: !Int, -- ^ number of inbound connections
-      outgoingConns :: !Int  -- ^ number of outbound connections
+      duplexConns         :: !Int, -- ^ number of negotiated duplex connections
+                                   --   (including DuplexState connections)
+      unidirectionalConns :: !Int, -- ^ number of negotiated unidirectional connections
+      inboundConns        :: !Int, -- ^ number of inbound connections
+      outboundConns       :: !Int  -- ^ number of outbound connections
     }
   deriving (Show, Eq, Ord)
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -658,7 +658,6 @@ data AbstractState
 -- | Counters for tracing and analysis purposes
 --
 data ConnectionManagerCounters = ConnectionManagerCounters {
-      prunableConns :: !Int, -- ^ number of connections relevant for pruning
       duplexConns   :: !Int, -- ^ number of negotiated duplex connections
                              -- (including DuplexState connections)
       uniConns      :: !Int, -- ^ number of negotiated unidirectional connections
@@ -668,11 +667,11 @@ data ConnectionManagerCounters = ConnectionManagerCounters {
   deriving (Show, Eq, Ord)
 
 instance Semigroup ConnectionManagerCounters where
-    ConnectionManagerCounters c1 d1 s1 i1 o1 <> ConnectionManagerCounters c2 d2 s2 i2 o2 =
-      ConnectionManagerCounters (c1 + c2) (d1 + d2) (s1 + s2) (i1 + i2) (o1 + o2)
+    ConnectionManagerCounters d1 s1 i1 o1 <> ConnectionManagerCounters d2 s2 i2 o2 =
+      ConnectionManagerCounters (d1 + d2) (s1 + s2) (i1 + i2) (o1 + o2)
 
 instance Monoid ConnectionManagerCounters where
-    mempty = ConnectionManagerCounters 0 0 0 0 0
+    mempty = ConnectionManagerCounters 0 0 0 0
 
 -- | Exceptions used by 'ConnectionManager'.
 --

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor/ControlChannel.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor/ControlChannel.hs
@@ -15,6 +15,7 @@ module Ouroboros.Network.InboundGovernor.ControlChannel
   , ServerControlChannel
   , newControlChannel
   , newOutboundConnection
+  , newInboundConnection
   ) where
 
 import           Control.Monad.Class.MonadSTM.Strict
@@ -112,3 +113,13 @@ newOutboundConnection
 newOutboundConnection channel connId dataFlow handle =
     writeMessage channel
                 (NewConnection Outbound connId dataFlow handle)
+
+newInboundConnection
+    :: ControlChannel m (NewConnection peerAddr handle)
+    -> ConnectionId peerAddr
+    -> DataFlow
+    -> handle
+    -> STM m ()
+newInboundConnection channel connId dataFlow handle =
+    writeMessage channel
+                 (NewConnection Inbound connId dataFlow handle)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
@@ -256,11 +256,7 @@ run ServerArguments {
                              serverConnectionManager
                              hardLimit socket peerAddr)
                        case a of
-                         Connected connId dataFlow handle ->
-                           atomically $
-                             ControlChannel.writeMessage
-                               serverControlChannel
-                               (ControlChannel.NewConnection Inbound connId dataFlow handle)
+                         Connected {}    -> pure ()
                          Disconnected {} -> do
                            close serverSnocket socket
                            pure ()

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -2255,9 +2255,9 @@ prop_connection_manager_counters serverAcc (ArbDataFlow dataFlow)
             . foldl'
                (\ st ce -> case ce of
                  StartClient _ ta ->
-                   Map.insert ta (ConnectionManagerCounters 1 0 1 0 0) st
+                   Map.insert ta (ConnectionManagerCounters 0 1 0 0) st
                  StartServer _ ta _ ->
-                   Map.insert ta (ConnectionManagerCounters 1 ifDuplex ifUni 0 0)
+                   Map.insert ta (ConnectionManagerCounters ifDuplex ifUni 0 0)
                                  st
                  _ -> st
                )
@@ -2274,8 +2274,8 @@ prop_connection_manager_counters serverAcc (ArbDataFlow dataFlow)
                            (\cmc' provenance ->
                              cmc' <>
                              if provenance == serverAddress
-                                then ConnectionManagerCounters 0 0 0 0 1
-                                else ConnectionManagerCounters 0 0 0 1 0
+                                then ConnectionManagerCounters 0 0 0 1
+                                else ConnectionManagerCounters 0 0 1 0
                            )
                            mempty
                            conns
@@ -2287,14 +2287,13 @@ prop_connection_manager_counters serverAcc (ArbDataFlow dataFlow)
     maxCounters :: ConnectionManagerCounters
                 -> ConnectionManagerCounters
                 -> ConnectionManagerCounters
-    maxCounters (ConnectionManagerCounters a b c d e)
-                (ConnectionManagerCounters a' b' c' d' e') =
+    maxCounters (ConnectionManagerCounters a b c d)
+                (ConnectionManagerCounters a' b' c' d') =
       ConnectionManagerCounters
         (max a a')
         (max b b')
         (max c c')
         (max d d')
-        (max e e')
 
     -- It is possible for the ObservableNetworkState to have discrepancies between the
     -- counters traced by TrConnectionManagerCounters. This leads to different
@@ -2313,11 +2312,11 @@ prop_connection_manager_counters serverAcc (ArbDataFlow dataFlow)
     collapseCounters :: Bool -- ^ Should we remove Duplex duplicate counters out
                              -- of the total sum.
                      -> ConnectionManagerCounters
-                     -> (Int, Int, Int, Int)
-    collapseCounters t (ConnectionManagerCounters a b c d e) =
+                     -> (Int, Int, Int)
+    collapseCounters t (ConnectionManagerCounters a b c d) =
       if t
-         then (a, b, c, d + e)
-         else (a, b, c, d + e - a)
+         then (a, b, c + d)
+         else (a, b, c + d - a)
 
     networkStateTracer getState =
       sayTracer

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -2838,12 +2838,12 @@ prop_never_above_hardlimit serverAcc
                 (TrConnectionManagerCounters cmc) ->
                     AllProperty
                     . counterexample ("HardLimit: " ++ show hardlimit ++
-                                      ", but got: " ++ show (incomingConns cmc) ++
-                                      " incoming connections!\n" ++
+                                      ", but got: " ++ show (inboundConns cmc) ++
+                                      " inbound connections!\n" ++
                                       show cmc
                                      )
                     . property
-                    $ incomingConns cmc <= fromIntegral hardlimit
+                    $ inboundConns cmc <= fromIntegral hardlimit
                 (TrPruneConnections prunnedSet numberToPrune choiceSet) ->
                   ( AllProperty
                   . counterexample (concat


### PR DESCRIPTION
- connection-manager: removed prunable counter
- server-test: fix prop_connection_manager_counters property
- connection-manager: rename record fields on ConnectionManagerCounter
- connection-manager: trace the number of full duplex connections
- connection-manager: let the cm pass handles to the inbound governor.
- connection-manager: qualified import of ControlChannel
