### PR TITLE
Ignore monitoring of cold hot cons beeing demoted

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -210,7 +210,8 @@ connections PeerSelectionActions{
 
     -- a hot -> cold transition has occurred if it is now cold, and it was hot
     asyncDemotion peeraddr PeerCold
-      | peeraddr `Set.member`    activePeers          = Just PeerCold
+      | peeraddr `Set.member`    activePeers
+      , peeraddr `Set.notMember` inProgressDemoteHot  = Just PeerCold
 
     asyncDemotion _        _                          = Nothing
 


### PR DESCRIPTION
Let the con monitor ignore currently cold connections that where hot and
is in the process of beeing demoted. This means will leave it up to the
demotion job to detect the error and fail.