### PR TITLE
Use ledger's neededTxInsForBlock

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -196,8 +196,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 20bd513b7ac9dcf0749f0ceb1df3d6b07a1b57c8
-  --sha256: 0pkcd3k2fpk76igfyaf7cqrcglnjs3rs9pka68wpkyp6z7qkixmz
+  tag: 1587462ac8b2e50af2691f5ad93d3c2aa4674ed1
+  --sha256: 195950d7r64mp36xmjvwzfb6iazzr8viylwfqbw7g06pcw7q7d4f
   subdir:
     base-deriving-via
     binary
@@ -212,8 +212,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 030c3b12f128f22b9d721a31b6b5ae1b75211d68
-  --sha256: 0h9qbdik8fnzv33582pvvhkjyv3wwlnshrwvwalh0yl4mmqdcz8x
+  tag: 32ea4347d98886f88f784d670e5fcf9dad2fb4e5
+  --sha256: 1pslr9f75fvqndzgjgxybi2qprd2il8054sc8jbsn4dqggqhj92p
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -241,8 +241,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 4417dfea15746596f51f313ef231fb9ecb1d02fc
-  --sha256: 0nx7jbql3mmd64f0kjxrv9azzyc61b6sm2xh5dil910lw891szwh
+  tag: ccf5bcb99ffe054dc8cd5626723f64e02708dbae
+  --sha256: 18569bgywilibz7r5jyxj9bid8g4fwr80cc0hd9rcm3jhasbgq8i
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -281,7 +281,7 @@ getUTxOShelley :: TickedLedgerState (ShelleyBlock era) mk
                -> SL.UTxO era
 getUTxOShelley tls =
     SL._utxo $
