### PR TITLE
Removed ST effects from IOSimPOR

### DIFF
--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -1463,23 +1463,16 @@ updateRaces newStep@Step{ stepThreadId = tid, stepEffect = newEffect }
           -- then any threads that it wakes up become non-concurrent also.
           let lessConcurrent = foldr Set.delete concurrent (effectWakeup newEffect) in
           if tid `elem` concurrent then
-            let theseStepsRace = isRacyThreadId tid
-                              && step `racingSteps` newStep
+            let theseStepsRace = isRacyThreadId tid && racingSteps step newStep
                 happensBefore  = step `happensBeforeStep` newStep
                 nondep' | happensBefore = nondep
                         | otherwise     = newStep : nondep
-                -- We cannot remove the 'tid' thread from the set of concurrent
-                -- threads if 'theseStepsRace'.  This was done previously in
-                -- order to record only the first race with each thread.  But
-                -- it can happen that the frist race will block a thread that
-                -- is scheduled to run until another later step unblock it
-                -- (e.g. 'modifyTMVar`).  If we remove the 'tid' from the set
-                -- of concurrent threads we can end up in a situation where
-                -- a schedule is not runnable, because the next thread to run
-                -- is still blocked (e.g. 'TMVar' is taken but not yet
-                -- released).
-                concurrent' | happensBefore = Set.delete tid lessConcurrent
-                            | otherwise     = concurrent
+                -- We will only record the first race with each thread---reversing
+                -- the first race makes the next race detectable. Thus we remove a
+                -- thread from the concurrent set after the first race.
+                concurrent' | happensBefore  = Set.delete tid lessConcurrent
+                            | theseStepsRace = Set.delete tid concurrent
+                            | otherwise      = concurrent
                 -- Here we record discovered races.
                 -- We only record a new race if we are following the default schedule,
                 -- to avoid finding the same race in different parts of the search space.

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -378,8 +378,7 @@ schedule thread@Thread{
 
     LiftST st k -> do
       x <- strictToLazyST st
-      let thread' = thread { threadControl = ThreadControl (k x) ctl,
-                             threadEffect  = effect <> liftSTEffect }
+      let thread' = thread { threadControl = ThreadControl (k x) ctl }
       schedule thread' simstate
 
     GetMonoTime k -> do

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
@@ -671,7 +671,7 @@ verifyAbstractTransition Transition { fromState, toState } =
       (UnnegotiatedSt Outbound, OutboundUniSt)  -> True
       -- @Negotiated^{Duplex}_{Outbound}@
       (UnnegotiatedSt Outbound, OutboundDupSt Ticking) -> True
-      (UnnegotiatedSt Outbound, TerminatingSt) -> True
+      (UnnegotiatedSt _,        TerminatingSt) -> True
 
       -- @DemotedToCold^{Unidirectional}_{Local}@
       (OutboundUniSt, OutboundIdleSt Unidirectional) -> True


### PR DESCRIPTION
ST effects are thread local, they never race with other steps.  This patch
reverts a previous fix commited in PR #3647.

Thanks for `IOSimPOR` we also found out that the transition:
`UnnegotiatedSt Inbound → TerminatingSt` should be valid, similarly to one for
outbound connections (see PR #3652, commit fbcb6aada).
