### PR TITLE
Avoid ordering peers based on peerid in blockfetch

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -162,7 +162,8 @@ fetchDecisions
 fetchDecisions fetchDecisionPolicy@FetchDecisionPolicy {
                  plausibleCandidateChain,
                  compareCandidateChains,
-                 blockFetchSize
+                 blockFetchSize,
+                 peerSalt
                }
                fetchMode
                currentChain
@@ -183,6 +184,7 @@ fetchDecisions fetchDecisionPolicy@FetchDecisionPolicy {
     -- Reorder chains based on consensus policy and network timing data.
   . prioritisePeerChains
       fetchMode
+      peerSalt
       compareCandidateChains
       blockFetchSize
   . map swizzleIG
@@ -207,7 +209,7 @@ fetchDecisions fetchDecisionPolicy@FetchDecisionPolicy {
   where
     -- Data swizzling functions to get the right info into each stage.
     swizzleI   (c, p@(_,     inflight,_,_,      _)) = (c,         inflight,       p)
-    swizzleIG  (c, p@(_,     inflight,gsvs,_,   _)) = (c,         inflight, gsvs, p)
+    swizzleIG  (c, p@(_,     inflight,gsvs,peer,_)) = (c,         inflight, gsvs, peer, p)
     swizzleSI  (c, p@(status,inflight,_,_,      _)) = (c, status, inflight,       p)
     swizzleSIG (c, p@(status,inflight,gsvs,peer,_)) = (c, status, inflight, gsvs, peer, p)
 
@@ -605,19 +607,20 @@ filterWithMaxSlotNo p maxSlotNo =
     AF.filterWithStop p ((> maxSlotNo) . MaxSlotNo . blockSlot)
 
 prioritisePeerChains
-  :: forall header peer. HasHeader header
+  :: forall extra header peer.
+   ( HasHeader header
+   , Hashable peer
+   )
   => FetchMode
+  -> Int
   -> (AnchoredFragment header -> AnchoredFragment header -> Ordering)
   -> (header -> SizeInBytes)
   -> [(FetchDecision (CandidateFragments header), PeerFetchInFlight header,
                                                   PeerGSV,
-                                                  peer)]
-  -> [(FetchDecision [AnchoredFragment header],   peer)]
-prioritisePeerChains FetchModeDeadline compareCandidateChains blockFetchSize =
-    --TODO: last tie-breaker is still original order (which is probably
-    -- peerid order). We should use a random tie breaker so that adversaries
-    -- cannot get any advantage.
-
+                                                  peer,
+                                                  extra )]
+  -> [(FetchDecision [AnchoredFragment header],   extra)]
+prioritisePeerChains FetchModeDeadline salt compareCandidateChains blockFetchSize =
     map (\(decision, peer) ->
             (fmap (\(_,_,fragment) -> fragment) decision, peer))
   . concatMap ( concat
@@ -647,9 +650,10 @@ prioritisePeerChains FetchModeDeadline compareCandidateChains blockFetchSize =
                    `on`
                       (\(band, chain, _fragments) -> (band, chain))))))
   . map annotateProbabilityBand
+  . sortBy (\(_, _, _, a, _) (_, _, _, b, _) -> compare (hashWithSalt salt a) (hashWithSalt salt b))
   where
-    annotateProbabilityBand (Left decline, _, _, peer) = (Left decline, peer)
-    annotateProbabilityBand (Right (chain,fragments), inflight, gsvs, peer) =
+    annotateProbabilityBand (Left decline, _, _, _, peer) = (Left decline, peer)
+    annotateProbabilityBand (Right (chain,fragments), inflight, gsvs, _, peer) =
         (Right (band, chain, fragments), peer)
       where
         band = probabilityBand $
@@ -667,7 +671,7 @@ prioritisePeerChains FetchModeDeadline compareCandidateChains blockFetchSize =
 
     chainHeadPoint (_,ChainSuffix c,_) = AF.headPoint c
 
-prioritisePeerChains FetchModeBulkSync compareCandidateChains blockFetchSize =
+prioritisePeerChains FetchModeBulkSync salt compareCandidateChains blockFetchSize =
     map (\(decision, peer) ->
             (fmap (\(_, _, fragment) -> fragment) decision, peer))
   . sortBy (comparingFst
@@ -679,9 +683,10 @@ prioritisePeerChains FetchModeBulkSync compareCandidateChains blockFetchSize =
                 `on`
                   (\(duration, chain, _fragments) -> (chain, duration)))))
   . map annotateDuration
+  . sortBy (\(_, _, _, a, _) (_, _, _, b, _) -> compare (hashWithSalt salt a) (hashWithSalt salt b))
   where
-    annotateDuration (Left decline, _, _, peer) = (Left decline, peer)
-    annotateDuration (Right (chain,fragments), inflight, gsvs, peer) =
+    annotateDuration (Left decline, _, _, _, peer) = (Left decline, peer)
+    annotateDuration (Right (chain,fragments), inflight, gsvs, _, peer) =
         (Right (duration, chain, fragments), peer)
       where
         -- TODO: consider if we should put this into bands rather than just


### PR DESCRIPTION
Peers where ordered based on SockAddr, which generally meant that all
peers would pick the same second choice peer to download blocks from in
Deadline mode. And the same third pick and so on.

This changes ranking so that peers are sorted based on the hash of their
address along with a random salt before any other ranking is done.