### PR TITLE
Fix: `test-storage:LedgerDB` test suite

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -96,7 +96,7 @@ module Ouroboros.Consensus.Ledger.Basics (
   , flushDbChangelog
   , prefixBackToAnchorDbChangelog
   , prefixDbChangelog
-  , pruneDbChangelog
+  , pruneVolatilePartDbChangelog
   , rollbackDbChangelog
   , youngestImmutableSlotDbChangelog
     -- ** Misc
@@ -907,10 +907,10 @@ extendDbChangelog dblog newState =
     ext (ApplySeqDiffMK sq) (ApplyDiffMK diff) =
       ApplySeqDiffMK $ extendSeqUtxoDiff sq slot diff
 
-pruneDbChangelog ::
+pruneVolatilePartDbChangelog ::
      GetTip (l EmptyMK)
   => SecurityParam -> DbChangelog l -> DbChangelog l
-pruneDbChangelog (SecurityParam k) dblog =
+pruneVolatilePartDbChangelog (SecurityParam k) dblog =
     Exn.assert (AS.length imm' + AS.length vol' == AS.length imm + AS.length vol) $
     DbChangelog {
         changelogDiffAnchor

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -153,16 +153,17 @@ module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
   , flush
   , readKeySets
   , readKeySetsVH
-    -- * Snapshots: Read from disk
+    -- * Snapshots
+    -- ** Read from disk
   , readSnapshot
-    -- * Snapshots: Write to disk
+    -- ** Write to disk
   , takeSnapshot
   , trimSnapshots
   , writeSnapshot
-    -- * Low-level API (primarily exposed for testing)
+    -- ** Low-level API (primarily exposed for testing)
   , deleteSnapshot
-  , snapshotToFileName
-  , snapshotToDirPath
+  , snapshotToStatePath
+  , snapshotToTablesPath
     -- ** Opaque
   , DiskSnapshot
     -- * Trace events
@@ -436,6 +437,7 @@ initLedgerDB replayTracer
               case eDB of
                 Left err -> do
                   traceWith tracer . InvalidSnapshot s $ err
+                  when (diskSnapshotIsTemporary s) $ deleteSnapshot hasFS s
                   tryNewestFirst (acc . InitFailure s err) ss
                 Right (db, replayed) ->
                   return (acc (InitFromSnapshot s tip), db, replayed, backingStore)
@@ -700,8 +702,8 @@ diskSnapshotIsPermanent = isJust . dsSuffix
 diskSnapshotIsTemporary :: DiskSnapshot -> Bool
 diskSnapshotIsTemporary = not . diskSnapshotIsPermanent
 
-snapshotToFileName :: DiskSnapshot -> String
-snapshotToFileName DiskSnapshot { dsNumber, dsSuffix } =
+snapshotToDirName :: DiskSnapshot -> String
+snapshotToDirName DiskSnapshot { dsNumber, dsSuffix } =
     show dsNumber <> suffix
   where
     suffix = case dsSuffix of
@@ -710,17 +712,17 @@ snapshotToFileName DiskSnapshot { dsNumber, dsSuffix } =
 
 -- | The path within the LgrDB's filesystem to the snapshot's directory
 snapshotToDirPath :: DiskSnapshot -> FsPath
-snapshotToDirPath = mkFsPath . (:[]) . snapshotToFileName
+snapshotToDirPath = mkFsPath . (:[]) . snapshotToDirName
 
 -- | The path within the LgrDB's filesystem to the file that contains the
 -- snapshot's serialized ledger state
 snapshotToStatePath :: DiskSnapshot -> FsPath
-snapshotToStatePath = mkFsPath . (\x -> [x, "state"]) . snapshotToFileName
+snapshotToStatePath = mkFsPath . (\x -> [x, "state"]) . snapshotToDirName
 
 -- | The path within the LgrDB's filesystem to the directory that contains a
 -- snapshot's backing store
 snapshotToTablesPath :: DiskSnapshot -> FsPath
-snapshotToTablesPath = mkFsPath . (\x -> [x, "tables"]) . snapshotToFileName
+snapshotToTablesPath = mkFsPath . (\x -> [x, "tables"]) . snapshotToDirName
 
 -- | The path within the LgrDB's filesystem to the directory that contains the
 -- backing store


### PR DESCRIPTION
Adds the `dbBackingStore` field to the database used in the tests plus integrates it in the operations.