### PR TITLE
Refine LedgerState serialization constraints

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -57,6 +57,9 @@ instance SupportedNetworkProtocolVersion DualByronBlock where
 
 instance SerialiseDiskConstraints DualByronBlock
 
+instance SufficientSerializationForAnyBackingStore (LedgerState DualByronBlock) where
+    codecLedgerTables = DualBlockLedgerTables codecLedgerTables codecLedgerTables
+
 instance EncodeDisk DualByronBlock DualByronBlock where
   encodeDisk _ = encodeDualBlock encodeByronBlock
 instance DecodeDisk DualByronBlock (Lazy.ByteString -> DualByronBlock) where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -52,7 +52,6 @@ import           Data.ByteString (ByteString)
 import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 
@@ -81,7 +80,6 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Util (ShowProxy (..), (..:))
-import           Ouroboros.Consensus.Util.CBOR.Simple
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
 import           Ouroboros.Consensus.Byron.Ledger.Conversions
@@ -196,10 +194,15 @@ instance TableStuff (LedgerState ByronBlock) where
   projectLedgerTables _st                 = NoByronLedgerTables
   withLedgerTables st NoByronLedgerTables = convertMapKind st
 
-  pureLedgerTables _f                                         = NoByronLedgerTables
-  mapLedgerTables  _f                     NoByronLedgerTables = NoByronLedgerTables
-  zipLedgerTables  _f NoByronLedgerTables NoByronLedgerTables = NoByronLedgerTables
-  foldLedgerTables _f                     NoByronLedgerTables = mempty
+  pureLedgerTables     _f                                         = NoByronLedgerTables
+  mapLedgerTables      _f                     NoByronLedgerTables = NoByronLedgerTables
+  traverseLedgerTables _f                     NoByronLedgerTables = pure NoByronLedgerTables
+  zipLedgerTables      _f NoByronLedgerTables NoByronLedgerTables = NoByronLedgerTables
+  foldLedgerTables     _f                     NoByronLedgerTables = mempty
+  foldLedgerTables2    _f NoByronLedgerTables NoByronLedgerTables = mempty
+
+instance SufficientSerializationForAnyBackingStore (LedgerState ByronBlock) where
+    codecLedgerTables = NoByronLedgerTables
 
 instance InMemory (LedgerState ByronBlock) where
   convertMapKind ByronLedgerState{..} = ByronLedgerState{..}
@@ -218,12 +221,6 @@ instance StowableLedgerTables (LedgerState ByronBlock) where
   stowLedgerTables     = convertMapKind
   unstowLedgerTables   = convertMapKind
   isCandidateForUnstow = isCandidateForUnstowDefault
-
-instance Typeable mk => ToCBOR (LedgerTables (LedgerState ByronBlock) mk) where
-  toCBOR NoByronLedgerTables = versionZeroProductToCBOR []
-
-instance Typeable mk => FromCBOR (LedgerTables (LedgerState ByronBlock) mk) where
-  fromCBOR = versionZeroProductFromCBOR "LedgerTables Byron" 0 $ pure NoByronLedgerTables
 
 {-------------------------------------------------------------------------------
   Supporting the various consensus interfaces

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -67,7 +67,7 @@ import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 import           NoThunks.Class (NoThunks)
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import           Cardano.Binary (fromCBOR, toCBOR)
 import           Cardano.Crypto.DSIGN (Ed25519DSIGN)
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_224, Blake2b_256)
 
@@ -84,7 +84,6 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD as HD
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (eitherToMaybe)
-import           Ouroboros.Consensus.Util.CBOR.Simple
 import           Ouroboros.Consensus.Util.RedundantConstraints
 import qualified Ouroboros.Consensus.Util.SOP as SOP
 
