### PR TITLE
Add: RunDual switch to use the legacy LedgerDB or not

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -109,7 +109,8 @@ import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index as Index
 import qualified Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy as LgrDB
-import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (ledgerDbCurrentValues)
+import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
+                     (RunAlsoLegacy (RunBoth), ledgerDbCurrentValues)
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk (LedgerDB')
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
 
@@ -660,7 +661,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                    -> m ()
     forkTxProducer coreNodeId registry clock cfg nodeSeed getLedgerDB mempool =
       void $ OracularClock.forkEachSlot registry clock "txProducer" $ \curSlotNo -> do
-        ledgerSt <- (ledgerState . ledgerDbCurrentValues) <$> atomically getLedgerDB
+        ledgerSt <- (ledgerState . maybe (error "tests can only be run with dual ledger for now")  id. ledgerDbCurrentValues) <$> atomically getLedgerDB
         -- Combine the node's seed with the current slot number, to make sure
         -- we generate different transactions in each slot.
         let txs = runGen
@@ -709,6 +710,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
         -- Misc
         , cdbTracer                 = instrumentationTracer <> nullDebugTracer
         , cdbTraceLedger            = nullDebugTracer
+        , cdbLedgerRunAlsoLegacy    = RunBoth
         , cdbRegistry               = registry
           -- TODO vary these
         , cdbGcDelay                = 0

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -73,6 +73,7 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Query as Query
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
+import Ouroboros.Consensus.Storage.LedgerDB.InMemory (RunAlsoLegacy(..))
 
 {-------------------------------------------------------------------------------
   Initialization
@@ -136,13 +137,19 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             LgrDB.decorateReplayTracerWithGoal
               immutableDbTipPoint
               (contramap TraceLedgerReplayEvent tracer)
+
       traceWith tracer $ TraceOpenEvent StartedOpeningLgrDB
       -- TODO confirm this env var is sufficient, eg for Benchmarking and QA Team
-      let runDual = maybe False (== "1") $ unsafePerformIO (lookupEnv "DUAL_LEDGER")
-      (lgrDB, replayed) <- LgrDB.openDB argsLgrDb
+      let runDual =
+            if LgrDB.lgrRunAlsoLegacy argsLgrDb == RunOnlyNew
+            then RunOnlyNew
+            else if maybe False (== "1") $ unsafePerformIO (lookupEnv "DISABLE_DUAL_LEDGER")
+                 then RunBoth
+                 else RunOnlyNew
+      (lgrDB, replayed) <- LgrDB.openDB (argsLgrDb { LgrDB.lgrRunAlsoLegacy = runDual })
                             lgrReplayTracer
                             immutableDB
-                            (Query.getAnyKnownBlock immutableDB volatileDB) runDual
+                            (Query.getAnyKnownBlock immutableDB volatileDB)
       traceWith tracer $ TraceOpenEvent OpenedLgrDB
 
       varInvalid      <- newTVarIO (WithFingerprint Map.empty (Fingerprint 0))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -36,6 +36,7 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
                      (DiskPolicy (..))
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
+import Ouroboros.Consensus.Storage.LedgerDB.InMemory (RunAlsoLegacy)
 
 {-------------------------------------------------------------------------------
   Arguments
@@ -65,6 +66,7 @@ data ChainDbArgs f m blk = ChainDbArgs {
       -- Misc
     , cdbTracer                 :: Tracer m (TraceEvent blk)
     , cdbTraceLedger            :: Tracer m (LedgerDB' blk)
+    , cdbLedgerRunAlsoLegacy    :: RunAlsoLegacy
     , cdbRegistry               :: HKD f (ResourceRegistry m)
     , cdbGcDelay                :: DiffTime
     , cdbGcInterval             :: DiffTime
@@ -185,6 +187,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , lgrGenesis          = cdbGenesis
         , lgrTracer           = contramap TraceLedgerEvent cdbTracer
         , lgrTraceLedger      = cdbTraceLedger
+        , lgrRunAlsoLegacy    = cdbLedgerRunAlsoLegacy
         }
     , ChainDbSpecificArgs {
           cdbsTracer          = cdbTracer
@@ -229,6 +232,7 @@ toChainDbArgs ImmutableDB.ImmutableDbArgs {..}
       -- Misc
     , cdbTracer                 = cdbsTracer
     , cdbTraceLedger            = lgrTraceLedger
+    , cdbLedgerRunAlsoLegacy    = lgrRunAlsoLegacy
     , cdbRegistry               = cdbsRegistry
     , cdbGcDelay                = cdbsGcDelay
     , cdbGcInterval             = cdbsGcInterval


### PR DESCRIPTION
Implements the ability to run only the modern implementation or both of them depending on an environment variable `DISABLE_DUAL_LEDGER`.