### PR TITLE
Add: PULL_REQUEST_TEMPLATE for GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Checklist
+
+- Branch
+    - [ ] Commit sequence broadly makes sense
+    - [ ] Commits have useful messages
+    - [ ] New tests are added if needed and existing tests are updated
+    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
+    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
+    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
+- Pull Request
+    - [ ] Self-reviewed the diff
+    - [ ] Useful pull request description at least containing the following information:
+      - What does this PR change?
+      - Why these changes were needed?
+      - How does this affect downstream repositories and/or end-users?
+      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
+    - [ ] Reviewer requested


### PR DESCRIPTION
New features and breaking changes are sometimes not easily visible for outer people that might update/integrate a dependency on our repository.

This is a first idea for a pull request template that might help ease these situations. In particular Consensus plans on maintaining its `interface-CHANGELOG.md` file and this is a good way to make sure it is updated if needed.