### PR TITLE
Haddock failure workaround

### DIFF
--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node/NodeKernel.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node/NodeKernel.hs
@@ -129,8 +129,8 @@ randomBlockGenerationArgs bgaSlotDuration bgaSeed quota =
                             let block = ConcreteBlock.fixupBlock anchor
                                       . ConcreteBlock.mkPartialBlock slot
                                       -- TODO:
-                                      -- * use ByteString, not String;
-                                      -- * cycle through some bodies
+                                      --  * use ByteString, not String;
+                                      --  * cycle through some bodies
                                       --
                                       $ ConcreteBlock.BlockBody (BSC.pack "")
                             in case randomR (0, 100) seed of


### PR DESCRIPTION
The Haddock documentation CRON job started failing on Nov 16 due to #3467, as the `-- *`s are interpreted as Haddock sections headings which are invalid in this place. Inserting extra spaces (like in many other cases in the codebase) resolves the issue.