### PR TITLE
Update the Alonzo PV to version 6 in db-analyser

### DIFF
--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -168,7 +168,7 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         , maryMaxTxCapacityOverrides    = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolParamsAlonzo {
-          alonzoProtVer                 = ProtVer 5 0
+          alonzoProtVer                 = ProtVer 6 0
         , alonzoMaxTxCapacityOverrides  = TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
       ProtocolTransitionParamsShelleyBased {


### PR DESCRIPTION
This matches the node configuration, and allows db-analyse to process
Alonzo-era blocks.