### PR TITLE
Fix haddock error

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -467,7 +467,7 @@ ledgerDbSwitch cfg numRollbacks trace newBlocks db =
           }
       Just db' -> case newBlocks of
         [] -> pure $ Right db'
-        -- ^ no blocks to apply to ledger state, return current LedgerDB
+        -- no blocks to apply to ledger state, return current LedgerDB
         (firstBlock:_) -> do
           let start   = PushStart . toRealPoint $ firstBlock
               goal    = PushGoal  . toRealPoint . last $ newBlocks


### PR DESCRIPTION
This produces an error when building `cardano-node`.
```src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs:470:9: error:
    parse error on input ‘-- ^ no blocks to apply to ledger state, return current LedgerDB’
    |
470 |         -- ^ no blocks to apply to ledger state, return current LedgerDB
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```