### PR TITLE
Fixes so prototype cardano-node can sync Byron from mainnet using in-mem backing store

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -220,7 +220,7 @@ instance ShowLedgerState (LedgerTables (LedgerState ByronBlock)) where
 instance StowableLedgerTables (LedgerState ByronBlock) where
   stowLedgerTables     = convertMapKind
   unstowLedgerTables   = convertMapKind
-  isCandidateForUnstow = isCandidateForUnstowDefault
+  isCandidateForUnstow = const True
 
 {-------------------------------------------------------------------------------
   Supporting the various consensus interfaces

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -154,7 +154,7 @@ instance ShowLedgerState (LedgerTables (LedgerState ByronSpecBlock)) where
 instance StowableLedgerTables (LedgerState ByronSpecBlock) where
   stowLedgerTables     = convertMapKind
   unstowLedgerTables   = convertMapKind
-  isCandidateForUnstow = isCandidateForUnstowDefault
+  isCandidateForUnstow = const True
 
 {-------------------------------------------------------------------------------
   Applying blocks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -204,6 +204,9 @@ tickOne ei slot index pcfg (Flip st) = Comp $ fmap FlipTickedLedgerState $
       embedLedgerResult (injectLedgerEvent index)
     $ applyChainTickLedgerResult (completeLedgerConfig' ei pcfg) slot st
 
+instance LedgerTablesCanHardFork '[x] where
+  hardForkInjectLedgerTablesKeysMK = InjectLedgerTables LedgerTablesOne :* Nil
+
 instance (SingleEraBlock x, TableStuff (LedgerState x)) => TableStuff (LedgerState (HardForkBlock '[x])) where
   newtype LedgerTables (LedgerState (HardForkBlock '[x])) mk = LedgerTablesOne (LedgerTables (LedgerState x) mk)
     deriving (Generic)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -734,6 +734,13 @@ instance
       decodeArityAndTag len tag = do
         len' <- CBOR.decodeListLen
         tag' <- CBOR.decodeWord8
+        -- @len@ here ought to match the @length xs@ in @encodeArityAndTag@ in
+        -- the corresponding 'ToCBOR' instance, so we need to add one in order
+        -- to match the length recorded in the CBOR stream (ie @len'@)
+        --
+        -- This use of 'when' corresponds to the use of 'decodeListLenOf'
+        -- throughout most of our CBOR decoders: it catches encoder/decoder
+        -- mismatches.
         when
           (1 + len /= len' || tag /= tag')
           (fail $ "decode @ApplyMapKind " <> show (smk, len, tag, len', tag'))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -706,6 +706,7 @@ instance
       encodeArityAndTag tag xs =
            CBOR.encodeListLen (1 + toEnum (length xs))
         <> CBOR.encodeWord8 tag
+        <> mconcat xs
 
 instance
      (Typeable mk, Ord k, FromCBOR k, FromCBOR v, SingI mk)
@@ -734,8 +735,8 @@ instance
         len' <- CBOR.decodeListLen
         tag' <- CBOR.decodeWord8
         when
-          (len /= 1 + len' || tag /= tag')
-          (fail $ "decode @ApplyMapKind " <> show (smk, len', tag'))
+          (1 + len /= len' || tag /= tag')
+          (fail $ "decode @ApplyMapKind " <> show (smk, len, tag, len', tag'))
 
 showsApplyMapKind :: (Show k, Show v) => ApplyMapKind' mk k v -> ShowS
 showsApplyMapKind = \case

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -268,7 +268,7 @@ instance
         , ledgerState = unstowLedgerTables ledgerState
         }
 
-  isCandidateForUnstow = isCandidateForUnstowDefault
+  isCandidateForUnstow = isCandidateForUnstow . ledgerState
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -250,6 +250,7 @@ ledgerDbWithAnchor ::
      , GetTip (l EmptyMK)
      , GetTip (l ValuesMK)
      , StowableLedgerTables l
+     , HasCallStack
      )
   => RunAlsoLegacy -> l EmptyMK -> LedgerDB l
 ledgerDbWithAnchor runAlsoLegacy anchor = LedgerDB {


### PR DESCRIPTION
Fixes CAD-3904.

These commits include small patches that ultimately enabled a `cardano-node` prototype (branch `nfrisby/CAD-3904-utxohd-inmem-only` in that repo) to sync Byron from `mainnet`. (It failed on the first non-empty Shelley block; CAD-4018 tracks that.)