-    SL._utxoState $
+    SL.lsUTxOState $
     SL.esLState $
     SL.nesEs $
     tickedShelleyLedgerState tls

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
@@ -3,14 +3,14 @@ module Test.ThreadNet.Infra.Alonzo (degenerateAlonzoGenesis) where
 import qualified Data.Map as Map
 
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
-import           Cardano.Ledger.Alonzo.Scripts (Prices (..))
+import           Cardano.Ledger.Alonzo.Scripts (Prices (..), CostModels (..))
 import           Cardano.Ledger.Shelley.API (Coin (..))
 
 degenerateAlonzoGenesis :: AlonzoGenesis
 degenerateAlonzoGenesis = AlonzoGenesis {
      coinsPerUTxOWord     = Coin 0
    , collateralPercentage = 0
-   , costmdls             = Map.empty
+   , costmdls             = CostModels Map.empty
    , maxBlockExUnits      = mempty
    , maxCollateralInputs  = 0
    , maxTxExUnits         = mempty

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -99,7 +99,7 @@ genTx _cfg slotNo TickedShelleyLedgerState { tickedShelleyLedgerState } genEnv =
     Just . mkShelleyTx <$> Gen.genTx
       genEnv
       ledgerEnv
-      (utxoSt, dpState)
+      (SL.LedgerState utxoSt dpState)
   where
     epochState :: SL.EpochState (MockShelley h)
     epochState = SL.nesEs tickedShelleyLedgerState
@@ -114,13 +114,13 @@ genTx _cfg slotNo TickedShelleyLedgerState { tickedShelleyLedgerState } genEnv =
 
     utxoSt :: SL.UTxOState (MockShelley h)
     utxoSt =
-        SL._utxoState
+        SL.lsUTxOState
       . SL.esLState
       $ epochState
 
     dpState :: SL.DPState (MockCrypto h)
     dpState =
-        SL._delegationState
+        SL.lsDPState
       . SL.esLState
       $ epochState
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
@@ -192,7 +192,6 @@ class ( SL.ShelleyBasedEra era
          , SL.Validated (Core.Tx era)
          )
 
-  getShelleyTxInputs :: Core.Tx era -> Set (SL.TxIn (EraCrypto era))
 
 -- | The default implementation of 'applyShelleyBasedTx', a thin wrapper around
 -- 'SL.applyTx'
@@ -215,33 +214,23 @@ defaultApplyShelleyBasedTx globals ledgerEnv mempoolState _wti tx =
       mempoolState
       tx
 
-defaultGetShelleyTxInputs ::
-     ( HasField "body"    (Core.Tx era)     (Core.TxBody era)
-     , HasField "inputs" (Core.TxBody era) (Set (SL.TxIn (EraCrypto era)))
-     )
-  => Core.Tx era -> Set (SL.TxIn (EraCrypto era))
-defaultGetShelleyTxInputs tx = getField @"inputs" $ getField @"body" tx
-
 instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (ShelleyEra c) where
   shelleyBasedEraName _ = "Shelley"
 
   applyShelleyBasedTx = defaultApplyShelleyBasedTx
-  getShelleyTxInputs  = defaultGetShelleyTxInputs
 
 instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (AllegraEra c) where
   shelleyBasedEraName _ = "Allegra"
 
   applyShelleyBasedTx = defaultApplyShelleyBasedTx
-  getShelleyTxInputs  = defaultGetShelleyTxInputs
 
 instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (MaryEra c) where
   shelleyBasedEraName _ = "Mary"
 
   applyShelleyBasedTx = defaultApplyShelleyBasedTx
-  getShelleyTxInputs  = defaultGetShelleyTxInputs
 
 instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (AlonzoEra c) where
@@ -284,13 +273,6 @@ instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
               tx{Alonzo.isValid = Alonzo.IsValid (not flag)}
         _ -> throwError e
                -- reject the transaction, protecting the local wallet
-
-  getShelleyTxInputs tx =
-        getField @"collateral" body
-      `Set.union`
-        getField @"inputs" body
-    where
-      body = getField @"body" tx
 
 -- not exported
 --

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -135,7 +135,7 @@ protocolUpdates genesis st = [
     SL.ProposedPPUpdates proposals =
           SL.proposals
         . SL._ppups
-        . SL._utxoState
+        . SL.lsUTxOState
         . SL.esLState
         . SL.nesEs
         . shelleyLedgerState

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -88,10 +88,12 @@ import           Ouroboros.Consensus.Util.Singletons (SingI)
 import           Ouroboros.Consensus.Util.Versioned
 
 import qualified Cardano.Ledger.BHeaderView as SL (BHeaderView)
+import qualified Cardano.Ledger.Block as Core
 import qualified Cardano.Ledger.Chain as Chain
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Core
 import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.Shelley.LedgerState as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL (makeHeaderView)
 import qualified Control.State.Transition.Extended as STS
 
@@ -100,7 +102,7 @@ import           Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
 import           Ouroboros.Consensus.Protocol.TPraos
                      (ConsensusConfig (tpraosParams), MaxMajorProtVer (..),
                      Ticked (TickedPraosLedgerView), tpraosMaxMajorPV)
-import           Ouroboros.Consensus.Shelley.Eras (EraCrypto, getShelleyTxInputs)
+import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Config
 import           Ouroboros.Consensus.Shelley.Ledger.TPraos ()
@@ -358,7 +360,7 @@ projectUtxoSL =
     . HD.UtxoValues
     . SL.unUTxO
     . SL._utxo
-    . SL._utxoState
+    . SL.lsUTxOState
     . SL.esLState
     . SL.nesEs
 
@@ -370,7 +372,7 @@ withUtxoSL nes (ApplyValuesMK (HD.UtxoValues m)) =
     nes {
         SL.nesEs = es {
             SL.esLState = us {
-                SL._utxoState = utxo {
+                SL.lsUTxOState = utxo {
                     SL._utxo = SL.UTxO m
                   }
               }
@@ -379,7 +381,7 @@ withUtxoSL nes (ApplyValuesMK (HD.UtxoValues m)) =
   where
     es   = SL.nesEs nes
     us   = SL.esLState es
-    utxo = SL._utxoState us
+    utxo = SL.lsUTxOState us
 
 {-------------------------------------------------------------------------------
   GetTip

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -523,14 +523,12 @@ instance ShelleyBasedEra era
                 , asoEvents     = STS.EPReturn
                 }
 
-  getBlockKeySets blk =
+  getBlockKeySets =
         ShelleyLedgerTables
-      $ ApplyKeysMK
-      $ HD.UtxoKeys
-      $ foldMap getShelleyTxInputs
-      $ Core.fromTxSeq @era txs
-    where
-      ShelleyBlock { shelleyBlockRaw = SL.Block _ txs } = blk
+      . ApplyKeysMK
+      . HD.UtxoKeys
+      . Core.neededTxInsForBlock
+      . shelleyBlockRaw
 
 data ShelleyReapplyException =
   forall era. Show (SL.BlockTransitionError era)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -65,7 +65,7 @@ import           Ouroboros.Consensus.Util.Condense
 import           Cardano.Ledger.Alonzo.PParams
 import           Cardano.Ledger.Alonzo.Tx (totExUnits)
 import qualified Cardano.Ledger.Core as Core (Tx)
-import qualified Cardano.Ledger.Era as SL (Crypto, TxSeq, fromTxSeq)
+import qualified Cardano.Ledger.Era as SL (TxSeq, fromTxSeq, getAllTxInputs)
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.TxIn as SL (txid)
 
@@ -154,7 +154,7 @@ instance ShelleyBasedEra era
         ShelleyLedger.ShelleyLedgerTables
       $ ApplyKeysMK
       $ HD.UtxoKeys
-      $ getShelleyTxInputs tx
+      $ SL.getAllTxInputs (getField @"body"  tx)
 
 mkShelleyTx :: forall era. ShelleyBasedEra era => Core.Tx era -> GenTx (ShelleyBlock era)
 mkShelleyTx tx = ShelleyTx (SL.txid @era (getField @"body" tx)) tx

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -307,8 +307,8 @@ set lens inner outer =
 theLedgerLens ::
      -- TODO SL.overNewEpochState should not require 'Applicative'
      Applicative f
-  => (      (SL.UTxOState era, SL.DPState (SL.Crypto era))
-       -> f (SL.UTxOState era, SL.DPState (SL.Crypto era))
+  => (      SL.MempoolState era
+       -> f (SL.MempoolState era)
      )
   ->    TickedLedgerState (ShelleyBlock era) mk
   -> f (TickedLedgerState (ShelleyBlock era) mk)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
@@ -58,8 +58,8 @@ instance c ~ EraCrypto era
         where
           pstate :: SL.PState c
           pstate =
-                SL._pstate
-              . SL._delegationState
+                SL.dpsPState
+              . SL.lsDPState
               . SL.esLState
               . SL.nesEs
               $ shelleyLedgerState

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -490,14 +490,14 @@ getProposedPPUpdates ::
      ShelleyBasedEra era
   => SL.NewEpochState era -> SL.ProposedPPUpdates era
 getProposedPPUpdates = SL.proposals . SL._ppups
-                     . SL._utxoState . SL.esLState . SL.nesEs
+                     . SL.lsUTxOState . SL.esLState . SL.nesEs
 
 -- Get the current 'EpochState.' This is mainly for debugging.
 getEpochState :: SL.NewEpochState era -> SL.EpochState era
 getEpochState = SL.nesEs
 
 getDState :: SL.NewEpochState era -> SL.DState (EraCrypto era)
-getDState = SL._dstate . SL._delegationState . SL.esLState . SL.nesEs
+getDState = SL.dpsDState . SL.lsDPState . SL.esLState . SL.nesEs
 
 getFilteredDelegationsAndRewardAccounts ::
      SL.NewEpochState era

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -465,9 +465,9 @@ registerGenesisStaking ::
 registerGenesisStaking staking nes = nes {
       SL.nesEs = epochState {
           SL.esLState = ledgerState {
-          SL._delegationState = dpState {
-              SL._dstate = dState'
-            , SL._pstate = pState'
+          SL.lsDPState = dpState {
+              SL.dpsDState = dState'
+            , SL.dpsPState = pState'
             }
         }
         , SL.esSnapshots = (SL.esSnapshots epochState) {
@@ -484,14 +484,14 @@ registerGenesisStaking staking nes = nes {
     SL.ShelleyGenesisStaking { sgsPools, sgsStake } = staking
     SL.NewEpochState { nesEs = epochState } = nes
     ledgerState = SL.esLState epochState
-    dpState = SL._delegationState ledgerState
+    dpState = SL.lsDPState ledgerState
 
     -- New delegation state. Since we're using base addresses, we only care
     -- about updating the '_delegations' field.
     --
     -- See STS DELEG for details
     dState' :: SL.DState (EraCrypto era)
-    dState' = (SL._dstate dpState) {
+    dState' = (SL.dpsDState dpState) {
           SL._unified = UM.unify
             ( Map.map (const $ SL.Coin 0)
                       . Map.mapKeys SL.KeyHashObj
@@ -502,7 +502,7 @@ registerGenesisStaking staking nes = nes {
     -- We consider pools as having been registered in slot 0
     -- See STS POOL for details
     pState' :: SL.PState (EraCrypto era)
-    pState' = (SL._pstate dpState) {
+    pState' = (SL.dpsPState dpState) {
           SL._pParams = sgsPools
         }
 
@@ -520,7 +520,7 @@ registerGenesisStaking staking nes = nes {
           -- Note that 'updateStakeDistribution' takes first the set of UTxO to
           -- delete, and then the set to add. In our case, there is nothing to
           -- delete, since this is an initial UTxO set.
-          (SL.updateStakeDistribution mempty mempty (SL._utxo (SL._utxoState ledgerState)))
+          (SL.updateStakeDistribution mempty mempty (SL._utxo (SL.lsUTxOState ledgerState)))
           dState'
           pState'
 
@@ -561,7 +561,7 @@ registerInitialFunds initialFunds nes = nes {
     epochState   = SL.nesEs          nes
     accountState = SL.esAccountState epochState
     ledgerState  = SL.esLState       epochState
-    utxoState    = SL._utxoState     ledgerState
+    utxoState    = SL.lsUTxOState    ledgerState
     utxo         = SL._utxo          utxoState
     reserves     = SL._reserves      accountState
 
@@ -584,7 +584,7 @@ registerInitialFunds initialFunds nes = nes {
     -- is nothing to delete in the incremental update.
     utxoToDel     = SL.UTxO mempty
     ledgerState'  = ledgerState {
-          SL._utxoState = utxoState {
+          SL.lsUTxOState = utxoState {
               SL._utxo        = utxo',
               -- Normally we would incrementally update here. But since we pass
               -- the full UTxO as "toAdd" rather than a delta, we simply


### PR DESCRIPTION
Instead of using our own version for fetching the needed inputs, now we use the one provided by the Ledger team

Note that this updates the dependencies on cardano-ledger, plutus and cardano-base