### PR TITLE
Reduce Nix closure size

### DIFF
--- a/nix/check-nixfmt.nix
+++ b/nix/check-nixfmt.nix
@@ -1,8 +1,11 @@
-{ runCommand, fd, nixfmt }:
+{ runCommand, fd, nixfmt, haskell-nix }:
 
 runCommand "check-nixfmt" {
   buildInputs = [ fd nixfmt ];
-  src = ./..;
+  src = haskell-nix.haskellLib.cleanGit {
+    name = "ouroboros-network-src";
+    src = ../.;
+  };
 } ''
   unpackPhase
   cd $sourceRoot

--- a/nix/check-stylish-network.nix
+++ b/nix/check-stylish-network.nix
@@ -1,9 +1,12 @@
-{ runCommand, fd, lib, stylish-haskell }:
+{ runCommand, fd, lib, stylish-haskell, haskell-nix }:
 
 runCommand "check-stylish-network" {
   meta.platforms = with lib.platforms; [ linux ];
   buildInputs = [ fd stylish-haskell ];
-  src = ./..;
+  src = haskell-nix.haskellLib.cleanGit {
+    name = "ouroboros-network-src";
+    src = ../.;
+  };
 } ''
   unpackPhase
   cd $sourceRoot

--- a/nix/check-stylish.nix
+++ b/nix/check-stylish.nix
@@ -1,9 +1,12 @@
-{ runCommand, fd, lib, stylish-haskell }:
+{ runCommand, fd, lib, stylish-haskell, haskell-nix }:
 
 runCommand "check-stylish" {
   meta.platforms = with lib.platforms; [ linux ];
   buildInputs = [ fd stylish-haskell ];
-  src = ./..;
+  src = haskell-nix.haskellLib.cleanGit {
+    name = "ouroboros-network-src";
+    src = ../.;
+  };
 } ''
   unpackPhase
   cd $sourceRoot


### PR DESCRIPTION
Reduce the closure size of `release.nix` (useful for remote building) by filtering the source (such that e.g. `dist-newstyle` and `.git` are not considered to be part of the derivation).

Before:
```
 $ nix path-info --derivation -Sh $(nix-instantiate release.nix)
/nix/store/833krq3p3jr7s7mbi3lwhb5791xv5d54-github-required.drv                      	 913.3M
/nix/store/940dy107863a26g6rs1h7ab2n8k9zn7d-ouroboros-network-0.1.0.0-tests-win64.drv	  21.4M
```
After:
```
/nix/store/4xchhdk69d1wprccm4m5f22dnjskkmih-github-required.drv                      	  54.7M
/nix/store/940dy107863a26g6rs1h7ab2n8k9zn7d-ouroboros-network-0.1.0.0-tests-win64.drv	  21.4M
```