### PR TITLE
connection-manager: mini-protocol params

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -443,7 +443,6 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
           ( apps
           , Diffusion.P2PApplications
               P2P.ApplicationsExtra {
-                P2P.daMiniProtocolParameters = miniProtocolParams,
                 P2P.daRethrowPolicy          = consensusRethrowPolicy (Proxy @blk),
                 P2P.daLocalRethrowPolicy     = localRethrowPolicy,
                 P2P.daPeerMetrics            = peerMetrics,

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -237,7 +237,6 @@ withBidirectionalConnectionManager snocket socket
         (makeConnectionHandler
           muxTracer
           SingInitiatorResponderMode
-          serverMiniProtocolBundle
           HandshakeArguments {
               -- TraceSendRecv
               haHandshakeTracer = ("handshake",) `contramap` debugTracer,
@@ -274,42 +273,6 @@ withBidirectionalConnectionManager snocket socket
               (\thread -> link thread
                        >> k connectionManager serverAddr)
   where
-    -- for a bidirectional mux we need to define 'Mu.xMiniProtocolInfo' for each
-    -- protocol for each direction.
-    serverMiniProtocolBundle :: Mux.MiniProtocolBundle InitiatorResponderMode
-    serverMiniProtocolBundle = Mux.MiniProtocolBundle
-        [ Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 1,
-            Mux.miniProtocolDir = Mux.ResponderDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 1,
-            Mux.miniProtocolDir = Mux.InitiatorDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 2,
-            Mux.miniProtocolDir = Mux.ResponderDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 2,
-            Mux.miniProtocolDir = Mux.InitiatorDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 3,
-            Mux.miniProtocolDir = Mux.ResponderDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 3,
-            Mux.miniProtocolDir = Mux.InitiatorDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        ]
-
     serverApplication :: LazySTM.TVar m [[Int]]
                       -> LazySTM.TVar m [[Int]]
                       -> LazySTM.TVar m [[Int]]

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
@@ -189,7 +189,6 @@ makeConnectionHandler
     -> SingMuxMode muxMode
     -- ^ describe whether this is outbound or inbound connection, and bring
     -- evidence that we can use mux with it.
-    -> MiniProtocolBundle muxMode
     -> HandshakeArguments (ConnectionId peerAddr) versionNumber versionData m
     -> Versions versionNumber versionData
                 (OuroborosBundle muxMode peerAddr ByteString m a b)
@@ -198,7 +197,6 @@ makeConnectionHandler
     -- exception to that thread, when trying to terminate the process.
     -> MuxConnectionHandler muxMode socket peerAddr versionNumber versionData ByteString m a b
 makeConnectionHandler muxTracer singMuxMode
-                      miniProtocolBundle
                       handshakeArguments
                       versionedApplication
                       (mainThreadId, rethrowPolicy) =
@@ -292,7 +290,7 @@ makeConnectionHandler muxTracer singMuxMode
                             connectionId
                             (readTVar <$> controlMessageBundle)
                             app
-                  mux <- newMux miniProtocolBundle
+                  mux <- newMux (mkMiniProtocolBundle muxBundle)
                   let !handle = Handle {
                           hMux            = mux,
                           hMuxBundle      = muxBundle,
@@ -359,7 +357,7 @@ makeConnectionHandler muxTracer singMuxMode
                             connectionId
                             (readTVar <$> controlMessageBundle)
                             app
-                  mux <- newMux miniProtocolBundle
+                  mux <- newMux (mkMiniProtocolBundle muxBundle)
                   let !handle = Handle {
                           hMux            = mux,
                           hMuxBundle      = muxBundle,

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -396,7 +396,6 @@ withInitiatorOnlyConnectionManager name timeouts trTracer cmTracer snocket local
       (makeConnectionHandler
         muxTracer
         SingInitiatorMode
-        clientMiniProtocolBundle
         HandshakeArguments {
             -- TraceSendRecv
             haHandshakeTracer = (name,) `contramap` nullTracer,
@@ -415,25 +414,6 @@ withInitiatorOnlyConnectionManager name timeouts trTracer cmTracer snocket local
       (\cm ->
         k cm `catch` \(e :: SomeException) -> throwIO e)
   where
-    clientMiniProtocolBundle :: Mux.MiniProtocolBundle InitiatorMode
-    clientMiniProtocolBundle = Mux.MiniProtocolBundle
-        [ Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 1,
-            Mux.miniProtocolDir = Mux.InitiatorDirectionOnly,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 2,
-            Mux.miniProtocolDir = Mux.InitiatorDirectionOnly,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 3,
-            Mux.miniProtocolDir = Mux.InitiatorDirectionOnly,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        ]
-
     clientApplication :: Bundle
                           (ConnectionId peerAddr
                             -> ControlMessageSTM m
@@ -587,7 +567,6 @@ withBidirectionalConnectionManager name timeouts
         (makeConnectionHandler
           muxTracer
           SingInitiatorResponderMode
-          serverMiniProtocolBundle
           HandshakeArguments {
               -- TraceSendRecv
               haHandshakeTracer = WithName name `contramap` nullTracer,
@@ -628,42 +607,6 @@ withBidirectionalConnectionManager name timeouts
           `catch` \(e :: SomeException) -> do
             throwIO e
   where
-    -- for a bidirectional mux we need to define 'Mux.MiniProtocolInfo' for each
-    -- protocol for each direction.
-    serverMiniProtocolBundle :: Mux.MiniProtocolBundle InitiatorResponderMode
-    serverMiniProtocolBundle = Mux.MiniProtocolBundle
-        [ Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 1,
-            Mux.miniProtocolDir = Mux.ResponderDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 1,
-            Mux.miniProtocolDir = Mux.InitiatorDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 2,
-            Mux.miniProtocolDir = Mux.ResponderDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 2,
-            Mux.miniProtocolDir = Mux.InitiatorDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 3,
-            Mux.miniProtocolDir = Mux.ResponderDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        , Mux.MiniProtocolInfo {
-            Mux.miniProtocolNum = Mux.MiniProtocolNum 3,
-            Mux.miniProtocolDir = Mux.InitiatorDirection,
-            Mux.miniProtocolLimits = Mux.MiniProtocolLimits maxBound
-          }
-        ]
-
     serverApplication :: Bundle
                           (ConnectionId peerAddr
                             -> ControlMessageSTM m

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -53,7 +53,6 @@ import           Ouroboros.Network.BlockFetch.Decision (FetchMode (..))
 import           Ouroboros.Network.ConnectionManager.Types (DataFlow (..))
 import qualified Ouroboros.Network.Diffusion as Diff
 import qualified Ouroboros.Network.Diffusion.P2P as Diff.P2P
-import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.Governor
                      (PeerSelectionTargets (..))
@@ -202,9 +201,8 @@ run blockGeneratorArgs limits ni na =
 
             appsExtra :: Diff.P2P.ApplicationsExtra NtNAddr m
             appsExtra = Diff.P2P.ApplicationsExtra
-              { Diff.P2P.daMiniProtocolParameters = NtN.defaultMiniProtocolParameters
-                -- TODO: simulation errors should be critical
-              , Diff.P2P.daRethrowPolicy          =
+              { -- TODO: simulation errors should be critical
+                Diff.P2P.daRethrowPolicy          =
                      muxErrorRethrowPolicy
                   <> ioErrorRethrowPolicy
 


### PR DESCRIPTION
The 'MiniProtocolBundle' (a list of 'MiniProtocolInfo') can be derived
from a 'MuxBundle' the same way this is done in the 'Network.Mux.Compat'
module.   This avoids passing the same information through two different
code paths.

Fixes input-output-hk/cardano-node#3568.
