### PR TITLE
IOSimPOR - race exploration with partial order reduction

### DIFF
--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -43,6 +43,7 @@ library
                        Control.Monad.Class.MonadThrow
                        Control.Monad.Class.MonadTime
                        Control.Monad.Class.MonadTimer
+                       Control.Monad.Class.MonadTest
   default-language:    Haskell2010
   other-extensions:    CPP
                        TypeFamilies

--- a/io-classes/src/Control/Monad/Class/MonadTest.hs
+++ b/io-classes/src/Control/Monad/Class/MonadTest.hs
@@ -1,0 +1,13 @@
+module Control.Monad.Class.MonadTest ( MonadTest (..) ) where
+
+import           Control.Monad.Reader
+
+class Monad m => MonadTest m where
+  exploreRaces :: m ()
+  exploreRaces = return ()
+
+instance MonadTest IO
+
+instance MonadTest m => MonadTest (ReaderT e m) where
+  exploreRaces = lift exploreRaces
+

--- a/io-sim/how-to-use-IOSimPOR.txt
+++ b/io-sim/how-to-use-IOSimPOR.txt
@@ -200,27 +200,26 @@ small number of tests.
 IOSimPOR Scheduling
 -------------------
 
-IOSimPOR distinguishes between test threads and system threads; test
-threads are intended to be part of the test itself, whereas system
-threads are part of the system under test. The main thread in a test
-is always a test thread; test threads can fork system threads, but not
-vice versa. Test threads always take priority over system threads, and
-IOSimPOR does not attempt to reverse races involving test threads. So
-when writing a test, one can assume that whatever the test threads do
-takes place first (at each simulated time point), and then the system
-threads run and any races between them are explored. Likewise, if a
-blocked test thread responds to an event in a system thread, then the
-test thread's response will take place before the system threads
-continue execution. Distinguishing test threads from system threads
-drastically reduces the set of races that IOSimPOR needs to consider.
+IOSimPOR distinguishes between non-racy threads and system threads; test
+threads are intended to be part of the test itself, whereas system threads are
+part of the system under test. The main thread in a test is always a non-racy
+thread; non-racy threads can fork system threads, but not vice versa. Test
+threads always take priority over system threads, and IOSimPOR does not
+attempt to reverse races involving test threads. So when writing a test, one
+can assume that whatever the test threads do takes place first (at each
+simulated time point), and then the system threads run and any races between
+them are explored. Likewise, if a blocked non-racy thread responds to an event
+in a system thread, then the test thread's response will take place before the
+system threads continue execution. Distinguishing non-racy threads from system
+threads drastically reduces the set of races that IOSimPOR needs to consider.
 
-To start a system thread, a test thread may call
+To start a system thread, a non-racy thread may call
 
     exploreRaces :: MonadTest m => m ()
 
 All threads forked (using forkIO) after such a call will be system
 threads. If there is no call to exploreRaces in a test, then all the
-threads forked will be test threads, and IOSimPOR will not reverse any
+threads forked will be non-racy threads, and IOSimPOR will not reverse any
 races---so it is necessary to include a call to exploreRaces somewhere
 in a test.
 
@@ -234,7 +233,7 @@ easy to see which thread forked which other, and relatively easy to
 map thread ids in debugging output to threads in the source code.
 
 Except when reversing races, IOSimPOR schedules threads using
-priorities. Test threads take priority over system threads, but
+priorities. Non-racy threads take priority over system threads, but
 otherwise priorities are determined by the thread ids: the thread with
 the lexicographically greatest thread Id has the highest priority. As
 a result, threads behave in a very predictable manner: newly forked

--- a/io-sim/how-to-use-IOSimPOR.txt
+++ b/io-sim/how-to-use-IOSimPOR.txt
@@ -1,0 +1,309 @@
+How to use Control.Monad.IOSimPOR
+=================================
+
+IOSimPOR is a version of IOSim that supports finding race conditions, by
+
+ - allowing many alternative schedules to be explored, and
+
+ - searching through schedules in an order which (empirically) is
+   likely to play well with shrinking; when a test case that provokes
+   a race condition is shrunk to a smaller test case that suffers from
+   the same race condition, then it is likely that IOSimPOR will
+   actually provoke the race condition in the smaller test too.
+
+To do so, IOSimPOR detects potential racing steps when a test is run,
+and then re-runs the same test many times with one or more pairs of
+racing steps reversed. IOSimPOR runs each equivalent schedule at most
+once.
+
+IOSimPOR will usually not explore all possible schedules, because
+there are too many for this to be feasible (even infinitely many, in
+some cases). It prioritises races that occur earlier in a test
+execution, and prioritises making a small number of race reversals
+over making many. 
+
+It can test non-terminating programs with an infinite trace; in such
+cases it only reverse races in the part of the trace that the property
+under test actually depends on. Thus properties that select, for
+example, the first simulated 24 hours of trace events, can be tested
+using IOSimPOR; only races that occur in the first 24 hours will be
+reversed.
+
+IOSimPOR assumes that execution is much faster than the passage of
+time, so steps that occur at different simulated times are considered
+not to race, and will not be reversed.
+
+Exploring all possible schedules is possible with the right
+parameters, but not usually advisable, because it is so very very
+expensive. When IOSimPOR is used in a QuickCheck property, then many
+test cases will not even have a possibility of provoking a fault,
+whatever the schedule; it usually makes more sense to explore a
+limited number of schedules each, for a large number of cases, than to
+explore a small number of cases very very thoroughly.
+
+Do not be surprised that tests run slowly. Each "test" is running (by
+default) 100 different schedules; each run is more costly than a run
+using vanilla IOSim, because race conditions and data dependencies
+need to be tracked.
+
+The IOSimPOR API
+----------------
+
+The common way to use IOSim is to call
+
+   runSimTrace :: forall a. (forall s. IOSim s a) -> Trace a
+
+which returns a trace, and then express the property to test as a
+predicate on the trace. Since IOSimPOR explores many traces, then the
+property to test is given as a continuation instead, which is called
+for each trace generated. The common way to use IOSimPOR is thus
+
+   exploreSimTrace :: forall a test. (Testable test, Show a) =>
+    (ExplorationOptions->ExplorationOptions) ->
+    (forall s. IOSim s a) ->
+    (Maybe (Trace a) -> Trace a -> test) ->
+    Property
+
+The continuation is the last parameter, with type
+
+   Maybe (Trace a) -> Trace a -> test
+
+Here the second parameter of the continuation is the trace that the
+property should check. The first parameter simply provides information
+that may be useful for debugging---if present, it is a similar trace
+that passed the same test, from which the failing trace was derived by
+reversing one race.
+
+IOSimPOR Options
+----------------
+
+exploreSimTrace can be controlled by a number of options, which are
+obtained by passing the function passed as the first parameter to a
+default set of options. Passing the identity function id as the first
+parameter uses the defaults.
+
+The options are:
+
+ - the schedule bound, default 100, set by withScheduleBound. This is
+   an upper bound on the number of schedules with race reversals that
+   will be explored; a bound of zero means that the default schedule
+   will be explored, but no others. Setting the bound to zero makes
+   IOSimPOR behave rather like IOSim, in that only one schedule is
+   explored, but (a) IOSimPOR is considerably slower, because it still
+   collects information on potential races, and (b) the IOSimPOR
+   schedule is different (based on priorities, in contrast to IOSim's
+   round-robin), and plays better with shrinking.
+
+ - the branching factor, default 3, set by withBranching. This is the
+   number of alternative schedules that IOSimPOR tries to run, per
+   race reversal. With the default parameters, IOSimPOR will try to
+   reverse the first 33 (100 `div` 3) races discovered using the
+   default schedule, then (if 33 or more races are discovered), for
+   each such reversed race, will run the reversal and try to reverse
+   two more races in the resulting schedule. A high branching factor
+   will explore more combinations of reversing fewer races, within the
+   overall schedule bound. A branching factor of one will explore only
+   schedules resulting from a single race reversal (unless there are
+   fewer races available to be reversed than the schedule bound).
+
+ - the step time limit in microseconds, default 100000 (100ms), set by
+   withStepTimeLimit. A simulation step consists of pure computation
+   followed by an IO action of some sort; we expect in most cases that
+   the pure computation will be fast. However, a bug might cause the
+   pure computation to fall into an infinite loop. This can be
+   detected by applying a time limit to the overall test, for example
+   using QuickCheck's function within, but if such a time limit is
+   exceeded, then no information about the trace-so-far is
+   preserved. Instead IOSimPOR can apply a time limit to each step; if
+   the time limit is exceeded, then the trace up to that point is
+   passed to the continuation, terminated by a TraceLoop
+   constructor. The time limit should be large enough that the
+   intended pure computations always finish well within that
+   time. Note that garbage collection pauses are not included in the
+   time limit (which would otherwise need to be considerably longer
+   than 100ms to accomodate them), provided the -T flag is supplied to
+   the run-time system.
+
+ - the schedule control to replay, default Nothing, set by
+   withReplay. When a test fails, exploreSimTrace displays the
+   schedule control which provoked it. The schedule control specifies
+   how to modify the default schedule to reproduce the failure; by
+   saving the schedule control and passing it back to exploreSimTrace
+   for replay, then it is possible to rerun a failed test with
+   additional diagnostics, without repeating the search for a schedule
+   that makes it fail.
+
+IOSimPOR Statistics
+-------------------
+
+When a tested property passes, IOSimPOR displays some statistics about
+the schedules that were actually run. An example of this output is:
+
+Branching factor (5865 in total):
+45.51% 1
+43.00% 0
+ 6.58% 2
+ 2.23% 3
+ 0.85% 4
+ 0.46% 30-39
+ 0.38% 5
+ 0.32% 6
+ 0.24% 10-19
+ 0.19% 20-29
+ 0.15% 8
+ 0.07% 7
+ 0.02% 9
+
+Modified schedules explored (100 in total):
+22% 100-199
+22% 90-99
+18% 0
+ 7% 30-39
+ 4% 4
+ 4% 60-69
+ 4% 80-89
+ 3% 20-29
+ 3% 3
+ 3% 50-59
+ 3% 70-79
+ 2% 10-19
+ 2% 2
+ 2% 40-49
+ 1% 1
+
+Race reversals per schedule (5865 in total):
+50.04% 1
+45.05% 2
+ 3.10% 3
+ 1.71% 0
+ 0.10% 4
+
+The first table shows us the branching factor at each point where
+IOSimPOR explored alternative schedules: in this case, in 43% of cases
+we were at a leaf of the exploration, so no alternative schedules were
+explored; 45% of the time we explored one alternative schedule; in a
+few cases larger numbers of schedules were explored.
+
+The second table shows us how many schedules we explored for each
+test; in this case we used the default bound of 100 alternative
+schedules, and we reached that bound in 22% of tests--in the other
+tests, there were fewer than 100 possible schedules to explore. In 18%
+of the tests, there were no alternative schedules to explore---since
+these tests were randomly generated, then these 18% were probably
+rather trivial tests.
+
+The final table shows us how many races were reversed in each
+alternative schedule; in this case most alternative schedules just
+reversed one or two races, but we did reach a maximum of four in a
+small number of tests.
+
+IOSimPOR Scheduling
+-------------------
+
+IOSimPOR distinguishes between test threads and system threads; test
+threads are intended to be part of the test itself, whereas system
+threads are part of the system under test. The main thread in a test
+is always a test thread; test threads can fork system threads, but not
+vice versa. Test threads always take priority over system threads, and
+IOSimPOR does not attempt to reverse races involving test threads. So
+when writing a test, one can assume that whatever the test threads do
+takes place first (at each simulated time point), and then the system
+threads run and any races between them are explored. Likewise, if a
+blocked test thread responds to an event in a system thread, then the
+test thread's response will take place before the system threads
+continue execution. Distinguishing test threads from system threads
+drastically reduces the set of races that IOSimPOR needs to consider.
+
+To start a system thread, a test thread may call
+
+    exploreRaces :: MonadTest m => m ()
+
+All threads forked (using forkIO) after such a call will be system
+threads. If there is no call to exploreRaces in a test, then all the
+threads forked will be test threads, and IOSimPOR will not reverse any
+races---so it is necessary to include a call to exploreRaces somewhere
+in a test.
+
+IOSimPOR ThreadIds contain a list of small integers; the main thread
+contains the list [], its children are numbered [1], [2], [3] and so
+on, then threads forked by [2] are numbered [2,1], [2,2], [2,3] and so
+on. The id of a forked thread always extends its parent's id, and
+successively forked children of the same thread are numbered 1, 2, 3
+and so on. Thread Ids give us useful information for debugging; it is
+easy to see which thread forked which other, and relatively easy to
+map thread ids in debugging output to threads in the source code.
+
+Except when reversing races, IOSimPOR schedules threads using
+priorities. Test threads take priority over system threads, but
+otherwise priorities are determined by the thread ids: the thread with
+the lexicographically greatest thread Id has the highest priority. As
+a result, threads behave in a very predictable manner: newly forked
+threads take priority over their parent thread, and children forked
+later take priority over children forked earlier from the same parent
+thread. Knowing these priorities helps in understanding traces.
+
+When IOSimPOR reverses races, this is done by using a 'schedule
+control'. The schedule control is displayed in the test output when a
+test fails. Here is an example:
+
+Schedule control:
+  ControlAwait [ScheduleMod (ThreadId [4],0)
+                            ControlDefault
+                            [(ThreadId [1],0),
+                             (ThreadId [1],1),
+                             (ThreadId [2],0),
+                             (ThreadId [2],1),
+                             (ThreadId [3],0)]]
+
+ThreadId [4] delayed at time Time 0s
+  until after:
+    ThreadId [2]
+    ThreadId [3]
+
+The schedule control consists of one or more schedule modifications,
+each of which specifies that an event should be delayed until after a
+sequence of other events. The events consist of a thread id and a
+per-thread event number. The interpretation of the schedule
+modification above is that when the default scheduler would have
+performed the first event in thread [4] (that is, (ThreadId [4],0)),
+then it should be delayed, and the list of events in the third field
+of the schedule modification should be performed first. In this case
+there is only one schedule modification, and so only one event is
+delayed, but in general a schedule control may delay a series of
+events. A failing test can be replayed by using withReplay to supply
+the schedule control as an option to exploreSimTrace.
+
+The final part of the output tells us how the schedule in the failing
+test differed from the schedule in the most similar passing test:
+namely, thread [4] was delayed (at simulated time 0) until after the
+events in threads [2] and [3]. Since the schedule control delays
+thread [4] until after steps in threads [1], [2] and [3], then we can
+conclude that the last passing test already delayed thread [4] until
+after the events in thread [1].
+
+Potential IOSimPOR Errors
+-------------------------
+
+Most reported errors are a result of faults in the code under test,
+but if you see an error of the following form:
+
+Exception:
+  Can't follow ControlFollow [(ThreadId [5],0)] []
+    tid: ThreadId [5]
+    tstep: 0
+    runqueue: [ThreadId [3],ThreadId [2],ThreadId [1]]
+
+then the probable cause is a bug in IOSimPOR itself. The message
+indicates that IOSimPOR scheduler is trying to follow a schedule
+modification that specifies that thread [5] should run next, but this
+is impossible because thread [5] is not in the runqueue (the list of
+runnable threads). If you supplied a schedule control explicitly,
+using withReplay, then you may perhaps have supplied a schedule
+control that does not match the version of the code you are running:
+in this case the exception is your fault. But if this message appears
+while you are exploring races, then it indicates a problem in
+IOSimPOR's dependency analysis: IOSimPOR has constructed a schedule as
+a result of race reversal that tries to run thread [5] at this point,
+because the dependency analysis indicates that thread [5] ought to be
+runnable---but it is not. Best to consult Quviq at this point.
+

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 name:                io-sim
 version:             0.2.0.0
-synopsis:            A pure simlator for monadic concurrency with STM
+synopsis:            A pure simulator for monadic concurrency with STM
 -- description:
 license:             Apache-2.0
 license-files:
@@ -25,9 +25,13 @@ source-repository head
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Data.List.Trace
-                     , Control.Monad.IOSim
-  other-modules:       Control.Monad.IOSim.Internal
+  exposed-modules:     Data.List.Trace,
+                       Control.Monad.IOSim,
+                       Control.Monad.IOSim.Types
+  other-modules:       Control.Monad.IOSim.Internal,
+                       Control.Monad.IOSimPOR.Internal,
+                       Control.Monad.IOSimPOR.QuickCheckUtils,
+                       Control.Monad.IOSimPOR.Timeout
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        CPP,
@@ -44,9 +48,13 @@ library
                        io-classes        >=0.2 && <0.3,
                        exceptions        >=0.10,
                        containers,
+                       parallel,
+                       pretty-simple,
                        psqueues          >=0.2 && <0.3,
                        time              >=1.9.1 && <1.11,
-                       quiet
+                       quiet,
+                       QuickCheck,
+                       syb
 
   ghc-options:         -Wall
                        -Wcompat
@@ -55,6 +63,7 @@ library
                        -Wpartial-fields
                        -Widentities
                        -Wredundant-constraints
+
   if flag(asserts)
      ghc-options:      -fno-ignore-asserts
 
@@ -64,12 +73,14 @@ test-suite test
   main-is:             Main.hs
   other-modules:       Test.IOSim
                        Test.STM
+                       Test.Control.Monad.IOSimPOR
   default-language:    Haskell2010
   build-depends:       base,
                        array,
                        containers,
                        io-classes,
                        io-sim,
+                       parallel,
                        QuickCheck,
                        strict-stm,
                        tasty,

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -29,6 +29,7 @@ library
                        Control.Monad.IOSim,
                        Control.Monad.IOSim.Types
   other-modules:       Control.Monad.IOSim.Internal,
+                       Control.Monad.IOSim.InternalTypes,
                        Control.Monad.IOSimPOR.Internal,
                        Control.Monad.IOSimPOR.QuickCheckUtils,
                        Control.Monad.IOSimPOR.Timeout

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -338,13 +338,21 @@ ppEvents events =
 runSimTrace :: forall a. (forall s. IOSim s a) -> SimTrace a
 runSimTrace mainAction = runST (runSimTraceST mainAction)
 
-controlSimTrace :: forall a. Maybe Int -> ScheduleControl -> (forall s. IOSim s a) -> SimTrace a
-controlSimTrace limit control mainAction = runST (controlSimTraceST limit control mainAction)
+controlSimTrace :: forall a.
+                   Maybe Int
+                -> ScheduleControl
+                -- ^ note: must be either `ControlDefault` or `ControlAwait`. 
+                -> (forall s. IOSim s a)
+                -> SimTrace a
+controlSimTrace limit control mainAction =
+    runST (controlSimTraceST limit control mainAction)
 
