### PR TITLE
Run LedgerDB OnDisk storage test

### DIFF
--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -525,8 +525,6 @@ deriving anyclass instance PayloadSemantics ptype =>
 deriving anyclass instance NoThunks (PayloadDependentState ptype mk) =>
   NoThunks  (LedgerState (TestBlockWith ptype) mk)
 
--- deriving anyclass instance PayloadSemantics ptype => ToExpr    (LedgerState (TestBlockWith ptype) mk)
-
 instance InMemory (LedgerState (TestBlockWith ())) where
   convertMapKind TestLedger {lastAppliedPoint} = TestLedger lastAppliedPoint EmptyPLDS
 

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -13,11 +13,13 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE QuantifiedConstraints      #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 -- | Minimal instantiation of the consensus layer to be able to run the ChainDB
@@ -29,15 +31,24 @@ module Test.Util.TestBlock (
   , Header (..)
   , LedgerTables (..)
   , StorageConfig (..)
-  , TestBlock (..)
   , TestBlockError (..)
+  , TestBlockWith (tbPayload)
   , TestHash (TestHash)
-  , firstBlock
+  , firstBlockWithPayload
   , forkBlock
   , modifyFork
-  , successorBlock
+  , successorBlockWithPayload
   , testHashFromList
   , unTestHash
+    -- ** Test block without payload
+  , TestBlock
+  , firstBlock
+  , successorBlock
+    -- ** Payload semantics
+  , PayloadSemantics (..)
+    -- * LedgerState
+  , LedgerState (TestLedger, payloadDependentState, lastAppliedPoint)
+  , Ticked1 (TickedTestLedger)
     -- * Chain
   , BlockChain (..)
   , blockChain
@@ -49,11 +60,13 @@ module Test.Util.TestBlock (
   , treeToBlocks
   , treeToChains
     -- * Ledger infrastructure
-  , lastAppliedBlock
   , singleNodeTestConfig
+  , singleNodeTestConfigWith
   , singleNodeTestConfigWithK
   , testInitExtLedger
+  , testInitExtLedgerWithState
   , testInitLedger
+  , testInitLedgerWithState
     -- * Support for tests
   , Permutation (..)
   , permute
@@ -66,6 +79,7 @@ import           Control.DeepSeq (force)
 import           Control.Monad.Except (throwError)
 import           Data.Functor.Identity (Identity (..))
 import           Data.Int
+import           Data.Kind (Type)
 import           Data.List (transpose)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -182,55 +196,87 @@ instance InMemory.ReadsKeySets Identity (LedgerState TestBlock) where
   readDb (InMemory.RewoundTableKeySets seqNo NoTestLedgerTables) =
       pure $ InMemory.UnforwardedReadSets seqNo NoTestLedgerTables
 
-data TestBlock = TestBlock {
-      tbHash  :: TestHash
-    , tbSlot  :: SlotNo
+-- | Test block parametrized on the payload type
+--
+-- For blocks without payload see the 'TestBlock' type alias.
+--
+-- By defining a 'PayloadSemantics' it is possible to obtain an 'ApplyBlock'
+-- instance. See the former class for more details.
+--
+data TestBlockWith ptype = TestBlockWith {
+      tbHash    :: TestHash
+    , tbSlot    :: SlotNo
       -- ^ We store a separate 'Block.SlotNo', as slots can have gaps between
       -- them, unlike block numbers.
       --
       -- Note that when generating a 'TestBlock', you must make sure that
       -- blocks with the same 'TestHash' have the same slot number.
-    , tbValid :: Bool
+    , tbValid   :: Bool
       -- ^ Note that when generating a 'TestBlock', you must make sure that
       -- blocks with the same 'TestHash' have the same value for 'tbValid'.
+    , tbPayload :: ptype
     }
   deriving stock    (Show, Eq, Ord, Generic)
   deriving anyclass (Serialise, NoThunks, ToExpr)
 
+-- | Create the first block in the given fork, @[fork]@, with the given payload.
+-- The 'SlotNo' will be 1.
+firstBlockWithPayload :: Word64 -> ptype -> TestBlockWith ptype
+firstBlockWithPayload forkNo payload = TestBlockWith
+    { tbHash    = TestHash (forkNo NE.:| [])
+    , tbSlot    = 1
+    , tbValid   = True
+    , tbPayload = payload
+    }
+
+-- | Create the successor of the given block without forking: @b -> b ++ [0]@ (in
+-- the printed representation) The 'SlotNo' is increased by 1.
+--
+-- In Zipper parlance, this corresponds to going down in a tree.
+successorBlockWithPayload ::
+  TestHash -> SlotNo -> ptype -> TestBlockWith ptype
+successorBlockWithPayload hash slot payload = TestBlockWith
+    { tbHash    = TestHash (NE.cons 0 (unTestHash hash))
+    , tbSlot    = succ slot
+    , tbValid   = True
+    , tbPayload = payload
+    }
+
 instance ShowProxy TestBlock where
 
-newtype instance Header TestBlock = TestHeader { testHeader :: TestBlock }
-  deriving stock   (Eq, Show)
+newtype instance Header (TestBlockWith ptype) =
+    TestHeader { testHeader :: TestBlockWith ptype }
+  deriving stock (Eq, Show)
   deriving newtype (NoThunks, Serialise)
 
-instance ShowProxy (Header TestBlock) where
+instance Typeable ptype => ShowProxy (Header (TestBlockWith ptype)) where
 
-instance GetHeader TestBlock where
-  getHeader = TestHeader
-  blockMatchesHeader (TestHeader blk') blk = blk == blk'
-  headerIsEBB = const Nothing
-
-type instance HeaderHash TestBlock = TestHash
-
-instance HasHeader TestBlock where
-  getHeaderFields = getBlockHeaderFields
-
-instance HasHeader (Header TestBlock) where
-  getHeaderFields (TestHeader TestBlock{..}) = HeaderFields {
+instance (Typeable ptype, Eq ptype) => HasHeader (Header (TestBlockWith ptype)) where
+  getHeaderFields (TestHeader TestBlockWith{..}) = HeaderFields {
         headerFieldHash    = tbHash
       , headerFieldSlot    = tbSlot
       , headerFieldBlockNo = fromIntegral . NE.length . unTestHash $ tbHash
       }
 
-instance GetPrevHash TestBlock where
+instance (Typeable ptype, Eq ptype) => GetHeader (TestBlockWith ptype) where
+  getHeader = TestHeader
+  blockMatchesHeader (TestHeader blk') blk = blk == blk'
+  headerIsEBB = const Nothing
+
+type instance HeaderHash (TestBlockWith ptype) = TestHash
+
+instance (Typeable ptype, Eq ptype) => HasHeader (TestBlockWith ptype) where
+  getHeaderFields = getBlockHeaderFields
+
+instance (Typeable ptype, Eq ptype) => GetPrevHash (TestBlockWith ptype) where
   headerPrevHash (TestHeader b) =
       case NE.nonEmpty . NE.tail . unTestHash . tbHash $ b of
         Nothing       -> GenesisHash
         Just prevHash -> BlockHash (TestHash prevHash)
 
-instance StandardHash TestBlock
+instance StandardHash (TestBlockWith ptype)
 
-instance Condense TestBlock where
+instance (Typeable ptype, Eq ptype) => Condense (TestBlockWith ptype) where
   condense b = mconcat [
         "(H:"
       , condense (blockHash b)
@@ -241,14 +287,14 @@ instance Condense TestBlock where
       , ")"
       ]
 
-instance Condense (Header TestBlock) where
+instance (Typeable ptype, Eq ptype) => Condense (Header (TestBlockWith ptype)) where
   condense = condense . testHeader
 
-instance Condense (ChainHash TestBlock) where
+instance Condense (ChainHash (TestBlockWith ptype)) where
   condense GenesisHash   = "genesis"
   condense (BlockHash h) = show h
 
-data instance BlockConfig TestBlock = TestBlockConfig {
+data instance BlockConfig (TestBlockWith ptype) = TestBlockConfig {
       -- | Number of core nodes
       --
       -- We need this in order to compute the 'ValidateView', which must
@@ -257,18 +303,10 @@ data instance BlockConfig TestBlock = TestBlockConfig {
     }
   deriving (Show, Generic, NoThunks)
 
--- | The 'TestBlock' does not need any codec config
-data instance CodecConfig TestBlock = TestBlockCodecConfig
-  deriving (Show, Generic, NoThunks)
-
--- | The 'TestBlock' does not need any storage config
-data instance StorageConfig TestBlock = TestBlockStorageConfig
-  deriving (Show, Generic, NoThunks)
-
-instance HasNetworkProtocolVersion TestBlock where
+instance HasNetworkProtocolVersion (TestBlockWith ptype) where
   -- Use defaults
 
-instance ConfigSupportsNode TestBlock where
+instance ConfigSupportsNode (TestBlockWith ptype) where
   getSystemStart = const (SystemStart dummyDate)
     where
       --  This doesn't matter much
@@ -276,6 +314,66 @@ instance ConfigSupportsNode TestBlock where
 
   getNetworkMagic = const (NetworkMagic 42)
 
+{-------------------------------------------------------------------------------
+  Payload semantics
+-------------------------------------------------------------------------------}
+
+class ( Typeable ptype
+      , Eq       ptype
+      , NoThunks ptype
+
+      , forall mk . Eq        (PayloadDependentState ptype mk)
+      , forall mk . Show      (PayloadDependentState ptype mk)
+      , forall mk . Generic   (PayloadDependentState ptype mk)
+      ,             Serialise (PayloadDependentState ptype EmptyMK)
+      , forall mk . NoThunks  (PayloadDependentState ptype mk)
+
+      , TickedTableStuff     (LedgerState (TestBlockWith ptype))
+      , StowableLedgerTables (LedgerState (TestBlockWith ptype))
+      , ShowLedgerState      (LedgerState (TestBlockWith ptype))
+
+      , NoThunks (LedgerTables (LedgerState (TestBlockWith ptype)) 'SeqDiffMK)
+      , NoThunks (LedgerTables (LedgerState (TestBlockWith ptype)) 'ValuesMK)
+      , FromCBOR (LedgerTables (LedgerState (TestBlockWith ptype)) 'ValuesMK)
+      , ToCBOR   (LedgerTables (LedgerState (TestBlockWith ptype)) 'ValuesMK)
+
+      , Eq        (PayloadDependentError ptype)
+      , Show      (PayloadDependentError ptype)
+      , Generic   (PayloadDependentError ptype)
+      , ToExpr    (PayloadDependentError ptype)
+      , Serialise (PayloadDependentError ptype)
+      , NoThunks  (PayloadDependentError ptype)
+
+      , NoThunks (CodecConfig (TestBlockWith ptype))
+
+      , NoThunks (StorageConfig (TestBlockWith ptype))
+      ) => PayloadSemantics ptype where
+
+  data PayloadDependentState ptype (mk :: MapKind) :: Type
+
+  type PayloadDependentError ptype :: Type
+
+  applyPayload ::
+       PayloadDependentState ptype ValuesMK
+    -> ptype
+    -> Either (PayloadDependentError ptype) (PayloadDependentState ptype TrackingMK)
+
+  -- | This function is used to implement the 'getBlockKeySets' function of the
+  -- 'ApplyBlock' class. Thus we assume that the payload contains all the
+  -- information needed to determine which keys should be retrieved from the
+  -- backing store to apply a 'TestBlockWith'.
+  getPayloadKeySets :: ptype -> TableKeySets (LedgerState (TestBlockWith ptype))
+
+instance PayloadSemantics () where
+  data PayloadDependentState () mk = EmptyPLDS
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (Serialise, NoThunks)
+
+  type PayloadDependentError () = ()
+
+  applyPayload _ _ = Right EmptyPLDS
+
+  getPayloadKeySets = const NoTestLedgerTables
 
 {-------------------------------------------------------------------------------
   NestedCtxt
@@ -298,29 +396,43 @@ instance HasNestedContent f TestBlock
   Test infrastructure: ledger state
 -------------------------------------------------------------------------------}
 
-type instance BlockProtocol TestBlock = Bft BftMockCrypto
+type instance BlockProtocol (TestBlockWith ptype) = Bft BftMockCrypto
 
-type instance Signed (Header TestBlock) = ()
-instance SignedHeader (Header TestBlock) where
+type instance Signed (Header (TestBlockWith ptype)) = ()
+instance SignedHeader (Header (TestBlockWith ptype)) where
   headerSigned _ = ()
 
-data TestBlockError =
+data TestBlockError ptype =
     -- | The hashes don't line up
     InvalidHash
-      (ChainHash TestBlock)  -- ^ Expected hash
-      (ChainHash TestBlock)  -- ^ Invalid hash
+      (ChainHash (TestBlockWith ptype))  -- ^ Expected hash
+      (ChainHash (TestBlockWith ptype))  -- ^ Invalid hash
 
     -- | The block itself is invalid
   | InvalidBlock
-  deriving (Eq, Show, Generic, NoThunks)
+  | InvalidPayload (PayloadDependentError ptype)
 
-instance BlockSupportsProtocol TestBlock where
+deriving stock instance Eq (PayloadDependentError ptype) => Eq (TestBlockError ptype)
+deriving stock instance Show (PayloadDependentError ptype) => Show (TestBlockError ptype)
+deriving stock instance Generic (TestBlockError ptype)
+
+deriving anyclass instance
+  ( Typeable ptype
+  , Generic (PayloadDependentError ptype)
+  , NoThunks (PayloadDependentError ptype)) => NoThunks (TestBlockError ptype)
+
+instance ( Typeable ptype
+         , Eq       ptype
+         , NoThunks ptype
+         , NoThunks (CodecConfig (TestBlockWith ptype))
+         , NoThunks (StorageConfig (TestBlockWith ptype))
+         ) => BlockSupportsProtocol (TestBlockWith ptype) where
   validateView TestBlockConfig{..} =
       bftValidateView bftFields
     where
       NumCoreNodes numCore = testBlockNumCoreNodes
 
-      bftFields :: Header TestBlock -> BftFields BftMockCrypto ()
+      bftFields :: Header (TestBlockWith ptype) -> BftFields BftMockCrypto ()
       bftFields (TestHeader tb) = BftFields {
             bftSignature = SignedDSIGN $ mockSign () (signKey (tbSlot tb))
           }
@@ -332,21 +444,7 @@ instance BlockSupportsProtocol TestBlock where
 
 type instance LedgerCfg (LedgerState TestBlock) = HardFork.EraParams
 
-instance GetTip (LedgerState TestBlock mk) where
-  getTip = castPoint . lastAppliedPoint
-
-instance GetTip (Ticked1 (LedgerState TestBlock) mk) where
-  getTip = castPoint . lastAppliedPoint . getTickedTestLedger
-
-instance IsLedger (LedgerState TestBlock) where
-  type LedgerErr (LedgerState TestBlock) = TestBlockError
-
-  type AuxLedgerEvent (LedgerState TestBlock) =
-    VoidLedgerEvent (LedgerState TestBlock)
-
-  applyChainTickLedgerResult _ _ (TestLedger l) = pureLedgerResult $ TickedTestLedger $ TestLedger l
-
-instance ShowLedgerState (LedgerState TestBlock) where
+instance PayloadSemantics ptype => ShowLedgerState (LedgerState (TestBlockWith ptype)) where
   showsLedgerState _sing = shows
 
 instance TableStuff (LedgerState TestBlock) where
@@ -354,8 +452,8 @@ instance TableStuff (LedgerState TestBlock) where
     deriving stock    (Generic, Eq, Show)
     deriving anyclass (NoThunks)
 
-  projectLedgerTables _                              = NoTestLedgerTables
-  withLedgerTables (TestLedger p) NoTestLedgerTables = TestLedger p
+  projectLedgerTables _                  = NoTestLedgerTables
+  withLedgerTables st NoTestLedgerTables = convertMapKind st
 
   pureLedgerTables _                                       = NoTestLedgerTables
   mapLedgerTables  _ NoTestLedgerTables                    = NoTestLedgerTables
@@ -377,73 +475,158 @@ instance ShowLedgerState (LedgerTables (LedgerState TestBlock)) where
   showsLedgerState _sing = shows
 
 instance StowableLedgerTables (LedgerState TestBlock) where
-  stowLedgerTables   (TestLedger p) = TestLedger p
-  unstowLedgerTables (TestLedger p) = TestLedger p
-  isCandidateForUnstow              = isCandidateForUnstowDefault
+  stowLedgerTables   (TestLedger p EmptyPLDS) = TestLedger p EmptyPLDS
+  unstowLedgerTables (TestLedger p EmptyPLDS) = TestLedger p EmptyPLDS
+  isCandidateForUnstow                        = isCandidateForUnstowDefault
 
-instance ApplyBlock (LedgerState TestBlock) TestBlock where
-  applyBlockLedgerResult _ tb@TestBlock{..} (TickedTestLedger TestLedger{..})
+instance PayloadSemantics ptype
+         => ApplyBlock (LedgerState (TestBlockWith ptype)) (TestBlockWith ptype) where
+  applyBlockLedgerResult _ tb@TestBlockWith{..} (TickedTestLedger TestLedger{..})
     | blockPrevHash tb /= pointHash lastAppliedPoint
     = throwError $ InvalidHash (pointHash lastAppliedPoint) (blockPrevHash tb)
     | not tbValid
     = throwError $ InvalidBlock
     | otherwise
-    = return     $ pureLedgerResult $ TestLedger (Chain.blockPoint tb)
+    = case applyPayload payloadDependentState tbPayload of
+        Left err  -> throwError $ InvalidPayload err
+        Right st' -> return     $ pureLedgerResult
+                                $ TestLedger {
+                                    lastAppliedPoint      = Chain.blockPoint tb
+                                  , payloadDependentState = st'
+                                  }
 
-  reapplyBlockLedgerResult _ tb _ =
-                   pureLedgerResult $ TestLedger (Chain.blockPoint tb)
+  reapplyBlockLedgerResult _ tb@TestBlockWith{..} (TickedTestLedger TestLedger{..}) =
+    case applyPayload payloadDependentState tbPayload of
+        Left err  -> error $ "Found an error when reapplying a block: " ++ show err
+        Right st' ->              pureLedgerResult
+                                $ TestLedger {
+                                    lastAppliedPoint      = Chain.blockPoint tb
+                                  , payloadDependentState = st'
+                                  }
 
-  getBlockKeySets _ = NoTestLedgerTables
 
-newtype instance LedgerState TestBlock mk =
+  getBlockKeySets = getPayloadKeySets . tbPayload
+
+data instance LedgerState (TestBlockWith ptype) mk =
     TestLedger {
-        -- The ledger state simply consists of the last applied block
-        lastAppliedPoint :: Point TestBlock
+        -- | The ledger state simply consists of the last applied block
+        lastAppliedPoint      :: Point (TestBlockWith ptype)
+        -- | State that depends on the application of the block payload to the
+        -- state.
+      , payloadDependentState :: PayloadDependentState ptype mk
       }
-  deriving stock   (Show, Eq, Generic)
-  deriving newtype (Serialise, NoThunks, ToExpr)
 
-instance InMemory (LedgerState TestBlock) where
-  convertMapKind TestLedger {..} = TestLedger {..}
+deriving stock instance PayloadSemantics ptype => Show    (LedgerState (TestBlockWith ptype) mk)
+deriving stock instance PayloadSemantics ptype => Eq      (LedgerState (TestBlockWith ptype) mk)
+deriving stock instance                           Generic (LedgerState (TestBlockWith ptype) mk)
+
+deriving anyclass instance PayloadSemantics ptype =>
+  Serialise (LedgerState (TestBlockWith ptype) EmptyMK)
+deriving anyclass instance NoThunks (PayloadDependentState ptype mk) =>
+  NoThunks  (LedgerState (TestBlockWith ptype) mk)
+
+-- deriving anyclass instance PayloadSemantics ptype => ToExpr    (LedgerState (TestBlockWith ptype) mk)
+
+instance InMemory (LedgerState (TestBlockWith ())) where
+  convertMapKind TestLedger {lastAppliedPoint} = TestLedger lastAppliedPoint EmptyPLDS
 
 instance InMemory (LedgerTables (LedgerState TestBlock)) where
   convertMapKind NoTestLedgerTables = NoTestLedgerTables
 
+testInitLedgerWithState ::
+  PayloadDependentState ptype mk -> LedgerState (TestBlockWith ptype) mk
+testInitLedgerWithState = TestLedger GenesisPoint
+
 -- Ticking has no effect
-newtype instance Ticked1 (LedgerState TestBlock) mk = TickedTestLedger {
-      getTickedTestLedger :: LedgerState TestBlock mk
+newtype instance Ticked1 (LedgerState (TestBlockWith ptype)) mk = TickedTestLedger {
+      getTickedTestLedger :: LedgerState (TestBlockWith ptype) mk
     }
-  deriving stock   (Eq)
+  -- deriving stock   (Eq)
 
-instance UpdateLedger TestBlock
+testInitExtLedgerWithState ::
+  PayloadDependentState ptype mk -> ExtLedgerState (TestBlockWith ptype) mk
+testInitExtLedgerWithState st = ExtLedgerState {
+      ledgerState = testInitLedgerWithState st
+    , headerState = genesisHeaderState ()
+    }
 
-instance InspectLedger TestBlock where
+type instance LedgerCfg (LedgerState (TestBlockWith ptype)) = HardFork.EraParams
+
+instance GetTip (LedgerState (TestBlockWith ptype) mk) where
+  getTip = castPoint . lastAppliedPoint
+
+instance GetTip (Ticked1 (LedgerState (TestBlockWith ptype)) mk) where
+  getTip = castPoint . lastAppliedPoint . getTickedTestLedger
+
+instance PayloadSemantics ptype => IsLedger (LedgerState (TestBlockWith ptype)) where
+  type LedgerErr (LedgerState (TestBlockWith ptype)) = TestBlockError ptype
+
+  type AuxLedgerEvent (LedgerState (TestBlockWith ptype)) =
+    VoidLedgerEvent (LedgerState (TestBlockWith ptype))
+
+  applyChainTickLedgerResult _ _ = pureLedgerResult . TickedTestLedger
+
+instance PayloadSemantics ptype => UpdateLedger (TestBlockWith ptype)
+
+instance InspectLedger (TestBlockWith ptype) where
   -- Defaults are fine
 
--- | Last applied block
---
--- Returns 'Nothing' if the ledger is empty.
-lastAppliedBlock :: LedgerState TestBlock mk -> Maybe TestBlock
-lastAppliedBlock (TestLedger p) = go p
-  where
-    -- We can only have applied valid blocks
-    go :: Point TestBlock -> Maybe TestBlock
-    go GenesisPoint           = Nothing
-    go (BlockPoint slot hash) = Just $ TestBlock hash slot True
-
-instance HasAnnTip TestBlock where
+instance (Typeable ptype, PayloadSemantics ptype) => HasAnnTip (TestBlockWith ptype) where
   -- Use defaults
 
-instance BasicEnvelopeValidation TestBlock where
+instance (Typeable ptype, PayloadSemantics ptype) => BasicEnvelopeValidation (TestBlockWith ptype) where
   -- The block number of a test block is derived from the length of the hash
   expectedFirstBlockNo _ = BlockNo 1
 
-instance ValidateEnvelope TestBlock where
+instance (Typeable ptype, PayloadSemantics ptype) => ValidateEnvelope (TestBlockWith ptype) where
   -- Use defaults
 
-instance LedgerSupportsProtocol TestBlock where
+instance (Typeable ptype, PayloadSemantics ptype) => LedgerSupportsProtocol (TestBlockWith ptype) where
   protocolLedgerView   _ _  = TickedTrivial
   ledgerViewForecastAt _    = trivialForecast
+
+singleNodeTestConfigWith ::
+     CodecConfig (TestBlockWith ptype)
+  -> StorageConfig (TestBlockWith ptype)
+  -> SecurityParam -> TopLevelConfig (TestBlockWith ptype)
+singleNodeTestConfigWith codecConfig storageConfig k = TopLevelConfig {
+      topLevelConfigProtocol = BftConfig {
+          bftParams  = BftParams { bftSecurityParam = k
+                                 , bftNumNodes      = numCoreNodes
+                                 }
+        , bftSignKey = SignKeyMockDSIGN 0
+        , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
+        }
+    , topLevelConfigLedger  = eraParams
+    , topLevelConfigBlock   = TestBlockConfig numCoreNodes
+    , topLevelConfigCodec   = codecConfig
+    , topLevelConfigStorage = storageConfig
+    }
+  where
+    slotLength :: SlotLength
+    slotLength = slotLengthFromSec 20
+
+    numCoreNodes :: NumCoreNodes
+    numCoreNodes = NumCoreNodes 1
+
+    eraParams :: HardFork.EraParams
+    eraParams = HardFork.defaultEraParams k slotLength
+
+
+{-------------------------------------------------------------------------------
+  Test blocks without payload
+-------------------------------------------------------------------------------}
+
+-- | Block without payload
+type TestBlock = TestBlockWith ()
+
+-- | The 'TestBlock' does not need any codec config
+data instance CodecConfig TestBlock = TestBlockCodecConfig
+  deriving (Show, Generic, NoThunks)
+
+-- | The 'TestBlock' does not need any storage config
+data instance StorageConfig TestBlock = TestBlockStorageConfig
+  deriving (Show, Generic, NoThunks)
 
 instance HasHardForkHistory TestBlock where
   type HardForkIndices TestBlock = '[TestBlock]
@@ -451,6 +634,8 @@ instance HasHardForkHistory TestBlock where
 
 data instance BlockQuery TestBlock fp result where
   QueryLedgerTip :: BlockQuery TestBlock SmallL (Point TestBlock)
+
+deriving instance Show (BlockQuery TestBlock fp result)
 
 instance SmallQuery (BlockQuery TestBlock) where
   proveSmallQuery k = \case
@@ -463,52 +648,26 @@ instance QueryLedger TestBlock where
 instance EqQuery (BlockQuery TestBlock) where
   eqQuery QueryLedgerTip QueryLedgerTip = Just Refl
 
-deriving instance Show (BlockQuery TestBlock fp result)
-
 instance ShowQuery (BlockQuery TestBlock) where
   showResult QueryLedgerTip = show
 
 instance IsQuery (BlockQuery TestBlock) where
 
 testInitLedger :: LedgerState TestBlock ValuesMK
-testInitLedger = TestLedger GenesisPoint
+testInitLedger = testInitLedgerWithState EmptyPLDS
 
 testInitExtLedger :: ExtLedgerState TestBlock ValuesMK
-testInitExtLedger = ExtLedgerState {
-      ledgerState = testInitLedger
-    , headerState = genesisHeaderState ()
-    }
+testInitExtLedger = testInitExtLedgerWithState EmptyPLDS
 
 -- | Trivial test configuration with a single core node
 singleNodeTestConfig :: TopLevelConfig TestBlock
 singleNodeTestConfig = singleNodeTestConfigWithK (SecurityParam 4)
 
 singleNodeTestConfigWithK :: SecurityParam -> TopLevelConfig TestBlock
-singleNodeTestConfigWithK k = TopLevelConfig {
-      topLevelConfigProtocol = BftConfig {
-          bftParams  = BftParams { bftSecurityParam = k
-                                 , bftNumNodes      = numCoreNodes
-                                 }
-        , bftSignKey = SignKeyMockDSIGN 0
-        , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
-        }
-    , topLevelConfigLedger  = eraParams
-    , topLevelConfigBlock   = TestBlockConfig numCoreNodes
-    , topLevelConfigCodec   = TestBlockCodecConfig
-    , topLevelConfigStorage = TestBlockStorageConfig
-    }
-  where
-    slotLength :: SlotLength
-    slotLength = slotLengthFromSec 20
-
-    numCoreNodes :: NumCoreNodes
-    numCoreNodes = NumCoreNodes 1
-
-    eraParams :: HardFork.EraParams
-    eraParams = HardFork.defaultEraParams k slotLength
+singleNodeTestConfigWithK = singleNodeTestConfigWith TestBlockCodecConfig TestBlockStorageConfig
 
 {-------------------------------------------------------------------------------
-  Chain of blocks
+  Chain of blocks (without payload)
 -------------------------------------------------------------------------------}
 
 newtype BlockChain = BlockChain Word64
@@ -525,32 +684,19 @@ instance Arbitrary BlockChain where
   arbitrary = BlockChain <$> choose (0, 30)
   shrink (BlockChain c) = BlockChain <$> shrink c
 
--- Create the first block in the given fork: @[fork]@
--- The 'SlotNo' will be 1.
+-- | See 'firstBlockWithPayload'.
 firstBlock :: Word64 -> TestBlock
-firstBlock forkNo = TestBlock
-    { tbHash  = TestHash (forkNo NE.:| [])
-    , tbSlot  = 1
-    , tbValid = True
-    }
+firstBlock forkNo = firstBlockWithPayload forkNo ()
 
--- Create the successor of the given block without forking:
--- @b -> b ++ [0]@ (in the printed representation)
--- The 'SlotNo' is increased by 1.
---
--- In Zipper parlance, this corresponds to going down in a tree.
+-- | See 'successorBlockWithPayload'.
 successorBlock :: TestBlock -> TestBlock
-successorBlock TestBlock{..} = TestBlock
-    { tbHash  = TestHash (NE.cons 0 (unTestHash tbHash))
-    , tbSlot  = succ tbSlot
-    , tbValid = True
-    }
+successorBlock TestBlockWith{tbHash, tbSlot} = successorBlockWithPayload tbHash tbSlot ()
 
 -- Modify the (last) fork number of the given block:
 -- @g@ -> @[.., f]@ -> @[.., g f]@
 -- The 'SlotNo' is left unchanged.
 modifyFork :: (Word64 -> Word64) -> TestBlock -> TestBlock
-modifyFork g tb@TestBlock{ tbHash = UnsafeTestHash (f NE.:| h) } = tb
+modifyFork g tb@TestBlockWith{ tbHash = UnsafeTestHash (f NE.:| h) } = tb
     { tbHash = let !gf = g f in UnsafeTestHash (gf NE.:| h)
     }
 
@@ -563,7 +709,7 @@ forkBlock :: TestBlock -> TestBlock
 forkBlock = modifyFork succ
 
 {-------------------------------------------------------------------------------
-  Tree of blocks
+  Tree of blocks (without payload)
 -------------------------------------------------------------------------------}
 
 newtype BlockTree = BlockTree (Tree ())
@@ -676,14 +822,14 @@ permute (Permutation n) = go (R.mkStdGen n)
   Additional Serialise instances
 -------------------------------------------------------------------------------}
 
-instance Serialise (AnnTip TestBlock) where
+instance Serialise (AnnTip (TestBlockWith ptype)) where
   encode = defaultEncodeAnnTip encode
   decode = defaultDecodeAnnTip decode
 
-instance Serialise (ExtLedgerState TestBlock EmptyMK) where
+instance PayloadSemantics ptype => Serialise (ExtLedgerState (TestBlockWith ptype) EmptyMK) where
   encode = encodeExtLedgerState encode encode encode
   decode = decodeExtLedgerState decode decode decode
 
-instance Serialise (RealPoint TestBlock) where
+instance Serialise (RealPoint (TestBlockWith ptype)) where
   encode = encodeRealPoint encode
   decode = decodeRealPoint decode

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -321,10 +321,6 @@ class ( ShowLedgerState (LedgerTables l)
   -- tables argument should not contain any data from eras that succeed the
   -- current era of the ledger state argument.
   --
-  --
-  -- TODO: we should explain what /younger/ means in this context. What is the
-  -- age of the content? The era associated to said content?
-  --
   -- TODO: reconsider the name: don't we use 'withX' in the context of bracket like functions?
   withLedgerTables :: l any -> LedgerTables l mk -> l mk
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -321,6 +321,10 @@ class ( ShowLedgerState (LedgerTables l)
   -- tables argument should not contain any data from eras that succeed the
   -- current era of the ledger state argument.
   --
+  --
+  -- TODO: we should explain what /younger/ means in this context. What is the
+  -- age of the content? The era associated to said content?
+  --
   -- TODO: reconsider the name: don't we use 'withX' in the context of bracket like functions?
   withLedgerTables :: l any -> LedgerTables l mk -> l mk
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -274,7 +274,7 @@ instance
         , ledgerState = unstowLedgerTables ledgerState
         }
 
-  isCandidateForUnstow = isCandidateForUnstowDefault
+  isCandidateForUnstow = isCandidateForUnstow . ledgerState
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE EmptyDataDeriving          #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -22,12 +21,15 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
+-- TODO stylish haskell insists on deleting this pragma if placed in the group above.
+{-# LANGUAGE DerivingStrategies       #-}
+
 
 module Ouroboros.Consensus.Storage.LedgerDB.InMemory (
     -- * LedgerDB proper
     LedgerDbCfg (..)
-  , ledgerDbWithAnchor
   , RunAlsoLegacy (..)
+  , ledgerDbWithAnchor
     -- ** opaque
   , LedgerDB
     -- * Ledger DB types (TODO: we might want to place this somewhere else)
@@ -71,9 +73,9 @@ module Ouroboros.Consensus.Storage.LedgerDB.InMemory (
   , ledgerDbSwitch
     -- * Exports for the benefit of tests
     -- ** Additional queries
+  , ledgerDbCurrentValues
   , ledgerDbIsSaturated
   , ledgerDbMaxRollback
-  , ledgerDbCurrentValues
     -- ** Pure API
   , ledgerDbPush'
   , ledgerDbPushMany'
@@ -254,10 +256,10 @@ ledgerDbWithAnchor ::
      )
   => RunAlsoLegacy -> l EmptyMK -> LedgerDB l
 ledgerDbWithAnchor runAlsoLegacy anchor = LedgerDB {
-      ledgerDbCheckpoints = case (isCandidateForUnstow anchor, runAlsoLegacy) of
-          (True, RunBoth) -> Just (Empty (Checkpoint (unstowLedgerTables anchor)))
-          (False, RunBoth) -> error "Requested to run with legacy DB but anchor loaded from disk has no in-mem UTxO"
-          _ -> Nothing
+    ledgerDbCheckpoints = case (isCandidateForUnstow anchor, runAlsoLegacy) of
+        (True , RunBoth) -> Just (Empty (Checkpoint (unstowLedgerTables anchor)))
+        (False, RunBoth) -> error "Requested to run with legacy DB but anchor loaded from disk has no in-mem UTxO"
+        _                -> Nothing
     , ledgerDbChangelog   = emptyDbChangeLog anchor
     }
 
@@ -709,7 +711,7 @@ ledgerDbOldest :: forall l.
   => LedgerDB l -> l EmptyMK
 ledgerDbOldest db =
     case stuffedLegacyAnchor of
-      Nothing -> immAnchor
+      Nothing  -> immAnchor
       Just sla -> Exn.assert (isFlushed sla) sla
   where
     immAnchor :: l EmptyMK

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -138,7 +138,7 @@
 -}
 module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
     -- * Opening the database
-    InitFailure(..)
+    InitFailure (..)
   , InitLog (..)
   , initLedgerDB
     -- ** Instantiate in-memory to @blk@
@@ -212,9 +212,9 @@ import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
 
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
-import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD as HD
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore as HD
+import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
 
 {-------------------------------------------------------------------------------
   Instantiate the in-memory DB to @blk@
@@ -383,7 +383,10 @@ initLedgerDB replayTracer
       traceWith replayTracer ReplayFromGenesis
       genesisLedger <- getGenesisLedger
       let replayTracer' = decorateReplayTracerWithStart (Point Origin) replayTracer
-          initDb        = ledgerDbWithAnchor runAlsoLegacy (stowLedgerTables genesisLedger)
+          initDb        =
+            case runAlsoLegacy of
+              RunBoth    -> ledgerDbWithAnchor runAlsoLegacy (stowLedgerTables genesisLedger)
+              RunOnlyNew -> ledgerDbWithAnchor runAlsoLegacy (forgetLedgerStateTables genesisLedger)
       backingStore <- newBackingStore hasFS (projectLedgerTables genesisLedger) -- TODO: needs to go into ResourceRegistry
       eDB <- runExceptT $ replayStartingWith
                             replayTracer'


### PR DESCRIPTION
This PR cherry picks commits b5dee3ad1cdef293ae7a9c98ccf842a8302276cc and 0222adc4846e5c33ce184cb35895a81f78cc9dd5 on top of [nfrisby/CAD-3877-utxo-hd-inmem](https://github.com/input-output-hk/ouroboros-network/tree/nfrisby/CAD-3877-utxo-hd-inmem), and adds on-disk tables to the ledger state used in `module Test.Ouroboros.Storage.LedgerDB.OnDisk`.