### PR TITLE
Platform independent TCPInfo trace

### DIFF
--- a/docs/interface-CHANGELOG.md
+++ b/docs/interface-CHANGELOG.md
@@ -1,0 +1,16 @@
+# Interface Change Log
+
+This change log file is written for the benefit of Cardano Node development
+team.  See [consensus
+CHANGELOG](../ouroboros-consensus/docs/interface-CHANGELOG.md) file for how
+this changelog is supposed to be used.
+
+
+## Circa 2022-03-08
+
+
+### Added
+
+- on Linux when `network-mux` is compiled with `tracetcpinfo` cabal flag, mux
+  will log `MuxTraceTCPInfo`.  For performance reasons this is disabled by
+  default.

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -94,10 +94,11 @@ library
                        Network.Mux.DeltaQ.TraceStatsSupport
                        Network.Mux.DeltaQ.TraceTransformer
                        Network.Mux.DeltaQ.TraceTypes
+                       Network.Mux.TCPInfo
                        Control.Concurrent.JobPool
 
   if os(linux)
-    other-modules:     Network.Mux.TCPInfo
+    other-modules:     Network.Mux.TCPInfo.Linux
 
   if os(windows)
     exposed-modules:

--- a/network-mux/src/Network/Mux/TCPInfo.hs
+++ b/network-mux/src/Network/Mux/TCPInfo.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE CPP #-}
+
+module Network.Mux.TCPInfo
+  ( StructTCPInfo (..)
+#if os_HOST_linux
+  , SocketOption (TCPInfoSocketOption)
+#endif
+  ) where
+
+#if os_HOST_linux
+import Network.Mux.TCPInfo.Linux
+#else
+data StructTCPInfo = TCPInfoUnavailable
+  deriving (Eq, Ord, Show)
+#endif
+

--- a/network-mux/src/Network/Mux/TCPInfo/Linux.hsc
+++ b/network-mux/src/Network/Mux/TCPInfo/Linux.hsc
@@ -15,9 +15,9 @@
 
 #include "HsNet.h"
 
-module Network.Mux.TCPInfo
+module Network.Mux.TCPInfo.Linux
   ( StructTCPInfo (..)
-  , SocketOption(TCPInfoSocketOption)
+  , SocketOption (TCPInfoSocketOption)
   ) where
 
 import           Foreign.C

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -29,9 +29,7 @@ import           GHC.Generics (Generic (..))
 import           Quiet (Quiet (..))
 
 import           Network.Mux.Types
-#ifdef linux_HOST_OS
 import           Network.Mux.TCPInfo
-#endif
 
 
 --
@@ -152,11 +150,7 @@ data MuxTrace =
     | MuxTraceStartedOnDemand MiniProtocolNum MiniProtocolDir
     | MuxTraceTerminating MiniProtocolNum MiniProtocolDir
     | MuxTraceShutdown
-#ifdef linux_HOST_OS
     | MuxTraceTCPInfo StructTCPInfo Word16
-#else
-    | MuxTraceTCPInfo Word16
-#endif
 
 instance Show MuxTrace where
     show MuxTraceRecvHeaderStart = printf "Bearer Receive Header Start"
@@ -194,7 +188,7 @@ instance Show MuxTrace where
     show (MuxTraceStartedOnDemand mid dir) = printf "Started on demand (%s) in %s" (show mid) (show dir)
     show (MuxTraceTerminating mid dir) = printf "Terminating (%s) in %s" (show mid) (show dir)
     show MuxTraceShutdown = "Mux shutdown"
-#ifdef linux_HOST_OS
+#ifdef os_HOST_linux
     show (MuxTraceTCPInfo StructTCPInfo
             { tcpi_snd_mss, tcpi_rcv_mss, tcpi_lost, tcpi_retrans
             , tcpi_rtt, tcpi_rttvar, tcpi_snd_cwnd }
@@ -207,6 +201,6 @@ instance Show MuxTrace where
         (fromIntegral tcpi_retrans :: Word)
         len
 #else
-    show (MuxTraceTCPInfo len) = printf "TCPInfo len %d" len
+    show (MuxTraceTCPInfo _ len) = printf "TCPInfo len %d" len
 #endif
 


### PR DESCRIPTION
- network-mux: platform independent TCP info trace
- Added interface-CHANGELOG.md file