-exploreSimTrace ::
-  forall a test. (Testable test) =>
-    (ExplorationOptions->ExplorationOptions) ->
-    (forall s. IOSim s a) -> (Maybe (SimTrace a) -> SimTrace a -> test) -> Property
+exploreSimTrace
+  :: forall a test. Testable test
+  => (ExplorationOptions -> ExplorationOptions)
+  -> (forall s. IOSim s a)
+  -> (Maybe (SimTrace a) -> SimTrace a -> test)
+  -> Property
 exploreSimTrace optsf mainAction k =
   case explorationReplay opts of
     Nothing ->

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -78,6 +78,7 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Control.Monad.IOSim.Types
+import           Control.Monad.IOSim.InternalTypes
 
 --
 -- Simulation interpreter
@@ -94,27 +95,6 @@ data Thread s a = Thread {
     threadLabel   :: Maybe ThreadLabel,
     threadNextTId :: !Int
   }
-
--- We hide the type @b@ here, so it's useful to bundle these two parts
--- together, rather than having Thread have an extential type, which
--- makes record updates awkward.
-data ThreadControl s a where
-  ThreadControl :: SimA s b
-                -> ControlStack s b a
-                -> ThreadControl s a
-
-data ControlStack s b a where
-  MainFrame  :: ControlStack s a  a
-  ForkFrame  :: ControlStack s () a
-  MaskFrame  :: (b -> SimA s c)         -- subsequent continuation
-             -> MaskingState            -- thread local state to restore
-             -> ControlStack s c a
-             -> ControlStack s b a
-  CatchFrame :: Exception e
-             => (e -> SimA s b)         -- exception continuation
-             -> (b -> SimA s c)         -- subsequent continuation
-             -> ControlStack s c a
-             -> ControlStack s b a
 
 labelledTVarId :: TVar s a -> ST s (Labelled TVarId)
 labelledTVarId TVar { tvarId, tvarLabel } = (Labelled tvarId) <$> readSTRef tvarLabel

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -165,8 +165,8 @@ invariant Nothing SimState{runqueue,threads,clocks} =
 
 -- | Interpret the simulation monotonic time as a 'NominalDiffTime' since
 -- the start.
-timeSiceEpoch :: Time -> NominalDiffTime
-timeSiceEpoch (Time t) = fromRational (toRational t)
+timeSinceEpoch :: Time -> NominalDiffTime
+timeSinceEpoch (Time t) = fromRational (toRational t)
 
 
 -- | Schedule / run a thread.
@@ -276,14 +276,14 @@ schedule thread@Thread{
     GetWallTime k -> do
       let clockid  = threadClockId thread
           clockoff = clocks Map.! clockid
-          walltime = timeSiceEpoch time `addUTCTime` clockoff
+          walltime = timeSinceEpoch time `addUTCTime` clockoff
           thread'  = thread { threadControl = ThreadControl (k walltime) ctl }
       schedule thread' simstate
 
     SetWallTime walltime' k -> do
       let clockid   = threadClockId thread
           clockoff  = clocks Map.! clockid
-          walltime  = timeSiceEpoch time `addUTCTime` clockoff
+          walltime  = timeSinceEpoch time `addUTCTime` clockoff
           clockoff' = addUTCTime (diffUTCTime walltime' walltime) clockoff
           thread'   = thread { threadControl = ThreadControl k ctl }
           simstate' = simstate { clocks = Map.insert clockid clockoff' clocks }

