### PR TITLE
CAD-4018 UTxO-HD Fix shelley bug

### DIFF
--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -191,16 +191,20 @@ emptyLedgerState = ByronLedgerState {
 
 ledgerStateAfterEBB :: LedgerState ByronBlock ValuesMK
 ledgerStateAfterEBB =
-      forgetLedgerStateTracking
+      mappendValues (projectLedgerTables emptyLedgerState)
+    . forgetLedgerStateTracking
     . reapplyLedgerBlock ledgerConfig exampleEBB
     . applyChainTick ledgerConfig (SlotNo 0)
+    . forgetLedgerStateTables
     $ emptyLedgerState
 
 exampleLedgerState :: LedgerState ByronBlock ValuesMK
 exampleLedgerState =
-      forgetLedgerStateTracking
+      mappendValues (projectLedgerTables ledgerStateAfterEBB)
+    . forgetLedgerStateTracking
     . reapplyLedgerBlock ledgerConfig exampleBlock
     . applyChainTick ledgerConfig (SlotNo 1)
+    . forgetLedgerStateTables
     $ ledgerStateAfterEBB
 
 exampleHeaderState :: HeaderState ByronBlock

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -264,7 +264,7 @@ byronPBftParams ByronSpecGenesis{..} =
 instance TxGen DualByronBlock where
   testGenTxs _coreNodeId _numCoreNodes curSlotNo cfg () = \st -> do
       n <- choose (0, 20)
-      go [] n $ applyChainTick (configLedger cfg) curSlotNo st
+      go [] n $ mappendValuesTicked (projectLedgerTables st) $ applyChainTick (configLedger cfg) curSlotNo $ forgetLedgerStateTables st
     where
       -- Attempt to produce @n@ transactions
       -- Stops when the transaction generator cannot produce more txs

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -26,7 +26,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
                      (currentState, getHardForkState)
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Tele
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig, LedgerState,
-                     TickedLedgerState, ValuesMK, applyChainTick)
+                     TickedLedgerState, ValuesMK, applyChainTick,
+                     mappendValuesTicked, projectLedgerTables, forgetLedgerStateTables)
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 
 import           Cardano.Crypto (toVerification)
@@ -223,9 +224,12 @@ migrateUTxO migrationInfo curSlot lcfg lst
   where
     mbUTxO :: Maybe (SL.UTxO (ShelleyEra c))
     mbUTxO =
-        fmap getUTxOShelley $
-        ejectShelleyTickedLedgerState $
-        applyChainTick lcfg curSlot lst
+          fmap getUTxOShelley
+        . ejectShelleyTickedLedgerState
+        . mappendValuesTicked (projectLedgerTables lst)
+        . applyChainTick lcfg curSlot
+        . forgetLedgerStateTables
+        $ lst
 
     MigrationInfo
       { byronMagic

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -64,7 +64,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (MockShelley h)) where
 
       | otherwise               = do
       n <- choose (0, 20)
-      go [] n $ applyChainTick lcfg curSlotNo lst
+      go [] n $ mappendValuesTicked (projectLedgerTables lst) $ applyChainTick lcfg curSlotNo $ forgetLedgerStateTables lst
     where
       ShelleyTxGenExtra
         { stgeGenEnv

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -425,9 +425,8 @@ instance ShelleyBasedEra era => IsLedger (LedgerState (ShelleyBlock era)) where
                                 shelleyLedgerTip
                               , shelleyLedgerState
                               , shelleyLedgerTransition
-                              , shelleyLedgerTables
                               } =
-      swizzle appTick <&> \l' ->
+    swizzle appTick <&> \l' ->
       TickedShelleyLedgerState {
           untickedShelleyLedgerTip      = shelleyLedgerTip
         , tickedShelleyLedgerTransition =
@@ -437,7 +436,7 @@ instance ShelleyBasedEra era => IsLedger (LedgerState (ShelleyBlock era)) where
             else
               shelleyLedgerTransition
         , tickedShelleyLedgerState      = l'
-        , tickedShelleyLedgerTables     = shelleyLedgerTables
+        , tickedShelleyLedgerTables     = polyEmptyLedgerTables
         }
     where
       globals = shelleyLedgerGlobals cfg

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -567,7 +567,9 @@ instance PayloadSemantics ptype => IsLedger (LedgerState (TestBlockWith ptype)) 
   type AuxLedgerEvent (LedgerState (TestBlockWith ptype)) =
     VoidLedgerEvent (LedgerState (TestBlockWith ptype))
 
