### PR TITLE
CAD-3783 DoneAddingBlock event tracer for block delay metrics

### DIFF
--- a/ouroboros-consensus-test/src/Test/Util/Orphans/IOLike.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/IOLike.hs
@@ -4,7 +4,11 @@ module Test.Util.Orphans.IOLike () where
 
 import           Control.Monad.IOSim
 import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.IOLike.MonadTimeOnlyForTracer
 import           Test.Util.Orphans.NoThunks ()
 
 instance IOLike (IOSim s) where
   forgetSignKeyKES = const $ return ()
+
+instance MonadTimeOnlyForTracer (IOSim s) where
+  getCurrentTimeOnlyForTracer = defaultgetCurrentTimeOnlyForTracer

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -333,6 +333,7 @@ newtype OverrideDelay m a = OverrideDelay {
            , MonadCatch
            , MonadMask
            , MonadMonotonicTime
+           , MonadTimeOnlyForTracer
            , MonadTime
            , MonadThread
            , MonadFork

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -184,9 +184,7 @@ initLgrDB
   -> Chain TestBlock
   -> m (LgrDB m TestBlock)
 initLgrDB k chain = do
-    varDB          <- newTVarIO genesisLedgerDB
-    varPrevApplied <- newTVarIO mempty
-    let lgrDB = mkLgrDB varDB varPrevApplied resolve args
+    lgrDB          <- mkLgrDB genesisLedgerDB resolve args
     LgrDB.validate lgrDB genesisLedgerDB BlockCache.empty 0 noopTrace
       (map getHeader (Chain.toOldestFirst chain)) >>= \case
         LgrDB.ValidateExceededRollBack _ ->

--- a/ouroboros-consensus/docs/interface-CHANGELOG.md
+++ b/ouroboros-consensus/docs/interface-CHANGELOG.md
@@ -56,6 +56,29 @@ may appear out of chronological order.
 The internals of each entry are organized similar to
 https://keepachangelog.com/en/1.1.0/, adapted to our plan explained above.
 
+## Circa 2021-12-13
+
+### Added
+
+- Added `DoneAddingBlock` to the ChainDB tracer events:
+  - It contains important times for each block we received or minted ourselves.
+  - This new event is emitted by code whose functional semantics does not
+    otherwise involve time so explicitly. We therefore use the new
+    `EventConstrainedData` utility type to preserve the narrowness of those
+    functions semantics.
+
+- Added the `EventAuxData` and `EventConstrainedData` utility types.
+  - These incur some extra pattern matching noise downstream (which could be
+    hidden by a corresponding pattern synonym), but allow us to preserve
+    intentionally explicit separation of concerns in the Consensus codebase
+    itself.
+  - EG `ChainSel` does not need `ConfigSupportsNode`, but the principal use case
+    of `DoneAddingBlock`, which `ChainSel` emits, does. `EventConstrainedData`
+    mitigates that mismatch by deferring the need for the `ConfigSupportsNode`
+    dictionary downstream (ie the `cardano-node` code), where that constraint is
+    more obviously suitable.
+  - So far, these are only present in the new `DoneAddingBlock` event.
+
 ## Circa 2021-10-13
 
 ### Added

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -175,6 +175,7 @@ library
                        Ouroboros.Consensus.Util.FileLock
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.IOLike
+                       Ouroboros.Consensus.Util.IOLike.MonadTimeOnlyForTracer
                        Ouroboros.Consensus.Util.MonadSTM.NormalForm
                        Ouroboros.Consensus.Util.MonadSTM.RAWLock
                        Ouroboros.Consensus.Util.MonadSTM.StrictMVar

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -172,6 +172,7 @@ library
                        Ouroboros.Consensus.Util.Counting
                        Ouroboros.Consensus.Util.DepPair
                        Ouroboros.Consensus.Util.EarlyExit
+                       Ouroboros.Consensus.Util.EventAuxData
                        Ouroboros.Consensus.Util.FileLock
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DerivingVia         #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE RankNTypes          #-}
@@ -10,6 +11,7 @@ module Ouroboros.Consensus.HardFork.History.Caching (
   ) where
 
 import           Data.Kind (Type)
+import           NoThunks.Class
 
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -28,9 +30,12 @@ data RunWithCachedSummary (xs :: [Type]) m = RunWithCachedSummary {
       -- internal state (compute a new summary) and try again. If that /still/
       -- fails, the 'PastHorizonException' is returned.
       --
-      cachedRunQuery :: forall a. Qry a
-                     -> STM m (Either PastHorizonException a)
+      cachedRunQuery ::
+        !(forall a. Qry a -> STM m (Either PastHorizonException a))
     }
+  deriving NoThunks via OnlyCheckWhnfNamed
+                          "RunWithCachedSummary"
+                          (RunWithCachedSummary xs m)
 
 -- | Construct 'RunWithCachedSummary' given action that computes the summary
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -47,6 +47,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (MaxSlotNo)
 import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
+import qualified Ouroboros.Network.Tracers.OnlyForTracer as OnlyForTracer
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TxSubmissionMempoolWriter)
 import qualified Ouroboros.Network.TxSubmission.Inbound as Inbound
