### PR TITLE
CAD-3817 LedgerDB initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ haddocks/
 
 # Ignore directory used by .github/bin/check-dependencies
 /tmp
+
+.dir-locals.el

--- a/ouroboros-consensus/.dir-locals.el
+++ b/ouroboros-consensus/.dir-locals.el
@@ -1,5 +1,0 @@
-;;; Directory Local Variables
-;;; For more information see (info "(emacs) Directory Variables")
-
-((nil
-  (fill-column . 80)))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -263,12 +263,12 @@ class (ShowLedgerState (LedgerTables l), Eq (l ValuesMK)) => TableStuff (l :: Le
   -- TODO: reconsider the name: don't we use 'withX' in the context of bracket like functions?
   withLedgerTables :: HasCallStack => l any -> LedgerTables l mk -> l mk
 
-  -- | Apply the differences in a tracking map to a values map. This is intended
+  -- | Apply the differences in a diff map to a values map. This is intended
   -- to be used to check that a ledger state computed by the old implementation
   -- and a ledger state computed by the new implementation both agree.
   --
   -- Old + ResultNew == ResultOld
-  applyTracking :: l ValuesMK -> l TrackingMK -> l ValuesMK
+  applyDiffs :: l ValuesMK -> l DiffMK -> l ValuesMK
 
 -- Separate so that we can have a 'TableStuff' instance for 'Ticked1' without
 -- involving double-ticked types.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -469,9 +469,7 @@ deriving instance ( Eq (LedgerState m mk)
                   , Bridge m a
                   ) => Eq (LedgerState (DualBlock m a) mk)
 
-instance ( ShowLedgerState (LedgerState m)
-         , ShowLedgerState (LedgerState a)
-         , Bridge m a
+instance ( Bridge m a
          ) => ShowLedgerState (LedgerState (DualBlock m a)) where
   showsLedgerState = error "showsLedgerState @DualBlock"
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -90,7 +90,7 @@ import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..),
-                     MapKind (EmptyMK))
+                     MapKind (..))
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
 import           Ouroboros.Consensus.Node.DbLock
@@ -526,7 +526,7 @@ openChainDB
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
-  -> ExtLedgerState blk EmptyMK
+  -> ExtLedgerState blk ValuesMK
      -- ^ Initial ledger
   -> ChainDbArgs Defaults m blk
   -> (ChainDbArgs Identity m blk -> ChainDbArgs Identity m blk)
@@ -546,7 +546,7 @@ mkChainDbArgs
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
-  -> ExtLedgerState blk EmptyMK
+  -> ExtLedgerState blk ValuesMK
      -- ^ Initial ledger
   -> ChunkInfo
   -> ChainDbArgs Defaults m blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -38,7 +38,7 @@ enumCoreNodes (NumCoreNodes numNodes) =
 -- | Data required to run the specified protocol.
 data ProtocolInfo m b = ProtocolInfo {
         pInfoConfig       :: TopLevelConfig b
-      , pInfoInitLedger   :: ExtLedgerState b EmptyMK -- ^ At genesis    TODO no UTxO? no stake addresses/credentials?
+      , pInfoInitLedger   :: ExtLedgerState b ValuesMK -- ^ The Genesis Ledger State contains an initial UTxO, so it has to use @ValuesMK@.
       , pInfoBlockForging :: m [BlockForging m b]
       }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -233,7 +233,6 @@ initBlockFetchConsensusInterface
        , BlockSupportsProtocol blk
        , SupportsNode.ConfigSupportsNode blk
        , History.HasHardForkHistory blk