-  applyChainTickLedgerResult _ _ = pureLedgerResult . TickedTestLedger
+  applyChainTickLedgerResult _ _ = pureLedgerResult
+                                 . TickedTestLedger
+                                 . noNewTickingValues
 
 instance PayloadSemantics ptype => UpdateLedger (TestBlockWith ptype)
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -465,8 +465,14 @@ ledgerState_AtoB ::
        TranslateLedgerState
        BlockA
        BlockB
-ledgerState_AtoB = InPairs.ignoringBoth $ TranslateLedgerState $ \_ LgrA{..} -> LgrB {
-      lgrB_tip = castPoint lgrA_tip
+ledgerState_AtoB =
+    InPairs.ignoringBoth
+  $ TranslateLedgerState {
+        translateLedgerStateWith = \_ LgrA{..} ->
+            LgrB {
+              lgrB_tip = castPoint lgrA_tip
+            }
+      , translateLedgerTablesWith = \NoATables -> NoBTables
     }
 
 chainDepState_AtoB ::

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -254,7 +254,9 @@ instance IsLedger (LedgerState BlockA) where
   type AuxLedgerEvent (LedgerState BlockA) =
     VoidLedgerEvent (LedgerState BlockA)
 
-  applyChainTickLedgerResult _ _ = pureLedgerResult . TickedLedgerStateA
+  applyChainTickLedgerResult _ _ = pureLedgerResult
+                                 . TickedLedgerStateA
+                                 . noNewTickingValues
 
 instance ApplyBlock (LedgerState BlockA) BlockA where
   applyBlockLedgerResult cfg blk =

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -227,7 +227,9 @@ instance IsLedger (LedgerState BlockB) where
   type AuxLedgerEvent (LedgerState BlockB) =
     VoidLedgerEvent (LedgerState BlockB)
 
-  applyChainTickLedgerResult _ _ = pureLedgerResult . TickedLedgerStateB
+  applyChainTickLedgerResult _ _ = pureLedgerResult
+                                 . TickedLedgerStateB
+                                 . noNewTickingValues
 
 instance ApplyBlock (LedgerState BlockB) BlockB where
   applyBlockLedgerResult   = \_ b _ -> return $ pureLedgerResult $ LgrB (blockPoint b)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -556,7 +556,9 @@ instance IsLedger (LedgerState TestBlock) where
   type AuxLedgerEvent (LedgerState TestBlock) =
     VoidLedgerEvent (LedgerState TestBlock)
 
-  applyChainTickLedgerResult _ _ = pureLedgerResult . TickedTestLedger
+  applyChainTickLedgerResult _ _ = pureLedgerResult
+                                 . TickedTestLedger
+                                 . noNewTickingValues
 
 instance ShowLedgerState (LedgerState TestBlock) where
   showsLedgerState _sing = shows

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -173,17 +173,18 @@ epochInfoPrecomputedTransitionInfo shape transition st =
 -------------------------------------------------------------------------------}
 
 -- | Extend the telescope until the specified slot is within the era at the tip
-extendToSlot :: forall xs mk .
-                (CanHardFork xs, IsApplyMapKind mk)
+extendToSlot :: forall xs.
+                (CanHardFork xs)
              => HardForkLedgerConfig xs
              -> SlotNo
-             -> HardForkState (Flip LedgerState mk) xs -> HardForkState (Flip LedgerState mk) xs
+             -> HardForkState (Flip LedgerState EmptyMK) xs -> HardForkState (Flip LedgerState ValuesMK) xs
 extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st) =
-      HardForkState . unI
+      HardForkState
+    . unI
     . Telescope.extend
