### PR TITLE
CAD-3935 Reorganize LedgerDB initialization

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -729,8 +729,16 @@ type TableReadSets l = LedgerTables l ValuesMK
 
 -- | TODO Once we remove the dual ledger, we won't need this anymore
 class StowableLedgerTables (l :: LedgerStateKind) where
-  stowLedgerTables   :: l ValuesMK -> l EmptyMK
-  unstowLedgerTables :: l EmptyMK  -> l ValuesMK
+  stowLedgerTables     :: l ValuesMK -> l EmptyMK
+  unstowLedgerTables   :: l EmptyMK  -> l ValuesMK
+  -- | When we deserialize a snapshot from the disk, said snapshot will be
+  -- @ExtLedgerState blk EmptyMK@ and we will try to unstow it to get the legacy
+  -- style ledger state. However, if we run without the legacy database, it will
+  -- be the case that the serialized ledger state is indeed deprived from a
+  -- UTxO, and unstowing it will result in an empty UTxO in the legacy database.
+  --
+  -- This function should check that the UTxO inside the ledger state is not empty.
+  isCandidateForUnstow :: l EmptyMK -> Bool
 
 {-------------------------------------------------------------------------------
   Changelog

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -216,7 +216,8 @@ ledgerDbWithAnchor ::
 ledgerDbWithAnchor runAlsoLegacy anchor = LedgerDB {
       ledgerDbCheckpoints = case (isCandidateForUnstow anchor, runAlsoLegacy) of
           (True, RunBoth) -> Just (Empty (Checkpoint (unstowLedgerTables anchor)))
-          _               -> Nothing
+          (False, RunBoth) -> error "Requested to run with legacy DB but anchor loaded from disk has no in-mem UTxO"
+          _ -> Nothing
     , ledgerDbChangelog   = emptyDbChangeLog anchor
     }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -17,7 +17,7 @@
 
 module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
     -- * Opening the database
-    InitFailure (..)
+    RecoverableInitFailure(..)
   , InitLog (..)
   , initLedgerDB
     -- ** Instantiate in-memory to @blk@
@@ -174,7 +174,7 @@ data InitLog blk =
     -- We record the reason why it was skipped.
     --
     -- NOTE: We should /only/ see this if data corrupted occurred.
-  | InitFailure DiskSnapshot (InitFailure blk) (InitLog blk)
+  | InitFailure DiskSnapshot (RecoverableInitFailure blk) (InitLog blk)
   deriving (Show, Eq, Generic)
 
 -- | Initialize the ledger DB from the most recent snapshot on disk
@@ -226,68 +226,38 @@ initLedgerDB replayTracer
              getGenesisLedger
              streamAPI
              runAlsoLegacy = do
-    snapshots <- listSnapshots hasFS
-    tryNewestFirst id snapshots
-  where
-    tryNewestFirst :: (InitLog blk -> InitLog blk)
-                   -> [DiskSnapshot]
-                   -> m ( InitLog blk
-                        , LedgerDB' blk
-                        , Word64
-                        , LedgerBackingStore m (ExtLedgerState blk)
-                        )
-    tryNewestFirst acc [] = do
-        -- We're out of snapshots. Start at genesis
-        traceWith replayTracer ReplayFromGenesis
-        genesisLedger <- getGenesisLedger
-        let replayTracer' = decorateReplayTracerWithStart (Point Origin) replayTracer
-            initDb        = ledgerDbWithAnchor runAlsoLegacy (stowLedgerTables genesisLedger)
-        -- TODO this needs to go in the resource registry
-        backingStore <- newBackingStore hasFS (projectLedgerTables genesisLedger)
-        ml     <- runExceptT
-                  $ initStartingWith
-                      replayTracer'
-                      cfg
-                      backingStore
-                      streamAPI
-                      initDb
-        case ml of
-          Left _  -> error "invariant violation: invalid current chain"
-          Right (l, replayed) -> return (acc InitFromGenesis, l, replayed, backingStore)
-    tryNewestFirst acc (s:ss) = do
-        -- If we fail to use this snapshot, delete it and try an older one
-        ml <- runExceptT $ initFromSnapshot
-                             replayTracer
-                             hasFS
-                             decLedger
-                             decHash
-                             cfg
-                             streamAPI
-                             s
-                             runAlsoLegacy
-        case ml of
-          Left err -> do
-            when (diskSnapshotIsTemporary s) $
-              -- We don't delete permanent snapshots, even if we couldn't parse
-              -- them
-              deleteSnapshot hasFS s
-            traceWith tracer $ InvalidSnapshot s err
-            tryNewestFirst (acc . InitFailure s err) ss
-          Right (r, l, replayed, backingStore) ->
-            return (acc (InitFromSnapshot s r), l, replayed, backingStore)
+    (initLog, initDb, backingStore, replayTracer') <- initFromSnapshotOrGenesis
+                                                        replayTracer
+                                                        tracer
+                                                        getGenesisLedger
+                                                        hasFS
+                                                        decLedger
+                                                        decHash
+                                                        runAlsoLegacy
+    (replayedDB, replayedBlocks) <- replayStartingWith
+                                        replayTracer'
+                                        cfg
+                                        backingStore
+                                        streamAPI
+                                        initDb
+    return (initLog, replayedDB, replayedBlocks, backingStore)
 
 {-------------------------------------------------------------------------------
   Internal: initialize using the given snapshot
 -------------------------------------------------------------------------------}
 
-data InitFailure blk =
+-- | Errors that can happen during initialization and cannot be recovered,
+-- leading to a call to @error@ and aborting the program.
+data FatalInitFailure blk = InitFailureTooRecent (RealPoint blk)
+  deriving (Show, Eq, Generic)
+
+-- | Internal errors which are recoverable and exposed through the chain of
+-- failures recorded in 'InitLog'.
+data RecoverableInitFailure blk =
     -- | We failed to deserialise the snapshot
     --
     -- This can happen due to data corruption in the ledger DB.
     InitFailureRead ReadIncrementalErr
-
-    -- | This snapshot is too recent (ahead of the tip of the chain)
-  | InitFailureTooRecent (RealPoint blk)
 
     -- | This snapshot was of the ledger state at genesis, even though we never
     -- take snapshots at genesis, so this is unexpected.
@@ -299,54 +269,79 @@ data InitFailure blk =
 -- If the chain DB or ledger layer reports an error, the whole thing is aborted
 -- and an error is returned. This should not throw any errors itself (ignoring
 -- unexpected exceptions such as asynchronous exceptions, of course).
-initFromSnapshot ::
+initFromSnapshotOrGenesis ::
      forall m blk . (
          IOLike m
        , LedgerSupportsProtocol blk
-       , InspectLedger blk
        , FromCBOR (LedgerTables (ExtLedgerState blk) ValuesMK)
        , ToCBOR   (LedgerTables (ExtLedgerState blk) ValuesMK)
        , HasCallStack
        )
   => Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
+  -> Tracer m (TraceEvent blk)
+  -> m (ExtLedgerState blk ValuesMK)
   -> SomeHasFS m
   -> (forall s. Decoder s (ExtLedgerState blk EmptyMK))
   -> (forall s. Decoder s (HeaderHash blk))
-  -> LedgerDbCfg (ExtLedgerState blk)
-  -> StreamAPI m blk
-  -> DiskSnapshot
   -> RunAlsoLegacy
-  -> ExceptT (InitFailure blk) m
-      ( RealPoint blk
+  -> m
+      ( InitLog blk
       , LedgerDB' blk
-      , Word64
       , LedgerBackingStore m (ExtLedgerState blk)
+      , Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
       )
-initFromSnapshot tracer hasFS decLedger decHash cfg streamAPI snapshot runAlsoLegacy = do
-    extLedgerSt <-
-        withExceptT InitFailureRead
-      $ readSnapshot hasFS decLedger decHash snapshot
-    let initialPoint =
-            withOrigin (Point Origin) annTipPoint
-          $ headerStateTip
-          $ headerState
-          $ extLedgerSt
-    case pointToWithOriginRealPoint (castPoint (getTip extLedgerSt)) of
-      Origin        -> throwError InitFailureGenesis
-      NotOrigin tip -> do
-        -- TODO this needs to go in the resource registry
-        backingStore <- restoreBackingStore hasFS snapshot
-        lift $ traceWith tracer $
-          ReplayFromSnapshot snapshot tip (ReplayStart initialPoint)
-        let tracer' = decorateReplayTracerWithStart initialPoint tracer
-        (initDB, replayed) <-
-          initStartingWith
-            tracer'
-            cfg
-            backingStore
-            streamAPI
-            (ledgerDbWithAnchor runAlsoLegacy extLedgerSt)
-        return (tip, initDB, replayed, backingStore)
+initFromSnapshotOrGenesis replayTracer snapshotTracer getGenesisLedger hasFS decLedger decHash runAlsoLegacy = do
+    listSnapshots hasFS >>= tryNewestFirst id
+  where
+    tryNewestFirst :: (InitLog blk -> InitLog blk)
+                   -> [DiskSnapshot]
+                   -> m ( InitLog   blk
+                        , LedgerDB' blk
+                        , LedgerBackingStore m (ExtLedgerState blk)
+                        , Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
+                        )
+    tryNewestFirst acc [] = do
+      -- We're out of snapshots. Start at genesis
+      traceWith replayTracer ReplayFromGenesis
+      genesisLedger <- getGenesisLedger
+      let replayTracer' = decorateReplayTracerWithStart (Point Origin) replayTracer
+          initDb        = ledgerDbWithAnchor runAlsoLegacy (stowLedgerTables genesisLedger)
+      backingStore <- newBackingStore hasFS (projectLedgerTables genesisLedger) -- TODO: needs to go into ResourceRegistry
+      return ( acc InitFromGenesis
+             , initDb
+             , backingStore
+             , replayTracer'
+             )
+
+    tryNewestFirst acc (s:ss) = do
+      eExtLedgerSt <- runExceptT $ readSnapshot hasFS decLedger decHash s
+      case eExtLedgerSt of
+        Left err -> do
+          when (diskSnapshotIsTemporary s) $
+            deleteSnapshot hasFS s
+          traceWith snapshotTracer . InvalidSnapshot s . InitFailureRead $ err
+          tryNewestFirst (acc . InitFailure s (InitFailureRead err)) ss
+        Right extLedgerSt -> do
+          let initialPoint =
+                withOrigin (Point Origin) annTipPoint
+                $ headerStateTip
+                $ headerState
+                $ extLedgerSt
+          case pointToWithOriginRealPoint (castPoint (getTip extLedgerSt)) of
+            Origin        -> do
+              -- Delete the snapshot of the Genesis ledger state. It should have
+              -- never existed.
+              deleteSnapshot hasFS s
+              traceWith snapshotTracer . InvalidSnapshot s $ InitFailureGenesis
+              tryNewestFirst (acc . InitFailure s InitFailureGenesis) []
+            NotOrigin tip -> do
+              backingStore <- restoreBackingStore hasFS s -- TODO this needs to go in the resource registry
+              traceWith replayTracer $
+                ReplayFromSnapshot s tip (ReplayStart initialPoint)
+              let tracer' = decorateReplayTracerWithStart initialPoint replayTracer
+                  initDb  = ledgerDbWithAnchor runAlsoLegacy extLedgerSt
+                  -- TODO: @js if the provided extLedgerSt has an empty UTxO, then we cannot run the legacy db
+              return (acc (InitFromSnapshot s tip), initDb, backingStore, tracer')
 
 -- | Overwrite the ChainDB tables with the snapshot's tables
 restoreBackingStore ::
@@ -357,10 +352,8 @@ restoreBackingStore ::
      )
   => SomeHasFS m
   -> DiskSnapshot
-  -> ExceptT (InitFailure blk) m (LedgerBackingStore m (ExtLedgerState blk))
-restoreBackingStore (SomeHasFS hasFS) snapshot = lift $ do
-    -- TODO reify errors into the ExceptT layer instead of lifting :grimace:
-
+  -> m (LedgerBackingStore m (ExtLedgerState blk))
+restoreBackingStore (SomeHasFS hasFS) snapshot = do
     -- TODO a backing store that actually resides on-disk during use should have
     -- a @new*@ function that receives both the location it should load from (ie
     -- 'loadPath') and also the location at which it should maintain itself (ie
@@ -469,8 +462,14 @@ flush (LedgerBackingStore backingStore) dblog =
       -> ApplyMapKind DiffMK k v
     prj (ApplySeqDiffMK sq) = ApplyDiffMK (HD.cumulativeDiffSeqUtxoDiff sq)
 
--- | Attempt to initialize the ledger DB starting from the given ledger DB
-initStartingWith ::
+-- | Replay all blocks in the Immutable database using the ''StreamAPI' provided
+-- on top of the given @LedgerDB' blk@.
+--
+-- If the starting snapshot is ahead than the Immutable database tip, this
+-- function will call @error@ and abort.
+--
+-- It will also return the number of blocks that were replayed.
+replayStartingWith ::
      forall m blk. (
          IOLike m
        , LedgerSupportsProtocol blk
@@ -482,12 +481,14 @@ initStartingWith ::
   -> LedgerBackingStore m (ExtLedgerState blk)
   -> StreamAPI m blk
   -> LedgerDB' blk
-  -> ExceptT (InitFailure blk) m (LedgerDB' blk, Word64)
-initStartingWith tracer cfg backingStore streamAPI initDb = do
-    streamAll streamAPI (castPoint (ledgerDbTip initDb))
-      InitFailureTooRecent
-      (initDb, 0)
-      push
+  -> m (LedgerDB' blk, Word64)
+replayStartingWith tracer cfg backingStore streamAPI initDb = do
+    eInitDB <- runExceptT $
+      streamAll streamAPI (castPoint (ledgerDbTip initDb))
+        InitFailureTooRecent
+        (initDb, 0)
+        push
+    either (\err -> error $ "invariant violation: invalid immutable chain. Error: " <> show err) return eInitDB
   where
     push :: blk -> (LedgerDB' blk, Word64) -> m (LedgerDB' blk, Word64)
     push blk !(!db, !replayed) = do
@@ -738,7 +739,7 @@ decorateReplayTracerWithStart
 decorateReplayTracerWithStart start = contramap ($ (ReplayStart start))
 
 data TraceEvent blk
-  = InvalidSnapshot DiskSnapshot (InitFailure blk)
+  = InvalidSnapshot DiskSnapshot (RecoverableInitFailure blk)
     -- ^ An on disk snapshot was skipped because it was invalid.
   | TookSnapshot DiskSnapshot (RealPoint blk)
     -- ^ A snapshot was written to disk.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -17,7 +17,7 @@
 
 module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
     -- * Opening the database
-    RecoverableInitFailure(..)
+    InitFailure(..)
   , InitLog (..)
   , initLedgerDB
     -- ** Instantiate in-memory to @blk@
@@ -174,7 +174,20 @@ data InitLog blk =
     -- We record the reason why it was skipped.
     --
     -- NOTE: We should /only/ see this if data corrupted occurred.
-  | InitFailure DiskSnapshot (RecoverableInitFailure blk) (InitLog blk)
+  | InitFailure DiskSnapshot (InitFailure blk) (InitLog blk)
+  deriving (Show, Eq, Generic)
+
+-- | Internal errors which are recoverable and exposed through the chain of
+-- failures recorded in 'InitLog'.
+data InitFailure blk =
+    -- | We failed to deserialise the snapshot
+    --
+    -- This can happen due to data corruption in the ledger DB.
+    InitFailureRead ReadIncrementalErr
+
+    -- | This snapshot was of the ledger state at genesis, even though we never
+    -- take snapshots at genesis, so this is unexpected.
+  | InitFailureGenesis
   deriving (Show, Eq, Generic)
 
 -- | Initialize the ledger DB from the most recent snapshot on disk
@@ -216,7 +229,7 @@ initLedgerDB ::
   -> m (ExtLedgerState blk ValuesMK) -- ^ Genesis ledger state
   -> StreamAPI m blk
   -> RunAlsoLegacy
-  -> m (InitLog blk, LedgerDB' blk, Word64, LedgerBackingStore m (ExtLedgerState blk))
+  -> m (InitLog blk, LedgerDB' blk, Word64, LedgerBackingStore' m blk)
 initLedgerDB replayTracer
              tracer
              hasFS
@@ -242,28 +255,6 @@ initLedgerDB replayTracer
                                         initDb
     return (initLog, replayedDB, replayedBlocks, backingStore)
 
-{-------------------------------------------------------------------------------
-  Internal: initialize using the given snapshot
--------------------------------------------------------------------------------}
-
--- | Errors that can happen during initialization and cannot be recovered,
--- leading to a call to @error@ and aborting the program.
-data FatalInitFailure blk = InitFailureTooRecent (RealPoint blk)
-  deriving (Show, Eq, Generic)
-
--- | Internal errors which are recoverable and exposed through the chain of
--- failures recorded in 'InitLog'.
-data RecoverableInitFailure blk =
-    -- | We failed to deserialise the snapshot
-    --
-    -- This can happen due to data corruption in the ledger DB.
-    InitFailureRead ReadIncrementalErr
-
-    -- | This snapshot was of the ledger state at genesis, even though we never
-    -- take snapshots at genesis, so this is unexpected.
-  | InitFailureGenesis
-  deriving (Show, Eq, Generic)
-
 -- | Attempt to initialize the ledger DB from the given snapshot
 --
 -- If the chain DB or ledger layer reports an error, the whole thing is aborted
@@ -287,7 +278,7 @@ initFromSnapshotOrGenesis ::
   -> m
       ( InitLog blk
       , LedgerDB' blk
-      , LedgerBackingStore m (ExtLedgerState blk)
+      , LedgerBackingStore' m blk
       , Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
       )
 initFromSnapshotOrGenesis replayTracer snapshotTracer getGenesisLedger hasFS decLedger decHash runAlsoLegacy = do
@@ -297,7 +288,7 @@ initFromSnapshotOrGenesis replayTracer snapshotTracer getGenesisLedger hasFS dec
                    -> [DiskSnapshot]
                    -> m ( InitLog   blk
                         , LedgerDB' blk
-                        , LedgerBackingStore m (ExtLedgerState blk)
+                        , LedgerBackingStore' m blk
                         , Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
                         )
     tryNewestFirst acc [] = do
@@ -340,8 +331,69 @@ initFromSnapshotOrGenesis replayTracer snapshotTracer getGenesisLedger hasFS dec
                 ReplayFromSnapshot s tip (ReplayStart initialPoint)
               let tracer' = decorateReplayTracerWithStart initialPoint replayTracer
                   initDb  = ledgerDbWithAnchor runAlsoLegacy extLedgerSt
-                  -- TODO: @js if the provided extLedgerSt has an empty UTxO, then we cannot run the legacy db
               return (acc (InitFromSnapshot s tip), initDb, backingStore, tracer')
+
+-- | Replay all blocks in the Immutable database using the ''StreamAPI' provided
+-- on top of the given @LedgerDB' blk@.
+--
+-- If the starting snapshot is ahead than the Immutable database tip, this
+-- function will call @error@ and abort.
+--
+-- It will also return the number of blocks that were replayed.
+replayStartingWith ::
+     forall m blk. (
+         IOLike m
+       , LedgerSupportsProtocol blk
+       , InspectLedger blk
+       , HasCallStack
+       )
+  => Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
+  -> LedgerDbCfg (ExtLedgerState blk)
+  -> LedgerBackingStore' m blk
+  -> StreamAPI m blk
+  -> LedgerDB' blk
+  -> m (LedgerDB' blk, Word64)
+replayStartingWith tracer cfg backingStore streamAPI initDb = do
+    eInitDB <- runExceptT $
+      streamAll streamAPI (castPoint (ledgerDbTip initDb))
+        id
+        (initDb, 0)
+        push
+    either (\pt -> error $ "invariant violation: snapshot (@" <> show pt <> ") is ahead of immutable db") return eInitDB
+  where
+    push :: blk -> (LedgerDB' blk, Word64) -> m (LedgerDB' blk, Word64)
+    push blk !(!db, !replayed) = do
+        !db' <- defaultReadKeySets (readKeySets backingStore) $
+                  ledgerDbPush cfg (ReapplyVal blk) db
+
+        -- TODO flush policy: flush less often?
+
+        -- It's OK to flush without a lock here, since the `LgrDB` has not
+        -- finishined initializing: only this thread has access to the backing
+        -- store.
+        db'' <- do
+          let (toFlush, toKeep) =
+                ledgerDbFlush DbChangelogFlushAllImmutable db'
+          flush backingStore toFlush
+          pure toKeep
+
+        -- TODO snapshot policy: create snapshots during replay?
+
+        let replayed' :: Word64
+            !replayed' = replayed + 1
+
+            events :: [LedgerEvent blk]
+            events = inspectLedger
+                       (getExtLedgerCfg (ledgerDbCfg cfg))
+                       (ledgerState (ledgerDbCurrent db))
+                       (ledgerState (ledgerDbCurrent db''))
+
+        traceWith tracer (ReplayedBlock (blockRealPoint blk) events)
+        return (db'', replayed')
+
+{-------------------------------------------------------------------------------
+  BackingStore utilities
+-------------------------------------------------------------------------------}
 
 -- | Overwrite the ChainDB tables with the snapshot's tables
 restoreBackingStore ::
@@ -352,7 +404,7 @@ restoreBackingStore ::
      )
   => SomeHasFS m
   -> DiskSnapshot
-  -> m (LedgerBackingStore m (ExtLedgerState blk))
+  -> m (LedgerBackingStore' m blk)
 restoreBackingStore (SomeHasFS hasFS) snapshot = do
     -- TODO a backing store that actually resides on-disk during use should have
     -- a @new*@ function that receives both the location it should load from (ie
@@ -416,6 +468,8 @@ newtype LedgerBackingStore m l = LedgerBackingStore
     )
   deriving (NoThunks)
 
+type LedgerBackingStore' m blk = LedgerBackingStore m (ExtLedgerState blk)
+
 readKeySets :: forall m l.
      (IOLike m, TableStuff l)
   => LedgerBackingStore m l
@@ -462,138 +516,8 @@ flush (LedgerBackingStore backingStore) dblog =
       -> ApplyMapKind DiffMK k v
     prj (ApplySeqDiffMK sq) = ApplyDiffMK (HD.cumulativeDiffSeqUtxoDiff sq)
 
--- | Replay all blocks in the Immutable database using the ''StreamAPI' provided
--- on top of the given @LedgerDB' blk@.
---
--- If the starting snapshot is ahead than the Immutable database tip, this
--- function will call @error@ and abort.
---
--- It will also return the number of blocks that were replayed.
-replayStartingWith ::
-     forall m blk. (
-         IOLike m
-       , LedgerSupportsProtocol blk
-       , InspectLedger blk
-       , HasCallStack
-       )
-  => Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
-  -> LedgerDbCfg (ExtLedgerState blk)
-  -> LedgerBackingStore m (ExtLedgerState blk)
-  -> StreamAPI m blk
-  -> LedgerDB' blk
-  -> m (LedgerDB' blk, Word64)
-replayStartingWith tracer cfg backingStore streamAPI initDb = do
-    eInitDB <- runExceptT $
-      streamAll streamAPI (castPoint (ledgerDbTip initDb))
-        InitFailureTooRecent
-        (initDb, 0)
-        push
-    either (\err -> error $ "invariant violation: invalid immutable chain. Error: " <> show err) return eInitDB
-  where
-    push :: blk -> (LedgerDB' blk, Word64) -> m (LedgerDB' blk, Word64)
-    push blk !(!db, !replayed) = do
-        !db' <- defaultReadKeySets (readKeySets backingStore) $
-                  ledgerDbPush cfg (ReapplyVal blk) db
-
-        -- TODO flush policy: flush less often?
-
-        -- It's OK to flush without a lock here, since the `LgrDB` has not
-        -- finishined initializing: only this thread has access to the backing
-        -- store.
-        db'' <- do
-          let (toFlush, toKeep) =
-                ledgerDbFlush DbChangelogFlushAllImmutable db'
-          flush backingStore toFlush
-          pure toKeep
-
-        -- TODO snapshot policy: create snapshots during replay?
-
-        let replayed' :: Word64
-            !replayed' = replayed + 1
-
-            events :: [LedgerEvent blk]
-            events = inspectLedger
-                       (getExtLedgerCfg (ledgerDbCfg cfg))
-                       (ledgerState (ledgerDbCurrent db))
-                       (ledgerState (ledgerDbCurrent db''))
-
-        traceWith tracer (ReplayedBlock (blockRealPoint blk) events)
-        return (db'', replayed')
-
 {-------------------------------------------------------------------------------
-  Write to disk
--------------------------------------------------------------------------------}
-
--- | Take a snapshot of the /oldest ledger state/ in the ledger DB
---
--- We write the /oldest/ ledger state to disk because the intention is to only
--- write ledger states to disk that we know to be immutable. Primarily for
--- testing purposes, 'takeSnapshot' returns the block reference corresponding
--- to the snapshot that we wrote.
---
--- If a snapshot with the same number already exists on disk or if the tip is at
--- genesis, no snapshot is taken.
---
--- Note that an EBB can have the same slot number and thus snapshot number as
--- the block after it. This doesn't matter. The one block difference in the
--- ledger state doesn't warrant an additional snapshot. The number in the name
--- of the snapshot is only indicative, we don't rely on it being correct.
---
--- NOTE: This is a lower-level API that takes a snapshot independent from
--- whether this snapshot corresponds to a state that is more than @k@ back.
---
--- TODO: Should we delete the file if an error occurs during writing?
-takeSnapshot ::
-     forall m blk.
-     ( MonadThrow m
-     , IsLedger (LedgerState blk)
-     , StandardHash blk
-     )
-  => Tracer m (TraceEvent blk)
-  -> SomeHasFS m
-  -> LedgerBackingStore m (ExtLedgerState blk)
-  -> (ExtLedgerState blk EmptyMK -> Encoding)
-  -> LedgerDB' blk -> m (Maybe (DiskSnapshot, RealPoint blk))
-takeSnapshot tracer hasFS backingStore encLedger db =
-    case pointToWithOriginRealPoint (castPoint (getTip oldest)) of
-      Origin ->
-        return Nothing
-      NotOrigin tip -> do
-        let number   = unSlotNo (realPointSlot tip)
-            snapshot = DiskSnapshot number Nothing
-        snapshots <- listSnapshots hasFS
-        if List.any ((== number) . dsNumber) snapshots then
-          return Nothing
-        else do
-          writeSnapshot hasFS backingStore encLedger snapshot oldest
-          traceWith tracer $ TookSnapshot snapshot tip
-          return $ Just (snapshot, tip)
-  where
-    oldest :: ExtLedgerState blk EmptyMK
-    oldest = ledgerDbOldest db
-
--- | Trim the number of on disk snapshots so that at most 'onDiskNumSnapshots'
--- snapshots are stored on disk. The oldest snapshots are deleted.
---
--- The deleted snapshots are returned.
-trimSnapshots ::
-     Monad m
-  => Tracer m (TraceEvent r)
-  -> SomeHasFS m
-  -> DiskPolicy
-  -> m [DiskSnapshot]
-trimSnapshots tracer hasFS DiskPolicy{..} = do
-    -- We only trim temporary snapshots
-    snapshots <- filter diskSnapshotIsTemporary <$> listSnapshots hasFS
-    -- The snapshot are most recent first, so we can simply drop from the
-    -- front to get the snapshots that are "too" old.
-    forM (drop (fromIntegral onDiskNumSnapshots) snapshots) $ \snapshot -> do
-      deleteSnapshot hasFS snapshot
-      traceWith tracer $ DeletedSnapshot snapshot
-      return snapshot
-
-{-------------------------------------------------------------------------------
-  Internal: reading from disk
+  Disk snapshots
 -------------------------------------------------------------------------------}
 
 data DiskSnapshot = DiskSnapshot {
@@ -626,55 +550,6 @@ diskSnapshotIsPermanent = isJust . dsSuffix
 -- deleted when trimming
 diskSnapshotIsTemporary :: DiskSnapshot -> Bool
 diskSnapshotIsTemporary = not . diskSnapshotIsPermanent
-
--- | Read snapshot from disk
-readSnapshot ::
-     forall m blk. IOLike m
-  => SomeHasFS m
-  -> (forall s. Decoder s (ExtLedgerState blk EmptyMK))
-  -> (forall s. Decoder s (HeaderHash blk))
-  -> DiskSnapshot
-  -> ExceptT ReadIncrementalErr m (ExtLedgerState blk EmptyMK)
-readSnapshot hasFS decLedger decHash = do
-      ExceptT
-    . readIncremental hasFS decoder
-    . snapshotToStatePath
-  where
-    decoder :: Decoder s (ExtLedgerState blk EmptyMK)
-    decoder = decodeSnapshotBackwardsCompatible (Proxy @blk) decLedger decHash
-
--- | Write snapshot to disk
-writeSnapshot ::
-     forall m blk. MonadThrow m
-  => SomeHasFS m
-  -> LedgerBackingStore m (ExtLedgerState blk)
-  -> (ExtLedgerState blk EmptyMK -> Encoding)
-  -> DiskSnapshot
-  -> ExtLedgerState blk EmptyMK -> m ()
-writeSnapshot (SomeHasFS hasFS) backingStore encLedger snapshot cs = do
-    createDirectory hasFS (snapshotToDirPath snapshot)
-    withFile hasFS (snapshotToStatePath snapshot) (WriteMode MustBeNew) $ \h ->
-      void $ hPut hasFS h $ CBOR.toBuilder (encode cs)
-    HD.bsCopy
-      (let LedgerBackingStore store = backingStore in store)
-      (SomeHasFS hasFS)
-      (HD.BackingStorePath (snapshotToTablesPath snapshot))
-  where
-    encode :: ExtLedgerState blk EmptyMK -> Encoding
-    encode = encodeSnapshot encLedger
-
--- | Delete snapshot from disk
-deleteSnapshot :: HasCallStack => SomeHasFS m -> DiskSnapshot -> m ()
-deleteSnapshot (SomeHasFS HasFS{..}) =
-    removeDirectoryRecursive . snapshotToDirPath
-
--- | List on-disk snapshots, highest number first.
-listSnapshots :: Monad m => SomeHasFS m -> m [DiskSnapshot]
-listSnapshots (SomeHasFS HasFS{..}) =
-    aux <$> listDirectory (mkFsPath [])
-  where
-    aux :: Set String -> [DiskSnapshot]
-    aux = List.sortOn (Down . dsNumber) . mapMaybe snapshotFromPath . Set.toList
 
 snapshotToFileName :: DiskSnapshot -> String
 snapshotToFileName DiskSnapshot { dsNumber, dsSuffix } =
@@ -716,8 +591,144 @@ snapshotFromPath fileName = do
       _ : str -> Just str
 
 {-------------------------------------------------------------------------------
+  Snapshots: Writing to disk
+-------------------------------------------------------------------------------}
+
+-- | Take a snapshot of the /oldest ledger state/ in the ledger DB
+--
+-- We write the /oldest/ ledger state to disk because the intention is to only
+-- write ledger states to disk that we know to be immutable. Primarily for
+-- testing purposes, 'takeSnapshot' returns the block reference corresponding
+-- to the snapshot that we wrote.
+--
+-- If a snapshot with the same number already exists on disk or if the tip is at
+-- genesis, no snapshot is taken.
+--
+-- Note that an EBB can have the same slot number and thus snapshot number as
+-- the block after it. This doesn't matter. The one block difference in the
+-- ledger state doesn't warrant an additional snapshot. The number in the name
+-- of the snapshot is only indicative, we don't rely on it being correct.
+--
+-- NOTE: This is a lower-level API that takes a snapshot independent from
+-- whether this snapshot corresponds to a state that is more than @k@ back.
+--
+-- TODO: Should we delete the file if an error occurs during writing?
+takeSnapshot ::
+     forall m blk.
+     ( MonadThrow m
+     , IsLedger (LedgerState blk)
+     , StandardHash blk
+     )
+  => Tracer m (TraceEvent blk)
+  -> SomeHasFS m
+  -> LedgerBackingStore' m blk
+  -> (ExtLedgerState blk EmptyMK -> Encoding)
+  -> LedgerDB' blk
+  -> m (Maybe (DiskSnapshot, RealPoint blk))
+takeSnapshot tracer hasFS backingStore encLedger db =
+    case pointToWithOriginRealPoint (castPoint (getTip oldest)) of
+      Origin ->
+        return Nothing
+      NotOrigin tip -> do
+        let number   = unSlotNo (realPointSlot tip)
+            snapshot = DiskSnapshot number Nothing
+        snapshots <- listSnapshots hasFS
+        if List.any ((== number) . dsNumber) snapshots then
+          return Nothing
+        else do
+          writeSnapshot hasFS backingStore encLedger snapshot oldest
+          traceWith tracer $ TookSnapshot snapshot tip
+          return $ Just (snapshot, tip)
+  where
+    oldest :: ExtLedgerState blk EmptyMK
+    oldest = ledgerDbOldest db
+
+-- | Write snapshot to disk
+writeSnapshot ::
+     forall m blk. MonadThrow m
+  => SomeHasFS m
+  -> LedgerBackingStore' m blk
+  -> (ExtLedgerState blk EmptyMK -> Encoding)
+  -> DiskSnapshot
+  -> ExtLedgerState blk EmptyMK
+  -> m ()
+writeSnapshot (SomeHasFS hasFS) backingStore encLedger snapshot cs = do
+    createDirectory hasFS (snapshotToDirPath snapshot)
+    withFile hasFS (snapshotToStatePath snapshot) (WriteMode MustBeNew) $ \h ->
+      void $ hPut hasFS h $ CBOR.toBuilder (encode cs)
+    HD.bsCopy
+      (let LedgerBackingStore store = backingStore in store)
+      (SomeHasFS hasFS)
+      (HD.BackingStorePath (snapshotToTablesPath snapshot))
+  where
+    encode :: ExtLedgerState blk EmptyMK -> Encoding
+    encode = encodeSnapshot encLedger
+
+-- | Trim the number of on disk snapshots so that at most 'onDiskNumSnapshots'
+-- snapshots are stored on disk. The oldest snapshots are deleted.
+--
+-- The deleted snapshots are returned.
+trimSnapshots ::
+     Monad m
+  => Tracer m (TraceEvent blk)
+  -> SomeHasFS m
+  -> DiskPolicy
+  -> m [DiskSnapshot]
+trimSnapshots tracer hasFS DiskPolicy{..} = do
+    -- We only trim temporary snapshots
+    snapshots <- filter diskSnapshotIsTemporary <$> listSnapshots hasFS
+    -- The snapshot are most recent first, so we can simply drop from the
+    -- front to get the snapshots that are "too" old.
+    forM (drop (fromIntegral onDiskNumSnapshots) snapshots) $ \snapshot -> do
+      deleteSnapshot hasFS snapshot
+      traceWith tracer $ DeletedSnapshot snapshot
+      return snapshot
+
+-- | Delete snapshot from disk
+deleteSnapshot :: HasCallStack => SomeHasFS m -> DiskSnapshot -> m ()
+deleteSnapshot (SomeHasFS HasFS{..}) =
+    removeDirectoryRecursive . snapshotToDirPath
+
+{-------------------------------------------------------------------------------
+  Snapshots: reading from disk
+-------------------------------------------------------------------------------}
+
+-- | Read snapshot from disk
+readSnapshot ::
+     forall m blk. IOLike m
+  => SomeHasFS m
+  -> (forall s. Decoder s (ExtLedgerState blk EmptyMK))
+  -> (forall s. Decoder s (HeaderHash blk))
+  -> DiskSnapshot
+  -> ExceptT ReadIncrementalErr m (ExtLedgerState blk EmptyMK)
+readSnapshot hasFS decLedger decHash = do
+      ExceptT
+    . readIncremental hasFS decoder
+    . snapshotToStatePath
+  where
+    decoder :: Decoder s (ExtLedgerState blk EmptyMK)
+    decoder = decodeSnapshotBackwardsCompatible (Proxy @blk) decLedger decHash
+
+-- | List on-disk snapshots, highest number first.
+listSnapshots :: Monad m => SomeHasFS m -> m [DiskSnapshot]
+listSnapshots (SomeHasFS HasFS{..}) =
+    aux <$> listDirectory (mkFsPath [])
+  where
+    aux :: Set String -> [DiskSnapshot]
+    aux = List.sortOn (Down . dsNumber) . mapMaybe snapshotFromPath . Set.toList
+
+{-------------------------------------------------------------------------------
   Trace events
 -------------------------------------------------------------------------------}
+
+data TraceEvent blk
+  = InvalidSnapshot DiskSnapshot (InitFailure blk)
+    -- ^ An on disk snapshot was skipped because it was invalid.
+  | TookSnapshot DiskSnapshot (RealPoint blk)
+    -- ^ A snapshot was written to disk.
+  | DeletedSnapshot DiskSnapshot
+    -- ^ An old or invalid on-disk snapshot was deleted
+  deriving (Generic, Eq, Show)
 
 -- | Add the tip of the Immutable DB to the trace event
 --
@@ -738,15 +749,6 @@ decorateReplayTracerWithStart
   -> Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
 decorateReplayTracerWithStart start = contramap ($ (ReplayStart start))
 
-data TraceEvent blk
-  = InvalidSnapshot DiskSnapshot (RecoverableInitFailure blk)
-    -- ^ An on disk snapshot was skipped because it was invalid.
-  | TookSnapshot DiskSnapshot (RealPoint blk)
-    -- ^ A snapshot was written to disk.
-  | DeletedSnapshot DiskSnapshot
-    -- ^ An old or invalid on-disk snapshot was deleted
-  deriving (Generic, Eq, Show)
-
 -- | Which point the replay started from
 newtype ReplayStart blk = ReplayStart (Point blk) deriving (Eq, Show)
 
@@ -757,8 +759,8 @@ newtype ReplayGoal blk = ReplayGoal (Point blk) deriving (Eq, Show)
 -- date w.r.t. the tip of the ImmutableDB during initialisation. As this
 -- process takes a while, we trace events to inform higher layers of our
 -- progress.
-data TraceReplayEvent blk
-  = -- | There were no LedgerDB snapshots on disk, so we're replaying all blocks
+data TraceReplayEvent blk =
+    -- | There were no LedgerDB snapshots on disk, so we're replaying all blocks
     -- starting from Genesis against the initial ledger.
     ReplayFromGenesis
         (ReplayGoal blk)  -- ^ the block at the tip of the ImmutableDB


### PR DESCRIPTION
Instead of the current tail-calling algorithm, this implements `initLedgerDB` in a sequential fashion with a clear separation between loading a snapshot to create a first version of the LedgerDB and the later replay of blocks in the immutable database.

Also, reorganizes the module to put together stuff about Snapshots, stuff about initialization, and renames `TraceEvent` which was a too generic name for only snapshot related events.