### PR TITLE
RootPeersDNS: garbage collect DNS results && test single source of truth

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
@@ -25,9 +25,9 @@ data PeerSource = PeerSourceLocalRoot
 -- For certain peers specified by configuration it would be an appropriate
 -- policy to keep them private.
 --
-data PeerAdvertise = DoAdvertisePeer
-                   | DoNotAdvertisePeer
-  deriving (Eq, Show, Generic)
+data PeerAdvertise = DoNotAdvertisePeer
+                   | DoAdvertisePeer
+  deriving (Eq, Show, Ord, Generic)
 
 instance FromJSON PeerAdvertise where
   parseJSON = withBool "PeerAdvertise" $


### PR DESCRIPTION
This PR extends the existing test suite for RootPeersDNS by making the MockRoots more robust, and adding a test to check if localRootPeersProvider has a single source of truth. It also fixes #3650.

This was motivated by a bug found by @karknu and fixed in #3641 .