-        ( InPairs.hmap (\f -> Require $ \(K t)
-                           -> Extend  $ \cur
-                           -> I $ howExtend f t cur)
+        ( InPairs.hcmap proxySingle (\f -> Require $ \(K t)
+                                        -> Extend  $ \cur
+                                        -> I $ howExtend f t cur)
         $ translate
         )
         (hczipWith
@@ -191,6 +192,16 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
            (fn .: whenExtend)
            pcfgs
            (getExactly (History.getShape hardForkLedgerConfigShape)))
+    -- In order to make this an automorphism, as required by 'Telescope.extend',
+    -- we have to promote the input to @ValuesMK@ albeit it being empty.
+    $ hcmap
+        proxySingle
+        (\c -> c { currentState = Flip
+                                . flip withLedgerTables polyEmptyLedgerTables
+                                . unFlip
+                                . currentState
+                                $ c }
+        )
     $ st
   where
     pcfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
@@ -198,11 +209,11 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
     ei    = epochInfoLedger ledgerCfg ledgerSt
 
     -- Return the end of this era if we should transition to the next
-    whenExtend :: SingleEraBlock                blk
-               => WrapPartialLedgerConfig       blk
-               -> K History.EraParams           blk
-               -> Current (Flip LedgerState mk) blk
-               -> (Maybe :.: K History.Bound)   blk
+    whenExtend :: SingleEraBlock                      blk
+               => WrapPartialLedgerConfig             blk
+               -> K History.EraParams                 blk
+               -> Current (Flip LedgerState ValuesMK) blk
+               -> (Maybe :.: K History.Bound)         blk
     whenExtend pcfg (K eraParams) cur = Comp $ K <$> do
         transition <- singleEraTransition'
                         pcfg
@@ -216,10 +227,11 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
         guard (slot >= History.boundSlot endBound)
         return endBound
 
-    howExtend :: TranslateLedgerState blk blk'
+    howExtend :: (TableStuff (LedgerState blk), TableStuff (LedgerState blk'))
+              => TranslateLedgerState blk blk'
               -> History.Bound
-              -> Current (Flip LedgerState mk) blk
-              -> (K Past blk, Current (Flip LedgerState mk) blk')
+              -> Current (Flip LedgerState ValuesMK) blk
+              -> (K Past blk, Current (Flip LedgerState ValuesMK) blk')
     howExtend f currentEnd cur = (
           K Past {
               pastStart    = currentStart cur
@@ -227,9 +239,25 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
             }
         , Current {
               currentStart = currentEnd
-            , currentState = Flip $ translateLedgerStateWith f
-                               (History.boundEpoch currentEnd)
-                               (unFlip $ currentState cur)
+            , currentState = Flip
+                             -- we need to bring back the values provided by
+                             -- previous translations. Note that if there is
+                             -- only one translation or if the previous
+                             -- translations don't add any new tables this will
+                             -- just be a no-op. See the haddock for
+                             -- 'translateLedgerTablesWith' for more
+                             -- information).
+                             . mappendValues ( translateLedgerTablesWith f
+                                               . projectLedgerTables
+                                               . unFlip
+                                               . currentState
+                                               $ cur
+                                             )
+                             . translateLedgerStateWith f (History.boundEpoch currentEnd)
+                             . forgetLedgerStateTables
+                             . unFlip
+                             . currentState
+                             $ cur
             }
         )
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -30,7 +30,7 @@ import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.History (Bound)
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK, IsApplyMapKind, LedgerState)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerState, EmptyMK, ValuesMK, LedgerTables)
 import           Ouroboros.Consensus.Ticked
 
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
@@ -102,12 +102,34 @@ newtype TranslateForecast f g x y = TranslateForecast {
         -> Except OutsideForecastRange (Ticked (g y))
     }
 
-newtype TranslateLedgerState x y = TranslateLedgerState {
-      translateLedgerStateWith :: forall mk .
-           IsApplyMapKind mk
-        => EpochNo
-        -> LedgerState x mk
-        -> LedgerState y mk
+-- | Translate a LedgerState across an era transition.
+--
+-- As new tables might be populated on an era transition, the return map kind is
+-- @ValuesMK@. If no tables are populated, normally this will be filled with
+-- @polyEmptyLedgerTables@.
+data TranslateLedgerState x y = TranslateLedgerState {
+        -- | How to translate a Ledger State during the era transition
+        translateLedgerStateWith ::
+            EpochNo
+         -> LedgerState x EmptyMK
+         -> LedgerState y ValuesMK
+
+        -- | How to translate tables on an era transition.
+        --
+        -- This is a rather technical subtlety. When performing a ledger state
+        -- translation, the provided input ledger state will be initially
+        -- populated with a @polyEmptyLedgerTables@. This step is required so
+        -- that the operation provided to 'Telescope.extend' is an automorphism.
+        --
+        -- If we only extend by one era, this function is a no-op, as the input
+        -- will be empty ledger states. However, if we extend across multiple
+        -- eras, previous eras might populate tables thus creating Values that
+        -- now need to be translated to newer eras. This function fills that
+        -- hole and allows us to promote tables from one era into tables from
+        -- the next era.
+      , translateLedgerTablesWith ::
+            LedgerTables (LedgerState x) ValuesMK
+         -> LedgerTables (LedgerState y) ValuesMK
     }
 
 -- | Knowledge in a particular era of the transition to the next era

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -118,6 +118,7 @@ rewind p (HeaderStateHistory history) = HeaderStateHistory <$>
       ((== p) . either headerStatePoint headerStatePoint)
       history
 
+
 {-------------------------------------------------------------------------------
   Validation
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -143,35 +143,43 @@ reapplyLedgerBlock ::
 reapplyLedgerBlock = lrResult ..: reapplyBlockLedgerResult
 
 tickThenApplyLedgerResult ::
-     ApplyBlock l blk
+     (ApplyBlock l blk, TickedTableStuff l)
   => LedgerCfg l
   -> blk
   -> l ValuesMK
   -> Except (LedgerErr l) (LedgerResult l (l TrackingMK))
 tickThenApplyLedgerResult cfg blk l = do
-  let lrTick = applyChainTickLedgerResult cfg (blockSlot blk) l
-  lrBlock <-   applyBlockLedgerResult     cfg            blk  (lrResult lrTick)
+  let lrTick = applyChainTickLedgerResult cfg (blockSlot blk) (forgetLedgerStateTables l)
+  lrBlock <-    applyBlockLedgerResult     cfg            blk  (mappendValuesTicked (projectLedgerTables l) $ lrResult lrTick)
+  let tickDiffs = zipLedgerTables calculateDifference polyEmptyLedgerTables
+                . projectLedgerTablesTicked
+                . lrResult
+                $ lrTick
   pure LedgerResult {
       lrEvents = lrEvents lrTick <> lrEvents lrBlock
-    , lrResult = lrResult lrBlock
+    , lrResult = mappendTracking tickDiffs $ lrResult lrBlock
     }
 
 tickThenReapplyLedgerResult ::
-     ApplyBlock l blk
+     (ApplyBlock l blk, TickedTableStuff l)
   => LedgerCfg l
   -> blk
   -> l ValuesMK
   -> LedgerResult l (l TrackingMK)
 tickThenReapplyLedgerResult cfg blk l =
-  let lrTick  = applyChainTickLedgerResult cfg (blockSlot blk) l
-      lrBlock = reapplyBlockLedgerResult   cfg            blk  (lrResult lrTick)
+  let lrTick    = applyChainTickLedgerResult cfg (blockSlot blk) (forgetLedgerStateTables l)
+      lrBlock   = reapplyBlockLedgerResult   cfg            blk  (mappendValuesTicked (projectLedgerTables l) $ lrResult lrTick)
+      tickDiffs = zipLedgerTables calculateDifference polyEmptyLedgerTables
+                . projectLedgerTablesTicked
+                . lrResult
+                $ lrTick
   in LedgerResult {
       lrEvents = lrEvents lrTick <> lrEvents lrBlock
-    , lrResult = lrResult lrBlock
+    , lrResult = mappendTracking tickDiffs $ lrResult lrBlock
     }
 
 tickThenApply ::
-     ApplyBlock l blk
+     (ApplyBlock l blk, TickedTableStuff l)
   => LedgerCfg l
   -> blk
   -> l ValuesMK
@@ -179,7 +187,7 @@ tickThenApply ::
 tickThenApply = fmap lrResult ..: tickThenApplyLedgerResult
 
 tickThenReapply ::
-     ApplyBlock l blk
+     (ApplyBlock l blk, TickedTableStuff l)
   => LedgerCfg l
   -> blk
   -> l ValuesMK

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -40,6 +40,7 @@ module Ouroboros.Consensus.Ledger.Basics (
   , IsLedger (..)
   , LedgerCfg
   , applyChainTick
+  , noNewTickingValues
     -- * Link block to its ledger
   , LedgerConfig
   , LedgerError
@@ -87,7 +88,7 @@ module Ouroboros.Consensus.Ledger.Basics (
     -- ** Queries
   , DiskLedgerView (..)
   , FootprintL (..)
-    -- ** Convenience alises
+    -- ** Convenience aliases
   , TableKeySets
   , TableReadSets
   , applyDiffsLedgerTables
@@ -97,6 +98,9 @@ module Ouroboros.Consensus.Ledger.Basics (
   , forgetTickedLedgerStateTracking
   , polyEmptyLedgerTables
   , trackingTablesToDiffs
+  , mappendValues
+  , mappendValuesTicked
+  , mappendTracking
     -- ** Special classes of ledger states
   , InMemory (..)
   , StowableLedgerTables (..)
@@ -286,6 +290,14 @@ class ( -- Requirements on the ledger state itself
   -- it would mean a /previous/ block set up the ledger state in such a way
   -- that as soon as a certain slot was reached, /any/ block would be invalid.
   --
+  -- Currently, ticking transformations don't require data from the ledger
+  -- tables, therefore the input map kind is fixed to @EmptyMK@. As translating
+  -- a @LedgerState@ between eras happens during the ticking operation on the
+  -- @HardForkBlock@ instance, the return type has to allow for new tables to be
+  -- populated in the translation thus it is set to @ValuesMK@. Currently this
+  -- does happen in the Byron to Shelley translation where the UTxO map is
+  -- populated.
+  --
   -- PRECONDITION: The slot number must be strictly greater than the slot at
   -- the tip of the ledger (except for EBBs, obviously..).
   --
@@ -299,20 +311,27 @@ class ( -- Requirements on the ledger state itself
   -- NOTE: The 'IsApplyMapKind' constraint is here for the same reason it's on
   -- 'projectLedgerTables'
   applyChainTickLedgerResult ::
-       IsApplyMapKind mk
-    => LedgerCfg l
+       LedgerCfg l
     -> SlotNo
-    -> l mk
-    -> LedgerResult l (Ticked1 l mk)
+    -> l EmptyMK
+    -> LedgerResult l (Ticked1 l ValuesMK)
 
 -- | 'lrResult' after 'applyChainTickLedgerResult'
 applyChainTick ::
-     (IsLedger l, IsApplyMapKind mk)
+     IsLedger l
   => LedgerCfg l
   -> SlotNo
-  -> l mk
-  -> Ticked1 l mk
+  -> l EmptyMK
+  -> Ticked1 l ValuesMK
 applyChainTick = lrResult ..: applyChainTickLedgerResult
+
+-- | When applying a block that is not on an era transition, ticking won't
+-- generate new values, so this function can be used to wrap the call to the
+-- ledger rules that perform the tick.
+noNewTickingValues :: TickedTableStuff l
+                   => l any
+                   -> l ValuesMK
+noNewTickingValues l = withLedgerTables l polyEmptyLedgerTables
 
 -- This can't be in IsLedger because we have a compositional IsLedger instance
 -- for LedgerState HardForkBlock but we will not (at least ast first) have a
@@ -439,6 +458,22 @@ zipOverLedgerTables f l tables2 =
       (\tables1 -> zipLedgerTables f tables1 tables2)
       l
 
+-- | Mappend the values in the tables and in the ledger state
+mappendValues ::
+     TableStuff l
+  => LedgerTables l ValuesMK
+  -> l ValuesMK
+  -> l ValuesMK
+mappendValues = flip (zipOverLedgerTables (\(ApplyValuesMK v1) (ApplyValuesMK v2) -> ApplyValuesMK $ v1 <> v2))
+
+-- | Mappend the differences in the tables and in the ledger state
+mappendTracking ::
+     TableStuff l
+  => LedgerTables l TrackingMK
+  -> l TrackingMK
+  -> l TrackingMK
+mappendTracking = flip (zipOverLedgerTables (\(ApplyTrackingMK v1 d1) (ApplyTrackingMK _ d2) -> ApplyTrackingMK v1 (d2 <> d1)))
+
 -- Separate so that we can have a 'TableStuff' instance for 'Ticked1' without
 -- involving double-ticked types.
 class TableStuff l => TickedTableStuff (l :: LedgerStateKind) where
@@ -483,6 +518,14 @@ zipOverLedgerTablesTicked f l tables2 =
     overLedgerTablesTicked
       (\tables1 -> zipLedgerTables f tables1 tables2)
       l
+
+-- | Mappend the values in the tables and in the ticked ledger state
+mappendValuesTicked ::
+     TickedTableStuff l
+  => LedgerTables l ValuesMK
+  -> Ticked1      l ValuesMK
+  -> Ticked1      l ValuesMK
+mappendValuesTicked = flip (zipOverLedgerTablesTicked (\(ApplyValuesMK v1) (ApplyValuesMK v2) -> ApplyValuesMK $ v1 <> v2))
 
 -- | This class provides a 'CodecMK' that can be used to encode/decode keys and
 -- values on @'LedgerTables' l mk@

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -127,7 +127,11 @@ mkMempool mpEnv = Mempool
             let snapshot =
                   pureGetSnapshotFor
                     cfg
-                    (ForgeInKnownSlot slot $ applyChainTick cfg slot $ ledgerState ls')
+                    (ForgeInKnownSlot slot
+                      $ mappendValuesTicked (projectLedgerTables $ ledgerState ls')
+                      $ applyChainTick cfg slot
+                      $ forgetLedgerStateTables
+                      $ ledgerState ls')
                     capacityOverride
                     is
             atomically $ putTMVar istate is

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
@@ -329,13 +329,16 @@ revalidateTxsFor capacityOverride cfg slot st lastTicketNo txTickets =
 
 -- | Tick the 'LedgerState' using the given 'BlockSlot'.
 tickLedgerState
-  :: forall blk mk. (UpdateLedger blk, ValidateEnvelope blk, IsApplyMapKind mk)
+  :: forall blk. (UpdateLedger blk, ValidateEnvelope blk)
   => LedgerConfig     blk
-  -> ForgeLedgerState blk mk
-  -> (SlotNo, TickedLedgerState blk mk)
+  -> ForgeLedgerState blk ValuesMK
+  -> (SlotNo, TickedLedgerState blk ValuesMK)
 tickLedgerState _cfg (ForgeInKnownSlot slot st) = (slot, st)
 tickLedgerState  cfg (ForgeInUnknownSlot st) =
-    (slot, applyChainTick cfg slot st)
+    (slot, mappendValuesTicked (projectLedgerTables st)
+         $ applyChainTick cfg slot
+         $ forgetLedgerStateTables st
+    )
   where
     -- Optimistically assume that the transactions will be included in a block
     -- in the next available slot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -516,7 +516,7 @@ forkBlockForging IS{..} blockForging =
         trace $ TraceNodeIsLeader currentSlot
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
-        let tickedLedgerState :: TickedLedgerState blk EmptyMK
+        let tickedLedgerState :: TickedLedgerState blk ValuesMK
             tickedLedgerState =
               applyChainTick
                 (configLedger cfg)


### PR DESCRIPTION
Ticking a ledger state now goes from `l EmptyMK` to `l ValuesMK`. Those differences are prepended to the ones produces by applying the block and therefore recorded in the `DbChangelog` as they should.