@@ -247,7 +248,7 @@ initBlockFetchConsensusInterface cfg chainDB getCandidates blockFetchSize btime 
         (toSummary <$> ChainDB.getCurrentLedger chainDB)
     let slotToUTCTime rp =
               fmap
-                (either errMsg toAbsolute)
+                (OnlyForTracer.pure . either errMsg toAbsolute)
             $ History.cachedRunQuery
                 cache
                 (fst <$> History.slotToWallclock (realPointSlot rp))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl (
   , NewTipInfo (..)
   , TraceAddBlockEvent (..)
   , TraceCopyToImmutableDBEvent (..)
+  , TraceDoneAddingBlockEvent (..)
   , TraceEvent (..)
   , TraceFollowerEvent (..)
   , TraceGCEvent (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -197,21 +197,22 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                     }
       h <- fmap CDBHandle $ newTVarIO $ ChainDbOpen env
       let chainDB = API.ChainDB
-            { addBlockAsync         = getEnv1    h ChainSel.addBlockAsync
-            , getCurrentChain       = getEnvSTM  h Query.getCurrentChain
-            , getLedgerDB           = getEnvSTM  h Query.getLedgerDB
-            , getTipBlock           = getEnv     h Query.getTipBlock
-            , getTipHeader          = getEnv     h Query.getTipHeader
-            , getTipPoint           = getEnvSTM  h Query.getTipPoint
-            , getBlockComponent     = getEnv2    h Query.getBlockComponent
-            , getIsFetched          = getEnvSTM  h Query.getIsFetched
-            , getIsValid            = getEnvSTM  h Query.getIsValid
-            , getMaxSlotNo          = getEnvSTM  h Query.getMaxSlotNo
-            , stream                = Iterator.stream  h
-            , newFollower           = Follower.newFollower h
-            , getIsInvalidBlock     = getEnvSTM  h Query.getIsInvalidBlock
-            , closeDB               = closeDB h
-            , isOpen                = isOpen  h
+            { addBlockAsync           = getEnv1    h ChainSel.addBlockAsync
+            , getCurrentChain         = getEnvSTM  h Query.getCurrentChain
+            , getLedgerDB             = getEnvSTM  h Query.getLedgerDB
+            , getTipBlock             = getEnv     h Query.getTipBlock
+            , getTipHeader            = getEnv     h Query.getTipHeader
+            , getTipPoint             = getEnvSTM  h Query.getTipPoint
+            , getBlockComponent       = getEnv2    h Query.getBlockComponent
+            , getIsFetched            = getEnvSTM  h Query.getIsFetched
+            , getIsValid              = getEnvSTM  h Query.getIsValid
+            , getMaxSlotNo            = getEnvSTM  h Query.getMaxSlotNo
+            , stream                  = Iterator.stream  h
+            , newFollower             = Follower.newFollower h
+            , getIsInvalidBlock       = getEnvSTM  h Query.getIsInvalidBlock
+            , calculateHeaderSlotTime = getEnvSTM1 h Query.getCalculateHeaderSlotTime
+            , closeDB                 = closeDB h
+            , isOpen                  = isOpen  h
             }
           testing = Internal
             { intCopyToImmutableDB       = getEnv  h Background.copyToImmutableDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -38,7 +38,8 @@ import           Control.Monad.Class.MonadTimer
 
 import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.IOLike (IOLike (..),
-                     MonadMonotonicTime (..), StrictMVar, StrictTVar)
+                     MonadMonotonicTime (..), MonadTimeOnlyForTracer (..),
+                     StrictMVar, StrictTVar)
 
 {-------------------------------------------------------------------------------
   Basic definitions
@@ -210,6 +211,9 @@ instance MonadST m => MonadST (WithEarlyExit m) where
 
 instance MonadMonotonicTime m => MonadMonotonicTime (WithEarlyExit m) where
   getMonotonicTime = lift getMonotonicTime
+
+instance MonadTimeOnlyForTracer m => MonadTimeOnlyForTracer (WithEarlyExit m) where
+  getCurrentTimeOnlyForTracer = lift getCurrentTimeOnlyForTracer
 
 instance MonadDelay m => MonadDelay (WithEarlyExit m) where
   threadDelay = lift . threadDelay

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/EventAuxData.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/EventAuxData.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Ouroboros.Consensus.Util.EventAuxData (
+    EventAuxData (..)
+  , EventConstrainedData (..)
+  ) where
+
+import           Data.Kind (Constraint)
+import           Data.Proxy (Proxy (..))
+import           GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
+
+{-------------------------------------------------------------------------------
+  Auxiliary data
+-------------------------------------------------------------------------------}
+
+-- | A wrapper for which '==' always returns 'True' and 'show' is a placeholder.
+--
+-- It is convenient for tracer event types to be particularly self-contained,
+-- which means they may contain more fields than absolutely necessary. In
+-- particular, some of those fields might be uninteresting in general. To
+-- emphasize these _auxiliaryness_ of these fields, to avoid the sometimes
+-- onerous instances required for such field's types, etc, wrap them in this
+-- data type.
+--
+-- In general, such a field should either have a value that never changes during
+-- a program execution (eg a pointer to some static config data) or else its
+-- value is effectively determined by other fields in the same tracer event data
+-- constructor by that constructor's invariants.
+--
+-- Most tracer events instantiate 'Eq' and 'Show', so we provide those trivial
+-- instances for this type.
+newtype EventAuxData (sym :: Symbol) a = EventAuxData { getEventAuxData :: a }
+
+instance Eq (EventAuxData sym a) where
+  (==) = \_ _ -> True
+
+-- | A string that includes @"EventAuxData"@ and @sym@ and moreover is correct
+-- Haskell syntax.
+instance KnownSymbol sym => Show (EventAuxData sym a) where
+  show _ = "(EventAuxData @\"" <> symbolVal (Proxy @sym) <> "\" _h)"
+
+{-------------------------------------------------------------------------------
+  Constrained data
+-------------------------------------------------------------------------------}
+
+-- | A type for data that is only availble if certain constraints are satsified
+--
+-- Because these constraints aren't necessarily available (otherwise this type
+-- would be useless), this is often an argument to 'EventAuxData'.
+newtype EventConstrainedData (c :: Constraint) a =
+  EventConstrainedData { getEventConstrainedData :: c => a }
+
+instance Functor (EventConstrainedData c) where
+  fmap f (EventConstrainedData a) = EventConstrainedData (f a)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -27,6 +27,7 @@ module Ouroboros.Consensus.Util.IOLike (
     -- *** MonadTime
   , DiffTime
   , MonadMonotonicTime (..)
+  , MonadTimeOnlyForTracer (..)
   , Time (..)
   , addTime
   , diffTime
@@ -50,9 +51,10 @@ import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime hiding (MonadTime (..))
 import           Control.Monad.Class.MonadTimer
+-- note: intentionally no import of MonadTime!
 
+import           Ouroboros.Consensus.Util.IOLike.MonadTimeOnlyForTracer
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.Orphans ()
 
@@ -72,6 +74,7 @@ class ( MonadAsync              m
       , MonadMonotonicTime      m
       , MonadEvaluate           m
       , MonadThrow         (STM m)
+      , MonadTimeOnlyForTracer  m
       , forall a. NoThunks (m a)
       , forall a. NoThunks a => NoThunks (StrictTVar m a)
       , forall a. NoThunks a => NoThunks (StrictMVar m a)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike/MonadTimeOnlyForTracer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike/MonadTimeOnlyForTracer.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Ouroboros.Consensus.Util.IOLike.MonadTimeOnlyForTracer (
+    MonadTimeOnlyForTracer (..)
+  , module X
+  , defaultgetCurrentTimeOnlyForTracer
+  ) where
+
+import           Control.Monad.Reader
+
+import           Control.Monad.Class.MonadTime hiding (MonadTime (..))
+import qualified Control.Monad.Class.MonadTime as X
+
+import           Ouroboros.Network.Tracers.OnlyForTracer (OnlyForTracer)
+
+{-------------------------------------------------------------------------------
+  MonadTimeOnlyForTracer
+-------------------------------------------------------------------------------}
+
+-- | A variation of 'MonadTime.MonadTime' from "Control.Monad.Class.MonadTime"
+-- that is immediately wrapped in 'OnlyForTracer'
+class MonadMonotonicTime m => MonadTimeOnlyForTracer m where
+  -- | Wall clock time.
+  --
+  getCurrentTimeOnlyForTracer :: m (OnlyForTracer UTCTime)
+
+-- | Defer to the actual 'X.MonadTime' from "Control.Monad.Class.MonadTime"
+defaultgetCurrentTimeOnlyForTracer :: X.MonadTime m => m (OnlyForTracer UTCTime)
+defaultgetCurrentTimeOnlyForTracer = pure <$> X.getCurrentTime
+
+instance MonadTimeOnlyForTracer IO where
+  getCurrentTimeOnlyForTracer = defaultgetCurrentTimeOnlyForTracer
+
+instance MonadTimeOnlyForTracer m => MonadTimeOnlyForTracer (ReaderT r m) where
+  getCurrentTimeOnlyForTracer = lift getCurrentTimeOnlyForTracer

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -73,6 +73,7 @@ library
                        Ouroboros.Network.NodeToClient
                        Ouroboros.Network.NodeToClient.Version
                        Ouroboros.Network.Tracers
+                       Ouroboros.Network.Tracers.OnlyForTracer
                        Ouroboros.Network.Point
                        Ouroboros.Network.PeerSelection.Types
                        Ouroboros.Network.PeerSelection.EstablishedPeers

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -126,6 +126,8 @@ import           Ouroboros.Network.BlockFetch.ClientRegistry
                    , bracketFetchClient, bracketKeepAliveClient
                    , bracketSyncWithFetchClient, setFetchClientContext )
 
+import           Ouroboros.Network.Tracers.OnlyForTracer (OnlyForTracer)
+
 
 -- | The consensus layer functionality that the block fetch logic requires.
 --
@@ -224,14 +226,14 @@ data BlockFetchConsensusInterface peer header block m =
        -- and consider its meaning at each call to this function. Relatedly,
        -- preserve that argument wrapper as much as possible when deriving
        -- ancillary functions\/interfaces from this function.
-       headerForgeUTCTime :: FromConsensus header -> STM m UTCTime,
+       headerForgeUTCTime :: FromConsensus header -> STM m (OnlyForTracer UTCTime),
 
        -- | Calculate when a block was forged.
        --
        -- PRECONDITION: Same as 'headerForgeUTCTime'.
        --
        -- WARNING: Same as 'headerForgeUTCTime'.
-       blockForgeUTCTime  :: FromConsensus block -> STM m UTCTime
+       blockForgeUTCTime  :: FromConsensus block -> STM m (OnlyForTracer UTCTime)
      }
 
 -- | Configuration for FetchDecisionPolicy.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -299,7 +299,7 @@ blockFetchClient _version controlMessageSTM reportFetched
             addFetchedBlock (castPoint (blockPoint header)) block
 
             forgeTime <- atomically $ blockForgeUTCTime $ FromConsensus block
-            let blockDelay = diffUTCTime now forgeTime
+            let blockDelay = diffUTCTime now <$> forgeTime
 
             let hf = getHeaderFields header
                 slotNo = headerFieldSlot hf

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -68,6 +68,8 @@ import qualified Ouroboros.Network.MockChain.Chain as C
 import           Ouroboros.Network.Point (withOrigin)
 import           Ouroboros.Network.Util.ShowProxy
 
+import qualified Ouroboros.Network.Tracers.OnlyForTracer as OnlyForTracer
+
 {-------------------------------------------------------------------------------
   Concrete block shape used currently in the network layer
 
@@ -363,8 +365,10 @@ instance Serialise BlockBody where
 -- It is only intended for use in tests. Notably it assumes a fixed system
 -- start time, slot length, and the absence of a hard fork (ie no
 -- HardForkCombinator). This is how it's available as a pure function.
-convertSlotToTimeForTestsAssumingNoHardFork :: SlotNo -> UTCTime
+convertSlotToTimeForTestsAssumingNoHardFork ::
+  SlotNo -> OnlyForTracer.OnlyForTracer UTCTime
 convertSlotToTimeForTestsAssumingNoHardFork sl =
+    OnlyForTracer.pure $
     flip addUTCTime startTime $
       --   ^^^ arbitrary start time for testing
     secondsToNominalDiffTime $

--- a/ouroboros-network/src/Ouroboros/Network/Tracers/OnlyForTracer.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Tracers/OnlyForTracer.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE Rank2Types    #-}
+
+-- | See 'OnlyForTracer'
+--
+-- Intended for qualified import.
+--
+-- > import           Ouroboros.Network.Tracers.OnlyForTracer (OnlyForTracer)
+-- > import qualified Ouroboros.Network.Tracers.OnlyForTracer as OnlyForTracer
+module Ouroboros.Network.Tracers.OnlyForTracer
+  ( OnlyForTracer (..)
+  , PolyRun (..)
+  , contramap
+  , mkPolyRun
+  , mkRun
+    -- * Convenience combinators
+  , contramapM
+  , lift
+  , mkTracerWith
+  , mkTracerWithPolyRun
+  , pure
+  , traceWith
+  ) where
+
+import           Prelude hiding (Applicative (..))
+import qualified Prelude
+
+import           Control.Tracer (Tracer (..))
+import qualified Control.Tracer as Tracer
+
+-- | An opaque box holding data that can only be accessed by a 'Tracer'
+--
+-- Note: In sufficient monads, the intended use can be subverted in order to
+-- leak the contained data outside of tracer invocations, but that should be
+-- caught and avoided during code review.
+newtype OnlyForTracer a = UnsafeOnlyForTracer {
+    -- | This is only safe to use _inside_ of another 'OnlyForTracer'
+    -- computation
+    unsafeRunOnlyForTracer :: a
+  }
+  deriving (Functor)
+  -- DO NOT DERIVE Foldable or Traversable -- those violate the intended use
+
+instance Prelude.Applicative OnlyForTracer where
+  pure = UnsafeOnlyForTracer
+  UnsafeOnlyForTracer f <*> UnsafeOnlyForTracer a = UnsafeOnlyForTracer (f a)
+
+-- | The only safe use of 'UnsafeOnlyForTracer'
+pure :: a -> OnlyForTracer a
+pure = Prelude.pure
+
+-- | The only way to eliminate the 'OnlyForTracer' structure is to let it
+-- influence a 'Tracer'
+contramap :: OnlyForTracer (a -> b) -> Tracer m b -> Tracer m a
+contramap = Tracer.contramap . unsafeRunOnlyForTracer
+
+-- | A exported wrapper only used to avoid impredicative polymorphism
+--
+-- TODO Once we switch to ghc-9.2, check to see if we should eliminate this
+-- wrapper, since ghc-9.2 will have improved impredicative polymorphism
+-- support.
+newtype PolyRun = PolyRun { run :: forall a. OnlyForTracer a -> a }
+
+-- | A polymorphic version of 'mkRun'
+mkPolyRun :: OnlyForTracer PolyRun
+mkPolyRun = pure $ PolyRun unsafeRunOnlyForTracer
+
+-- | Since 'OnlyForTracer' is inescapable (excepting the note on its Haddock),
+-- it's sound for any 'OnlyForTracer' computation to trivially eliminate the
+-- 'OnlyForTracer' layer
+--
+-- Note: compare this to a hypothetical constant of type @M (M a -> a)@ for
+-- some specific monad @M@.
+mkRun :: OnlyForTracer (OnlyForTracer a -> a)
+mkRun = fmap run mkPolyRun
+
+{-------------------------------------------------------------------------------
+  Convenient aliases
+-------------------------------------------------------------------------------}
+
+-- We define these aliases without using any @unsafe*@ functions, so that we
+-- can't accidentally break the established invariants.
+
+lift :: Tracer m a -> Tracer m (OnlyForTracer a)
+lift = contramap mkRun
+
+contramapM :: Monad m
+           => OnlyForTracer (a -> m b)
+           -> Tracer m b
+           -> Tracer m a
+contramapM kOft bTr =
+    contramap
+      (fmap (\kRun a -> kRun kOft a) mkRun)
+      (Tracer.contramapM id bTr)
+
+traceWith :: Tracer m a -> OnlyForTracer a -> m ()
+traceWith = Tracer.traceWith . lift
+
+mkTracerWith :: OnlyForTracer a -> (a -> Tracer m b) -> Tracer m b
+mkTracerWith aOft mk =
+    contramap
+      (fmap (\aRun b -> (aRun, b)) mkRun)
+      (Tracer $ \(aRun, b) -> Tracer.traceWith (mk (aRun aOft)) b)
+
+mkTracerWithPolyRun :: (PolyRun -> Tracer m a) -> Tracer m a
+mkTracerWithPolyRun = mkTracerWith mkPolyRun

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -39,6 +39,8 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import qualified Ouroboros.Network.AnchoredFragment as AnchoredFragment
 import           Ouroboros.Network.Block
 
+import           Ouroboros.Network.Tracers.OnlyForTracer (OnlyForTracer)
+
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
 import           Ouroboros.Network.Mux (ControlMessageSTM)
@@ -262,7 +264,7 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
 --
 
 sampleBlockFetchPolicy1 :: (MonadSTM m, HasHeader header, HasHeader block)
-                        => (forall x. HasHeader x => FromConsensus x -> STM m UTCTime)
+                        => (forall x. HasHeader x => FromConsensus x -> STM m (OnlyForTracer UTCTime))
                         -> TestFetchedBlockHeap m block
                         -> AnchoredFragment header
                         -> Map peer (AnchoredFragment header)


### PR DESCRIPTION
Fixes #3382.

The commits are well-separated; likely best reviewed individually.

Issue 3382 (aka CAD-3783) is resolved by this PR by the addition of the new `DoneAddingBlock` event, specifically the `UTCTime`s it contains.

This PR introduces a few lightweight types that help preserve the separation of concerns within the code itself, despite needing to calculate those times. In particular, the correct input-output behavior of the code that emits this new event does not otherwise require any of the times necessary to construct the event. We accordingly use the `OnlyForTracer` newtype to limit what the the new monadic constraint and new ChainDB logic that compute these times can influence (ie only `Tracer`s). Similarly, the `ChainSel` code that emits the event doesn't otherwise need access to the constraints that are required for the principal intended use of the event; hence the `EventConstrainedData` newtype in the tracer event itself.