### PR TITLE
Updated cardano-base & avoid libsecp256k1 on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,12 +130,27 @@ jobs:
       run: |
         cat ./cabal.project.local.ci >> ./cabal.project.local
 
+    - name: Configure (Linux)
+      if: matrix.os == "ubuntu-20.04"
         cat >> cabal.project.local <<EOF
         package cardano-crypto-praos
           flags: -external-libsodium-vrf
         EOF
 
         cat ./cabal.project.local
+
+    - name: Configure (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        echo "FIXME: can't install from sources, so instead libsecp256k1 support is disabled"
+        cat >> cabal.project.local <<EOF
+        package cardano-crypto-praos
+          flags: -external-libsodium-vrf
+        package cardano-crypto-class
+          flags: -secp256k1-support
+        package cardano-crypto-tests
+          flags: -secp256k1-support
+        EOF
 
     - name: Install happy
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -196,8 +196,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 20bd513b7ac9dcf0749f0ceb1df3d6b07a1b57c8
-  --sha256: 0pkcd3k2fpk76igfyaf7cqrcglnjs3rs9pka68wpkyp6z7qkixmz
+  tag: 394c4637c24d82325bd04ceb99c8e8df5617e663
+  --sha256: 02q8y69za5b0vsnj9qga1364vkmfc1kh35d0yshw1lf7nw9bls8m
   subdir:
     base-deriving-via
     binary


### PR DESCRIPTION
Closes #3678, `libsecp256k1` is not available on Windows.