### PR TITLE
Avoid ordering peers based on peerid in blockfetch

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
@@ -51,7 +51,7 @@ comparePeerGSV activePeers salt (a, a_p) (b, b_p) =
                                else gs a
         gs_b = if isActive b_p then activeAdvantage * gs b
                                else gs b in
-    if abs (gs_a - gs_b) < 0.05*gs_a
+    if abs (gs_a - gs_b) < 0.05 * max gs_a gs_b
        then compare (hashWithSalt salt a_p) (hashWithSalt salt b_p)
        else compare gs_a gs_b
   where

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
@@ -15,6 +15,7 @@ module Ouroboros.Network.BlockFetch.DeltaQ
   , estimateResponseDeadlineProbability
   , estimateExpectedResponseDuration
   , comparePeerGSV
+  , comparePeerGSV'
   ) where
 
 import           Control.Monad.Class.MonadTime
@@ -66,6 +67,18 @@ comparePeerGSV activePeers salt (a, a_p) (b, b_p) =
     gs PeerGSV { outboundGSV = GSV g_out _s_out _v_out,
                  inboundGSV  = GSV g_in  _s_in  _v_in
                } = g_out + g_in
+
+-- | Order two PeerGSVs based on `g`.
+-- Like comparePeerGSV but doesn't take active status into account
+comparePeerGSV' :: forall peer.
+      ( Hashable peer
+      , Ord peer
+      )
+      => Int
+      -> (PeerGSV, peer)
+      -> (PeerGSV, peer)
+      -> Ordering
+comparePeerGSV' = comparePeerGSV Set.empty
 
 
 calculatePeerFetchInFlightLimits :: PeerGSV -> PeerFetchInFlightLimits


### PR DESCRIPTION
Peers where ordered based on SockAddr, which generally meant that all
peers would pick the same second choice peer to download blocks from in
Deadline mode. And the same third pick and so on.

This changes ranking so that peers are sorted based on G.