### PR TITLE
Set LOCALE_ARCHIVE in nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -55,6 +55,13 @@ let
       hp2pretty = "0.10";
     };
 
+    shellHook = ''
+      export LANG="en_US.UTF-8"
+    '' + lib.optionalString
+      (pkgs.glibcLocales != null && stdenv.hostPlatform.libc == "glibc") ''
+        export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"
+      '';
+
     inherit withHoogle;
   };
 


### PR DESCRIPTION
This fixes the

    <stdout>: commitBuffer: invalid argument (invalid character)

error using the solution described [here].

[here]: https://nixos.org/manual/nixpkgs/stable/#locales

Credit goes to @nfrisby (who cribbed it from the `cardano-node` repo)