### PR TITLE
Update downstream dependencies.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2022-01-17T00:00:00Z
+index-state: 2022-02-18T00:00:00Z
 
 packages: ./typed-protocols
           ./typed-protocols-cborg
@@ -160,17 +160,11 @@ allow-newer:
   monoidal-containers:aeson,
   size-based:template-haskell,
 
-  -- TODO: This is only needed until index-state is updated to 2021-02-17 or later.
-  test-framework:random,
-  test-framework-quickcheck2:random
-
 constraints:
   -- bizarre issue: in earlier versions they define their own 'GEq', in newer
   -- ones they reuse the one from 'some', but there isn't e.g. a proper version
   -- constraint from dependent-sum-template (which is the library we actually use).
   , dependent-sum > 0.6.2.0
-  -- needed until we update past cardano-ledger@43f7c7318e38c501c2d2a2c680251c7c1f78d0fd
-  , hashable < 1.3.4.0
 
 -- ---------------------------------------------------------
 -- The "cabal" wrapper script provided by nix-shell will cut off / restore the remainder of this file
@@ -203,8 +197,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 41545ba3ac6b3095966316a99883d678b5ab8da8
-  --sha256: 0icq9y3nnl42fz536da84414av36g37894qnyw4rk3qkalksqwir
+  tag: 20bd513b7ac9dcf0749f0ceb1df3d6b07a1b57c8
+  --sha256: 0pkcd3k2fpk76igfyaf7cqrcglnjs3rs9pka68wpkyp6z7qkixmz
   subdir:
     base-deriving-via
     binary
@@ -219,11 +213,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 3df3ca8db4d52952cb750e8859b71f0a371323af
-  --sha256: 0jacfhqnj76cyjwdxz05h7rqmdasgxp9skd01f5y61xraz746x21
+  tag: 030c3b12f128f22b9d721a31b6b5ae1b75211d68
+  --sha256: 0h9qbdik8fnzv33582pvvhkjyv3wwlnshrwvwalh0yl4mmqdcz8x
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
+    eras/babbage/impl
     eras/byron/chain/executable-spec
     eras/byron/crypto
     eras/byron/crypto/test
@@ -247,8 +242,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 44358f6e534a9dd4be32a081f22ff0a649061f90
-  --sha256: 0sn3bcrm8qzmgvp8qs5bxfr7aizb02r3dwq0dyxw3kxhx3qs40fh
+  tag: 4417dfea15746596f51f313ef231fb9ecb1d02fc
+  --sha256: 0nx7jbql3mmd64f0kjxrv9azzyc61b6sm2xh5dil910lw891szwh
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,16 +1,56 @@
 {
-    "haskell.nix": {
+    "hackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions for Hackage",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4cf90b36955597d0151940eabfb1b61a8ec42256",
+        "sha256": "1gdy89dgv2n5ibb6lc03y6k0y9pcacdrlfgv6ipd9bwrivkhdaa9",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/4cf90b36955597d0151940eabfb1b61a8ec42256.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
+        "version": "b3c99d7f13df89a9a918c835ecb7114098912962"
+      },
+      "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "659b73698e06c02cc0f3029383bd383c8acdbe98",
-        "sha256": "0i91iwa11sq0v82v0zl82npnb4qqfm71y7gn3giyaixslm73kspk",
+        "rev": "7e06e14ae1b894445254fe41288bfa7dd4ccbc6f",
+        "sha256": "0kn5jwb11fy80nnxxhki7a3qwfrr03yb5p04ikpki8n0gfrmdz8s",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/659b73698e06c02cc0f3029383bd383c8acdbe98.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/7e06e14ae1b894445254fe41288bfa7dd4ccbc6f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
+        "version": "962ecfed3a4fb656b5a91d89159291e00ed766bc"
+      },
+      "iohk-nix": {
+        "branch": "master",
+        "description": "nix scripts shared across projects",
+        "homepage": null,
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
+        "sha256": "0gwppj37fphjssw9s99xs7yyxylxzi6fdc9g1sq6w7yyx46lrf0i",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
+        "version": "60fe72cf807a4ec4409a53883d5c3af77f60f721"
+      },
+      "nixpkgs": {
+        "builtin": true,
+        "branch": "nixpkgs-unstable",
+        "description": "Nix Packages collection",
+        "homepage": "",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "sha256": "0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
+      },
     "hls-released": {
         "branch": "master",
         "builtin": false,
@@ -22,18 +62,6 @@
         "sha256": "1rbdcl89y85cz31k4qk48zg8qdyywrzzjvh28q36bpm215qhgd74",
         "type": "tarball",
         "url": "https://github.com/haskell/haskell-language-server/archive/1.6.1.1.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "iohk-nix": {
-        "branch": "master",
-        "description": "nix scripts shared across projects",
-        "homepage": null,
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "rev": "9d6ee3dcb3482f791e40ed991ad6fc649b343ad4",
-        "sha256": "1czln6yq11xq7lah230n58r4y2zsl5gg3dghcm909l30v7mxsdhb",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/9d6ee3dcb3482f791e40ed991ad6fc649b343ad4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -312,7 +312,7 @@ library
                      , psqueues          >=0.2.3 && <0.3
                      , random
                      , quiet             >=0.2   && <0.3
-                     , semialign         >=1.1   && <1.2
+                     , semialign         >=1.1
                      , serialise         >=0.2   && <0.3
                      , sop-core          >=0.5   && <0.6
                      , stm               >=2.5   && <2.6


### PR DESCRIPTION
This bumps:
- base
- ledger
- plutus

In addition, the index-state and pinned nix dependencies are synced with
those in base and ledger (and node).

A spurious upper bound on the `semialign` dependecy is dropped, since
this prevented building with aeson > 2.0.0. which is needed for other
components.