@@ -496,10 +495,16 @@ instance CardanoHardForkConstraints c => TableStuff (LedgerState (CardanoBlock c
           hfstate
           tables
 
-  pureLedgerTables f                                                 = CardanoLedgerTables f
-  mapLedgerTables  f                         (CardanoLedgerTables x) = CardanoLedgerTables (f x)
-  zipLedgerTables  f (CardanoLedgerTables l) (CardanoLedgerTables r) = CardanoLedgerTables (f l r)
-  foldLedgerTables f                         (CardanoLedgerTables x) = f x
+  pureLedgerTables     f                                                 = CardanoLedgerTables f
+  mapLedgerTables      f                         (CardanoLedgerTables x) = CardanoLedgerTables (f x)
+  traverseLedgerTables f                         (CardanoLedgerTables x) = CardanoLedgerTables <$> f x
+  zipLedgerTables      f (CardanoLedgerTables l) (CardanoLedgerTables r) = CardanoLedgerTables (f l r)
+  foldLedgerTables     f                         (CardanoLedgerTables x) = f x
+  foldLedgerTables2    f (CardanoLedgerTables l) (CardanoLedgerTables r) = f l r
+
+instance CardanoHardForkConstraints c
+      => SufficientSerializationForAnyBackingStore (LedgerState (CardanoBlock c)) where
+    codecLedgerTables = CardanoLedgerTables (CodecMK toCBOR toCBOR fromCBOR fromCBOR)
 
 deriving newtype instance PraosCrypto c => Eq (LedgerTables (LedgerState (CardanoBlock c)) EmptyMK)
 deriving newtype instance PraosCrypto c => Eq (LedgerTables (LedgerState (CardanoBlock c)) ValuesMK)
@@ -628,18 +633,6 @@ instance CardanoHardForkConstraints c => TickedTableStuff (LedgerState (CardanoB
               tickedHardForkLedgerStatePerEra
               tables
         }
-
-instance
-     CardanoHardForkConstraints c
-  => ToCBOR (LedgerTables (LedgerState (CardanoBlock c)) ValuesMK) where
-  toCBOR (CardanoLedgerTables utxo) = versionZeroProductToCBOR [toCBOR utxo]
-
-instance
-     CardanoHardForkConstraints c
-  => FromCBOR (LedgerTables (LedgerState (CardanoBlock c)) ValuesMK) where
-  fromCBOR =
-        versionZeroProductFromCBOR "CardanoLedgerTables" 1
-      $ CardanoLedgerTables <$> fromCBOR
 
 instance CardanoHardForkConstraints c => LedgerTablesCanHardFork (CardanoEras c) where
   hardForkInjectLedgerTablesKeysMK =

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -77,7 +77,7 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks (..))
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import           Cardano.Binary (ToCBOR (..))
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, SHA256, ShortHash)
 import qualified Cardano.Crypto.Hash as Hash
 
@@ -393,28 +393,23 @@ instance (SimpleCrypto c, Typeable ext) => TableStuff (LedgerState (SimpleBlock 
   projectLedgerTables _st                                = NoMockTables
   withLedgerTables    (SimpleLedgerState x) NoMockTables = SimpleLedgerState x
 
-  pureLedgerTables _f                           = NoMockTables
-  mapLedgerTables  _f              NoMockTables = NoMockTables
-  zipLedgerTables  _f NoMockTables NoMockTables = NoMockTables
-  foldLedgerTables _f              NoMockTables = mempty
+  pureLedgerTables     _f                           = NoMockTables
+  mapLedgerTables      _f              NoMockTables = NoMockTables
+  traverseLedgerTables _f              NoMockTables = pure NoMockTables
+  zipLedgerTables      _f NoMockTables NoMockTables = NoMockTables
+  foldLedgerTables     _f              NoMockTables = mempty
+  foldLedgerTables2    _f NoMockTables NoMockTables = mempty
 
 instance (SimpleCrypto c, Typeable ext) => TickedTableStuff (LedgerState (SimpleBlock c ext)) where
   projectLedgerTablesTicked _st                                 = NoMockTables
   withLedgerTablesTicked    (TickedSimpleLedgerState st) tables =
       TickedSimpleLedgerState $ withLedgerTables st tables
 
+instance SufficientSerializationForAnyBackingStore (LedgerState (SimpleBlock c ext)) where
+    codecLedgerTables = NoMockTables
+
 instance ShowLedgerState (LedgerTables (LedgerState (SimpleBlock c ext))) where
   showsLedgerState _sing = shows
-
-instance
-     (Typeable c, Typeable ext)
-  => ToCBOR (LedgerTables (LedgerState (SimpleBlock c ext)) ValuesMK) where
-  toCBOR NoMockTables = CBOR.encodeNull
-
-instance
-     (Typeable c, Typeable ext)
-  => FromCBOR (LedgerTables (LedgerState (SimpleBlock c ext)) ValuesMK) where
-  fromCBOR = NoMockTables <$ CBOR.decodeNull
 
 instance
      (Typeable ext, SimpleCrypto c)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -59,7 +59,6 @@ import qualified Control.Exception as Exception
 import           Control.Monad.Except
 import           Data.Functor ((<&>))
 import           Data.Functor.Identity
-import           Data.Typeable (Typeable)
 import           Data.Word
 import           GHC.Generics (Generic)
 import           GHC.Records
@@ -278,10 +277,14 @@ instance ShelleyBasedEra era => TableStuff (LedgerState (ShelleyBlock era)) wher
 
   mapLedgerTables f (ShelleyLedgerTables utxo) = ShelleyLedgerTables (f utxo)
 
+  traverseLedgerTables f (ShelleyLedgerTables utxo) = ShelleyLedgerTables <$> (f utxo)
+
   zipLedgerTables f (ShelleyLedgerTables utxoL) (ShelleyLedgerTables utxoR) =
       ShelleyLedgerTables (f utxoL utxoR)
 
   foldLedgerTables f (ShelleyLedgerTables utxo) = f utxo
+
+  foldLedgerTables2 f (ShelleyLedgerTables utxo1) (ShelleyLedgerTables utxo2) = f utxo1 utxo2
 
 instance ShelleyBasedEra era => TickedTableStuff (LedgerState (ShelleyBlock era)) where
   projectLedgerTablesTicked        = tickedShelleyLedgerTables
@@ -302,20 +305,8 @@ instance ShelleyBasedEra era => TickedTableStuff (LedgerState (ShelleyBlock era)
 deriving newtype  instance (ShelleyBasedEra era, Eq       (mk (SL.TxIn (EraCrypto era)) (Core.TxOut era))) => Eq       (LedgerTables (LedgerState (ShelleyBlock era)) mk)
 deriving anyclass instance (ShelleyBasedEra era, NoThunks (mk (SL.TxIn (EraCrypto era)) (Core.TxOut era))) => NoThunks (LedgerTables (LedgerState (ShelleyBlock era)) mk)
 
-instance
-     (ShelleyBasedEra era, Typeable mk, SingI mk)
-  => ToCBOR (LedgerTables (LedgerState (ShelleyBlock era)) (ApplyMapKind' mk)) where
-  toCBOR (ShelleyLedgerTables utxoTable) =
-      CBOR.encodeListLen 2 <> CBOR.encodeTag 0 <> toCBOR utxoTable
-
-instance
-     (ShelleyBasedEra era, Typeable mk, SingI mk)
-  => FromCBOR (LedgerTables (LedgerState (ShelleyBlock era)) (ApplyMapKind' mk)) where
-  fromCBOR = do
-      CBOR.decodeListLenOf 2
-      tag <- CBOR.decodeTag
-      unless (0 == tag) $ fail "ShelleyLedgerTables"
-      ShelleyLedgerTables <$> fromCBOR
+instance ShelleyBasedEra era => SufficientSerializationForAnyBackingStore (LedgerState (ShelleyBlock era)) where
+    codecLedgerTables = ShelleyLedgerTables (CodecMK toCBOR toCBOR fromCBOR fromCBOR)
 
 instance ShelleyBasedEra era => ShowLedgerState (LedgerTables (LedgerState (ShelleyBlock era))) where
   showsLedgerState _mk (ShelleyLedgerTables utxo) =

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -59,8 +59,6 @@ module Test.Util.TestBlock (
   , permute
   ) where
 
-import qualified Codec.CBOR.Decoding as CBOR
-import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (Serialise (..))
 import           Control.DeepSeq (force)
 import           Control.Monad.Except (throwError)
@@ -77,14 +75,12 @@ import           Data.Time.Clock (UTCTime (..))
 import           Data.Tree (Tree (..))
 import qualified Data.Tree as Tree
 import           Data.TreeDiff (ToExpr)
-import           Data.Typeable (Typeable)
 import           Data.Word
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import qualified System.Random as R
 import           Test.QuickCheck hiding (Result)
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Crypto.DSIGN
 
 import           Ouroboros.Network.Magic (NetworkMagic (..))
@@ -357,16 +353,15 @@ instance TableStuff (LedgerState TestBlock) where
   projectLedgerTables _                              = NoTestLedgerTables
   withLedgerTables (TestLedger p) NoTestLedgerTables = TestLedger p
 
-  pureLedgerTables _                                       = NoTestLedgerTables
-  mapLedgerTables  _ NoTestLedgerTables                    = NoTestLedgerTables
-  zipLedgerTables  _ NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
-  foldLedgerTables _ NoTestLedgerTables                    = mempty
+  pureLedgerTables     _                                       = NoTestLedgerTables
+  mapLedgerTables      _ NoTestLedgerTables                    = NoTestLedgerTables
+  traverseLedgerTables _ NoTestLedgerTables                    = pure NoTestLedgerTables
+  zipLedgerTables      _ NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
+  foldLedgerTables     _ NoTestLedgerTables                    = mempty
+  foldLedgerTables2    _ NoTestLedgerTables NoTestLedgerTables = mempty
 
-instance Typeable mk => ToCBOR (LedgerTables (LedgerState TestBlock) mk) where
-  toCBOR NoTestLedgerTables = CBOR.encodeNull
-
-instance Typeable mk => FromCBOR (LedgerTables (LedgerState TestBlock) mk) where
-  fromCBOR = NoTestLedgerTables <$ CBOR.decodeNull
+instance SufficientSerializationForAnyBackingStore (LedgerState TestBlock) where
+    codecLedgerTables = NoTestLedgerTables
 
 instance TickedTableStuff (LedgerState TestBlock) where
   projectLedgerTablesTicked _                         = NoTestLedgerTables

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -34,8 +34,6 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Time (dawnOfTime)
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
-
 import qualified Ouroboros.Network.MockChain.Chain as Mock
 
 import           Ouroboros.Consensus.Block
@@ -375,10 +373,15 @@ instance TableStuff (LedgerState (HardForkBlock '[BlockA, BlockB])) where
   projectLedgerTables _st            = NoAbTables
   withLedgerTables    st  NoAbTables = convertMapKind st
 
-  pureLedgerTables _f                       = NoAbTables
-  mapLedgerTables  _f            NoAbTables = NoAbTables
-  zipLedgerTables  _f NoAbTables NoAbTables = NoAbTables
-  foldLedgerTables _f            NoAbTables = mempty
+  pureLedgerTables     _f                       = NoAbTables
+  mapLedgerTables      _f            NoAbTables = NoAbTables
+  traverseLedgerTables _f            NoAbTables = pure NoAbTables
+  zipLedgerTables      _f NoAbTables NoAbTables = NoAbTables
+  foldLedgerTables     _f            NoAbTables = mempty
+  foldLedgerTables2    _f NoAbTables NoAbTables = mempty
+
+instance SufficientSerializationForAnyBackingStore (LedgerState (HardForkBlock '[BlockA, BlockB])) where
+    codecLedgerTables = NoAbTables
 
 instance TickedTableStuff (LedgerState (HardForkBlock '[BlockA, BlockB])) where
   projectLedgerTablesTicked _ = NoAbTables
@@ -406,12 +409,6 @@ instance InMemory (Ticked1 (LedgerState (HardForkBlock '[BlockA, BlockB]))) wher
           (Proxy @(Compose (Compose InMemory Ticked1) LedgerState))
           (FlipTickedLedgerState . convertMapKind . getFlipTickedLedgerState)
           hfstate
-
-instance ToCBOR (LedgerTables (LedgerState (HardForkBlock '[BlockA, BlockB])) ValuesMK) where
-  toCBOR NoAbTables = toCBOR ()
-
-instance FromCBOR (LedgerTables (LedgerState (HardForkBlock '[BlockA, BlockB])) ValuesMK) where
-  fromCBOR = (\() -> NoAbTables) <$> fromCBOR
 
 instance ShowLedgerState (LedgerTables (LedgerState (HardForkBlock '[BlockA, BlockB]))) where
   showsLedgerState _mk = shows

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -54,7 +54,6 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Slotting.EpochInfo
 
 import           Test.Util.Time (dawnOfTime)
@@ -199,12 +198,6 @@ instance StowableLedgerTables (LedgerState BlockA) where
   unstowLedgerTables   = convertMapKind
   isCandidateForUnstow = isCandidateForUnstowDefault
 
-instance ToCBOR (LedgerTables (LedgerState BlockA) ValuesMK) where
-  toCBOR NoATables = toCBOR ()
-
-instance FromCBOR (LedgerTables (LedgerState BlockA) ValuesMK) where
-  fromCBOR = (\() -> NoATables) <$> fromCBOR
-
 -- | Ticking has no state on the A ledger state
 newtype instance Ticked1 (LedgerState BlockA) mk = TickedLedgerStateA {
       getTickedLedgerStateA :: LedgerState BlockA mk
@@ -222,10 +215,15 @@ instance TableStuff (LedgerState BlockA) where
   projectLedgerTables _st           = NoATables
   withLedgerTables    st  NoATables = convertMapKind st
 
-  pureLedgerTables _f                     = NoATables
-  mapLedgerTables  _f           NoATables = NoATables
-  zipLedgerTables  _f NoATables NoATables = NoATables
-  foldLedgerTables _f           NoATables = mempty
+  pureLedgerTables     _f                     = NoATables
+  mapLedgerTables      _f           NoATables = NoATables
+  traverseLedgerTables _f           NoATables = pure NoATables
+  zipLedgerTables      _f NoATables NoATables = NoATables
+  foldLedgerTables     _f           NoATables = mempty
+  foldLedgerTables2    _f NoATables NoATables = mempty
+
+instance SufficientSerializationForAnyBackingStore (LedgerState BlockA) where
+    codecLedgerTables = NoATables
 
 instance (ShowLedgerState (LedgerTables (LedgerState BlockA))) where
   showsLedgerState _sing = shows

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -45,8 +45,6 @@ import           Data.Void
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
-
 import           Test.Util.Time (dawnOfTime)
 
 import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
@@ -178,10 +176,15 @@ instance TableStuff (LedgerState BlockB) where
   projectLedgerTables _st           = NoBTables
   withLedgerTables    st  NoBTables = convertMapKind st
 
-  pureLedgerTables _f                     = NoBTables
-  mapLedgerTables  _f           NoBTables = NoBTables
-  zipLedgerTables  _f NoBTables NoBTables = NoBTables
-  foldLedgerTables _f           NoBTables = mempty
+  pureLedgerTables     _f                     = NoBTables
+  mapLedgerTables      _f           NoBTables = NoBTables
+  traverseLedgerTables _f           NoBTables = pure NoBTables
+  zipLedgerTables      _f NoBTables NoBTables = NoBTables
+  foldLedgerTables     _f           NoBTables = mempty
+  foldLedgerTables2    _f NoBTables NoBTables = mempty
+
+instance SufficientSerializationForAnyBackingStore (LedgerState BlockB) where
+    codecLedgerTables = NoBTables
 
 instance TickedTableStuff (LedgerState BlockB) where
   projectLedgerTablesTicked _ = NoBTables
@@ -205,12 +208,6 @@ instance StowableLedgerTables (LedgerState BlockB) where
   stowLedgerTables     = convertMapKind
   unstowLedgerTables   = convertMapKind
   isCandidateForUnstow = isCandidateForUnstowDefault
-
-instance ToCBOR (LedgerTables (LedgerState BlockB) ValuesMK) where
-  toCBOR NoBTables = toCBOR ()
-
-instance FromCBOR (LedgerTables (LedgerState BlockB) ValuesMK) where
-  fromCBOR = (\() -> NoBTables) <$> fromCBOR
 
 -- | Ticking has no state on the B ledger state
 newtype instance Ticked1 (LedgerState BlockB) mk = TickedLedgerStateB {

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -83,7 +83,6 @@ import           Test.QuickCheck
 
 import           Control.Monad.Class.MonadThrow
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Crypto.DSIGN
 
 import qualified Ouroboros.Network.MockChain.Chain as Chain
@@ -570,16 +569,15 @@ instance TableStuff (LedgerState TestBlock) where
   projectLedgerTables _st                    = NoTestLedgerTables
   withLedgerTables    st  NoTestLedgerTables = convertMapKind st
 
-  pureLedgerTables _                                       = NoTestLedgerTables
-  mapLedgerTables  _ NoTestLedgerTables                    = NoTestLedgerTables
-  zipLedgerTables  _ NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
-  foldLedgerTables _ NoTestLedgerTables                    = mempty
+  pureLedgerTables     _                                       = NoTestLedgerTables
+  mapLedgerTables      _                    NoTestLedgerTables = NoTestLedgerTables
+  traverseLedgerTables _                    NoTestLedgerTables = pure NoTestLedgerTables
+  zipLedgerTables      _ NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
+  foldLedgerTables     _                    NoTestLedgerTables = mempty
+  foldLedgerTables2    _ NoTestLedgerTables NoTestLedgerTables = mempty
 
-instance Typeable mk => ToCBOR (LedgerTables (LedgerState TestBlock) mk) where
-  toCBOR NoTestLedgerTables = toCBOR ()
-
-instance Typeable mk => FromCBOR (LedgerTables (LedgerState TestBlock) mk) where
-  fromCBOR = (\() -> NoTestLedgerTables) <$> fromCBOR
+instance SufficientSerializationForAnyBackingStore (LedgerState TestBlock) where
+    codecLedgerTables = NoTestLedgerTables
 
 instance StowableLedgerTables (LedgerState TestBlock) where
   stowLedgerTables     = convertMapKind

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -81,12 +81,12 @@ import           Data.Kind (Type)
 import           Data.SOP.Strict
 import           Data.Word
 
-import           Cardano.Binary (FromCBOR, ToCBOR, enforceSize)
+import           Cardano.Binary (enforceSize)
 
 import           Ouroboros.Network.Block (Serialised)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Ledger.Basics (LedgerTables, ValuesMK)
+import           Ouroboros.Consensus.Ledger.Basics (SufficientSerializationForAnyBackingStore)
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
@@ -273,9 +273,10 @@ class ( CanHardFork xs
       , All (DecodeDiskDepIx (NestedCtxt Header)) xs
         -- Required for 'getHfcBinaryBlockInfo'
       , All HasBinaryBlockInfo xs
-        -- Required for snapshotting the in-memory backing store
-      , FromCBOR (LedgerTables (LedgerState (HardForkBlock xs)) ValuesMK)
-      , ToCBOR   (LedgerTables (LedgerState (HardForkBlock xs)) ValuesMK)
+        -- Tables on the HardForkCombinator are not compositionally defined,
+        -- therefore this constraint is needed and will have to be satisfied by
+        -- each instantiation of 'HardForkBlock'.
+      , SufficientSerializationForAnyBackingStore (LedgerState (HardForkBlock xs))
       ) => SerialiseHFC xs where
 
   encodeDiskHfcBlock :: CodecConfig (HardForkBlock xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -20,14 +22,16 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
                      (Flip (..))
 import           Ouroboros.Consensus.HeaderValidation
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK)
+import           Ouroboros.Consensus.Ledger.Basics (EmptyMK, SufficientSerializationForAnyBackingStore)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util ((.:))
 
 import           Ouroboros.Consensus.Storage.ChainDB
 import           Ouroboros.Consensus.Storage.Serialisation
 
-instance SerialiseHFC xs => SerialiseDiskConstraints  (HardForkBlock xs)
+instance ( SerialiseHFC xs
+         , SufficientSerializationForAnyBackingStore (LedgerState (HardForkBlock xs)))
+      => SerialiseDiskConstraints  (HardForkBlock xs)
 
 {-------------------------------------------------------------------------------
   'ReconstructNestedCtxt'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -67,8 +67,6 @@ import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
-import           Cardano.Binary (FromCBOR, ToCBOR)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
@@ -153,8 +151,7 @@ type LgrDbSerialiseConstraints blk =
   , DecodeDisk blk (AnnTip      blk)
   , EncodeDisk blk (ChainDepState (BlockProtocol blk))
   , DecodeDisk blk (ChainDepState (BlockProtocol blk))
-  , FromCBOR (LedgerTables (LedgerState blk) ValuesMK)
-  , ToCBOR   (LedgerTables (LedgerState blk) ValuesMK)
+  , SufficientSerializationForAnyBackingStore (LedgerState blk)
   )
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Drop `LedgerState l ValuesMK` constraints for `ToCBOR` and `FromCBOR`
which were used only by the in-memory backend, and build that from the
`ToCBOR` and `FromCBOR` instance of `k` and `v`.

Define the new `CodecMK` map kind and use it to produce suitable codecs
depending on `l :: LedgerStateKind`.

Closes CAD-3992.