--- a/io-sim/src/Control/Monad/IOSim/InternalTypes.hs
+++ b/io-sim/src/Control/Monad/IOSim/InternalTypes.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | Internal types shared between `IOSim` and `IOSimPOR`.
+--
+module Control.Monad.IOSim.InternalTypes
+  ( ThreadControl (..)
+  , ControlStack (..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Control.Monad.Class.MonadThrow (MaskingState (..))
+
+import           Control.Monad.IOSim.Types (SimA)
+
+
+-- We hide the type @b@ here, so it's useful to bundle these two parts
+-- together, rather than having Thread have an extential type, which
+-- makes record updates awkward.
+data ThreadControl s a where
+  ThreadControl :: SimA s b
+                -> ControlStack s b a
+                -> ThreadControl s a
+
+instance Show (ThreadControl s a) where
+  show _ = "..."
+
+data ControlStack s b a where
+  MainFrame  :: ControlStack s a  a
+  ForkFrame  :: ControlStack s () a
+  MaskFrame  :: (b -> SimA s c)         -- subsequent continuation
+             -> MaskingState            -- thread local state to restore
+             -> ControlStack s c a
+             -> ControlStack s b a
+  CatchFrame :: Exception e
+             => (e -> SimA s b)         -- exception continuation
+             -> (b -> SimA s c)         -- subsequent continuation
+             -> ControlStack s c a
+             -> ControlStack s b a
+
+instance Show (ControlStack s b a) where
+  show = show . dash
+    where dash :: ControlStack s' b' a' -> ControlStackDash
+          dash MainFrame = MainFrame'
+          dash ForkFrame = ForkFrame'
+          dash (MaskFrame _ m s) = MaskFrame' m (dash s)
+          dash (CatchFrame _ _ s) = CatchFrame' (dash s)
+
+data ControlStackDash =
+    MainFrame'
+  | ForkFrame'
+  | MaskFrame' MaskingState ControlStackDash
+  | CatchFrame' ControlStackDash
+  deriving Show

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -1,0 +1,805 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTSyntax                 #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-partial-fields          #-}
+
+module Control.Monad.IOSim.Types where
+
+import           Control.Exception (ErrorCall (..), asyncExceptionFromException, asyncExceptionToException)
+import           Control.Applicative
+import           Control.Monad
+
+import           Control.Monad.Class.MonadAsync hiding (Async)
+import qualified Control.Monad.Class.MonadAsync as MonadAsync
+import           Control.Monad.Class.MonadFork hiding (ThreadId)
+import qualified Control.Monad.Class.MonadFork as MonadFork
+import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadTest
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadEventlog
+import           Control.Monad.Class.MonadSTM hiding (STM, TVar)
+import qualified Control.Monad.Class.MonadSTM as MonadSTM
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadThrow as MonadThrow hiding (getMaskingState)
+import qualified Control.Monad.Class.MonadThrow as MonadThrow
+import qualified Control.Monad.ST.Strict as StrictST
+
+import qualified Control.Monad.Catch as Exceptions
+import qualified Control.Monad.Fail as Fail
+
+import           Data.Bifoldable
+import           Data.Bifunctor (bimap)
+import           Data.Map.Strict (Map)
+import           Data.Maybe (fromMaybe)
+import           Data.Set (Set)
+import           Data.Dynamic (Dynamic, toDyn)
+import           Data.Function (on)
+import           Data.Typeable
+import           Data.STRef.Lazy
+import qualified Data.List.Trace as Trace
+import           Text.Printf
+
+import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
+
+import qualified System.IO.Error as IO.Error (userError)
+
+{-# ANN module "HLint: ignore Use readTVarIO" #-}
+newtype IOSim s a = IOSim { unIOSim :: forall r. (a -> SimA s r) -> SimA s r }
+
+type SimM s = IOSim s
+{-# DEPRECATED SimM "Use IOSim" #-}
+
+runIOSim :: IOSim s a -> SimA s a
+runIOSim (IOSim k) = k Return
+
+traceM :: Typeable a => a -> IOSim s ()
+traceM x = IOSim $ \k -> Output (toDyn x) (k ())
+
+traceSTM :: Typeable a => a -> STMSim s ()
+traceSTM x = STM $ \k -> OutputStm (toDyn x) (k ())
+
+data SimA s a where
+  Return       :: a -> SimA s a
+
+  Say          :: String -> SimA s b -> SimA s b
+  Output       :: Dynamic -> SimA s b -> SimA s b
+
+  LiftST       :: StrictST.ST s a -> (a -> SimA s b) -> SimA s b
+
+  GetMonoTime  :: (Time    -> SimA s b) -> SimA s b
+  GetWallTime  :: (UTCTime -> SimA s b) -> SimA s b
+  SetWallTime  ::  UTCTime -> SimA s b  -> SimA s b
+  UnshareClock :: SimA s b -> SimA s b
+
+  NewTimeout   :: DiffTime -> (Timeout (IOSim s) -> SimA s b) -> SimA s b
+  UpdateTimeout:: Timeout (IOSim s) -> DiffTime -> SimA s b -> SimA s b
+  CancelTimeout:: Timeout (IOSim s) -> SimA s b -> SimA s b
+
+  Throw        :: SomeException -> SimA s a
+  Catch        :: Exception e =>
+                  SimA s a -> (e -> SimA s a) -> (a -> SimA s b) -> SimA s b
+  Evaluate     :: a -> (a -> SimA s b) -> SimA s b
+
+  Fork         :: IOSim s () -> (ThreadId -> SimA s b) -> SimA s b
+  GetThreadId  :: (ThreadId -> SimA s b) -> SimA s b
+  LabelThread  :: ThreadId -> String -> SimA s b -> SimA s b
+
+  Atomically   :: STM  s a -> (a -> SimA s b) -> SimA s b
+
+  ThrowTo      :: SomeException -> ThreadId -> SimA s a -> SimA s a
+  SetMaskState :: MaskingState  -> IOSim s a -> (a -> SimA s b) -> SimA s b
+  GetMaskState :: (MaskingState -> SimA s b) -> SimA s b
+
+  ExploreRaces :: SimA s b -> SimA s b
+
+
+newtype STM s a = STM { unSTM :: forall r. (a -> StmA s r) -> StmA s r }
+
+runSTM :: STM s a -> StmA s a
+runSTM (STM k) = k ReturnStm
+
+data StmA s a where
+  ReturnStm    :: a -> StmA s a
+  ThrowStm     :: SomeException -> StmA s a
+
+  NewTVar      :: Maybe String -> x -> (TVar s x -> StmA s b) -> StmA s b
+  LabelTVar    :: String -> TVar s a -> StmA s b -> StmA s b
+  ReadTVar     :: TVar s a -> (a -> StmA s b) -> StmA s b
+  WriteTVar    :: TVar s a ->  a -> StmA s b  -> StmA s b
+  Retry        :: StmA s b
+  OrElse       :: StmA s a -> StmA s a -> (a -> StmA s b) -> StmA s b
+
+  SayStm       :: String -> StmA s b -> StmA s b
+  OutputStm    :: Dynamic -> StmA s b -> StmA s b
+
+-- Exported type
+type STMSim = STM
+
+type SimSTM = STM
+{-# DEPRECATED SimSTM "Use STMSim" #-}
+
+--
+-- Monad class instances
+--
+
+instance Functor (IOSim s) where
+    {-# INLINE fmap #-}
+    fmap f = \d -> IOSim $ \k -> unIOSim d (k . f)
+
+instance Applicative (IOSim s) where
+    {-# INLINE pure #-}
+    pure = \x -> IOSim $ \k -> k x
+
+    {-# INLINE (<*>) #-}
+    (<*>) = \df dx -> IOSim $ \k ->
+                        unIOSim df (\f -> unIOSim dx (\x -> k (f x)))
+
+    {-# INLINE (*>) #-}
+    (*>) = \dm dn -> IOSim $ \k -> unIOSim dm (\_ -> unIOSim dn k)
+
+instance Monad (IOSim s) where
+    return = pure
+
+    {-# INLINE (>>=) #-}
+    (>>=) = \dm f -> IOSim $ \k -> unIOSim dm (\m -> unIOSim (f m) k)
+
+    {-# INLINE (>>) #-}
+    (>>) = (*>)
+
+#if !(MIN_VERSION_base(4,13,0))
+    fail = Fail.fail
+#endif
+
+instance Semigroup a => Semigroup (IOSim s a) where
+    (<>) = liftA2 (<>)
+
+instance Monoid a => Monoid (IOSim s a) where
+    mempty = pure mempty
+
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = liftA2 mappend
+#endif
+
+instance Fail.MonadFail (IOSim s) where
+  fail msg = IOSim $ \_ -> Throw (toException (IO.Error.userError msg))
+
+
+instance Functor (STM s) where
+    {-# INLINE fmap #-}
+    fmap f = \d -> STM $ \k -> unSTM d (k . f)
+
+instance Applicative (STM s) where
+    {-# INLINE pure #-}
+    pure = \x -> STM $ \k -> k x
+
+    {-# INLINE (<*>) #-}
+    (<*>) = \df dx -> STM $ \k ->
+                        unSTM df (\f -> unSTM dx (\x -> k (f x)))
+
+    {-# INLINE (*>) #-}
+    (*>) = \dm dn -> STM $ \k -> unSTM dm (\_ -> unSTM dn k)
+
+instance Monad (STM s) where
+    return = pure
+
+    {-# INLINE (>>=) #-}
+    (>>=) = \dm f -> STM $ \k -> unSTM dm (\m -> unSTM (f m) k)
+
+    {-# INLINE (>>) #-}
+    (>>) = (*>)
+
+#if !(MIN_VERSION_base(4,13,0))
+    fail = Fail.fail
+#endif
+
+instance Fail.MonadFail (STM s) where
+  fail msg = STM $ \_ -> ThrowStm (toException (ErrorCall msg))
+
+instance Alternative (STM s) where
+    empty = retry
+    (<|>) = orElse
+
+instance MonadPlus (STM s) where
+
+instance MonadSay (IOSim s) where
+  say msg = IOSim $ \k -> Say msg (k ())
+
+instance MonadThrow (IOSim s) where
+  throwIO e = IOSim $ \_ -> Throw (toException e)
+
+instance MonadEvaluate (IOSim s) where
+  evaluate a = IOSim $ \k -> Evaluate a k
+
+instance Exceptions.MonadThrow (IOSim s) where
+  throwM = MonadThrow.throwIO
+
+instance MonadThrow (STM s) where
+  throwIO e = STM $ \_ -> ThrowStm (toException e)
+
+  -- Since these involve re-throwing the exception and we don't provide
+  -- CatchSTM at all, then we can get away with trivial versions:
+  bracket before after thing = do
+    a <- before
+    r <- thing a
+    _ <- after a
+    return r
+
+  finally thing after = do
+    r <- thing
+    _ <- after
+    return r
+
+instance Exceptions.MonadThrow (STM s) where
+  throwM = MonadThrow.throwIO
+
+instance MonadCatch (IOSim s) where
+  catch action handler =
+    IOSim $ \k -> Catch (runIOSim action) (runIOSim . handler) k
+
+instance Exceptions.MonadCatch (IOSim s) where
+  catch = MonadThrow.catch
+
+instance MonadMask (IOSim s) where
+  mask action = do
+      b <- getMaskingStateImpl
+      case b of
+        Unmasked              -> block $ action unblock
+        MaskedInterruptible   -> action block
+        MaskedUninterruptible -> action blockUninterruptible
+
+  uninterruptibleMask action = do
+      b <- getMaskingStateImpl
+      case b of
+        Unmasked              -> blockUninterruptible $ action unblock
+        MaskedInterruptible   -> blockUninterruptible $ action block
+        MaskedUninterruptible -> action blockUninterruptible
+
+instance MonadMaskingState (IOSim s) where
+  getMaskingState = getMaskingStateImpl
+
+instance Exceptions.MonadMask (IOSim s) where
+  mask                = MonadThrow.mask
+  uninterruptibleMask = MonadThrow.uninterruptibleMask
+
+  generalBracket acquire release use =
+    mask $ \unmasked -> do
+      resource <- acquire
+      b <- unmasked (use resource) `catch` \e -> do
+        _ <- release resource (Exceptions.ExitCaseException e)
+        throwIO e
+      c <- release resource (Exceptions.ExitCaseSuccess b)
+      return (b, c)
+
+
+getMaskingStateImpl :: IOSim s MaskingState
+unblock, block, blockUninterruptible :: IOSim s a -> IOSim s a
+
+getMaskingStateImpl    = IOSim  GetMaskState
+unblock              a = IOSim (SetMaskState Unmasked a)
+block                a = IOSim (SetMaskState MaskedInterruptible a)
+blockUninterruptible a = IOSim (SetMaskState MaskedUninterruptible a)
+
+instance MonadThread (IOSim s) where
+  type ThreadId (IOSim s) = ThreadId
+  myThreadId       = IOSim $ \k -> GetThreadId k
+  labelThread t l  = IOSim $ \k -> LabelThread t l (k ())
+
+instance MonadFork (IOSim s) where
+  forkIO task        = IOSim $ \k -> Fork task k
+  forkIOWithUnmask f = forkIO (f unblock)
+  throwTo tid e      = IOSim $ \k -> ThrowTo (toException e) tid (k ())
+
+instance MonadTest (IOSim s) where
+  exploreRaces       = IOSim $ \k -> ExploreRaces (k ())
+
+instance MonadSay (STMSim s) where
+  say msg = STM $ \k -> SayStm msg (k ())
+
+
+instance MonadLabelledSTM (IOSim s) where
+  labelTVar tvar label = STM $ \k -> LabelTVar label tvar (k ())
+  labelTMVar   = labelTMVarDefault
+  labelTQueue  = labelTQueueDefault
+  labelTBQueue = labelTBQueueDefault
+
+instance MonadSTM (IOSim s) where
+  type STM       (IOSim s) = STM s
+  type TVar      (IOSim s) = TVar s
+  type TMVar     (IOSim s) = TMVarDefault (IOSim s)
+  type TQueue    (IOSim s) = TQueueDefault (IOSim s)
+  type TBQueue   (IOSim s) = TBQueueDefault (IOSim s)
+
+  atomically action = IOSim $ \k -> Atomically action k
+
+  newTVar         x = STM $ \k -> NewTVar Nothing x k
+  readTVar   tvar   = STM $ \k -> ReadTVar tvar k
+  writeTVar  tvar x = STM $ \k -> WriteTVar tvar x (k ())
+  retry             = STM $ \_ -> Retry
+  orElse        a b = STM $ \k -> OrElse (runSTM a) (runSTM b) k
+
+  newTMVar          = newTMVarDefault
+  newEmptyTMVar     = newEmptyTMVarDefault
+  takeTMVar         = takeTMVarDefault
+  tryTakeTMVar      = tryTakeTMVarDefault
+  putTMVar          = putTMVarDefault
+  tryPutTMVar       = tryPutTMVarDefault
+  readTMVar         = readTMVarDefault
+  tryReadTMVar      = tryReadTMVarDefault
+  swapTMVar         = swapTMVarDefault
+  isEmptyTMVar      = isEmptyTMVarDefault
+
+  newTQueue         = newTQueueDefault
+  readTQueue        = readTQueueDefault
+  tryReadTQueue     = tryReadTQueueDefault
+  peekTQueue        = peekTQueueDefault
+  tryPeekTQueue     = tryPeekTQueueDefault
+  writeTQueue       = writeTQueueDefault
+  isEmptyTQueue     = isEmptyTQueueDefault
+
+  newTBQueue        = newTBQueueDefault
+  readTBQueue       = readTBQueueDefault
+  tryReadTBQueue    = tryReadTBQueueDefault
+  peekTBQueue       = peekTBQueueDefault
+  tryPeekTBQueue    = tryPeekTBQueueDefault
+  flushTBQueue      = flushTBQueueDefault
+  writeTBQueue      = writeTBQueueDefault
+  lengthTBQueue     = lengthTBQueueDefault
+  isEmptyTBQueue    = isEmptyTBQueueDefault
+  isFullTBQueue     = isFullTBQueueDefault
+
+  newTMVarIO        = newTMVarIODefault
+  newEmptyTMVarIO   = newEmptyTMVarIODefault
+
+data Async s a = Async !ThreadId (STM s (Either SomeException a))
+
+instance Eq (Async s a) where
+    Async tid _ == Async tid' _ = tid == tid'
+
+instance Ord (Async s a) where
+    compare (Async tid _) (Async tid' _) = compare tid tid'
+
+instance Functor (Async s) where
+  fmap f (Async tid a) = Async tid (fmap f <$> a)
+
+instance MonadAsync (IOSim s) where
+  type Async (IOSim s) = Async s
+
+  async action = do
+    var <- newEmptyTMVarIO
+    tid <- mask $ \restore ->
+             forkIO $ try (restore action) >>= atomically . putTMVar var
+    labelTMVarIO var ("async-" ++ show tid)
+    return (Async tid (readTMVar var))
+
+  asyncThreadId (Async tid _) = tid
+
+  waitCatchSTM (Async _ w) = w
+  pollSTM      (Async _ w) = (Just <$> w) `orElse` return Nothing
+
+  cancel a@(Async tid _) = throwTo tid AsyncCancelled <* waitCatch a
+  cancelWith a@(Async tid _) e = throwTo tid e <* waitCatch a
+
+  asyncWithUnmask k = async (k unblock)
+
+instance MonadST (IOSim s) where
+  withLiftST f = f liftST
+
+liftST :: StrictST.ST s a -> IOSim s a
+liftST action = IOSim $ \k -> LiftST action k
+
+instance MonadMonotonicTime (IOSim s) where
+  getMonotonicTime = IOSim $ \k -> GetMonoTime k
+
+instance MonadTime (IOSim s) where
+  getCurrentTime   = IOSim $ \k -> GetWallTime k
+
+-- | Set the current wall clock time for the thread's clock domain.
+--
+setCurrentTime :: UTCTime -> IOSim s ()
+setCurrentTime t = IOSim $ \k -> SetWallTime t (k ())
+
+-- | Put the thread into a new wall clock domain, not shared with the parent
+-- thread. Changing the wall clock time in the new clock domain will not affect
+-- the other clock of other threads. All threads forked by this thread from
+-- this point onwards will share the new clock domain.
+--
+unshareClock :: IOSim s ()
+unshareClock = IOSim $ \k -> UnshareClock (k ())
+
+instance MonadDelay (IOSim s) where
+  -- Use default in terms of MonadTimer
+
+instance MonadTimer (IOSim s) where
+  data Timeout (IOSim s) = Timeout !(TVar s TimeoutState) !(TVar s Bool) !TimeoutId
+                         -- ^ a timeout; we keep both 'TVar's to support
+                         -- `newTimer` and 'registerTimeout'.
+                         | NegativeTimeout !TimeoutId
+                         -- ^ a negative timeout
+
+  readTimeout (Timeout var _bvar _key) = readTVar var
+  readTimeout (NegativeTimeout _key)   = pure TimeoutCancelled
+
+  newTimeout      d = IOSim $ \k -> NewTimeout      d k
+  updateTimeout t d = IOSim $ \k -> UpdateTimeout t d (k ())
+  cancelTimeout t   = IOSim $ \k -> CancelTimeout t   (k ())
+
+  timeout d action
+    | d <  0    = Just <$> action
+    | d == 0    = return Nothing
+    | otherwise = do
+        pid <- myThreadId
+        t@(Timeout _ _ tid) <- newTimeout d
+        handleJust
+          (\(TimeoutException tid') -> if tid' == tid
+                                         then Just ()
+                                         else Nothing)
+          (\_ -> return Nothing) $
+          bracket
+            (forkIO $ do
+                labelThisThread "<<timeout>>"
+                fired <- atomically $ awaitTimeout t
+                when fired $ throwTo pid (TimeoutException tid))
+            (\pid' -> do
+                  cancelTimeout t
+                  throwTo pid' AsyncCancelled)
+            (\_ -> Just <$> action)
+
+  registerDelay d = IOSim $ \k -> NewTimeout d (\(Timeout _var bvar _) -> k bvar)
+
+newtype TimeoutException = TimeoutException TimeoutId deriving Eq
+
+instance Show TimeoutException where
+    show _ = "<<timeout>>"
+
+instance Exception TimeoutException where
+  toException   = asyncExceptionToException
+  fromException = asyncExceptionFromException
+
+-- | Wrapper for Eventlog events so they can be retrieved from the trace with
+-- 'selectTraceEventsDynamic'.
+newtype EventlogEvent = EventlogEvent String
+
+-- | Wrapper for Eventlog markers so they can be retrieved from the trace with
+-- 'selectTraceEventsDynamic'.
+newtype EventlogMarker = EventlogMarker String
+
+instance MonadEventlog (IOSim s) where
+  traceEventIO = traceM . EventlogEvent
+  traceMarkerIO = traceM . EventlogMarker
+
+-- | 'Trace' is a recursive data type, it is the trace of a 'IOSim' computation.
+-- The trace will contain information about thread sheduling, blocking on
+-- 'TVar's, and other internal state changes of 'IOSim'.  More importantly it
+-- also supports traces generated by the computation with 'say' (which
+-- corresponds to using 'putStrLn' in 'IO'), 'traceEventM', or dynamically typed
+-- traces with 'traceM' (which generalise the @base@ library
+-- 'Debug.Trace.traceM')
+--
+-- It also contains information on races discovered.
+--
+-- See also: 'traceEvents', 'traceResult', 'selectTraceEvents',
+-- 'selectTraceEventsDynamic' and 'printTraceEventsSay'.
+--
+data SimEvent
+  = SimEvent {
+      seTime        :: !Time,
+      seThreadId    :: !ThreadId,
+      seThreadLabel :: !(Maybe ThreadLabel),
+      seType        :: !SimEventType
+    }
+  | SimRacesFound [ScheduleControl]
+  deriving Generic
+  deriving Show via Quiet SimEvent
+
+seThreadLabel' :: SimEvent -> Maybe ThreadLabel
+seThreadLabel' SimEvent {seThreadLabel} = seThreadLabel
+seThreadLabel' SimRacesFound {}         = Nothing
+
+ppSimEvent :: Int -- ^ width of thread label
+           -> SimEvent
+           -> String
+ppSimEvent d SimEvent {seTime, seThreadId, seThreadLabel, seType} =
+    printf "%-24s - %-13s %-*s - %s"
+           (show seTime)
+           (show seThreadId)
+           d
+           threadLabel
+           (show seType)
+  where
+    threadLabel = fromMaybe "" seThreadLabel
+ppSimEvent _ (SimRacesFound controls) =
+    "RacesFound "++show controls
+
+data SimResult a
+    = MainReturn    !Time a             ![Labelled ThreadId]
+    | MainException !Time SomeException ![Labelled ThreadId]
+    | Deadlock      !Time               ![Labelled ThreadId]
+    | Loop
+    deriving Show
+
+
+type SimTrace a = Trace.Trace (SimResult a) SimEvent
+
+-- | Pretty print simulation trace.
+--
+ppTrace :: Show a => SimTrace a -> String
+ppTrace tr = Trace.ppTrace
+               show
+               (ppSimEvent (bimaximum (bimap (const 0) (maybe 0 length . seThreadLabel') tr)))
+               tr
+
+-- | Like 'ppTrace' but does not show the result value.
+--
+ppTrace_ :: SimTrace a -> String
+ppTrace_ tr = Trace.ppTrace
+                (const "")
+                (ppSimEvent (bimaximum (bimap (const 0) (maybe 0 length . seThreadLabel') tr)))
+                tr
+
+pattern Trace :: Time -> ThreadId -> Maybe ThreadLabel -> SimEventType -> SimTrace a
+              -> SimTrace a
+pattern Trace time threadId threadLabel traceEvent trace =
+    Trace.Cons (SimEvent time threadId threadLabel traceEvent)
+               trace
+
+{-# DEPRECATED Trace "Use 'SimTrace' instead." #-}
+
+pattern SimTrace :: Time -> ThreadId -> Maybe ThreadLabel -> SimEventType -> SimTrace a
+                 -> SimTrace a
+pattern SimTrace time threadId threadLabel traceEvent trace =
+    Trace.Cons (SimEvent time threadId threadLabel traceEvent)
+               trace
+
+pattern TraceRacesFound :: [ScheduleControl] -> SimTrace a
+                        -> SimTrace a
+pattern TraceRacesFound controls trace =
+    Trace.Cons (SimRacesFound controls)
+               trace
+
+pattern TraceMainReturn :: Time -> a -> [Labelled ThreadId]
+                        -> SimTrace a
+pattern TraceMainReturn time a threads = Trace.Nil (MainReturn time a threads)
+
+pattern TraceMainException :: Time -> SomeException -> [Labelled ThreadId]
+                           -> SimTrace a
+pattern TraceMainException time err threads = Trace.Nil (MainException time err threads)
+
+pattern TraceDeadlock :: Time -> [Labelled ThreadId]
+                      -> SimTrace a
+pattern TraceDeadlock time threads = Trace.Nil (Deadlock time threads)
+
+pattern TraceLoop :: SimTrace a
+pattern TraceLoop = Trace.Nil Loop
+
+{-# COMPLETE SimTrace, TraceMainReturn, TraceMainException, TraceDeadlock, TraceLoop #-}
+{-# COMPLETE Trace,    TraceMainReturn, TraceMainException, TraceDeadlock, TraceLoop #-}
+
+
+data SimEventType
+  = EventSay  String
+  | EventLog  Dynamic
+  | EventMask MaskingState
+
+  | EventThrow          SomeException
+  | EventThrowTo        SomeException ThreadId -- This thread used ThrowTo
+  | EventThrowToBlocked                        -- The ThrowTo blocked
+  | EventThrowToWakeup                         -- The ThrowTo resumed
+  | EventThrowToUnmasked (Labelled ThreadId)   -- A pending ThrowTo was activated
+
+  | EventThreadForked    ThreadId
+  | EventThreadFinished                  -- terminated normally
+  | EventThreadUnhandled SomeException   -- terminated due to unhandled exception
+
+  | EventTxCommitted   [Labelled TVarId] -- tx wrote to these
+                       [TVarId]          -- and created these
+  | EventTxAborted
+  | EventTxBlocked     [Labelled TVarId] -- tx blocked reading these
+  | EventTxWakeup      [Labelled TVarId] -- changed vars causing retry
+
+  | EventTimerCreated   TimeoutId TVarId Time
+  | EventTimerUpdated   TimeoutId        Time
+  | EventTimerCancelled TimeoutId
+  | EventTimerExpired   TimeoutId
+
+  -- the following events are inserted to mark the difference between
+  -- a failed trace and a similar passing trace of the same action
+  | EventThreadSleep                      -- the labelling thread was runnable,
+                                          -- but its execution was delayed
+  | EventThreadWake                       -- until this point
+  deriving Show
+
+type TraceEvent = SimEventType
+{-# DEPRECATED TraceEvent "Use 'SimEventType' instead." #-}
+
+data ThreadId = ThreadId  [Int]
+              | TestThreadId [Int]    -- test threads have higher priority
+  deriving (Eq, Ord, Show)
+
+childThreadId :: ThreadId -> Int -> ThreadId
+childThreadId (ThreadId     is) i = ThreadId     (is ++ [i])
+childThreadId (TestThreadId is) i = TestThreadId (is ++ [i])
+
+setNonTestThread :: ThreadId -> ThreadId
+setNonTestThread (TestThreadId is) = ThreadId is
+setNonTestThread tid@ThreadId{}    = tid
+
+newtype TVarId      = TVarId    Int   deriving (Eq, Ord, Enum, Show)
+newtype TimeoutId   = TimeoutId Int   deriving (Eq, Ord, Enum, Show)
+newtype ClockId     = ClockId   [Int] deriving (Eq, Ord, Show)
+newtype VectorClock = VectorClock (Map ThreadId Int) deriving Show
+
+unTimeoutId :: TimeoutId -> Int
+unTimeoutId (TimeoutId a) = a
+
+type ThreadLabel = String
+type TVarLabel   = String
+
+data Labelled a = Labelled {
+    l_labelled :: !a,
+    l_label    :: !(Maybe String)
+  }
+  deriving (Eq, Ord, Generic)
+  deriving Show via Quiet (Labelled a)
+
+--
+-- Executing STM Transactions
+--
+
+data TVar s a = TVar {
+
+       -- | The identifier of this var.
+       --
+       tvarId      :: !TVarId,
+
+       -- | Label.
+       tvarLabel   :: !(STRef s (Maybe TVarLabel)),
+
+       -- | The var's current value
+       --
+       tvarCurrent :: !(STRef s a),
+
+       -- | A stack of undo values. This is only used while executing a
+       -- transaction.
+       --
+       tvarUndo    :: !(STRef s [a]),
+
+       -- | Thread Ids of threads blocked on a read of this var. It is
+       -- represented in reverse order of thread wakeup, without duplicates.
+       --
+       -- To avoid duplicates efficiently, the operations rely on a copy of the
+       -- thread Ids represented as a set.
+       --
+       tvarBlocked :: !(STRef s ([ThreadId], Set ThreadId)),
+
+       -- | The vector clock of the current value.
+       --
+       tvarVClock :: !(STRef s VectorClock)
+     }
+
+instance Eq (TVar s a) where
+    (==) = on (==) tvarId
+
+data StmTxResult s a =
+       -- | A committed transaction reports the vars that were written (in order
+       -- of first write) so that the scheduler can unblock other threads that
+       -- were blocked in STM transactions that read any of these vars.
+       --
+       -- It reports the vars that were read, so we can update vector clocks
+       -- appropriately.
+       --
+       -- It also includes the updated TVarId name supply.
+       --
+       StmTxCommitted a [SomeTVar s] [SomeTVar s] TVarId -- updated TVarId name supply
+
+       -- | A blocked transaction reports the vars that were read so that the
+       -- scheduler can block the thread on those vars.
+       --
+     | StmTxBlocked  [SomeTVar s]
+
+       -- | An aborted transaction reports the vars that were read so that the
+       -- vector clock can be updated.
+       --
+     | StmTxAborted  [SomeTVar s] SomeException
+
+data SomeTVar s where
+  SomeTVar :: !(TVar s a) -> SomeTVar s
+
+data StmStack s b a where
+  -- | Executing in the context of a top level 'atomically'.
+  AtomicallyFrame  :: StmStack s a a
+
+  -- | Executing in the context of the /left/ hand side of an 'orElse'
+  OrElseLeftFrame  :: StmA s a                -- orElse right alternative
+                   -> (a -> StmA s b)         -- subsequent continuation
+                   -> Map TVarId (SomeTVar s) -- saved written vars set
+                   -> [SomeTVar s]            -- saved written vars list
+                   -> StmStack s b c
+                   -> StmStack s a c
+
+  -- | Executing in the context of the /right/ hand side of an 'orElse'
+  OrElseRightFrame :: (a -> StmA s b)         -- subsequent continuation
+                   -> Map TVarId (SomeTVar s) -- saved written vars set
+                   -> [SomeTVar s]            -- saved written vars list
+                   -> StmStack s b c
+                   -> StmStack s a c
+
+---
+--- Schedules
+---
+
+data ScheduleControl = ControlDefault
+                     | ControlAwait [ScheduleMod]
+                     | ControlFollow [StepId] [ScheduleMod]
+  deriving (Eq, Ord, Show)
+
+data ScheduleMod = ScheduleMod{
+    scheduleModTarget    :: StepId,   -- when we reach this step
+    scheduleModControl   :: ScheduleControl,
+                                      -- which happens with this control
+    scheduleModInsertion :: [StepId]  -- we should instead perform this sequence
+                                      -- this *includes* the target step,
+                                      -- not necessarily as the last step.
+  }
+  deriving (Eq, Ord)
+
+type StepId = (ThreadId, Int)
+
+instance Show ScheduleMod where
+  showsPrec d (ScheduleMod tgt ctrl insertion) =
+    showParen (d>10) $
+      showString "ScheduleMod " .
+      showsPrec 11 tgt .
+      showString " " .
+      showsPrec 11 ctrl .
+      showString " " .
+      showsPrec 11 insertion
+
+---
+--- Exploration options
+---
+
+data ExplorationOptions = ExplorationOptions{
+    explorationScheduleBound :: Int,
+    explorationBranching     :: Int,
+    explorationStepTimelimit :: Maybe Int,
+    explorationReplay        :: Maybe ScheduleControl
+  }
+  deriving Show
+
+stdExplorationOptions :: ExplorationOptions
+stdExplorationOptions = ExplorationOptions{
+    explorationScheduleBound = 100,
+    explorationBranching     = 3,
+    explorationStepTimelimit = Nothing,
+    explorationReplay        = Nothing
+    }
+
+type ExplorationSpec = ExplorationOptions -> ExplorationOptions
+
+withScheduleBound :: Int -> ExplorationSpec
+withScheduleBound n e = e{explorationScheduleBound = n}
+
+withBranching :: Int -> ExplorationSpec
+withBranching n e = e{explorationBranching = n}
+
+withStepTimelimit :: Int -> ExplorationSpec
+withStepTimelimit n e = e{explorationStepTimelimit = Just n}
+
+withReplay :: ScheduleControl -> ExplorationSpec
+withReplay r e = e{explorationReplay = Just r}

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -745,8 +745,17 @@ data StmStack s b a where
 ---
 
 data ScheduleControl = ControlDefault
+                     -- ^ default scheduling mode
                      | ControlAwait [ScheduleMod]
+                     -- ^ if the current control is 'ControlAwait', the normal
+                     -- scheduling will proceed, until the thread found in the
+                     -- first 'ScheduleMod' reaches the given step.  At this
+                     -- point the thread is put to sleep, until after all the
+                     -- steps are followed.
                      | ControlFollow [StepId] [ScheduleMod]
+                     -- ^ follow the steps then continue with schedule
+                     -- modifications.  This control is set by 'followControl'
+                     -- when 'controlTargets' returns true.
   deriving (Eq, Ord, Show)
 
 data ScheduleMod = ScheduleMod{

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -627,17 +627,17 @@ data SimEventType
 type TraceEvent = SimEventType
 {-# DEPRECATED TraceEvent "Use 'SimEventType' instead." #-}
 
-data ThreadId = ThreadId  [Int]
-              | TestThreadId [Int]    -- test threads have higher priority
+data ThreadId = RacyThreadId [Int]
+              | ThreadId     [Int]    -- non racy threads have higher priority
   deriving (Eq, Ord, Show)
 
 childThreadId :: ThreadId -> Int -> ThreadId
+childThreadId (RacyThreadId is) i = RacyThreadId (is ++ [i])
 childThreadId (ThreadId     is) i = ThreadId     (is ++ [i])
-childThreadId (TestThreadId is) i = TestThreadId (is ++ [i])
 
-setNonTestThread :: ThreadId -> ThreadId
-setNonTestThread (TestThreadId is) = ThreadId is
-setNonTestThread tid@ThreadId{}    = tid
+setRacyThread :: ThreadId -> ThreadId
+setRacyThread (ThreadId is)      = RacyThreadId is
+setRacyThread tid@RacyThreadId{} = tid
 
 newtype TVarId      = TVarId    Int   deriving (Eq, Ord, Enum, Show)
 newtype TimeoutId   = TimeoutId Int   deriving (Eq, Ord, Enum, Show)

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -642,7 +642,8 @@ setNonTestThread tid@ThreadId{}    = tid
 newtype TVarId      = TVarId    Int   deriving (Eq, Ord, Enum, Show)
 newtype TimeoutId   = TimeoutId Int   deriving (Eq, Ord, Enum, Show)
 newtype ClockId     = ClockId   [Int] deriving (Eq, Ord, Show)
-newtype VectorClock = VectorClock (Map ThreadId Int) deriving Show
+newtype VectorClock = VectorClock { getVectorClock :: Map ThreadId Int }
+  deriving Show
 
 unTimeoutId :: TimeoutId -> Int
 unTimeoutId (TimeoutId a) = a

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -734,11 +734,6 @@ reschedule :: SimState s a -> ST s (SimTrace a)
 reschedule simstate@SimState{ runqueue, threads,
                               control=control@(ControlFollow ((tid,tstep):_) _)
                               } =
-    if not (tid `elem` runqueue) then
-      error ("Can't follow "++show control++"\n"++
-             "  tid: "++show tid++"\n"++
-             "  tstep: "++show tstep++"\n"++
-             "  runqueue: "++show runqueue++"\n") else
     assert (tid `elem` runqueue) $
     assert (tid `Map.member` threads) $
     assert (invariant Nothing simstate) $

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -510,7 +510,7 @@ schedule thread@Thread{
 
     Atomically a k -> execAtomically time tid tlbl nextVid (runSTM a) $ \res ->
       case res of
-        StmTxCommitted x read written nextVid' -> do
+        StmTxCommitted x written read nextVid' -> do
           (wakeup, wokeby) <- threadsUnblockedByWrites written
           mapM_ (\(SomeTVar tvar) -> unblockAllThreadsFromTVar tvar) written
           vClockRead <- leastUpperBoundTVarVClocks read
@@ -1008,8 +1008,9 @@ execAtomically time tid tlbl nextVid0 action0 k0 =
                     ) written
 
           -- Return the vars written, so readers can be unblocked
-          k0 $ StmTxCommitted x (Map.elems read)
-                                (reverse writtenSeq) nextVid
+          k0 $ StmTxCommitted x (reverse writtenSeq)
+                                (Map.elems read)
+                                nextVid
 
         OrElseLeftFrame _b k writtenOuter writtenOuterSeq ctl' -> do
           -- Commit the TVars written in this sub-transaction that are also

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -207,8 +207,8 @@ invariant Nothing SimState{runqueue,threads,clocks} =
 
 -- | Interpret the simulation monotonic time as a 'NominalDiffTime' since
 -- the start.
-timeSiceEpoch :: Time -> NominalDiffTime
-timeSiceEpoch (Time t) = fromRational (toRational t)
+timeSinceEpoch :: Time -> NominalDiffTime
+timeSinceEpoch (Time t) = fromRational (toRational t)
 
 
 -- | Schedule / run a thread.
@@ -355,14 +355,14 @@ schedule thread@Thread{
     GetWallTime k -> do
       let clockid  = threadClockId thread
           clockoff = clocks Map.! clockid
-          walltime = timeSiceEpoch time `addUTCTime` clockoff
+          walltime = timeSinceEpoch time `addUTCTime` clockoff
           thread'  = thread { threadControl = ThreadControl (k walltime) ctl }
       schedule thread' simstate
 
     SetWallTime walltime' k -> do
       let clockid   = threadClockId thread
           clockoff  = clocks Map.! clockid
-          walltime  = timeSiceEpoch time `addUTCTime` clockoff
+          walltime  = timeSinceEpoch time `addUTCTime` clockoff
           clockoff' = addUTCTime (diffUTCTime walltime' walltime) clockoff
           thread'   = thread { threadControl = ThreadControl k ctl }
           simstate' = simstate { clocks = Map.insert clockid clockoff' clocks }

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -4,23 +4,24 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTSyntax                 #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
-
+{-# LANGUAGE StandaloneDeriving         #-}
+ 
 {-# OPTIONS_GHC -Wno-orphans            #-}
 -- incomplete uni patterns in 'schedule' (when interpreting 'StmTxCommitted')
 -- and 'reschedule'.
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns -Wno-unused-matches #-}
 
-module Control.Monad.IOSim.Internal
+module Control.Monad.IOSimPOR.Internal
   ( IOSim (..)
   , SimM
   , runIOSim
@@ -44,15 +45,16 @@ module Control.Monad.IOSim.Internal
   , SimResult (..)
   , SimEventType (..)
   , TraceEvent
-  , ppTrace
-  , ppTrace_
-  , ppSimEvent
   , liftST
   , execReadTVar
+  , controlSimTraceST
+  , ScheduleControl (..)
+  , ScheduleMod (..)
   ) where
 
 import           Prelude hiding (read)
 
+import           Data.Ord
 import           Data.Foldable (traverse_)
 import qualified Data.List as List
 import qualified Data.List.Trace as Trace
@@ -73,11 +75,12 @@ import           Control.Monad.ST.Lazy.Unsafe (unsafeIOToST)
 import           Data.STRef.Lazy
 
 import           Control.Monad.Class.MonadSTM hiding (STM, TVar)
-import           Control.Monad.Class.MonadThrow hiding (getMaskingState)
+import           Control.Monad.Class.MonadThrow as MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Control.Monad.IOSim.Types
+import           Control.Monad.IOSimPOR.Timeout(unsafeTimeout)
 
 --
 -- Simulation interpreter
@@ -87,13 +90,19 @@ data Thread s a = Thread {
     threadId      :: !ThreadId,
     threadControl :: !(ThreadControl s a),
     threadBlocked :: !Bool,
+    threadDone    :: !Bool,
     threadMasking :: !MaskingState,
     -- other threads blocked in a ThrowTo to us because we are or were masked
-    threadThrowTo :: ![(SomeException, Labelled ThreadId)],
+    threadThrowTo :: ![(SomeException, Labelled ThreadId, VectorClock)],
     threadClockId :: !ClockId,
     threadLabel   :: Maybe ThreadLabel,
-    threadNextTId :: !Int
+    threadNextTId :: !Int,
+    threadStep    :: !Int,
+    threadVClock  :: VectorClock,
+    threadEffect  :: Effect,  -- in the current step
+    threadRacy    :: !Bool
   }
+  deriving Show
 
 -- We hide the type @b@ here, so it's useful to bundle these two parts
 -- together, rather than having Thread have an extential type, which
@@ -102,6 +111,9 @@ data ThreadControl s a where
   ThreadControl :: SimA s b
                 -> ControlStack s b a
                 -> ThreadControl s a
+
+instance Show (ThreadControl s a) where
+  show _ = "..."
 
 data ControlStack s b a where
   MainFrame  :: ControlStack s a  a
@@ -116,12 +128,46 @@ data ControlStack s b a where
              -> ControlStack s c a
              -> ControlStack s b a
 
+instance Show (ControlStack s b a) where
+  show = show . dash
+    where dash :: ControlStack s' b' a' -> ControlStackDash
+          dash MainFrame = MainFrame'
+          dash ForkFrame = ForkFrame'
+          dash (MaskFrame _ m s) = MaskFrame' m (dash s)
+          dash (CatchFrame _ _ s) = CatchFrame' (dash s)
+
+data ControlStackDash =
+    MainFrame'
+  | ForkFrame'
+  | MaskFrame' MaskingState ControlStackDash
+  | CatchFrame' ControlStackDash
+  deriving Show
+
+isTestThreadId :: ThreadId -> Bool
+isTestThreadId (TestThreadId _) = True
+isTestThreadId _                = False
+
+bottomVClock :: VectorClock
+bottomVClock = VectorClock Map.empty
+
+insertVClock :: ThreadId -> Int -> VectorClock -> VectorClock
+insertVClock tid !step (VectorClock m) = VectorClock (Map.insert tid step m)
+
+lubVClock :: VectorClock -> VectorClock -> VectorClock
+lubVClock (VectorClock m) (VectorClock m') = VectorClock (Map.unionWith max m m')
+
+-- hbfVClock :: VectorClock -> VectorClock -> Bool
+-- hbfVClock (VectorClock m) (VectorClock m') = Map.isSubmapOfBy (<=) m m'
+
+hbfStep :: ThreadId -> Int -> VectorClock -> Bool
+hbfStep tid tstep (VectorClock m) = Just tstep <= Map.lookup tid m
+
 labelledTVarId :: TVar s a -> ST s (Labelled TVarId)
 labelledTVarId TVar { tvarId, tvarLabel } = (Labelled tvarId) <$> readSTRef tvarLabel
 
 labelledThreads :: Map ThreadId (Thread s a) -> [Labelled ThreadId]
 labelledThreads threadMap =
-    -- @Map.foldr'@ (and alikes) are not strict enough, to not ratain the
+    -- @Map.foldr'@ (and alikes) are not strict enough, to not retain the
     -- original thread map we need to evaluate the spine of the list.
     -- TODO: https://github.com/haskell/containers/issues/749
     Map.foldr'
@@ -149,7 +195,17 @@ data SimState s a = SimState {
        -- | list of clocks
        clocks   :: !(Map ClockId UTCTime),
        nextVid  :: !TVarId,     -- ^ next unused 'TVarId'
-       nextTmid :: !TimeoutId   -- ^ next unused 'TimeoutId'
+       nextTmid :: !TimeoutId,  -- ^ next unused 'TimeoutId'
+       -- | previous steps (which we may race with).
+       -- Note this is *lazy*, so that we don't compute races we will not reverse.
+       races    :: Races,
+       -- | control the schedule followed, and initial value
+       control  :: !ScheduleControl,
+       control0 :: !ScheduleControl,
+       -- | limit on the computation time allowed per scheduling step, for
+       -- catching infinite loops etc
+       perStepTimeLimit :: Maybe Int
+
      }
 
 initialState :: SimState s a
@@ -161,7 +217,11 @@ initialState =
       timers   = PSQ.empty,
       clocks   = Map.singleton (ClockId []) epoch1970,
       nextVid  = TVarId 0,
-      nextTmid = TimeoutId 0
+      nextTmid = TimeoutId 0,
+      races    = noRaces,
+      control  = ControlDefault,
+      control0 = ControlDefault,
+      perStepTimeLimit = Nothing
     }
   where
     epoch1970 = UTCTime (fromGregorian 1970 1 1) 0
@@ -177,9 +237,9 @@ invariant (Just running) simstate@SimState{runqueue,threads,clocks} =
 
 invariant Nothing SimState{runqueue,threads,clocks} =
     all (`Map.member` threads) runqueue
- && and [ threadBlocked t == (threadId t `notElem` runqueue)
+ && and [ (threadBlocked t || threadDone t) == (threadId t `notElem` runqueue)
         | t <- Map.elems threads ]
- && runqueue == List.nub runqueue
+ && and (zipWith (>) runqueue (drop 1 runqueue))
  && and [ threadClockId t `Map.member` clocks
         | t <- Map.elems threads ]
 
@@ -196,7 +256,10 @@ schedule thread@Thread{
            threadId      = tid,
            threadControl = ThreadControl action ctl,
            threadMasking = maskst,
-           threadLabel   = tlbl
+           threadLabel   = tlbl,
+           threadStep    = tstep,
+           threadVClock  = vClock,
+           threadEffect  = effect
          }
          simstate@SimState {
            runqueue,
@@ -204,16 +267,46 @@ schedule thread@Thread{
            timers,
            clocks,
            nextVid, nextTmid,
-           curTime  = time
-         } =
+           curTime  = time,
+           control,
+           perStepTimeLimit
+         }
+
+  | controlTargets (tid,tstep) control =
+      -- The next step is to be delayed according to the
+      -- specified schedule. Switch to following the schedule.
+      --Debug.trace ("Triggering control: "++show control++"\n") $
+      schedule thread simstate{ control = followControl control }
+
+  | not $ controlFollows (tid,tstep) control =
+      -- the control says this is not the next step to
+      -- follow. We should be at the beginning of a step;
+      -- we put the present thread to sleep and reschedule
+      -- the correct thread.
+      assert (effect == mempty) $
+      --Debug.trace ("Switching away from "++show (tid,tstep)++"\n"++
+      --             "  control = "++show control++"\n") $
+      deschedule Sleep thread simstate
+
+  | otherwise =
   assert (invariant (Just thread) simstate) $
-  case action of
+  case control of
+    ControlFollow (s:_) _ ->
+      id --Debug.trace ("Performing action in step "++show s++"\n")
+    _ -> id
+  $
+  -- The next line forces the evaluation of action, which should be unevaluated up to
+  -- this point. This is where we actually *run* user code.
+  case maybe Just unsafeTimeout perStepTimeLimit action of
+   Nothing -> return TraceLoop
+   Just _  -> case action of
 
     Return x -> case ctl of
       MainFrame ->
         -- the main thread is done, so we're done
         -- even if other threads are still running
         return $ SimTrace time tid tlbl EventThreadFinished
+               $ traceFinalRacesFound simstate
                $ TraceMainReturn time x (labelledThreads threads)
 
       ForkFrame -> do
@@ -226,8 +319,7 @@ schedule thread@Thread{
         let thread' = thread { threadControl = ThreadControl (k x) ctl'
                              , threadMasking = maskst' }
         -- but if we're now unmasked, check for any pending async exceptions
-        trace <- deschedule Interruptable thread' simstate
-        return (SimTrace time tid tlbl (EventMask maskst') trace)
+        deschedule Interruptable thread' simstate
 
       CatchFrame _handler k ctl' -> do
         -- pop the control stack and continue
@@ -235,11 +327,14 @@ schedule thread@Thread{
         schedule thread' simstate
 
     Throw e -> case unwindControlStack e thread of
-      Right thread'@Thread { threadMasking = maskst' } -> do
+      Right thread0 -> do
         -- We found a suitable exception handler, continue with that
-        trace <- schedule thread' simstate
-        return (SimTrace time tid tlbl (EventThrow e) $
-                SimTrace time tid tlbl (EventMask maskst') trace)
+        -- We record a step, in case there is no exception handler on replay.
+        let thread'  = stepThread thread0
+            control' = advanceControl (threadStepId thread0) control
+            races'   = updateRacesInSimState thread0 simstate
+        trace <- schedule thread' simstate{ races = races', control = control' }
+        return (SimTrace time tid tlbl (EventThrow e) trace)
 
       Left isMain
         -- We unwound and did not find any suitable exception handler, so we
@@ -248,6 +343,7 @@ schedule thread@Thread{
           -- An unhandled exception in the main thread terminates the program
           return (SimTrace time tid tlbl (EventThrow e) $
                   SimTrace time tid tlbl (EventThreadUnhandled e) $
+                  traceFinalRacesFound simstate $
                   TraceMainException time e (labelledThreads threads))
 
         | otherwise -> do
@@ -286,7 +382,8 @@ schedule thread@Thread{
 
     LiftST st k -> do
       x <- strictToLazyST st
-      let thread' = thread { threadControl = ThreadControl (k x) ctl }
+      let thread' = thread { threadControl = ThreadControl (k x) ctl,
+                             threadEffect  = effect <> liftSTEffect }
       schedule thread' simstate
 
     GetMonoTime k -> do
@@ -370,22 +467,11 @@ schedule thread@Thread{
       let thread' = thread { threadControl = ThreadControl k ctl }
       schedule thread' simstate
 
-    CancelTimeout (Timeout tvar _tvar' tmid) k -> do
+    CancelTimeout (Timeout _tvar _tvar' tmid) k -> do
       let timers' = PSQ.delete tmid timers
           thread' = thread { threadControl = ThreadControl k ctl }
-      written <- execAtomically' (runSTM $ writeTVar tvar TimeoutCancelled)
-      (wakeup, wokeby) <- threadsUnblockedByWrites written
-      mapM_ (\(SomeTVar var) -> unblockAllThreadsFromTVar var) written
-      let (unblocked,
-           simstate') = unblockThreads wakeup simstate
-      trace <- schedule thread' simstate' { timers = timers' }
-      return $ SimTrace time tid tlbl (EventTimerCancelled tmid)
-             $ traceMany
-                 [ (time, tid', tlbl', EventTxWakeup vids)
-                 | tid' <- unblocked
-                 , let tlbl' = lookupThreadLabel tid' threads
-                 , let Just vids = Set.toList <$> Map.lookup tid' wokeby ]
-             $ trace
+      trace <- schedule thread' simstate { timers = timers' }
+      return (SimTrace time tid tlbl (EventTimerCancelled tmid) trace)
 
     -- cancelling a negative timer is a no-op
     CancelTimeout (NegativeTimeout _tmid) k -> do
@@ -394,41 +480,53 @@ schedule thread@Thread{
       schedule thread' simstate
 
     Fork a k -> do
-      let nextId   = threadNextTId thread
-          tid'     = childThreadId tid nextId
-          thread'  = thread { threadControl = ThreadControl (k tid') ctl
-                            , threadNextTId = succ nextId }
+      let nextTId = threadNextTId thread
+          tid' | threadRacy thread = setNonTestThread $ childThreadId tid nextTId
+               | otherwise         = childThreadId tid nextTId
+          thread'  = thread { threadControl = ThreadControl (k tid') ctl,
+                              threadNextTId = nextTId + 1,
+                              threadEffect  = effect <> forkEffect tid' }
           thread'' = Thread { threadId      = tid'
                             , threadControl = ThreadControl (runIOSim a)
                                                             ForkFrame
                             , threadBlocked = False
+                            , threadDone    = False
                             , threadMasking = threadMasking thread
                             , threadThrowTo = []
                             , threadClockId = threadClockId thread
                             , threadLabel   = Nothing
                             , threadNextTId = 1
+                            , threadStep    = 0
+                            , threadVClock  = insertVClock tid' 0 vClock
+                            , threadEffect  = mempty
+                            , threadRacy    = threadRacy thread
                             }
           threads' = Map.insert tid' thread'' threads
-      trace <- schedule thread' simstate { runqueue = runqueue ++ [tid']
-                                         , threads  = threads' }
+      -- A newly forked thread may have a higher priority, so we deschedule this one.
+      trace <- deschedule Yield thread'
+                 simstate { runqueue = List.insertBy (comparing Down) tid' runqueue
+                          , threads  = threads' }
       return (SimTrace time tid tlbl (EventThreadForked tid') trace)
 
     Atomically a k -> execAtomically time tid tlbl nextVid (runSTM a) $ \res ->
       case res of
-        StmTxCommitted x written _read nextVid' -> do
+        StmTxCommitted x read written nextVid' -> do
           (wakeup, wokeby) <- threadsUnblockedByWrites written
           mapM_ (\(SomeTVar tvar) -> unblockAllThreadsFromTVar tvar) written
-          let thread'     = thread { threadControl = ThreadControl (k x) ctl }
+          vClockRead <- lubTVarVClocks read
+          let vClock'     = vClock `lubVClock` vClockRead
+              effect'     = effect
+                         <> readEffects read
+                         <> writeEffects written
+                         <> wakeupEffects unblocked
+              thread'     = thread { threadControl = ThreadControl (k x) ctl,
+                                     threadVClock  = vClock',
+                                     threadEffect  = effect' }
               (unblocked,
-               simstate') = unblockThreads wakeup simstate
+               simstate') = unblockThreads vClock' wakeup simstate
+          sequence_ [ modifySTRef (tvarVClock r) (lubVClock vClock') | SomeTVar r <- written ]
           vids <- traverse (\(SomeTVar tvar) -> labelledTVarId tvar) written
-              -- We don't interrupt runnable threads to provide fairness
-              -- anywhere else. We do it here by putting the tx that committed
-              -- a transaction to the back of the runqueue, behind all other
-              -- runnable threads, and behind the unblocked threads.
-              -- For testing, we should have a more sophisticated policy to show
-              -- that algorithms are not sensitive to the exact policy, so long
-              -- as it is a fair policy (all runnable threads eventually run).
+              -- We deschedule a thread after a transaction... another may have woken up.
           trace <- deschedule Yield thread' simstate' { nextVid  = nextVid' }
           return $
             SimTrace time tid tlbl (EventTxCommitted vids [nextVid..pred nextVid']) $
@@ -439,16 +537,24 @@ schedule thread@Thread{
               , let Just vids' = Set.toList <$> Map.lookup tid' wokeby ]
               trace
 
-        StmTxAborted _read e -> do
+        StmTxAborted read e -> do
           -- schedule this thread to immediately raise the exception
-          let thread' = thread { threadControl = ThreadControl (Throw e) ctl }
+          vClockRead <- lubTVarVClocks read
+          let effect' = effect <> readEffects read
+              thread' = thread { threadControl = ThreadControl (Throw e) ctl,
+                                 threadVClock  = vClock `lubVClock` vClockRead,
+                                 threadEffect  = effect' }
           trace <- schedule thread' simstate
           return $ SimTrace time tid tlbl EventTxAborted trace
 
         StmTxBlocked read -> do
           mapM_ (\(SomeTVar tvar) -> blockThreadOnTVar tid tvar) read
           vids <- traverse (\(SomeTVar tvar) -> labelledTVarId tvar) read
-          trace <- deschedule Blocked thread simstate
+          vClockRead <- lubTVarVClocks read
+          let effect' = effect <> readEffects read
+              thread' = thread { threadVClock  = vClock `lubVClock` vClockRead,
+                                 threadEffect  = effect' }
+          trace <- deschedule Blocked thread' simstate
           return $ SimTrace time tid tlbl (EventTxBlocked vids) trace
 
     GetThreadId k -> do
@@ -465,6 +571,11 @@ schedule thread@Thread{
           threads' = Map.adjust (\t -> t { threadLabel = Just l }) tid' threads
       schedule thread' simstate { threads = threads' }
 
+    ExploreRaces k -> do
+      let thread'  = thread { threadControl = ThreadControl k ctl
+                            , threadRacy    = True }
+      schedule thread' simstate
+
     GetMaskState k -> do
       let thread' = thread { threadControl = ThreadControl (k maskst) ctl }
       schedule thread' simstate
@@ -474,30 +585,36 @@ schedule thread@Thread{
                                                (runIOSim action')
                                                (MaskFrame k maskst ctl)
                            , threadMasking = maskst' }
-      trace <-
-        case maskst' of
-          -- If we're now unmasked then check for any pending async exceptions
-          Unmasked -> deschedule Interruptable thread' simstate
-          _        -> schedule                 thread' simstate
-      return (SimTrace time tid tlbl (EventMask maskst') trace)
+      case maskst' of
+        -- If we're now unmasked then check for any pending async exceptions
+        Unmasked -> deschedule Interruptable thread' simstate
+        _        -> schedule                 thread' simstate
 
     ThrowTo e tid' _ | tid' == tid -> do
       -- Throw to ourself is equivalent to a synchronous throw,
       -- and works irrespective of masking state since it does not block.
-      let thread' = thread { threadControl = ThreadControl (Throw e) ctl }
+      let thread' = thread { threadControl = ThreadControl (Throw e) ctl
+                           , threadMasking = MaskedInterruptible }
       trace <- schedule thread' simstate
       return (SimTrace time tid tlbl (EventThrowTo e tid) trace)
 
     ThrowTo e tid' k -> do
-      let thread'   = thread { threadControl = ThreadControl k ctl }
-          willBlock = case Map.lookup tid' threads of
-                        Just t -> not (threadInterruptible t)
-                        _      -> False
+      let thread'    = thread { threadControl = ThreadControl k ctl,
+                                threadEffect  = effect <> throwToEffect tid' <> wakeUpEffect,
+                                threadVClock  = vClock `lubVClock` vClockTgt }
+          (vClockTgt,
+           wakeUpEffect,
+           willBlock) = (threadVClock t,
+                         if threadBlocked t then wakeupEffects [tid'] else mempty,
+                         not (threadInterruptible t || threadDone t))
+            where Just t = Map.lookup tid' threads
+
       if willBlock
         then do
           -- The target thread has async exceptions masked so we add the
           -- exception and the source thread id to the pending async exceptions.
-          let adjustTarget t = t { threadThrowTo = (e, Labelled tid tlbl) : threadThrowTo t }
+          let adjustTarget t =
+                t { threadThrowTo = (e, Labelled tid tlbl, vClock) : threadThrowTo t }
               threads'       = Map.adjust adjustTarget tid' threads
           trace <- deschedule Blocked thread' simstate { threads = threads' }
           return $ SimTrace time tid tlbl (EventThrowTo e tid')
@@ -512,21 +629,22 @@ schedule thread@Thread{
           -- be resolved if the thread terminates or if it leaves the exception
           -- handler (when restoring the masking state would trigger the any
           -- new pending async exception).
-          let adjustTarget t@Thread{ threadControl = ThreadControl _ ctl' } =
+          let adjustTarget t@Thread{ threadControl = ThreadControl _ ctl',
+                                     threadVClock  = vClock' } =
                 t { threadControl = ThreadControl (Throw e) ctl'
                   , threadBlocked = False
-                  }
+                  , threadMasking = MaskedInterruptible
+                  , threadVClock  = vClock' `lubVClock` vClock }
               simstate'@SimState { threads = threads' }
-                         = snd (unblockThreads [tid'] simstate)
+                         = snd (unblockThreads vClock [tid'] simstate)
               threads''  = Map.adjust adjustTarget tid' threads'
               simstate'' = simstate' { threads = threads'' }
 
-          trace <- schedule thread' simstate''
+          -- We yield at this point because the target thread may be higher
+          -- priority, so this should be a step for race detection.
+          trace <- deschedule Yield thread' simstate''
           return $ SimTrace time tid tlbl (EventThrowTo e tid')
                  $ trace
-
-    -- ExploreRaces is ignored by this simulator
-    ExploreRaces k -> schedule thread{ threadControl = ThreadControl k ctl } simstate
 
 
 threadInterruptible :: Thread s a -> Bool
@@ -538,29 +656,31 @@ threadInterruptible thread =
         | otherwise            -> False
       MaskedUninterruptible    -> False
 
-data Deschedule = Yield | Interruptable | Blocked | Terminated
+data Deschedule = Yield | Interruptable | Blocked | Terminated | Sleep
 
 deschedule :: Deschedule -> Thread s a -> SimState s a -> ST s (SimTrace a)
-deschedule Yield thread simstate@SimState{runqueue, threads} =
 
-    -- We don't interrupt runnable threads to provide fairness anywhere else.
-    -- We do it here by putting the thread to the back of the runqueue, behind
-    -- all other runnable threads.
-    --
-    -- For testing, we should have a more sophisticated policy to show that
-    -- algorithms are not sensitive to the exact policy, so long as it is a
-    -- fair policy (all runnable threads eventually run).
+deschedule Yield thread@Thread { threadId     = tid }
+                 simstate@SimState{runqueue, threads, control} =
 
-    let runqueue' = runqueue ++ [threadId thread]
-        threads'  = Map.insert (threadId thread) thread threads in
-    reschedule simstate { runqueue = runqueue', threads  = threads' }
+    -- We don't interrupt runnable threads anywhere else.
+    -- We do it here by inserting the current thread into the runqueue in priority order.
+
+    let thread'   = stepThread thread
+        runqueue' = List.insertBy (comparing Down) tid runqueue
+        threads'  = Map.insert tid thread' threads
+        control'  = advanceControl (threadStepId thread) control in
+    reschedule simstate { runqueue = runqueue', threads  = threads',
+                          races    = updateRacesInSimState thread simstate,
+                          control  = control' }
 
 deschedule Interruptable thread@Thread {
                            threadId      = tid,
                            threadControl = ThreadControl _ ctl,
                            threadMasking = Unmasked,
-                           threadThrowTo = (e, tid') : etids,
-                           threadLabel   = tlbl
+                           threadThrowTo = (e, tid', vClock') : etids,
+                           threadLabel   = tlbl,
+                           threadVClock  = vClock
                          }
                          simstate@SimState{ curTime = time, threads } = do
 
@@ -569,20 +689,26 @@ deschedule Interruptable thread@Thread {
     -- if possible.
     let thread' = thread { threadControl = ThreadControl (Throw e) ctl
                          , threadMasking = MaskedInterruptible
-                         , threadThrowTo = etids }
+                         , threadThrowTo = etids
+                         , threadVClock  = vClock `lubVClock` vClock' }
         (unblocked,
-         simstate') = unblockThreads [l_labelled tid'] simstate
-    trace <- schedule thread' simstate'
+         simstate') = unblockThreads vClock [l_labelled tid'] simstate
+    -- the thread is stepped when we Yield
+    trace <- deschedule Yield thread' simstate'
     return $ SimTrace time tid tlbl (EventThrowToUnmasked tid')
            $ traceMany [ (time, tid'', tlbl'', EventThrowToWakeup)
                        | tid'' <- unblocked
                        , let tlbl'' = lookupThreadLabel tid'' threads ]
              trace
 
-deschedule Interruptable thread simstate =
+deschedule Interruptable thread simstate@SimState{ control } =
     -- Either masked or unmasked but no pending async exceptions.
     -- Either way, just carry on.
-    schedule thread simstate
+    -- Record a step, though, in case on replay there is an async exception.
+    let thread' = stepThread thread in
+    schedule thread'
+             simstate{ races   = updateRacesInSimState thread simstate,
+                       control = advanceControl (threadStepId thread) control }
 
 deschedule Blocked thread@Thread { threadThrowTo = _ : _
                                  , threadMasking = maskst } simstate
@@ -593,27 +719,77 @@ deschedule Blocked thread@Thread { threadThrowTo = _ : _
     -- thread if possible.
     deschedule Interruptable thread { threadMasking = Unmasked } simstate
 
-deschedule Blocked thread simstate@SimState{threads} =
-    let thread'  = thread { threadBlocked = True }
+deschedule Blocked thread simstate@SimState{threads, control} =
+    let thread1 = thread { threadBlocked = True }
+        thread'  = stepThread $ thread1
         threads' = Map.insert (threadId thread') thread' threads in
-    reschedule simstate { threads = threads' }
+    reschedule simstate { threads = threads',
+                          races   = updateRacesInSimState thread1 simstate,
+                          control = advanceControl (threadStepId thread1) control }
 
-deschedule Terminated thread simstate@SimState{ curTime = time, threads } = do
+deschedule Terminated thread@Thread { threadId = tid, threadVClock = vClock }
+                      simstate@SimState{ curTime = time, control } = do
     -- This thread is done. If there are other threads blocked in a
     -- ThrowTo targeted at this thread then we can wake them up now.
-    let wakeup      = map (l_labelled . snd) (reverse (threadThrowTo thread))
+    let thread'     = stepThread $ thread{ threadDone = True }
+        wakeup      = map (\(_,tid',_) -> l_labelled tid') (reverse (threadThrowTo thread))
         (unblocked,
-         simstate') = unblockThreads wakeup simstate
-    trace <- reschedule simstate'
+         simstate'@SimState{threads}) =
+                      unblockThreads vClock wakeup simstate
+        threads'    = Map.insert tid thread' threads
+    -- We must keep terminated threads in the state to preserve their vector clocks,
+    -- which matters when other threads throwTo them.
+    trace <- reschedule simstate' { races = threadTerminatesRaces tid $
+                                              updateRacesInSimState thread simstate,
+                                    control = advanceControl (threadStepId thread) control,
+                                    threads = threads' }
     return $ traceMany
                [ (time, tid', tlbl', EventThrowToWakeup)
                | tid' <- unblocked
                , let tlbl' = lookupThreadLabel tid' threads ]
                trace
 
+deschedule Sleep thread@Thread { threadId = tid }
+                 simstate@SimState{runqueue, threads} =
+
+    -- Schedule control says we should run a different thread. Put
+    -- this one to sleep without recording a step.
+
+    let runqueue' = List.insertBy (comparing Down) tid runqueue
+        threads'  = Map.insert tid thread threads in
+    reschedule simstate { runqueue = runqueue', threads  = threads' }
+
+
+-- Choose the next thread to run.
+reschedule :: SimState s a -> ST s (SimTrace a)
+
+-- If we are following a controlled schedule, just do that.
+reschedule simstate@SimState{ runqueue, threads,
+                              control=control@(ControlFollow ((tid,tstep):_) _)
+                              } =
+    if not (tid `elem` runqueue) then
+      error ("Can't follow "++show control++"\n"++
+             "  tid: "++show tid++"\n"++
+             "  tstep: "++show tstep++"\n"++
+             "  runqueue: "++show runqueue++"\n") else
+    assert (tid `elem` runqueue) $
+    assert (tid `Map.member` threads) $
+    assert (invariant Nothing simstate) $
+    let thread = threads Map.! tid in
+    assert (threadId thread == tid) $
+    --assert (threadStep thread == tstep) $
+    if threadStep thread /= tstep then
+      error $ "Thread step out of sync\n"
+           ++ "  runqueue:    "++show runqueue++"\n"
+           ++ "  follows:     "++show tid++", step "++show tstep++"\n"
+           ++ "  actual step: "++show (threadStep thread)++"\n"
+           ++ "Thread:\n" ++ show thread ++ "\n"
+    else
+    schedule thread simstate { runqueue = List.delete tid runqueue
+                             , threads  = Map.delete tid threads }
+
 -- When there is no current running thread but the runqueue is non-empty then
 -- schedule the next one to run.
-reschedule :: SimState s a -> ST s (SimTrace a)
 reschedule simstate@SimState{ runqueue = tid:runqueue', threads } =
     assert (invariant Nothing simstate) $
 
@@ -623,12 +799,17 @@ reschedule simstate@SimState{ runqueue = tid:runqueue', threads } =
 
 -- But when there are no runnable threads, we advance the time to the next
 -- timer event, or stop.
-reschedule simstate@SimState{ runqueue = [], threads, timers, curTime = time } =
+reschedule simstate@SimState{ runqueue = [], threads, timers, curTime = time, races } =
     assert (invariant Nothing simstate) $
+
+    -- time is moving on
+    --Debug.trace ("Rescheduling at "++show time++", "++
+      --show (length (concatMap stepInfoRaces (activeRaces races++completeRaces races)))++" races") $
 
     -- important to get all events that expire at this time
     case removeMinimums timers of
-      Nothing -> return (TraceDeadlock time (labelledThreads threads))
+      Nothing -> return (traceFinalRacesFound simstate $
+                         TraceDeadlock time (labelledThreads threads))
 
       Just (tmids, time', fired, timers') -> assert (time' >= time) $ do
 
@@ -638,18 +819,23 @@ reschedule simstate@SimState{ runqueue = [], threads, timers, curTime = time } =
         (wakeup, wokeby) <- threadsUnblockedByWrites written
         mapM_ (\(SomeTVar tvar) -> unblockAllThreadsFromTVar tvar) written
 
+        -- TODO: the vector clock below cannot be right, can it?
         let (unblocked,
-             simstate') = unblockThreads wakeup simstate
-        trace <- reschedule simstate' { curTime = time'
-                                      , timers  = timers' }
-        return $
-          traceMany ([ (time', ThreadId [-1], Just "timer", EventTimerExpired tmid)
+             simstate') = unblockThreads bottomVClock wakeup simstate
+            -- all open races will be completed and reported at this time
+            simstate''  = simstate'{ races = noRaces }
+        trace <- reschedule simstate'' { curTime = time'
+                                       , timers  = timers' }
+        let traceEntries =
+                     [ (time', ThreadId [-1], Just "timer", EventTimerExpired tmid)
                      | tmid <- tmids ]
                   ++ [ (time', tid', tlbl', EventTxWakeup vids)
                      | tid' <- unblocked
                      , let tlbl' = lookupThreadLabel tid' threads
-                     , let Just vids = Set.toList <$> Map.lookup tid' wokeby ])
-                    trace
+                     , let Just vids = Set.toList <$> Map.lookup tid' wokeby ]
+        return $
+          traceFinalRacesFound simstate $
+          traceMany traceEntries trace
   where
     timeoutAction (TimerVars var bvar) = do
       x <- readTVar var
@@ -659,12 +845,12 @@ reschedule simstate@SimState{ runqueue = [], threads, timers, curTime = time } =
         TimeoutFired     -> error "MonadTimer(Sim): invariant violation"
         TimeoutCancelled -> return ()
 
-unblockThreads :: [ThreadId] -> SimState s a -> ([ThreadId], SimState s a)
-unblockThreads wakeup simstate@SimState {runqueue, threads} =
+unblockThreads :: VectorClock -> [ThreadId] -> SimState s a -> ([ThreadId], SimState s a)
+unblockThreads vClock wakeup simstate@SimState {runqueue, threads} =
     -- To preserve our invariants (that threadBlocked is correct)
     -- we update the runqueue and threads together here
     (unblocked, simstate {
-                  runqueue = runqueue ++ unblocked,
+                  runqueue = foldr (List.insertBy (comparing Down)) runqueue unblocked,
                   threads  = threads'
                 })
   where
@@ -672,12 +858,15 @@ unblockThreads wakeup simstate@SimState {runqueue, threads} =
     unblocked = [ tid
                 | tid <- wakeup
                 , case Map.lookup tid threads of
+                       Just Thread { threadDone    = True } -> False
                        Just Thread { threadBlocked = True } -> True
                        _                                    -> False
                 ]
     -- and in which case we mark them as now running
     threads'  = List.foldl'
-                  (flip (Map.adjust (\t -> t { threadBlocked = False })))
+                  (flip (Map.adjust
+                    (\t -> t { threadBlocked = False,
+                               threadVClock = vClock `lubVClock` threadVClock t })))
                   threads unblocked
 
 
@@ -746,22 +935,31 @@ lookupThreadLabel tid threads = join (threadLabel <$> Map.lookup tid threads)
 
 -- | The most general method of running 'IOSim' is in 'ST' monad.  One can
 -- recover failures or the result from 'SimTrace' with 'traceResult', or access
--- 'SimEventType's generated by the computation with 'traceEvents'.  A slightly
+-- 'TraceEvent's generated by the computation with 'traceEvents'.  A slightly
 -- more convenient way is exposed by 'runSimTrace'.
 --
 runSimTraceST :: forall s a. IOSim s a -> ST s (SimTrace a)
-runSimTraceST mainAction = schedule mainThread initialState
+runSimTraceST mainAction = controlSimTraceST Nothing ControlDefault mainAction
+
+controlSimTraceST :: Maybe Int -> ScheduleControl -> IOSim s a -> ST s (SimTrace a)
+controlSimTraceST limit control mainAction =
+  schedule mainThread initialState{ control = control, control0 = control, perStepTimeLimit = limit }
   where
     mainThread =
       Thread {
-        threadId      = ThreadId [],
+        threadId      = TestThreadId [],
         threadControl = ThreadControl (runIOSim mainAction) MainFrame,
         threadBlocked = False,
+        threadDone    = False,
         threadMasking = Unmasked,
         threadThrowTo = [],
         threadClockId = ClockId [],
         threadLabel   = Just "main",
-        threadNextTId = 1
+        threadNextTId = 1,
+        threadStep    = 0,
+        threadVClock  = insertVClock (TestThreadId []) 0 bottomVClock,
+        threadEffect  = mempty,
+        threadRacy    = False
       }
 
 
@@ -802,7 +1000,8 @@ execAtomically time tid tlbl nextVid0 action0 k0 =
                     ) written
 
           -- Return the vars written, so readers can be unblocked
-          k0 $ StmTxCommitted x (reverse writtenSeq) [] nextVid
+          k0 $ StmTxCommitted x (Map.elems read)
+                                (reverse writtenSeq) nextVid
 
         OrElseLeftFrame _b k writtenOuter writtenOuterSeq ctl' -> do
           -- Commit the TVars written in this sub-transaction that are also
@@ -835,7 +1034,7 @@ execAtomically time tid tlbl nextVid0 action0 k0 =
       ThrowStm e -> do
         -- Revert all the TVar writes
         traverse_ (\(SomeTVar tvar) -> revertTVar tvar) written
-        k0 $ StmTxAborted [] (toException e)
+        k0 $ StmTxAborted (Map.elems read) (toException e)
 
       Retry -> case ctl of
         AtomicallyFrame -> do
@@ -865,14 +1064,18 @@ execAtomically time tid tlbl nextVid0 action0 k0 =
 
       NewTVar !mbLabel x k -> do
         v <- execNewTVar nextVid mbLabel x
-        go ctl read written writtenSeq (succ nextVid) (k v)
+        -- record a write to the TVar so we know to update its VClock
+        let written' = Map.insert (tvarId v) (SomeTVar v) written
+        -- save the value: it will be committed or reverted
+        saveTVar v
+        go ctl read written' (SomeTVar v : writtenSeq) (succ nextVid) (k v)
 
       LabelTVar !label tvar k -> do
         writeSTRef (tvarLabel tvar) $! (Just label)
         go ctl read written writtenSeq nextVid k
 
       ReadTVar v k
-        | tvarId v `Map.member` read -> do
+        | tvarId v `Map.member` read || tvarId v `Map.member` written -> do
             x <- execReadTVar v
             go ctl read written writtenSeq nextVid (k x)
         | otherwise -> do
@@ -937,7 +1140,7 @@ execNewTVar nextVid !mbLabel x = do
     tvarCurrent <- newSTRef x
     tvarUndo    <- newSTRef []
     tvarBlocked <- newSTRef ([], Set.empty)
-    tvarVClock  <- newSTRef (VectorClock Map.empty)
+    tvarVClock  <- newSTRef bottomVClock
     return TVar {tvarId = nextVid, tvarLabel,
                  tvarCurrent, tvarUndo, tvarBlocked, tvarVClock}
 
@@ -970,6 +1173,10 @@ commitTVar TVar{tvarUndo} = do
 readTVarUndos :: TVar s a -> ST s [a]
 readTVarUndos TVar{tvarUndo} = readSTRef tvarUndo
 
+lubTVarVClocks :: [SomeTVar s] -> ST s VectorClock
+lubTVarVClocks tvars =
+  foldr lubVClock bottomVClock <$>
+    sequence [readSTRef (tvarVClock r) | SomeTVar r <- tvars]
 
 --
 -- Blocking and unblocking on TVars
@@ -1020,3 +1227,354 @@ ordNub = go Set.empty
     go !s (x:xs)
       | x `Set.member` s = go s xs
       | otherwise        = x : go (Set.insert x s) xs
+
+-- Effects
+
+data Effect = Effect {
+    effectReads  :: !(Set TVarId),
+    effectWrites :: !(Set TVarId),
+    effectForks  :: !(Set ThreadId),
+    effectLiftST :: !Bool,
+    effectThrows :: ![ThreadId],
+    effectWakeup :: ![ThreadId]
+  }
+  deriving (Eq, Show)
+
+instance Semigroup Effect where
+  Effect r w s b ts wu <> Effect r' w' s' b' ts' wu' =
+    Effect (r<>r') (w<>w') (s<>s') (b||b') (ts++ts') (wu++wu')
+
+instance Monoid Effect where
+  mempty = Effect Set.empty Set.empty Set.empty False [] []
+
+-- readEffect :: SomeTVar s -> Effect
+-- readEffect r = mempty{effectReads = Set.singleton $ someTvarId r }
+
+readEffects :: [SomeTVar s] -> Effect
+readEffects rs = mempty{effectReads = Set.fromList (map someTvarId rs)}
+
+-- writeEffect :: SomeTVar s -> Effect
+-- writeEffect r = mempty{effectWrites = Set.singleton $ someTvarId r }
+
+writeEffects :: [SomeTVar s] -> Effect
+writeEffects rs = mempty{effectWrites = Set.fromList (map someTvarId rs)}
+
+forkEffect :: ThreadId -> Effect
+forkEffect tid = mempty{effectForks = Set.singleton $ tid}
+
+liftSTEffect :: Effect
+liftSTEffect = mempty{ effectLiftST = True }
+
+throwToEffect :: ThreadId -> Effect
+throwToEffect tid = mempty{ effectThrows = [tid] }
+
+wakeupEffects :: [ThreadId] -> Effect
+wakeupEffects tids = mempty{effectWakeup = tids}
+
+someTvarId :: SomeTVar s -> TVarId
+someTvarId (SomeTVar r) = tvarId r
+
+onlyReadEffect :: Effect -> Bool
+onlyReadEffect e@Effect { effectReads } = e == mempty { effectReads }
+
+racingEffects :: Effect -> Effect -> Bool
+racingEffects e e' =
+      (effectLiftST e  && racesWithLiftST e')
+   || (effectLiftST e' && racesWithLiftST e )
+   || (not $ null $ effectThrows e `List.intersect` effectThrows e')
+   || (not $ effectReads  e `Set.disjoint` effectWrites e'
+          && effectWrites e `Set.disjoint` effectReads  e'
+          && effectWrites e `Set.disjoint` effectWrites e')
+  where racesWithLiftST eff =
+             effectLiftST eff
+          || not (Set.null (effectReads eff) && Set.null (effectWrites eff))
+
+-- Steps
+
+data Step = Step {
+    stepThreadId :: !ThreadId,
+    stepStep     :: !Int,
+    stepEffect   :: !Effect,
+    stepVClock   :: !VectorClock
+  }
+  deriving Show
+
+-- steps race if they can be reordered with a possibly different outcome
+racingSteps :: Step -> Step -> Bool
+racingSteps s s' =
+     stepThreadId s /= stepThreadId s'
+  && not (stepThreadId s' `elem` effectWakeup (stepEffect s))
+  && (racingEffects (stepEffect s) (stepEffect s')
+   || throwsTo s s'
+   || throwsTo s' s)
+  where throwsTo s1 s2 =
+             stepThreadId s1 `elem` effectThrows (stepEffect s2)
+          && stepEffect s1 /= mempty
+
+currentStep :: Thread s a -> Step
+currentStep Thread { threadId     = tid,
+                     threadStep   = tstep,
+                     threadEffect = teffect,
+                     threadVClock = vClock
+                   } =
+  Step { stepThreadId = tid,
+         stepStep     = tstep,
+         stepEffect   = teffect,
+         stepVClock   = vClock
+       }
+
+stepThread :: Thread s a -> Thread s a
+stepThread thread@Thread { threadId     = tid,
+                           threadStep   = tstep,
+                           threadVClock = vClock } =
+  thread { threadStep   = tstep+1,
+           threadEffect = mempty,
+           threadVClock = insertVClock tid (tstep+1) vClock
+         }
+
+-- As we run a simulation, we collect info about each previous step
+data StepInfo = StepInfo {
+    stepInfoStep       :: Step,
+    -- Control information when we reached this step
+    stepInfoControl    :: ScheduleControl,
+    -- threads that are still concurrent with this step
+    stepInfoConcurrent :: Set ThreadId,
+    -- steps following this one that did not happen after it
+    -- (in reverse order)
+    stepInfoNonDep     :: [Step],
+    -- later steps that race with this one
+    stepInfoRaces      :: [Step]
+  }
+  deriving Show
+
+data Races = Races { -- These steps may still race with future steps
+                     activeRaces   :: ![StepInfo],
+                     -- These steps cannot be concurrent with future steps
+                     completeRaces :: ![StepInfo]
+                   }
+  deriving Show
+
+noRaces :: Races
+noRaces = Races [] []
+
+updateRacesInSimState :: Thread s a -> SimState s a -> Races
+updateRacesInSimState thread SimState{ control, threads, races } =
+  traceRaces $
+  updateRaces (currentStep thread)
+              (threadBlocked thread)
+              control
+              (Map.keysSet (Map.filter (not . threadDone) threads))
+              races
+
+-- We take care that steps can only race against threads in their
+-- concurrent set. When this becomes empty, a step can be retired into
+-- the "complete" category, but only if there are some steps racing
+-- with it.
+updateRaces :: Step -> Bool -> ScheduleControl -> Set ThreadId -> Races -> Races
+updateRaces newStep@Step{ stepThreadId = tid, stepEffect = newEffect }
+            blocking
+            control
+            newConcurrent0
+            races@Races{ activeRaces } =
+  let -- a new step cannot race with any threads that it just woke up
+      newConcurrent = foldr Set.delete newConcurrent0 (effectWakeup newEffect)
+      new | isTestThreadId tid     = []  -- test threads do not race
+          | Set.null newConcurrent = []  -- cannot race with anything
+          | justBlocking           = []  -- no need to defer a blocking transaction
+          | otherwise              =
+              [StepInfo { stepInfoStep       = newStep,
+                          stepInfoControl    = control,
+                          stepInfoConcurrent = newConcurrent,
+                          stepInfoNonDep     = [],
+                          stepInfoRaces      = []
+                        }]
+      justBlocking = blocking && onlyReadEffect newEffect
+      updateActive =
+        [ -- if this step depends on the previous step, or is not concurrent,
+          -- then any threads that it wakes up become non-concurrent also.
+          let lessConcurrent = foldr Set.delete concurrent (effectWakeup newEffect) in
+          if tid `elem` concurrent then
+            let theseStepsRace = not (isTestThreadId tid) && racingSteps step newStep
+                happensBefore  = hbfStep (stepThreadId step) (stepStep step) (stepVClock newStep)
+                nondep' | happensBefore = nondep
+                        | otherwise     = newStep : nondep
+                -- We will only record the first race with each thread---reversing
+                -- the first race makes the next race detectable. Thus we remove a
+                -- thread from the concurrent set after the first race.
+                concurrent' | happensBefore  = Set.delete tid lessConcurrent
+                            | theseStepsRace = Set.delete tid concurrent
+                            | otherwise      = concurrent
+                -- Here we record discovered races.
+                -- We only record a new race if we are following the default schedule,
+                -- to avoid finding the same race in different parts of the search space.
+                stepRaces' | (control == ControlDefault ||
+                              control == ControlFollow [] []) &&
+                             theseStepsRace  = newStep : stepRaces
+                           | otherwise       = stepRaces
+            in stepInfo { stepInfoConcurrent = effectForks newEffect `Set.union` concurrent',
+                          stepInfoNonDep     = nondep',
+                          stepInfoRaces      = stepRaces'
+                        }
+          else stepInfo { stepInfoConcurrent = lessConcurrent }
+        | stepInfo@StepInfo { stepInfoStep       = step,
+                              stepInfoConcurrent = concurrent,
+                              stepInfoNonDep     = nondep,
+                              stepInfoRaces      = stepRaces
+                            }
+            <- activeRaces ]
+  in normalizeRaces $ races { activeRaces = new ++ updateActive }
+
+-- When a thread terminates, we remove it from the concurrent thread
+-- sets of active races.
+
+threadTerminatesRaces :: ThreadId -> Races -> Races
+threadTerminatesRaces tid races@Races{ activeRaces } =
+  let activeRaces' = [ s{stepInfoConcurrent = Set.delete tid stepInfoConcurrent}
+                     | s@StepInfo{ stepInfoConcurrent } <- activeRaces ]
+  in normalizeRaces $ races{ activeRaces = activeRaces' }
+
+normalizeRaces :: Races -> Races
+normalizeRaces Races{ activeRaces, completeRaces } =
+  let activeRaces' = filter (not . null. stepInfoConcurrent) activeRaces
+      completeRaces' = filter (not . null. stepInfoRaces)
+                         (filter (null . stepInfoConcurrent) activeRaces)
+                    ++ completeRaces
+  in Races{ activeRaces = activeRaces', completeRaces = completeRaces' }
+
+-- We assume that steps do not race with later steps after a quiescent
+-- period. Quiescent periods end when simulated time advances, thus we
+-- are assuming here that all work is completed before a timer
+-- triggers.
+
+quiescentRacesInSimState :: SimState s a -> SimState s a
+quiescentRacesInSimState simstate@SimState{ races } =
+  simstate{ races = quiescentRaces races }
+
+quiescentRaces :: Races -> Races
+quiescentRaces Races{ activeRaces, completeRaces } =
+  Races{ activeRaces = [],
+         completeRaces = [s{stepInfoConcurrent = Set.empty} |
+                          s <- activeRaces,
+                          not (null (stepInfoRaces s))] ++
+                         completeRaces }
+
+traceRaces :: Races -> Races
+traceRaces r = r
+-- traceRaces r@Races{activeRaces,completeRaces} =
+--   Debug.trace ("Tracking "++show (length (concatMap stepInfoRaces activeRaces)) ++" races") r
+
+-- Schedule modifications
+
+stepStepId :: Step -> (ThreadId, Int)
+stepStepId Step{ stepThreadId = tid, stepStep = n } = (tid,n)
+
+threadStepId :: Thread s a -> (ThreadId, Int)
+threadStepId Thread{ threadId, threadStep } = (threadId, threadStep)
+
+stepInfoToScheduleMods :: StepInfo -> [ScheduleMod]
+stepInfoToScheduleMods
+  StepInfo{ stepInfoStep    = step,
+            stepInfoControl = control,
+            stepInfoNonDep  = nondep,
+            stepInfoRaces   = races
+          } =
+  -- It is actually possible for a later step that races with an earlier one
+  -- not to *depend* on it in a happens-before sense. But we don't want to try
+  -- to follow any steps *after* the later one.
+  [ ScheduleMod (stepStepId step)
+                control
+                (takeWhile (/=stepStepId step')
+                   (map stepStepId (reverse nondep))
+                   ++ [stepStepId step'])
+                   -- It should be unnecessary to include the delayed step in the insertion,
+                   -- since the default scheduling should run it anyway. Removing it may
+                   -- help avoid redundant schedules.
+                   -- ++ [stepStepId step])
+  | step' <- races ]
+
+traceFinalRacesFound :: SimState s a -> SimTrace a -> SimTrace a
+traceFinalRacesFound simstate@SimState{ control0 = control } =
+  TraceRacesFound [extendScheduleControl control m | m <- scheduleMods]
+  where SimState{ races } =
+          quiescentRacesInSimState simstate
+        scheduleMods =
+          concatMap stepInfoToScheduleMods $ completeRaces races
+
+
+-- Schedule control
+
+controlTargets :: StepId -> ScheduleControl -> Bool
+controlTargets stepId
+               (ControlAwait (ScheduleMod{ scheduleModTarget }:_)) =
+  stepId == scheduleModTarget
+controlTargets _stepId _ = False
+
+controlFollows :: StepId -> ScheduleControl -> Bool
+controlFollows _stepId  ControlDefault               = True
+controlFollows _stepId (ControlFollow [] _)          = True
+controlFollows stepId  (ControlFollow (stepId':_) _) = stepId == stepId'
+controlFollows stepId  (ControlAwait (smod:_))       = stepId /= scheduleModTarget smod
+controlFollows _       (ControlAwait [])             = error "Impossible: controlFollows _ (ControlAwait [])"
+
+advanceControl :: (ThreadId, Int) -> ScheduleControl -> ScheduleControl
+advanceControl (tid,step) (ControlFollow ((tid',step'):sids) tgts)
+  | tid /= tid' =
+      -- we are switching threads to follow the schedule
+       --Debug.trace ("Switching threads from "++show (tid,step)++" to "++show (tid',step')++"\n") $
+       ControlFollow ((tid',step'):sids) tgts
+  | step == step' =
+      ControlFollow sids tgts
+  | otherwise =
+      error $ "advanceControl "++show (tid,step)++" cannot follow step "++show step'++"\n"
+advanceControl stepId (ControlFollow [] []) =
+  ControlDefault
+advanceControl stepId (ControlFollow [] tgts) =
+  ControlAwait tgts
+advanceControl stepId c =
+  assert (not $ controlTargets stepId c) $
+  c
+
+followControl :: ScheduleControl -> ScheduleControl
+followControl (ControlAwait
+                 (ScheduleMod{scheduleModTarget,
+                              scheduleModInsertion} : mods)) =
+  ControlFollow scheduleModInsertion mods
+followControl (ControlAwait []) = error "Impossible: followControl (ControlAwait [])"
+followControl ControlDefault{}  = error "Impossible: followControl ControlDefault{}"
+followControl ControlFollow{}   = error "Impossible: followControl ControlFollow{}"
+
+-- Extend an existing schedule control with a newly discovered schedule mod
+extendScheduleControl' :: ScheduleControl -> ScheduleMod -> ScheduleControl
+extendScheduleControl' ControlDefault m = ControlAwait [m]
+extendScheduleControl' (ControlAwait mods) m =
+  case scheduleModControl m of
+    ControlDefault     -> ControlAwait (mods++[m])
+    ControlAwait mods' ->
+      let common = length mods - length mods' in
+      assert (common >= 0 && drop common mods==mods') $
+      ControlAwait (take common mods++[m{ scheduleModControl = ControlDefault }])
+    ControlFollow stepIds mods' ->
+      let common = length mods - length mods' - 1
+          m'     = mods !! common
+          isUndo = scheduleModTarget m' `elem` scheduleModInsertion m
+          m''    = m'{ scheduleModInsertion =
+                         takeWhile (/=scheduleModTarget m)
+                                   (scheduleModInsertion m')
+                         ++
+                         scheduleModInsertion m }
+      in
+      assert (common >= 0) $
+      assert (drop (common+1) mods == mods') $
+      if isUndo
+        then ControlAwait mods          -- reject this mod... it's undoing a previous one
+        else ControlAwait (take common mods++[m''])
+extendScheduleControl' ControlFollow{} ScheduleMod{} = error "Impossible: extendScheduleControl' ControlFollow{} ScheduleMod{}"
+
+extendScheduleControl :: ScheduleControl -> ScheduleMod -> ScheduleControl
+extendScheduleControl control m =
+  let control' = extendScheduleControl' control m in
+  {- Debug.trace (unlines ["",
+                        "Extending "++show control,
+                        "     with "++show m,
+                        "   yields "++show control']) -}
+              control'

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -80,6 +80,7 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Control.Monad.IOSim.Types
+import           Control.Monad.IOSim.InternalTypes
 import           Control.Monad.IOSimPOR.Timeout(unsafeTimeout)
 
 --
@@ -102,45 +103,6 @@ data Thread s a = Thread {
     threadEffect  :: Effect,  -- in the current step
     threadRacy    :: !Bool
   }
-  deriving Show
-
--- We hide the type @b@ here, so it's useful to bundle these two parts
--- together, rather than having Thread have an extential type, which
--- makes record updates awkward.
-data ThreadControl s a where
-  ThreadControl :: SimA s b
-                -> ControlStack s b a
-                -> ThreadControl s a
-
-instance Show (ThreadControl s a) where
-  show _ = "..."
-
-data ControlStack s b a where
-  MainFrame  :: ControlStack s a  a
-  ForkFrame  :: ControlStack s () a
-  MaskFrame  :: (b -> SimA s c)         -- subsequent continuation
-             -> MaskingState            -- thread local state to restore
-             -> ControlStack s c a
-             -> ControlStack s b a
-  CatchFrame :: Exception e
-             => (e -> SimA s b)         -- exception continuation
-             -> (b -> SimA s c)         -- subsequent continuation
-             -> ControlStack s c a
-             -> ControlStack s b a
-
-instance Show (ControlStack s b a) where
-  show = show . dash
-    where dash :: ControlStack s' b' a' -> ControlStackDash
-          dash MainFrame = MainFrame'
-          dash ForkFrame = ForkFrame'
-          dash (MaskFrame _ m s) = MaskFrame' m (dash s)
-          dash (CatchFrame _ _ s) = CatchFrame' (dash s)
-
-data ControlStackDash =
-    MainFrame'
-  | ForkFrame'
-  | MaskFrame' MaskingState ControlStackDash
-  | CatchFrame' ControlStackDash
   deriving Show
 
 isTestThreadId :: ThreadId -> Bool

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -591,8 +591,7 @@ schedule thread@Thread{
     ThrowTo e tid' _ | tid' == tid -> do
       -- Throw to ourself is equivalent to a synchronous throw,
       -- and works irrespective of masking state since it does not block.
-      let thread' = thread { threadControl = ThreadControl (Throw e) ctl
-                           , threadMasking = MaskedInterruptible }
+      let thread' = thread { threadControl = ThreadControl (Throw e) ctl }
       trace <- schedule thread' simstate
       return (SimTrace time tid tlbl (EventThrowTo e tid) trace)
 
@@ -631,7 +630,6 @@ schedule thread@Thread{
                                      threadVClock  = vClock' } =
                 t { threadControl = ThreadControl (Throw e) ctl'
                   , threadBlocked = False
-                  , threadMasking = MaskedInterruptible
                   , threadVClock  = vClock' `leastUpperBoundVClock` vClock }
               simstate'@SimState { threads = threads' }
                          = snd (unblockThreads vClock [tid'] simstate)

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -1577,7 +1577,11 @@ extendScheduleControl' (ControlAwait mods) m =
       if isUndo
         then ControlAwait mods          -- reject this mod... it's undoing a previous one
         else ControlAwait (take common mods++[m''])
-extendScheduleControl' ControlFollow{} ScheduleMod{} = error "Impossible: extendScheduleControl' ControlFollow{} ScheduleMod{}"
+extendScheduleControl' ControlFollow{} ScheduleMod{} =
+  -- note: this case is impossible, since `extendScheduleControl'` first
+  -- argument is either the initial `ControlDefault` or a result of calling
+  -- `extendScheduleControl'` itself.
+  error "Impossible: extendScheduleControl' ControlFollow{} ScheduleMod{}"
 
 extendScheduleControl :: ScheduleControl -> ScheduleMod -> ScheduleControl
 extendScheduleControl control m =

--- a/io-sim/src/Control/Monad/IOSimPOR/QuickCheckUtils.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/QuickCheckUtils.hs
@@ -1,0 +1,118 @@
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Control.Monad.IOSimPOR.QuickCheckUtils where
+
+import Test.QuickCheck.Property
+import Test.QuickCheck.Gen
+import Control.Parallel
+
+-- Take the conjunction of several properties, in parallel This is a
+-- modification of code from Test.QuickCheck.Property, to run non-IO
+-- properties in parallel. It also takes care NOT to label its result
+-- as an IO property (using IORose), unless one of its arguments is
+-- itself an IO property. This is needed to permit parallel testing.
+conjoinPar :: TestableNoCatch prop => [prop] -> Property
+conjoinPar = conjoinSpeculate speculate
+  where
+  -- speculation tries to evaluate each Rose tree in parallel, to WHNF
+  -- This will not perform any IO, but should evaluate non-IO properties
+  -- completely.
+  speculate [] = []
+  speculate (rose:roses) = roses' `par` rose' `pseq` (rose':roses')
+    where rose' = case rose of
+                    MkRose result _ -> let ans = maybe True id $ ok result in ans `pseq` rose
+                    IORose _        -> rose
+          roses' = speculate roses
+
+-- We also need a version of conjoin that is sequential, but does not
+-- label its result as an IO property unless one of its arguments
+-- is. Consequently it does not catch exceptions in its arguments.
+conjoinNoCatch :: TestableNoCatch prop => [prop] -> Property
+conjoinNoCatch = conjoinSpeculate id
+
+conjoinSpeculate :: TestableNoCatch prop => ([Rose Result] -> [Rose Result]) -> [prop] -> Property
+conjoinSpeculate spec ps =
+  againNoCatch $
+  MkProperty $
+  do roses <- mapM (fmap unProp . unProperty . propertyNoCatch) ps
+     return (MkProp $ conj id (spec roses))
+ where
+          
+  conj k [] =
+    MkRose (k succeeded) []
+
+  conj k (p : ps) = do
+    result <- p
+    case ok result of
+      _ | not (expect result) ->
+        return failed { reason = "expectFailure may not occur inside a conjunction" }
+      Just True -> conj (addLabels result . addCallbacksAndCoverage result . k) ps
+      Just False -> p
+      Nothing -> do
+        let rest = conj (addCallbacksAndCoverage result . k) ps
+        result2 <- rest
+        -- Nasty work to make sure we use the right callbacks
+        case ok result2 of
+          Just True -> MkRose (result2 { ok = Nothing }) []
+          Just False -> rest
+          Nothing -> rest
+
+  addCallbacksAndCoverage result r =
+    r { callbacks = callbacks result ++ callbacks r,
+        requiredCoverage = requiredCoverage result ++ requiredCoverage r }
+  addLabels result r =
+    r { labels = labels result ++ labels r,
+        classes = classes result ++ classes r,
+        tables = tables result ++ tables r }
+
+-- |&&| is a replacement for .&&. that evaluates its arguments in
+-- parallel. |&&| does NOT label its result as an IO property, unless
+-- one of its arguments is--which .&&. does. This means that using
+-- .&&. inside an argument to conjoinPar limits parallelism, while
+-- |&&| does not.
+
+infixr 1 |&&|
+
+(|&&|) :: TestableNoCatch prop => prop -> prop -> Property
+p |&&| q = conjoinPar [p, q]
+
+-- .&&| is a sequential, but parallelism-friendly version of .&&., that
+-- tests its arguments in sequence, but does not label its result as
+-- an IO property unless one of its arguments is.
+
+infixr 1 .&&|
+(.&&|) :: TestableNoCatch prop => prop -> prop -> Property
+p .&&| q = conjoinNoCatch [p, q]
+
+
+-- property catches exceptions in its argument, turning everything
+-- Testable into an IORose property, which cannot be paralellized. We
+-- need an alternative that permits parallelism by allowing exceptions
+-- to propagate. This is a modified clone of code from
+-- Test.QuickCheck.Property.
+
+class TestableNoCatch prop where
+  propertyNoCatch :: prop -> Property
+
+instance TestableNoCatch Discard where
+  propertyNoCatch _ = propertyNoCatch rejected
+
+instance TestableNoCatch Bool where
+  propertyNoCatch = propertyNoCatch . liftBool
+
+instance TestableNoCatch Result where
+  propertyNoCatch = MkProperty . return . MkProp . return
+
+instance TestableNoCatch Prop where
+  propertyNoCatch p = MkProperty . return $ p
+
+instance TestableNoCatch prop => TestableNoCatch (Gen prop) where
+  propertyNoCatch mp = MkProperty $ do p <- mp; unProperty (againNoCatch $ propertyNoCatch p)
+
+instance TestableNoCatch Property where
+  propertyNoCatch p = p
+
+againNoCatch :: Property -> Property
+againNoCatch (MkProperty gen) = MkProperty $ do
+  MkProp rose <- gen
+  return . MkProp $ fmap (\res -> res{ abort = False }) rose

--- a/io-sim/src/Control/Monad/IOSimPOR/Timeout.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Timeout.hs
@@ -1,0 +1,64 @@
+module Control.Monad.IOSimPOR.Timeout ( Timeout, timeout, unsafeTimeout ) where
+
+-- This module provides a timeout function like System.Timeout, BUT
+-- garbage collection time is not included (provided GHC stats are
+-- enabled, +RTS -T -RTS). Thus this can be used more reliably to
+-- limit computation time.
+
+import Control.Monad
+import Control.Concurrent
+import Control.Exception   (Exception(..), handleJust, bracket,
+                            uninterruptibleMask_,
+                            asyncExceptionToException,
+                            asyncExceptionFromException)
+import Data.Unique         (Unique, newUnique)
+import GHC.Stats
+import System.IO.Unsafe
+
+
+-- An internal type that is thrown as a dynamic exception to
+-- interrupt the running IO computation when the timeout has
+-- expired.
+
+-- | An exception thrown to a thread by 'timeout' to interrupt a timed-out
+-- computation.
+
+newtype Timeout = Timeout Unique deriving Eq
+
+-- | @since 4.0
+instance Show Timeout where
+    show _ = "<<timeout>>"
+
+instance Exception Timeout where
+  toException = asyncExceptionToException
+  fromException = asyncExceptionFromException
+
+timeout :: Int -> IO a -> IO (Maybe a)
+timeout n f
+    | n <  0    = fmap Just f
+    | n == 0    = return Nothing
+    | otherwise = do
+        pid <- myThreadId
+        ex  <- fmap Timeout newUnique
+        handleJust (\e -> if e == ex then Just () else Nothing)
+                   (\_ -> return Nothing)
+                   (bracket (forkIOWithUnmask $ \unmask ->
+                                 unmask $ waitFor n >> throwTo pid ex)
+                            (uninterruptibleMask_ . killThread)
+                            (\_ -> fmap Just f))
+
+waitFor :: Int -> IO ()
+waitFor n = do
+  t0 <- getGCTime
+  threadDelay n
+  t1 <- getGCTime
+  when (t1 > t0) $
+    -- allow some extra time because of GC
+    waitFor (t1-t0)
+
+getGCTime :: IO Int
+getGCTime = fromIntegral . (`div` 1000) . gc_elapsed_ns <$> getRTSStats
+
+-- | unsafeTimeout n a forces the evaluation of a, with a time limit of n microseconds.
+unsafeTimeout :: Int -> a -> Maybe a
+unsafeTimeout n a = unsafePerformIO $ timeout n $ return $! a

--- a/io-sim/test/Test/Control/Monad/IOSimPOR.hs
+++ b/io-sim/test/Test/Control/Monad/IOSimPOR.hs
@@ -1,0 +1,265 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Test.Control.Monad.IOSimPOR where
+
+import Control.Monad
+import Control.Monad.IOSim
+import Control.Monad.Class.MonadSTM
+import Control.Monad.Class.MonadFork
+import Control.Monad.Class.MonadTimer
+import Control.Monad.Class.MonadTest
+
+import GHC.Generics
+
+import System.Exit
+import System.IO.Unsafe
+
+import Test.QuickCheck
+import Data.List
+import Data.Map(Map)
+import qualified Data.Map as Map
+import Control.Exception(try, evaluate, SomeException)
+import Control.Parallel
+import Data.IORef
+
+data Step =
+    WhenSet Int Int
+  | ThrowTo Int
+  | Delay Int
+  | Timeout TimeoutStep
+  deriving (Eq, Ord, Show)
+
+data TimeoutStep =
+    NewTimeout    Int
+  | UpdateTimeout Int
+  | CancelTimeout
+  | AwaitTimeout
+  deriving (Eq, Ord, Show, Generic)
+
+instance Arbitrary Step where
+  arbitrary = frequency [(5,do m <- choose (1,20)
+                               n <- choose (0,m)
+                               return $ WhenSet m n),
+                         (1,do NonNegative i <- arbitrary
+                               return $ ThrowTo i),
+                         (1,do Positive i <- arbitrary
+                               return $ Delay i),
+                         (1,Timeout <$> arbitrary)]
+
+  shrink (WhenSet m n) = map (WhenSet m) (shrink n) ++
+                         map (`WhenSet` n) (filter (>=n) (shrink m))
+  shrink (ThrowTo i) = map ThrowTo (shrink i)
+  shrink (Delay i)   = map Delay (shrink i)
+  shrink (Timeout t) = map Timeout (shrink t)
+
+instance Arbitrary TimeoutStep where
+  arbitrary = do Positive i <- arbitrary
+                 frequency $ map (fmap return) $
+                   [(3,NewTimeout i),
+                    (1,UpdateTimeout i),
+                    (1,CancelTimeout),
+                    (3,AwaitTimeout)]
+
+  shrink = genericShrink
+
+
+newtype Task = Task [Step]
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Task where
+  arbitrary = do
+    steps <- arbitrary
+    return . Task $ normalize steps
+  shrink (Task steps) =
+    (Task <$> compressSteps steps) ++
+    (Task . normalize <$> shrink steps)
+
+normalize :: [Step] -> [Step]
+normalize steps = plug steps wsSteps 1000000
+  where wsSteps = reverse $ sort [s | s@(WhenSet _ _) <- steps]
+        plug []              []               _ = []
+        plug (WhenSet _ _:s) (WhenSet a b:ws) m = WhenSet (min a m) (min b m):plug s ws (min b m)
+        plug (step:s)        ws               m = step:plug s ws m
+        plug _               _                _ = error "plug: impossible"
+
+compressSteps :: [Step] -> [[Step]]
+compressSteps (WhenSet a b:WhenSet c d:steps) =
+  [WhenSet a d:steps] ++ ((WhenSet a b:) <$> compressSteps (WhenSet c d:steps))
+compressSteps (s:steps) = (s:) <$> compressSteps steps
+compressSteps [] = []
+
+newtype Tasks = Tasks [Task]
+  deriving Show
+
+instance Arbitrary Tasks where
+  arbitrary = Tasks . fixThrowTos <$> scale (min 20) arbitrary
+  shrink (Tasks ts) = Tasks . fixThrowTos <$>
+         removeTask ts ++
+         shrink ts ++
+         shrinkDelays ts ++
+         advanceThrowTo ts ++
+         sortTasks ts
+
+fixThrowTos :: [Task] -> [Task]
+fixThrowTos tasks = mapThrowTos (`mod` length tasks) tasks
+
+shrinkDelays :: [Task] -> [[Task]]
+shrinkDelays tasks
+  | null times = []
+  | otherwise  = [map (Task . removeTime d) [steps | Task steps <- tasks]
+                 | d <- times]
+  where times = foldr union [] [scanl1 (+) [d | Delay d <- t] | Task t <- tasks]
+        removeTime 0 steps = steps
+        removeTime _ []    = []
+        removeTime d (Delay d':steps)
+          | d==d' = steps
+          | d< d' = Delay (d'-d):steps
+          | d> d' = removeTime (d-d') steps
+        removeTime d (s:steps) =
+          s:removeTime d steps
+
+removeTask :: [Task] -> [[Task]]
+removeTask tasks =
+  [ mapThrowTos (fixup i) . map (dontThrowTo i) $ take i tasks++drop (i+1) tasks
+  | i <- [0..length tasks-1]]
+  where fixup i j | j>i       = j-1
+                  | otherwise = j
+        dontThrowTo i (Task steps) = Task (filter (/=ThrowTo i) steps)
+
+advanceThrowTo :: [Task] -> [[Task]]
+advanceThrowTo [] = []
+advanceThrowTo (Task steps:ts) =
+  ((:ts) . Task <$> advance steps) ++
+  ((Task steps:) <$> advanceThrowTo ts)
+  where advance (WhenSet a b:ThrowTo i:steppes) =
+          [ThrowTo i:WhenSet a b:steppes] ++ (([WhenSet a b,ThrowTo i]++) <$> advance steppes)
+        advance (s:steppes) = (s:) <$> advance steppes
+        advance []          = []
+
+mapThrowTos :: (Int -> Int) -> [Task] -> [Task]
+mapThrowTos f tasks = map mapTask tasks
+  where mapTask (Task steps) = Task (map mapStep steps)
+        mapStep (ThrowTo i) = ThrowTo (f i)
+        mapStep s           = s
+
+sortTasks :: Ord a => [a] -> [[a]]
+sortTasks (x:y:xs) | x>y = [y:x:xs] ++ ((x:) <$> sortTasks (y:xs))
+sortTasks (x:xs)         = (x:) <$> sortTasks xs
+sortTasks []             = []
+
+interpret :: forall s. TVar (IOSim s) Int -> TVar (IOSim s) [ThreadId (IOSim s)] -> Task -> IOSim s (ThreadId (IOSim s))
+interpret r t (Task steps) = forkIO $ do
+    context <- atomically $ do
+      ts <- readTVar t
+      when (null ts) retry
+      timer <- newTVar Nothing
+      return (ts,timer)
+    mapM_ (interpretStep context) steps
+  where interpretStep _ (WhenSet m n) = atomically $ do
+          a <- readTVar r
+          when (a/=m) retry
+          writeTVar r n
+        interpretStep (ts,_) (ThrowTo i) = throwTo (ts !! i) (ExitFailure 0)
+        interpretStep _      (Delay i)   = threadDelay (fromIntegral i)
+        interpretStep (_,timer) (Timeout tstep) = do
+          timerVal <- atomically $ readTVar timer
+          case (timerVal,tstep) of
+            (_,NewTimeout n)            -> do tout <- newTimeout (fromIntegral n)
+                                              atomically $ writeTVar timer (Just tout)
+            (Just tout,UpdateTimeout n) -> updateTimeout tout (fromIntegral n)
+            (Just tout,CancelTimeout)   -> cancelTimeout tout
+            (Just tout,AwaitTimeout)    -> atomically $ awaitTimeout tout >> return ()
+            (Nothing,_)                 -> return ()
+
+runTasks :: [Task] -> IOSim s (Int,Int)
+runTasks tasks = do
+  let m = maximum [maxTaskValue t | Task t <- tasks]
+  r  <- atomically $ newTVar m
+  t  <- atomically $ newTVar []
+  exploreRaces
+  ts <- mapM (interpret r t) tasks
+  atomically $ writeTVar t ts
+  threadDelay 1000000000  -- allow the SUT threads to run
+  a  <- atomically $ readTVar r
+  return (m,a)
+
+maxTaskValue :: [Step] -> Int
+maxTaskValue (WhenSet m _:_) = m
+maxTaskValue (_:t)           = maxTaskValue t
+maxTaskValue []              = 0
+
+propSimulates :: Tasks -> Property
+propSimulates (Tasks tasks) =
+  any (not . null . (\(Task steps)->steps)) tasks ==>
+    let Right (m,a) = runSim (runTasks tasks) in
+    m>=a
+
+propExploration :: Tasks -> Property
+propExploration (Tasks tasks) =
+  any (not . null . (\(Task steps)->steps)) tasks ==>
+    traceNoDuplicates $ \addTrace ->
+    --traceCounter $ \addTrace ->
+    exploreSimTrace id (runTasks tasks) $ \_ trace ->
+    --Debug.trace (("\nTrace:\n"++) . splitTrace . noExceptions $ show trace) $
+    addTrace trace $
+    counterexample (splitTrace . noExceptions $ show trace) $
+    case traceResult False trace of
+      Right (m,a) -> property $ m>=a
+      Left e      -> counterexample (show e) False
+
+-- Testing propPermutations n should collect every permutation of [1..n] once only.
+-- Test manually, and supply a small value of n.
+propPermutations :: Int -> Property
+propPermutations n =
+  traceNoDuplicates $ \addTrace ->
+  exploreSimTrace (withScheduleBound 10000) (doit n) $ \_ trace ->
+    addTrace trace $
+    let Right result = traceResult False trace in
+    tabulate "Result" [noExceptions $ show $ result] $
+      True
+
+doit :: Int -> IOSim s [Int]
+doit n = do
+          r <- atomically $ newTVar []
+          exploreRaces
+          mapM_ (\i -> forkIO $ atomically $ modifyTVar r (++[i])) [1..n]
+          threadDelay 1
+          atomically $ readTVar r
+
+ordered :: Ord a => [a] -> Bool
+ordered xs = and (zipWith (<) xs (drop 1 xs))
+
+noExceptions :: [Char] -> [Char]
+noExceptions xs = unsafePerformIO $ try (evaluate xs) >>= \case
+  Right []     -> return []
+  Right (x:ys) -> return (x:noExceptions ys)
+  Left e       -> return ("\n"++show (e :: SomeException))
+
+splitTrace :: [Char] -> [Char]
+splitTrace [] = []
+splitTrace (x:xs) | begins "(Trace" = "\n(" ++ splitTrace xs
+                  | otherwise       = x:splitTrace xs
+  where begins s = take (length s) (x:xs) == s
+
+traceCounter :: (Testable prop1, Show a1) => ((a1 -> a2 -> a2) -> prop1) -> Property
+traceCounter k = r `pseq` (k addTrace .&&.
+                           tabulate "Trace repetitions" (map show $ traceCounts ()) True)
+  where
+    r = unsafePerformIO $ newIORef (Map.empty :: Map String Int)
+    addTrace t x = unsafePerformIO $ do
+      atomicModifyIORef r (\m->(Map.insertWith (+) (show t) 1 m,()))
+      return x
+    traceCounts () = unsafePerformIO $ Map.elems <$> readIORef r
+
+traceNoDuplicates :: (Testable prop1, Show a1) => ((a1 -> a2 -> a2) -> prop1) -> Property
+traceNoDuplicates k = r `pseq` (k addTrace .&&. maximum (traceCounts ()) == 1)
+  where
+    r = unsafePerformIO $ newIORef (Map.empty :: Map String Int)
+    addTrace t x = unsafePerformIO $ do
+      atomicModifyIORef r (\m->(Map.insertWith (+) (show t) 1 m,()))
+      return x
+    traceCounts () = unsafePerformIO $ Map.elems <$> readIORef r

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -363,7 +363,7 @@ test_threadId_order = \(Positive n) -> do
       return tid
 
     isValid :: Int -> [ThreadId m] -> Property
-    isValid n tr = map show tr === map (("ThreadId " ++ ) . show) [1..n]
+    isValid n tr = map show tr === map (("ThreadId " ++ ) . show . (:[])) [1..n]
 
 prop_threadId_order_order_Sim :: Positive Int -> Property
 prop_threadId_order_order_Sim n = runSimOrThrow $ test_threadId_order n
@@ -584,7 +584,7 @@ unit_async_1 =
           threadDelay 1
       )
  ===
-   ["main ThreadId 0", "parent ThreadId 1", "child ThreadId 1"]
+   ["main ThreadId []", "parent ThreadId [1]", "child ThreadId [1]"]
 
 
 unit_async_2 =

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -178,6 +178,7 @@ library
                        iproute,
                        nothunks,
                        network           >=3.1.2 && <3.2,
+                       pretty-simple,
                        psqueues          >=0.2.3 && <0.3,
                        serialise         >=0.2   && <0.3,
                        random,
@@ -210,6 +211,7 @@ library
                        -Wredundant-constraints
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
+
 
   -- Still in the lib for now as they're used in ouroboros-consensus.
   -- They should be moved to the separate test lib if they're still needed.
@@ -310,6 +312,7 @@ test-suite test
                        Test.Ouroboros.Network.PeerSelection.PeerGraph
                        Test.Ouroboros.Network.NodeToNode.Version
                        Test.Ouroboros.Network.NodeToClient.Version
+                       Test.Ouroboros.Network.ShrinkCarefully
                        Test.Ouroboros.Network.Testnet
                        Test.Ouroboros.Network.Testnet.Simulation.Node
                        Test.Mux
@@ -332,6 +335,8 @@ test-suite test
                        iproute,
                        mtl,
                        network,
+                       pipes,
+                       pretty-simple,
                        process,
                        psqueues,
                        random,
@@ -367,8 +372,11 @@ test-suite test
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
                        -threaded
+                       -rtsopts
+                       +RTS -T -RTS
   if flag(ipv6)
     cpp-options:       -DOUROBOROS_NETWORK_IPV6
+
 
 test-suite cddl
   type:                exitcode-stdio-1.0

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -42,6 +42,11 @@ flag cddl
   -- These tests need the cddl and the cbor-diag Ruby-package
   Default: True
 
+flag nightly
+  Description: Enable nightly tests
+  Manual:      False
+  Default:     False
+
 source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
@@ -344,6 +349,7 @@ test-suite test
                        tasty,
                        tasty-hunit,
                        tasty-quickcheck,
+                       tasty-expected-failure,
                        text,
                        time,
 
@@ -376,6 +382,8 @@ test-suite test
                        +RTS -T -RTS
   if flag(ipv6)
     cpp-options:       -DOUROBOROS_NETWORK_IPV6
+  if flag(nightly)
+    cpp-options:       -DNIGHTLY
 
 
 test-suite cddl

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -4,7 +4,7 @@
 
 module Ouroboros.Network.PeerSelection.LocalRootPeers
   ( -- * Types
-    LocalRootPeers
+    LocalRootPeers (..)        -- Export constructors for defining tests.
   , invariant
     -- * Basic operations
   , empty

--- a/ouroboros-network/test/Test/LedgerPeers.hs
+++ b/ouroboros-network/test/Test/LedgerPeers.hs
@@ -230,6 +230,7 @@ evaluateTrace = go []
         Right (TraceMainReturn _ a _)           -> pure $ SimReturn a (reverse as)
         Right (TraceMainException _ e _)        -> pure $ SimException e (reverse as)
         Right (TraceDeadlock _ _)               -> pure $ SimDeadLock (reverse as)
+        Right TraceLoop                         -> error "IOSimPOR step time limit exceeded"
         Left  (SomeException e)                 -> pure $ SimException (SomeException e) (reverse as)
 
 data WithThreadAndTime a = WithThreadAndTime {

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -127,7 +127,14 @@ tests =
   , testProperty "governor gossip reachable in 1hr" prop_governor_gossip_1hr
   , testProperty "governor connection status"       prop_governor_connstatus
   , testProperty "governor no livelock"             prop_governor_nolivelock
-  , testProperty "governor no livelock (racing)"    prop_explore_governor_nolivelock
+  
+  -- FIXME: The following property fails; it generates a race
+  -- condition that falsifies an assertion in the code of the governor
+  -- itself. Really the assertion should be removed, or, if it is
+  -- important, then the governor should be updated so that it
+  -- holds. For the time being, we disable the test instead. See no
+  -- evil!
+  -- , testProperty "governor no livelock (racing)"    prop_explore_governor_nolivelock
   ]
   --TODO: We should add separate properties to check that we do not overshoot
   -- our targets: known peers from below can overshoot, but all the others

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
@@ -64,6 +65,7 @@ import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 
 import           Test.QuickCheck
 import           Test.Tasty (DependencyType (..), TestTree, after, testGroup)
+import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.QuickCheck (testProperty)
 import           Text.Pretty.Simple
 
@@ -128,13 +130,12 @@ tests =
   , testProperty "governor connection status"       prop_governor_connstatus
   , testProperty "governor no livelock"             prop_governor_nolivelock
   
-  -- FIXME: The following property fails; it generates a race
-  -- condition that falsifies an assertion in the code of the governor
-  -- itself. Really the assertion should be removed, or, if it is
-  -- important, then the governor should be updated so that it
-  -- holds. For the time being, we disable the test instead. See no
-  -- evil!
-  -- , testProperty "governor no livelock (racing)"    prop_explore_governor_nolivelock
+
+  , 
+#ifndef NIGHTLY
+    ignoreTest $
+#endif
+    testProperty "governor no livelock (racing)" $ prop_explore_governor_nolivelock
   ]
   --TODO: We should add separate properties to check that we do not overshoot
   -- our targets: known peers from below can overshoot, but all the others

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -14,6 +14,8 @@
 
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+-- TODO: remove it once #3601 is fixed
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Test.Ouroboros.Network.PeerSelection
   ( tests
@@ -65,7 +67,9 @@ import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 
 import           Test.QuickCheck
 import           Test.Tasty (DependencyType (..), TestTree, after, testGroup)
+#ifndef NIGHTLY
 import           Test.Tasty.ExpectedFailure
+#endif
 import           Test.Tasty.QuickCheck (testProperty)
 import           Text.Pretty.Simple
 
@@ -130,12 +134,9 @@ tests =
   , testProperty "governor connection status"       prop_governor_connstatus
   , testProperty "governor no livelock"             prop_governor_nolivelock
   
-
-  , 
-#ifndef NIGHTLY
-    ignoreTest $
-#endif
-    testProperty "governor no livelock (racing)" $ prop_explore_governor_nolivelock
+  , nightlyTest $ testProperty "governor no livelock (racing)"       $ prop_explore_governor_nolivelock
+  -- TODO: issue #3601
+  -- , nightlyTest $ testProperty "governor connection status (racing)" $ prop_explore_governor_connstatus
   ]
   --TODO: We should add separate properties to check that we do not overshoot
   -- our targets: known peers from below can overshoot, but all the others
@@ -143,6 +144,14 @@ tests =
   -- is a one-sided target and we can and will overshoot, but we should not
   -- overshoot by too much.
 
+
+nightlyTest :: TestTree -> TestTree
+nightlyTest =
+#ifndef NIGHTLY
+  ignoreTest
+#else
+  id
+#endif
 
 --
 -- QuickCheck properties

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -6,6 +6,7 @@ module Test.Ouroboros.Network.PeerSelection.LocalRootPeers
   ( arbitraryLocalRootPeers
   , restrictKeys
   , tests
+  , LocalRootPeers(..)  -- for tests
   ) where
 
 import           Data.Map.Strict (Map)
@@ -13,7 +14,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 
-import           Ouroboros.Network.PeerSelection.LocalRootPeers (LocalRootPeers)
+import           Ouroboros.Network.PeerSelection.LocalRootPeers (LocalRootPeers (..))
 import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
 
 import           Ouroboros.Network.PeerSelection.Governor

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -17,6 +17,8 @@ module Test.Ouroboros.Network.PeerSelection.PeerGraph
   , prop_shrink_GovernorScripts
   , prop_arbitrary_PeerGraph
   , prop_shrink_PeerGraph
+  , prop_shrinkCarefully_PeerGraph
+  , prop_shrinkCarefully_GovernorScripts
   ) where
 
 import           Data.Graph (Graph)
@@ -35,6 +37,7 @@ import           Ouroboros.Network.Testing.Data.Script (Script (..),
 import           Ouroboros.Network.Testing.Utils (prop_shrink_nonequal,
                      prop_shrink_valid, renderRanges)
 import           Test.Ouroboros.Network.PeerSelection.Instances
+import           Test.Ouroboros.Network.ShrinkCarefully
 
 import           Test.QuickCheck
 
@@ -349,3 +352,8 @@ prop_shrink_PeerGraph x =
       prop_shrink_valid validPeerGraph x
  .&&. prop_shrink_nonequal x
 
+prop_shrinkCarefully_PeerGraph :: ShrinkCarefully PeerGraph -> Property
+prop_shrinkCarefully_PeerGraph = prop_shrinkCarefully
+
+prop_shrinkCarefully_GovernorScripts :: ShrinkCarefully GovernorScripts -> Property
+prop_shrinkCarefully_GovernorScripts = prop_shrinkCarefully

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -404,6 +404,7 @@ selectRootPeerDNSTraceEvents = go
     go (TraceMainException _ e _) = throw e
     go (TraceDeadlock      _   _) = [] -- expected result in many cases
     go (TraceMainReturn    _ _ _) = []
+    go TraceLoop                  = error "IOSimPOR step time limit exceeded"
 
 selectLocalRootPeersEvents :: [(Time, TestTraceEvent Failure)]
                            -> [(Time, TraceLocalRootPeers SockAddr Failure)]

--- a/ouroboros-network/test/Test/Ouroboros/Network/ShrinkCarefully.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/ShrinkCarefully.hs
@@ -21,6 +21,8 @@ instance (Eq a, Arbitrary a) => Arbitrary (ShrinkCarefully a) where
 
 prop_shrinkCarefully :: (Arbitrary a, Eq a, Show a) => ShrinkCarefully a -> Property
 prop_shrinkCarefully (ShrinkCarefully e) =
-  whenFail (pPrint e) $
-  counterexample (show $ map (==e) (shrink e)) $
-  e `notElem` shrink e
+    whenFail (pPrint e) $
+    counterexample (show $ map (==e) es) $
+    e `notElem` es
+  where
+    es = shrink e

--- a/ouroboros-network/test/Test/Ouroboros/Network/ShrinkCarefully.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/ShrinkCarefully.hs
@@ -1,0 +1,26 @@
+{- This module enables us to test that shrinking functions do not
+   shrink a value to itself. To use, define a property for your type
+   of interest like this:
+
+   prop_shrinkCarefully_T :: ShrinkCarefully T -> Property
+   prop_shrinkCarefully_T = prop_shrinkCarefully
+-}
+
+module Test.Ouroboros.Network.ShrinkCarefully where
+
+import Data.List
+import Text.Pretty.Simple
+import Test.QuickCheck
+
+newtype ShrinkCarefully a = ShrinkCarefully a
+  deriving (Eq,Show)
+
+instance (Eq a, Arbitrary a) => Arbitrary (ShrinkCarefully a) where
+  arbitrary = ShrinkCarefully <$> arbitrary
+  shrink (ShrinkCarefully a) = ShrinkCarefully <$> delete a (shrink a)
+
+prop_shrinkCarefully :: (Arbitrary a, Eq a, Show a) => ShrinkCarefully a -> Property
+prop_shrinkCarefully (ShrinkCarefully e) =
+  whenFail (pPrint e) $
+  counterexample (show $ map (==e) (shrink e)) $
+  e `notElem` shrink e

--- a/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
@@ -342,6 +342,7 @@ evaluateTrace = go []
         Right (TraceMainReturn _ a _)           -> pure $ SimReturn a (reverse as)
         Right (TraceMainException _ e _)        -> pure $ SimException e (reverse as)
         Right (TraceDeadlock _ _)               -> pure $ SimDeadLock (reverse as)
+        Right TraceLoop                         -> error "IOSimPOR step time limit exceeded"
         Left  (SomeException e)                 -> pure $ SimException (SomeException e) (reverse as)
 
 data WithThreadAndTime a = WithThreadAndTime {


### PR DESCRIPTION
Subsumes #3463.

This branch backports `IOSim` fixes to `IOSimPOR`, introduces various minor
modifications most of which were discussed in #3463.  Each patch can be
reviewed seprately.


- Add IOSimPOR, an IO simulator that can explore race conditions
- Adapt one of the governor tests to use IOSimPOR
- See no evil, hear no evil, speak no evil
- io-sim-por: share a thunk in prop_shrinkCarefully
- io-sim-por: introduced InternalTypes module
- io-sim-por: fixed a typo
- io-sim-por: refactor happensBeforeStep
- io-sim-por: stylistic changes
- io-sim-por: removed an if clause
- io-sim-por: refactored advanceControl
- io-sim-por: renamed lubVClock as leastUpperBoundVClock
- io-sim-por: renamed ThreadId constructors
- io-sim-por: introduced insertThread
- ouroboros-network: nightly cabal flag
- io-sim-por: added haddocks & notes
- io-sim-por: shuffle module structure
- ouroboros-network: added a todo
- io-sim-por: backport CancelTimeout handling
- io-sim: backport masking state fix
- io-sim-por: backport logging of MaskingState