-       , IsLedger (LedgerState blk)
        )
     => TopLevelConfig blk
     -> ChainDB m blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -61,7 +61,7 @@ data ChainDbArgs f m blk = ChainDbArgs {
     , cdbTopLevelConfig         :: HKD f (TopLevelConfig blk)
     , cdbChunkInfo              :: HKD f ChunkInfo
     , cdbCheckIntegrity         :: HKD f (blk -> Bool)
-    , cdbGenesis                :: HKD f (m (ExtLedgerState blk EmptyMK))
+    , cdbGenesis                :: HKD f (m (ExtLedgerState blk ValuesMK))
     , cdbCheckInFuture          :: HKD f (CheckInFuture m blk)
     , cdbImmutableDbCacheConfig :: ImmutableDB.CacheConfig
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -1,23 +1,26 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE MultiWayIf          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE TypeApplications    #-}
-
-{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE BangPatterns         #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingVia          #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE MultiWayIf           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
     -- * Opening the database
     InitFailure (..)
   , InitLog (..)
+  , NewLedgerInitParams (..)
+  , OldLedgerInitParams (..)
   , initLedgerDB
     -- ** Instantiate in-memory to @blk@
   , AnnLedgerError'
@@ -67,8 +70,6 @@ import           Text.Read (readMaybe)
 import           Ouroboros.Network.Block (Point (Point))
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.HeaderValidation
-                     (HeaderState (headerStateTip), annTipPoint)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
@@ -80,6 +81,8 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
 
+import           Cardano.Slotting.Slot (WithOrigin (At))
+import           Control.Monad.Trans.Except (throwE)
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
 
@@ -104,45 +107,49 @@ data NextBlock blk = NoMoreBlocks | NextBlock blk
 -- tip to bring the ledger up to date with the tip of the immutable DB.
 --
 -- In CPS form to enable the use of 'withXYZ' style iterator init functions.
-data StreamAPI m blk = StreamAPI {
-      -- | Start streaming after the specified block
-      streamAfter :: forall a. HasCallStack
-        => Point blk
-        -- Reference to the block corresponding to the snapshot we found
-        -- (or 'GenesisPoint' if we didn't find any)
+data StreamAPI m e blk = StreamAPI {
+  -- | Start streaming after the specified block up to the end of the
+  -- immutable database.
+  streamAfter :: forall a. HasCallStack
+              => Point blk
+              -- Reference to the block corresponding to the snapshot we found
+              -- (or 'Point Origin' if we didn't find any)
 
-        -> (Either (RealPoint blk) (m (NextBlock blk)) -> m a)
-        -- Get the next block (by value)
-        --
-        -- Should be @Left pt@ if the snapshot we found is more recent than the
-        -- tip of the immutable DB. Since we only store snapshots to disk for
-        -- blocks in the immutable DB, this can only happen if the immutable DB
-        -- got truncated due to disk corruption. The returned @pt@ is a
-        -- 'RealPoint', not a 'Point', since it must always be possible to
-        -- stream after genesis.
-        -> m a
-    }
+              -> (Either (RealPoint blk) (m (NextBlock blk)) -> ExceptT e m a)
+              -- Get the next block (by value)
+              --
+              -- Should be @Left pt@ if the snapshot we found is more recent than the
+              -- tip of the immutable DB. Since we only store snapshots to disk for
+              -- blocks in the immutable DB, this can only happen if the immutable DB
+              -- got truncated due to disk corruption. The returned @pt@ is a
+              -- 'RealPoint', not a 'Point', since it must always be possible to
+              -- stream after genesis.
+              -> ExceptT e m a
+  }
 
 -- | Stream all blocks
 streamAll ::
      forall m blk e a. (Monad m, HasCallStack)
-  => StreamAPI m blk
-  -> Point blk             -- ^ Starting point for streaming
-  -> (RealPoint blk -> e)  -- ^ Error when tip not found
-  -> a                     -- ^ Starting point when tip /is/ found
-  -> (blk -> a -> m a)     -- ^ Update function for each block
+  => StreamAPI m e blk
+  -> Point blk                           -- ^ Starting point for streaming
+  -> (RealPoint blk -> e)                -- ^ Error when tip not found
+  -> a                                   -- ^ Starting point when tip /is/ found
+  -> (blk -> a -> ExceptT e m (Maybe a)) -- ^ Update function for each block with stop condition
   -> ExceptT e m a
-streamAll StreamAPI{..} tip notFound e f = ExceptT $
+streamAll StreamAPI{..} tip notFound e f =
     streamAfter tip $ \case
-      Left tip' -> return $ Left (notFound tip')
+      Left tip' -> throwE (notFound tip')
 
       Right getNext -> do
-        let go :: a -> m a
-            go a = do mNext <- getNext
+        let go :: a -> ExceptT e m a
+            go a = do mNext <- lift $ getNext
                       case mNext of
                         NoMoreBlocks -> return a
-                        NextBlock b  -> go =<< f b a
-        Right <$> go e
+                        NextBlock b  -> maybe (return a) go =<< f b a
+        go e
+
+-- | The @StreamAPI@ type refined to expect an exception of type @InitFailure@
+type StreamAPI' m blk = StreamAPI m (InitFailure blk) blk
 
 {-------------------------------------------------------------------------------
   Initialize the DB
@@ -169,29 +176,42 @@ data InitLog blk =
     --
     -- NOTE: We should /only/ see this if data corrupted occurred.
   | InitFailure DiskSnapshot (InitFailure blk) (InitLog blk)
-  deriving (Show, Eq, Generic)
+  deriving (Eq, Show, Generic)
 
--- | Initialize the ledger DB from the most recent snapshot on disk
+-- | Grouped parameters specific only for the old-style LedgerDB
+data OldLedgerInitParams m blk = OldLedgerInitParams {
+    oldFS      :: SomeHasFS m
+  , oldDecoder :: forall s. Decoder s (ExtLedgerState blk ValuesMK)
+  }
+
+-- | Grouped parameters specific only for the new-style LedgerDB
+data NewLedgerInitParams m blk = NewLedgerInitParams {
+    newFS      :: SomeHasFS m
+  , newDecoder :: forall s. Decoder s (ExtLedgerState blk EmptyMK)
+  , backend    :: OnDiskLedgerStDb m (ExtLedgerState blk) blk
+  }
+
+-- | Initialize the ledger DB
 --
--- If no such snapshot can be found, use the genesis ledger DB. Returns the
--- initialized DB as well as the block reference corresponding to the snapshot
--- we found on disk (the latter primarily for testing/monitoring purposes).
+-- This will:
+-- 1. deserialize the most recent found snapshot for each of the internal databases
+-- 2. bring up the database that is behind until they are at the same tip
+-- 3. replay the remaining blocks on the immutable database on both databases
 --
--- We do /not/ catch any exceptions thrown during streaming; should any be
--- thrown, it is the responsibility of the 'ChainDB' to catch these
--- and trigger (further) validation. We only discard snapshots if
+-- If no snapshot is found on either database, it will be initialized with the
+-- Genesis ledger state.
 --
--- * We cannot deserialise them, or
--- * they are /ahead/ of the chain
+-- During replay, no exceptions are caught, and instead it should be
+-- responsibility of the 'ChainDB' to actually catch them and, if needed,
+-- trigger further validation.
 --
--- It is possible that the Ledger DB will not be able to roll back @k@ blocks
--- after initialization if the chain has been truncated (data corruption).
+-- Snapshots will be deleted if:
 --
--- We do /not/ attempt to use multiple ledger states from disk to construct the
--- ledger DB. Instead we load only a /single/ ledger state from disk, and
--- /compute/ all subsequent ones. This is important, because the ledger states
--- obtained in this way will (hopefully) share much of their memory footprint
--- with their predecessors.
+-- * We cannot deserialize them, except if they are permanent snapshots.
+-- * they are /ahead/ of the chain.
+--
+-- After initialization, if there was data corruptuion on the immutable
+-- database, the LedgerDB might not be able to rollback @k@ blocks.
 initLedgerDB ::
      forall m blk. (
          IOLike m
@@ -201,75 +221,295 @@ initLedgerDB ::
        )
   => Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
   -> Tracer m (TraceEvent blk)
-  -> SomeHasFS m
-  -> OnDiskLedgerStDb m (ExtLedgerState blk)
-  -> (forall s. Decoder s (ExtLedgerState blk EmptyMK))
+  -> OldLedgerInitParams m blk
+  -> NewLedgerInitParams m blk
   -> (forall s. Decoder s (HeaderHash blk))
   -> LedgerDbCfg (ExtLedgerState blk)
-  -> m (ExtLedgerState blk EmptyMK) -- ^ Genesis ledger state
-  -> StreamAPI m blk
-  -> m (InitLog blk, LedgerDB' blk, Word64)
-initLedgerDB replayTracer
-             tracer
-             hasFS
-             onDiskLedgerDbSt
-             decLedger
-             decHash
-             cfg
-             _getGenesisLedger
-             streamAPI = do
-    snapshots <- listSnapshots hasFS
-    -- Here we'd get the dbhandle
-    --
-    -- We can use this dbhandle to fetch the restore points.
-    tryNewestFirst id snapshots
+  -> m (ExtLedgerState blk ValuesMK)                     -- ^ Genesis ledger state
+  -> StreamAPI' m blk
+  -> Bool
+  -> m ((Maybe (InitLog blk), InitLog blk), LedgerDB' blk, Word64)
+initLedgerDB replayTracer tracer OldLedgerInitParams{..} NewLedgerInitParams{..} decHash cfg getGenesisLedger streamAPI runAlsoOld = do
+
+    mOldLedgerDB <- if runAlsoOld then Just <$> oldInitLedgerDB
+                                                       getGenesisLedger
+                                                       oldFS
+                                                       oldDecoder
+                                                       decHash
+                                  else return Nothing
+
+    (initLog', newStyleDB, replayTracer') <- newInitLedgerDB
+                                              replayTracer
+                                              tracer
+                                              getGenesisLedger
+                                              newFS
+                                              newDecoder
+                                              decHash
+                                              backend
+
+    ml <- runExceptT $
+      case mOldLedgerDB of
+        Nothing ->
+          -- We are only going to ever use the new-style LedgerDB
+          let
+            ledgerDb = combine Nothing newStyleDB
+          in
+            (Nothing,) <$> initStartingWith replayTracer' cfg backend streamAPI ledgerDb
+        Just (initLog, oldStyleDB) -> do
+          let oldTip = pointSlot . getTip $ oldLedgerDbCurrent oldStyleDB
+              newTip = pointSlot . getTip $ newLedgerDbCurrent newStyleDB
+          -- We are going to use both databases
+          (inSyncDB, replayedOnNew) <-
+            case compare oldTip newTip of
+              -- The new-style database is behind the old-style one
+              GT -> do
+                (newStyleDB', replayed) <- initializeNewDB replayTracer' newStyleDB oldTip
+                return (combine (Just oldStyleDB) newStyleDB', replayed)
+
+              -- The old-style database is behind the new-style one
+              LT -> do
+                (oldStyleDB', _) <- initializeOldDB replayTracer' oldStyleDB newTip
+                return (combine (Just oldStyleDB') newStyleDB, 0)
+
+              -- The databases are in sync
+              EQ -> return (combine (Just oldStyleDB) newStyleDB, 0)
+
+          -- from this point on, apply blocks on both databases
+          (initializedDb, replayedOnBoth) <- initStartingWith replayTracer' cfg backend streamAPI inSyncDB
+          return (Just initLog, (initializedDb, replayedOnBoth + replayedOnNew))
+    case ml of
+      Left InitFailureNotInSyncWithUTxO -> error "invariant violation: UTxO-HD backend is not in sync with snapshots"
+      Left err -> error $ "invariant violation: invalid current chain:" <> show err
+      Right (initLog, (ledgerDB, replayedBlocks)) -> return ((initLog, initLog'), ledgerDB, replayedBlocks)
+  where
+    combine :: Maybe (OldLedgerDB (ExtLedgerState blk))
+            -> NewLedgerDB (ExtLedgerState blk)
+            -> LedgerDB (ExtLedgerState blk)
+    combine = mkLedgerDB @(ExtLedgerState blk) @blk
+
+    initializeDB
+      :: Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
+      -> db
+      -> (db -> Point blk)                                          -- ^ Get current tip point function
+      -> (ExtLedgerCfg blk
+          -> Ap m1 l blk (ReadsKeySets m1 l)
+          -> db
+          -> DbReader
+               m
+               (ExtLedgerState blk)
+               (Either
+                  (RealPoint blk, LedgerErr (ExtLedgerState blk))
+                  resultingLedger))                                 -- ^ Apply block function
+      -> (resultingLedger -> db -> db)                              -- ^ Push block function
+      -> WithOrigin SlotNo                                          -- ^ Goal point
+      -> ExceptT (InitFailure blk) m (db, Word64)
+    initializeDB replayTracer' initDb getCur apBlock push goal =
+      initDatabaseWithStreamAndUpd
+        streamAPI
+        initDb
+        getCur
+        (\blk (db, replayed) -> if At (blockSlot blk) > goal
+                                then
+                                  -- We have already replayed enough blocks, the databases are in sync now
+                                  return Nothing
+                                else do
+                                  lift $ traceWith replayTracer' (ReplayedBlock (blockRealPoint blk) [])
+
+                                  -- Apply the block to the tip of the db
+                                  resultingLedgerState <-   lift (defaultReadKeySets (readKeySets backend)
+                                                                   $ apBlock (ledgerDbCfg cfg) (ReapplyVal blk) db)
+
+                                  -- Embed the computation in an @ExceptT (InitFailure blk) (NewLedgerDB l)@ as
+                                  -- we need to do so for the @StreamAPI@ interface, but as we know that we are
+                                  -- reapplying blocks, we don't need to rethrow an @AnnLedgerError@ as it will never happen.
+                                  result <- either
+                                    (\(_, err) -> error $ "invariant violation: invalid current chain:" <> show err)
+                                    return
+                                    resultingLedgerState
+                                  -- TODO: add some trace
+                                  return . Just . (, replayed + 1) $ push result db)
+
+    initializeNewDB :: Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
+                    -> NewLedgerDB (ExtLedgerState blk)
+                    -> WithOrigin SlotNo
+                    -> ExceptT (InitFailure blk) m (NewLedgerDB (ExtLedgerState blk), Word64)
+    initializeNewDB replayTracer' newStyleDB oldTip =
+      initializeDB replayTracer' newStyleDB (castPoint . getTip . newLedgerDbCurrent) newApplyBlock pushLedgerStateNew oldTip
+
+
+    initializeOldDB :: Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
+                    -> OldLedgerDB (ExtLedgerState blk)
+                    -> WithOrigin SlotNo
+                    -> ExceptT (InitFailure blk) m (OldLedgerDB (ExtLedgerState blk), Word64)
+    initializeOldDB replayTracer' oldStyleDB newTip =
+      initializeDB replayTracer' oldStyleDB (castPoint . getTip . oldLedgerDbCurrent) oldApplyBlock (pushLedgerStateOld (ledgerDbCfgSecParam cfg) . snd) newTip
+
+{-------------------------------------------------------------------------------
+ Load snapshots from the disk
+-------------------------------------------------------------------------------}
+
+-- | Load a snapshot from disk. Depending on the decoder, the snapshot is
+-- expected to be of the @mk@ that the decoder knows how to decode.
+--
+-- This will throw an exception @InitFailureRead@ if it can't deserialize a
+-- snapshot or an @InitFailureGenesis@ if we are trying to load a snapshot that
+-- corresponds to Genesis, which should never happen as we don't ever serialize
+-- a ledger state corresponding to Genesis.
+loadSnapshot :: ( IOLike m
+                , LedgerSupportsProtocol blk
+                )
+             => Maybe (Tracer m (ReplayGoal blk -> TraceReplayEvent blk))
+             -> SomeHasFS m
+             -> (forall s. Decoder s (ExtLedgerState blk mk))
+             -> (forall s. Decoder s (HeaderHash blk))
+             -> DiskSnapshot                      -- ^ Which snapshot to load from the filesystem
+             -> ExceptT (InitFailure blk)
+                        m
+                        ( ExtLedgerState blk mk
+                        , RealPoint blk   -- The real point corresponding to the deserialized ledger state
+                        , Maybe (Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk))
+                        )
+loadSnapshot tracer fs dec decHash ss  = do
+      initSS <- withExceptT InitFailureRead $ readSnapshot fs dec decHash ss
+      let initialPoint = castPoint (getTip initSS)
+      case pointToWithOriginRealPoint initialPoint of
+        Origin -> throwError InitFailureGenesis
+        NotOrigin tip -> do
+          maybe (return ()) (\t -> lift $ traceWith t $ ReplayFromSnapshot ss tip (ReplayStart initialPoint)) tracer
+          return (initSS, tip, decorateReplayTracerWithStart initialPoint <$> tracer)
+
+
+{-------------------------------------------------------------------------------
+ Old initialization of LedgerDB
+-------------------------------------------------------------------------------}
+
+-- | Initialize the ledger DB in the old way from the most recent snapshot on disk
+--
+-- If no such snapshot can be found, use the genesis ledger DB. Returns the
+-- initialized old DB as well as the block reference corresponding to the snapshot
+-- we found on disk (the latter primarily for testing/monitoring purposes).
+--
+-- We only discard snapshots if we cannot deserialise them.
+--
+-- It is possible that the Ledger DB will not be able to roll back @k@ blocks
+-- after initialization if the chain has been truncated (data corruption).
+--
+-- We do /not/ attempt to use multiple ledger states from disk to construct the
+-- ledger DB. Instead we load only a /single/ ledger state from disk, and
+-- /compute/ all subsequent ones. This is important, because the ledger states
+-- obtained in this way will (hopefully) share much of their memory footprint
+-- with their predecessors.
+oldInitLedgerDB :: forall m blk. ( IOLike m
+                   , LedgerSupportsProtocol blk
+                   , HasCallStack
+                   )
+                => m (ExtLedgerState blk ValuesMK)                     -- ^ Action that gives the Genesis ledger state
+                -> SomeHasFS m                                         -- ^ Filesystem containing the old ledger snapshots
+                -> (forall s. Decoder s (ExtLedgerState blk ValuesMK)) -- ^ A decoder for the old ledger snapshots
+                -> (forall s. Decoder s (HeaderHash blk))
+                -> m ( InitLog blk
+                     , OldLedgerDB (ExtLedgerState blk)
+                     )
+oldInitLedgerDB getGenesisLedger hasFS decLedger decHash = do
+    listSnapshots hasFS >>= tryNewestFirst id
   where
     tryNewestFirst :: (InitLog blk -> InitLog blk)
                    -> [DiskSnapshot]
-                   -> m (InitLog blk, LedgerDB' blk, Word64)
+                   -> m (InitLog blk, OldLedgerDB (ExtLedgerState blk))
     tryNewestFirst acc [] = do
-        -- We're out of snapshots. Start at genesis
-        traceWith replayTracer ReplayFromGenesis
-        initDb <- ledgerDbWithAnchor <$> undefined --getGenesisLedger TODO: Commented to unlock further work. Implementing initialization will fix this.
-        let replayTracer' = decorateReplayTracerWithStart (Point Origin) replayTracer
-        ml     <- runExceptT
-                  -- TODO: here initStartingWith could and should probably flush!
-                  --
-                  -- If we're replaying from genesis (or simply replaying a very
-                  -- large number of blocks) we will need to flush from time to
-                  -- time inside this function.
-                  --
-                  -- Note that at the moment no LedgerDB snapshots are taken by
-                  -- this function.
-                  --
-                  -- Note that whatever restore point we take here, it will
-                  -- belong to the immutable part of the chain. So the restore
-                  -- point will not lie ahead of the immutable DB tip.
-                  $ initStartingWith replayTracer' cfg onDiskLedgerDbSt streamAPI initDb
-        case ml of
-          Left _  -> error "invariant violation: invalid current chain"
-          Right (l, replayed) -> return (acc InitFromGenesis, l, replayed)
+      -- We're out of snapshots. Start at genesis
+      initSS <- getGenesisLedger
+      return ( acc InitFromGenesis
+             , oldLedgerDbWithAnchor initSS
+             )
     tryNewestFirst acc (s:ss) = do
-        -- If we fail to use this snapshot, delete it and try an older one
-        ml <- runExceptT $ initFromSnapshot
-                             replayTracer
-                             hasFS
-                             decLedger
-                             decHash
-                             cfg
-                             onDiskLedgerDbSt
-                             streamAPI
-                             s
+      ml <- runExceptT $ loadSnapshot Nothing hasFS decLedger decHash s
+      case ml of
+        Left err -> do
+          when (diskSnapshotIsTemporary s) $
+            -- We don't delete permanent snapshots, even if we couldn't parse
+            -- them
+            deleteSnapshot hasFS s
+          tryNewestFirst (acc . InitFailure s err) ss
+        Right (ls, pt, _) -> do
+          return ( acc (InitFromSnapshot s pt)
+                 , oldLedgerDbWithAnchor ls
+                 )
+
+{-------------------------------------------------------------------------------
+ New initialization of LedgerDB
+-------------------------------------------------------------------------------}
+
+-- | Initialize a DbChangelog from the snapshot in the disk.
+--
+-- If there are multiple snapshots we can only be sure that the latest one
+-- corresponds to what was flushed to the disk and therefore we can only try to
+-- deserialize that one. If the point on said snapshot and the point on the disk
+-- data is not the same one, this will throw an assertion failure.
+--
+-- If we fail to deserialize the last snapshot, we cannot try previous ones
+-- because they will be misaligned with the on disk data, so we can just revert
+-- to Genesis.
+newInitLedgerDB :: forall m blk.
+                   ( IOLike m
+                   , LedgerSupportsProtocol blk
+                   , HasCallStack
+                   )
+                => Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
+                -> Tracer m (TraceEvent blk)
+                -> m (ExtLedgerState blk ValuesMK)                    -- ^ An action to get the Genesis ledger state
+                -> SomeHasFS m                                        -- ^ The filesystem with the new snapshots
+                -> (forall s. Decoder s (ExtLedgerState blk EmptyMK)) -- ^ A decoder for new snapshots
+                -> (forall s. Decoder s (HeaderHash blk))
+                -> OnDiskLedgerStDb m (ExtLedgerState blk) blk
+                -> m ( InitLog blk
+                     , NewLedgerDB (ExtLedgerState blk)
+                     , Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
+                     )
+newInitLedgerDB replayTracer tracer getGenesisLedger hasFS decLedger decHash onDiskLedgerDbSt = do
+    snapshots <- findNewSnapshot hasFS
+    case snapshots of
+      Nothing -> initUsingGenesis
+      Just s  -> do
+        ml <- runExceptT $ loadSnapshot (Just replayTracer) hasFS decLedger decHash s
         case ml of
           Left err -> do
-            when (diskSnapshotIsTemporary s) $
-              -- We don't delete permanent snapshots, even if we couldn't parse
-              -- them
-              deleteSnapshot hasFS s
+            -- Here we don't guard for permanent snapshots because if we have a
+            -- permanent snapshot at slot @s@ which fails to deserialize, we
+            -- will start from genesis, and if we don't remove it and we don't
+            -- go past it, the next time we will also fail to deserialize it and
+            -- start again from Genesis.
+            deleteSnapshot hasFS s
             traceWith tracer $ InvalidSnapshot s err
-            tryNewestFirst (acc . InitFailure s err) ss
-          Right (r, l, replayed) ->
-            return (acc (InitFromSnapshot s r), l, replayed)
+            (l, db, tr) <- initUsingGenesis
+            return (InitFailure s err l, db, tr)
+          Right (initSS, pt', replayTracer') -> do
+            pt'' <- odlsGetPt onDiskLedgerDbSt
+
+            -- if the @pt'@ from the deserialized ledger state is not in sync
+            -- with the @pt''@ that the disk backend claims to be at, we cannot
+            -- use this snapshot as it is not in sync with the disk, and as we
+            -- cannot have previous snapshots we can just start from Genesis.
+
+            if realPointToPoint pt' == pt''
+              then return ( InitFromSnapshot s pt'
+                          , newLedgerDbWithEmptyAnchor pt'' initSS
+                          , maybe (error "unreachable as we provided a Just to loadSnapshot") id replayTracer'
+                          )
+              else do
+                -- Same as above, we don't guard against permanent snapshots.
+                deleteSnapshot hasFS s
+                traceWith tracer $ InvalidSnapshot s InitFailureNotInSyncWithUTxO
+                (l, db, tr) <- initUsingGenesis
+                return (InitFailure s InitFailureNotInSyncWithUTxO l, db, tr)
+  where initUsingGenesis = do
+          initSS <- getGenesisLedger
+          writeGenesisUTxO onDiskLedgerDbSt initSS
+          let replayTracer' = decorateReplayTracerWithStart (Point Origin) replayTracer
+          return ( InitFromGenesis
+                 , newLedgerDbWithAnchor initSS
+                 , replayTracer'
+                 )
 
 {-------------------------------------------------------------------------------
   Internal: initialize using the given snapshot
@@ -287,49 +527,13 @@ data InitFailure blk =
     -- | This snapshot was of the ledger state at genesis, even though we never
     -- take snapshots at genesis, so this is unexpected.
   | InitFailureGenesis
+
+    -- | The new-style snapshot is not in sync with the on-disk UTxO
+  | InitFailureNotInSyncWithUTxO
   deriving (Show, Eq, Generic)
 
--- | Attempt to initialize the ledger DB from the given snapshot
---
--- If the chain DB or ledger layer reports an error, the whole thing is aborted
--- and an error is returned. This should not throw any errors itself (ignoring
--- unexpected exceptions such as asynchronous exceptions, of course).
-initFromSnapshot ::
-     forall m blk . (
-         IOLike m
-       , LedgerSupportsProtocol blk
-       , InspectLedger blk
-       , HasCallStack
-       )
-  => Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
-  -> SomeHasFS m
-  -> (forall s. Decoder s (ExtLedgerState blk EmptyMK))
-  -> (forall s. Decoder s (HeaderHash blk))
-  -> LedgerDbCfg (ExtLedgerState blk)
-  -> OnDiskLedgerStDb m (ExtLedgerState blk)
-  -> StreamAPI m blk
-  -> DiskSnapshot
-  -> ExceptT (InitFailure blk) m (RealPoint blk, LedgerDB' blk, Word64)
-initFromSnapshot tracer hasFS decLedger decHash cfg readLedgerDb streamAPI ss = undefined -- TODO: Commented to unlock further work. Implementing initialization will fix this.
-    -- initSS <- withExceptT InitFailureRead $
-    --             readSnapshot hasFS decLedger decHash ss
-    -- let initialPoint = withOrigin (Point Origin) annTipPoint $ headerStateTip $ headerState $ initSS
-    -- case pointToWithOriginRealPoint (castPoint (getTip initSS)) of
-    --   Origin        -> throwError InitFailureGenesis
-    --   NotOrigin tip -> do
-    --     lift $ traceWith tracer $ ReplayFromSnapshot ss tip (ReplayStart initialPoint)
-    --     let tracer' = decorateReplayTracerWithStart initialPoint tracer
-    --     (initDB, replayed) <-
-    --       initStartingWith
-    --         tracer'
-    --         cfg
-    --         readLedgerDb
-    --         streamAPI
-    --         (ledgerDbWithAnchor initSS)
-    --     return (tip, initDB, replayed)
 
-
-mkOnDiskLedgerStDb :: SomeHasFS m -> m (OnDiskLedgerStDb m l)
+mkOnDiskLedgerStDb :: SomeHasFS m -> m (OnDiskLedgerStDb m l blk)
 mkOnDiskLedgerStDb = undefined
   -- \(SomeHasFS fs) -> do
   --   dbhandle <- hOpen fs "ledgerStateDb"
@@ -344,7 +548,7 @@ mkOnDiskLedgerStDb = undefined
 -- | On disk ledger state API.
 --
 --
-data OnDiskLedgerStDb m l =
+data OnDiskLedgerStDb m l blk =
   OnDiskLedgerStDb
   { rewindTableKeySets  :: () -- TODO: move the corresponding function from
                                -- InMemory here.
@@ -369,11 +573,30 @@ data OnDiskLedgerStDb m l =
     {- -* other restore point ops ... -}
   , closeDb             :: m ()
     -- ^ This closes the captured handle.
+  , odlsGetPt           :: m (Point blk)
+    -- ^ Get the point representing the latest ledger state flushed to the disk
+  , writeGenesisUTxO    :: l ValuesMK -> m ()
+    -- ^ Write the initial Genesis UTxO to the disk
   }
-  deriving NoThunks via OnlyCheckWhnfNamed "OnDiskLedgerStDb" (OnDiskLedgerStDb m l)
+  deriving NoThunks via OnlyCheckWhnfNamed "OnDiskLedgerStDb" (OnDiskLedgerStDb m l blk)
 
+-- | A generalization of initializing a database by consuming a StreamAPI.
+initDatabaseWithStreamAndUpd ::
+     forall m blk ledgerDb. (Monad m, HasCallStack)
+  => StreamAPI' m blk
+  -> ledgerDb
+  -> (ledgerDb -> Point blk)
+  -> (blk -> (ledgerDb, Word64) -> ExceptT (InitFailure blk) m (Maybe (ledgerDb, Word64)))
+  -> ExceptT (InitFailure blk) m (ledgerDb, Word64)
+initDatabaseWithStreamAndUpd streamAPI initDb getPoint push = do
+    streamAll streamAPI (getPoint initDb)
+      InitFailureTooRecent
+      (initDb, 0)
+      push
 
--- | Attempt to initialize the ledger DB starting from the given ledger DB
+-- | Attempt to initialize the ledger DB starting from the given ledger DB by
+-- streaming blocks from the immutable database up to the immutable database
+-- tip.
 initStartingWith ::
      forall m blk. (
          Monad m
@@ -383,20 +606,17 @@ initStartingWith ::
        )
   => Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
   -> LedgerDbCfg (ExtLedgerState blk)
-  -> OnDiskLedgerStDb m (ExtLedgerState blk)
-  -> StreamAPI m blk
+  -> OnDiskLedgerStDb m (ExtLedgerState blk) blk
+  -> StreamAPI' m blk
   -> LedgerDB' blk
   -> ExceptT (InitFailure blk) m (LedgerDB' blk, Word64)
 initStartingWith tracer cfg onDiskLedgerDbSt streamAPI initDb = do
-    streamAll streamAPI (castPoint (ledgerDbTip initDb))
-      InitFailureTooRecent
-      (initDb, 0)
-      push
+    initDatabaseWithStreamAndUpd streamAPI initDb (castPoint . ledgerDbTip) push
   where
-    push :: blk -> (LedgerDB' blk, Word64) -> m (LedgerDB' blk, Word64)
-    push blk !(!db, !replayed) = do
-        !db' <- defaultReadKeySets (readKeySets onDiskLedgerDbSt) $
-                  ledgerDbPush cfg (ReapplyVal blk) db
+    push :: blk -> (LedgerDB' blk, Word64) -> ExceptT (InitFailure blk) m (Maybe (LedgerDB' blk, Word64))
+    push blk !(!db, !replayed) = lift $ do
+        !db' <- defaultReadKeySets (readKeySets onDiskLedgerDbSt)
+                $ ledgerDbPush cfg (ReapplyVal blk) db
         -- TODO: here it is important that we don't have a lock acquired.
 
         -- Alternatively, we could chose not to check for a lock when we're
@@ -421,7 +641,7 @@ initStartingWith tracer cfg onDiskLedgerDbSt streamAPI initDb = do
                        (ledgerState (ledgerDbCurrent db''))
 
         traceWith tracer (ReplayedBlock (blockRealPoint blk) events)
-        return (db'', replayed')
+        return $ Just (db'', replayed')
 
 {-------------------------------------------------------------------------------
   Write to disk
@@ -527,18 +747,18 @@ diskSnapshotIsTemporary = not . diskSnapshotIsPermanent
 
 -- | Read snapshot from disk
 readSnapshot ::
-     forall m blk. IOLike m
+     forall m blk mk. IOLike m
   => SomeHasFS m
-  -> (forall s. Decoder s (ExtLedgerState blk EmptyMK))
+  -> (forall s. Decoder s (ExtLedgerState blk mk))
   -> (forall s. Decoder s (HeaderHash blk))
   -> DiskSnapshot
-  -> ExceptT ReadIncrementalErr m (ExtLedgerState blk EmptyMK)
+  -> ExceptT ReadIncrementalErr m (ExtLedgerState blk mk)
 readSnapshot hasFS decLedger decHash =
       ExceptT
     . readIncremental hasFS decoder
     . snapshotToPath
   where
-    decoder :: Decoder s (ExtLedgerState blk EmptyMK)
+    decoder :: Decoder s (ExtLedgerState blk mk)
     decoder = decodeSnapshotBackwardsCompatible (Proxy @blk) decLedger decHash
 
 -- | Write snapshot to disk
@@ -563,6 +783,19 @@ deleteSnapshot (SomeHasFS HasFS{..}) = removeFile . snapshotToPath
 listSnapshots :: Monad m => SomeHasFS m -> m [DiskSnapshot]
 listSnapshots (SomeHasFS HasFS{..}) =
     aux <$> listDirectory (mkFsPath [])
+  where
+    aux :: Set String -> [DiskSnapshot]
+    aux = List.sortOn (Down . dsNumber) . mapMaybe snapshotFromPath . Set.toList
+
+-- | Only one new-style snapshot should exist on the system. This functions
+-- returns it or returns Nothing. If multiple snapshots are found, it will
+-- return the one with the highest number (as it is expected to be the newest).
+findNewSnapshot :: Monad m => SomeHasFS m -> m (Maybe DiskSnapshot)
+findNewSnapshot (SomeHasFS HasFS{..}) = do
+    ls <- listDirectory (mkFsPath [])
+    case aux ls of
+      []  -> return Nothing
+      s:_ -> return (Just s)
   where
     aux :: Set String -> [DiskSnapshot]
     aux = List.sortOn (Down . dsNumber) . mapMaybe snapshotFromPath . Set.toList
@@ -620,7 +853,7 @@ data TraceEvent blk
     -- ^ A snapshot was written to disk.
   | DeletedSnapshot DiskSnapshot
     -- ^ An old or invalid on-disk snapshot was deleted
-  deriving (Generic, Eq, Show)
+  deriving (Show, Eq, Generic)
 
 -- | Which point the replay started from
 newtype ReplayStart blk = ReplayStart (Point blk) deriving (Eq, Show)


### PR DESCRIPTION
Implement the ledgerDB initialization as a series of steps:
1. Load both DBs from the latest snapshot on disk.
    1. The old DB will retry with an older snapshot on failure and use the genesis state if none are valid.
    2. The new DB will try only the last one and use the genesis state otherwise.
2. Get them in sync, pushing blocks to the one that is behind.
3. Replay the blocks from the shared tip to the Immutable db tip on both databases. 

Also closes CAD-3857