### PR TITLE
Fix: Stylish-haskell script now finds every file

### DIFF
--- a/scripts/ci/check-stylish.sh
+++ b/scripts/ci/check-stylish.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 # TODO the export of the <= operator TxLimits crashes stylish-haskell
-fd -p ouroboros-consensus* -e hs -E Setup.hs -E Ouroboros/Consensus/Mempool/TxLimits.hs -X stylish-haskell -i
+fd -p ouroboros-consensus -e hs -E Setup.hs -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs -X stylish-haskell -i
 
 git diff --exit-code


### PR DESCRIPTION
As @amesgen mentioned, the glob was messing up the directories `fd` would search in.