### PR TITLE
Cabal index-state and compiler version

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.4"]
+        ghc: ["8.10.7"]
         os: [ubuntu-latest]
 
     steps:
@@ -71,7 +71,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.4.0.0'
+        cabal-version: '3.6.2.0'
 
     - name: Install build environment
       if: matrix.os == 'ubuntu-latest'

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,5 @@
-index-state: 2022-01-17T00:00:00Z
+index-state: 2022-02-18T00:00:00Z
+with-compiler: ghc-8.10.7
 
 packages: ./typed-protocols
           ./typed-protocols-cborg


### PR DESCRIPTION
Sync index-state, and compiler version with the node repo
input-output-hk/cardano-node#3639
