### PR TITLE
Enabled accept errors in net-sim testing

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1753,7 +1753,7 @@ withConnectionManager ConnectionManagerArguments {
                     --
                     -- Key was overwritten in the dictionary (stateVar),
                     -- so we do not trace anything as it was already traced upon
-                    -- overwritting.
+                    -- overwriting.
                      else return [ ]
 
 

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -565,7 +565,6 @@ data SnocketTrace m addr
     -- ^ TODO: Document meaning of 'Maybe (Maybe OpenState)'
     | STClosingQueue Bool
     | STClosedQueue  Bool
-    | STClosedWhenReading
     | STAcceptFailure SockType SomeException
     | STAccepting
     | STAccepted      addr

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -142,7 +142,7 @@ mkConnection tr bearerInfo connId@ConnectionId { localAddress, remoteAddress } =
           . STAttenuatedChannelTrace connId
           )
           `contramap` tr)
-        ( ( WithAddr (Just localAddress) (Just remoteAddress)
+        ( ( WithAddr (Just remoteAddress) (Just localAddress)
           . STAttenuatedChannelTrace ConnectionId
               { localAddress  = remoteAddress
               , remoteAddress = localAddress

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -350,7 +350,7 @@ instance (Typeable addr, Show addr)
 
 
 -- | A type class for global IP address scheme.  Every node in the simulation
--- has an ephemeral address.  Every node in the simulation has an implicite ipv4
+-- has an ephemeral address.  Every node in the simulation has an implicit ipv4
 -- and ipv6 address (if one is not bound by explicitly).
 --
 class GlobalAddressScheme addr where

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -1483,7 +1483,7 @@ multinodeExperiment
     -> AcceptedConnectionsLimit
     -> MultiNodeScript req peerAddr
     -> m ()
-multinodeExperiment inboundTrTracer trTracer cmTracer inboundTracer
+multinodeExperiment inboundTrTracer trTracer inboundTracer cmTracer
                     snocket addrFamily serverAddr accInit
                     dataFlow0 acceptedConnLimit
                     (MultiNodeScript script _) =
@@ -1613,7 +1613,7 @@ multinodeExperiment inboundTrTracer trTracer cmTracer inboundTracer
                 Duplex ->
                   Job ( withBidirectionalConnectionManager
                           name simTimeouts
-                          inboundTrTracer trTracer inboundTracer cmTracer
+                          inboundTrTracer trTracer cmTracer inboundTracer
                           snocket fd (Just localAddr) serverAcc
                           (mkNextRequests connVar)
                           timeLimitsHandshake
@@ -1635,7 +1635,7 @@ multinodeExperiment inboundTrTracer trTracer cmTracer inboundTracer
                       (show name)
                 Unidirectional ->
                   Job ( withInitiatorOnlyConnectionManager
-                          name simTimeouts trTracer inboundTracer snocket (Just localAddr)
+                          name simTimeouts trTracer cmTracer snocket (Just localAddr)
                           (mkNextRequests connVar)
                           timeLimitsHandshake
                           acceptedConnLimit

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -269,7 +269,7 @@ oneshotNextRequests ClientAndServerData {
                       warmInitiatorRequests,
                       establishedInitiatorRequests
                     } = do
-    -- we pass a `StricTVar` with all the requests to each initiator.  This way
+    -- we pass a `StrictTVar` with all the requests to each initiator.  This way
     -- the each round (which runs a single instance of `ReqResp` protocol) will
     -- use its own request list.
     hotRequestsVar         <- newTVarIO hotInitiatorRequests
@@ -1067,7 +1067,7 @@ data MultiNodeScript req peerAddr = MultiNodeScript
   deriving (Show)
 
 -- | A sequence of connection events that make up a test scenario for `prop_multinode_Sim_Pruning`.
--- This test optimizes for triggering prunings.
+-- This test optimizes for triggering pruning.
 data MultiNodePruningScript req = MultiNodePruningScript
   { mnpsAcceptedConnLimit :: AcceptedConnectionsLimit
     -- ^ Should yield small values to trigger pruning
@@ -1275,7 +1275,7 @@ prop_generator_MultiNodeScript (MultiNodeScript script _) =
 maxAcceptedConnectionsLimit :: AcceptedConnectionsLimit
 maxAcceptedConnectionsLimit = AcceptedConnectionsLimit maxBound maxBound 0
 
--- | This Script has a percentage of events more favorable to trigger pruning
+-- | This Script has a percentage of events more favourable to trigger pruning
 --   transitions. And forces a bidirectional connection between each server.
 --   It also starts inbound protocols in order to trigger the:
 --
@@ -1290,7 +1290,7 @@ instance Arbitrary req =>
          Arbitrary (MultiNodePruningScript req) where
   arbitrary = do
     Positive len <- scale ((* 2) . (`div` 3)) arbitrary
-    -- NOTE: Although we still do not enforce the configured hardlimit to be
+    -- NOTE: Although we still do not enforce the configured hard limit to be
     -- strictly positive. We assume that the hard limit is always bigger than
     -- 0.
     Small hardLimit <- (`div` 10) <$> arbitrary
@@ -1849,7 +1849,7 @@ instance Arbitrary ArbDataFlow where
 data ActivityType
     = IdleConn
 
-    -- | Active connections are onces that reach any of the state:
+    -- | Active connections are once that reach any of the state:
     --
     -- - 'InboundSt'
     -- - 'OutobundUniSt'
@@ -2431,9 +2431,9 @@ prop_connection_manager_counters serverAcc (ArbDataFlow dataFlow)
           -- connections.
           --
           -- TODO: we are computing upper bound of contribution of each
-          -- address seprately.  This avoids tracking timing information of
-          -- events, which is less acurate but it might be less fragile.  We
-          -- should investiage if it's possible to make accurate and robust
+          -- address separately.  This avoids tracking timing information of
+          -- events, which is less accurate but it might be less fragile.  We
+          -- should investigate if it's possible to make accurate and robust
           -- time series of counter changes.
           connectionManagerCounters =
               foldMap' id
@@ -2594,17 +2594,17 @@ prop_timeouts_enforced serverAcc (ArbDataFlow dataFlow)
     -- verifyTimeouts checks that in all \tau transition states the timeout is
     -- respected. It does so by checking the stream of abstract transitions
     -- paired with the time they happened, for a given connection; and checking
-    -- that transitions from \tau states to any other happens withing the correct
+    -- that transitions from \tau states to any other happens within the correct
     -- timeout bounds. One note is that for the example
     -- InboundIdleState^\tau -> OutboundState^\tau -> OutboundState sequence
     -- The first transition would be fine, but for the second we need the time
     -- when we transitioned into InboundIdleState and not OutboundState.
     --
     verifyTimeouts :: Maybe (AbstractState, Time)
-                   -- ^ Map of first occurence of a given \tau state
+                   -- ^ Map of first occurrence of a given \tau state
                    -> [(Time , AbstractTransitionTrace SimAddr)]
                    -- ^ Stream of abstract transitions for a given connection
-                   -- paired with the time it ocurred
+                   -- paired with the time it occurred
                    -> Property
     verifyTimeouts state [] =
       counterexample
@@ -3604,7 +3604,7 @@ unit_connection_terminated_when_negotiating =
         multiNodeScript
 
 
--- | Split 'AbstractTransitionTrace' into seprate connections.  This relies on
+-- | Split 'AbstractTransitionTrace' into separate connections.  This relies on
 -- the property that every connection is terminated with 'UnknownConnectionSt'.
 -- This property is verified by 'verifyAbstractTransitionOrder'.
 --

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -2518,10 +2518,7 @@ prop_connection_manager_counters serverAcc (ArbDataFlow dataFlow)
          else (a, b, c + d - a)
 
     networkStateTracer getState =
-      sayTracer
-      <> (Tracer $ \_ -> do
-      state <- getState
-      traceM state)
+      Tracer $ \_ -> getState >>= traceM
 
     sim :: IOSim s ()
     sim = do

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -3577,6 +3577,7 @@ unit_connection_terminated_when_negotiating =
           , abiOutboundAttenuation = NoAttenuation FastSpeed
           , abiInboundWriteFailure = Nothing
           , abiOutboundWriteFailure = Just 3
+          , abiAcceptFailure = Nothing
           , abiSDUSize = LargeSDU
           }
       multiNodeScript =

--- a/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
@@ -337,7 +337,13 @@ toBearerInfo abi =
         biOutboundAttenuation  = attenuation (abiOutboundAttenuation abi),
         biInboundWriteFailure  = abiInboundWriteFailure abi,
         biOutboundWriteFailure = abiOutboundWriteFailure abi,
-        biAcceptFailures       = Nothing, -- TODO
+        biAcceptFailures       = (\(errDelay, errType) ->
+                                   ( delay errDelay
+                                   , case errType of
+                                      AbsIOErrConnectionAborted -> IOErrConnectionAborted
+                                      AbsIOErrResourceExhausted -> IOErrResourceExhausted
+                                   )
+                                 ) <$> abiAcceptFailure abi,
         biSDUSize              = toSduSize (abiSDUSize abi)
       }
 

--- a/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
@@ -324,6 +324,11 @@ clientServerSimulation payloads =
 -- Auxiliary
 --
 
+-- TODO: should be defined where 'AbsBearerInfo' is defined, but it also
+-- requires access to 'ouroboros-network-framework' where 'BearerInfo' is
+-- defined.  This can be fixed by moving `ouroboros-network-testing` to
+-- `ouroboros-network-framework:testlib`.
+--
 toBearerInfo :: AbsBearerInfo -> BearerInfo
 toBearerInfo abi =
     BearerInfo {

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/Data/AbsBearerInfo.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/Data/AbsBearerInfo.hs
@@ -18,6 +18,7 @@ module Ouroboros.Network.Testing.Data.AbsBearerInfo
   , absNoAttenuation
   , AbsBearerInfo (..)
   , toNonFailingAbsBearerInfoScript
+  , AbsIOErrType (..)
   ) where
 
 import           Control.Monad.Class.MonadTime (DiffTime, Time (..), addTime)
@@ -164,12 +165,26 @@ attenuation (ErrorInterval speed from len) =
             else Failure
         )
 
+data AbsIOErrType = AbsIOErrConnectionAborted
+                  | AbsIOErrResourceExhausted
+  deriving (Eq, Show)
+
+instance Arbitrary AbsIOErrType where
+    arbitrary = elements [ AbsIOErrConnectionAborted
+                         , AbsIOErrResourceExhausted
+                         ]
+    shrink AbsIOErrConnectionAborted = [AbsIOErrResourceExhausted]
+    shrink AbsIOErrResourceExhausted = []
+
 data AbsBearerInfo = AbsBearerInfo
     { abiConnectionDelay      :: !AbsDelay
     , abiInboundAttenuation   :: !AbsAttenuation
     , abiOutboundAttenuation  :: !AbsAttenuation
     , abiInboundWriteFailure  :: !(Maybe Int)
     , abiOutboundWriteFailure :: !(Maybe Int)
+    , abiAcceptFailure        :: !(Maybe ( AbsDelay
+                                         , AbsIOErrType
+                                         ))
     , abiSDUSize              :: !AbsSDUSize
     }
   deriving (Eq, Show)
@@ -181,12 +196,13 @@ absNoAttenuation = AbsBearerInfo
     , abiOutboundAttenuation  = NoAttenuation NormalSpeed
     , abiInboundWriteFailure  = Nothing
     , abiOutboundWriteFailure = Nothing
+    , abiAcceptFailure        = Nothing
     , abiSDUSize              = NormalSDU
     }
 
 canFail :: AbsBearerInfo -> Bool
 canFail abi = getAny $
-      case abiInboundAttenuation abi of
+       case abiInboundAttenuation abi of
          NoAttenuation {} -> Any False
          _                -> Any True
     <> case abiOutboundAttenuation abi of
@@ -198,6 +214,9 @@ canFail abi = getAny $
     <> case abiOutboundWriteFailure abi of
          Nothing -> Any False
          _       -> Any True
+    <> case abiAcceptFailure abi of
+         Nothing -> Any False
+         _       -> Any True
 
 instance Arbitrary AbsBearerInfo where
     arbitrary =
@@ -206,12 +225,18 @@ instance Arbitrary AbsBearerInfo where
                       <*> arbitrary
                       <*> genWriteFailure
                       <*> genWriteFailure
+                      <*> genAcceptFailure
                       <*> arbitrary
       where
         genWriteFailure =
           frequency
             [ (2, pure Nothing)
             , (1, Just <$> arbitrarySizedNatural)
+            ]
+        genAcceptFailure =
+          frequency
+            [ (2, pure Nothing)
+            , (1, (\a b -> Just (a,b)) <$> arbitrary <*> arbitrary)
             ]
 
     shrink abi =
@@ -279,6 +304,7 @@ toNonFailingAbsBearerInfoScript (AbsBearerInfoScript script) =
          , abiOutboundWriteFailure = Nothing
          , abiInboundAttenuation   = unfailAtt $ abiInboundAttenuation bi
          , abiOutboundAttenuation  = unfailAtt $ abiOutboundAttenuation bi
+         , abiAcceptFailure        = Nothing
          }
 
     unfailAtt (ErrorInterval    speed _ _) = NoAttenuation speed

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/Data/AbsBearerInfo.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/Data/AbsBearerInfo.hs
@@ -282,7 +282,7 @@ instance Arbitrary AbsBearerInfoScript where
     | script'
         <- map (NonEmpty.fromList . fixupAbsBearerInfos)
         . filter (not . List.null)
-         -- TODO: shrinking of 'AbsBearerInfo' needs to be more aggresive to use
+         -- TODO: shrinking of 'AbsBearerInfo' needs to be more aggressive to use
          -- @shrinkList shrink@
          $ shrinkList (const []) (NonEmpty.toList script)
     , script' /= script


### PR DESCRIPTION
Fixes #3315

- ouroboros-network-framework: added todo
- sim-net: removed IOErrThrowOrReturn as an abstraction leak
- sim-net: reset channel when accept errors
- net-sim: added abiAcceptFailure
- net-sim: refactor TestError
- net-sim: fix prop_connect_to_accepting_socket
- Fixed some typos
