### PR TITLE
Block diffusion pipelining

### DIFF
--- a/network-mux/tools/cardano-ping.hs
+++ b/network-mux/tools/cardano-ping.hs
@@ -127,6 +127,7 @@ supportedNodeToNodeVersions :: Word32 -> [NodeVersion]
 supportedNodeToNodeVersions magic =
   [ NodeToNodeVersionV7 magic False
   , NodeToNodeVersionV8 magic False
+  , NodeToNodeVersionV9 magic False
   ]
 
 supportedNodeToClientVersions :: Word32 -> [NodeVersion]
@@ -206,6 +207,7 @@ data NodeVersion =       NodeToClientVersionV9  Word32
                        | NodeToNodeVersionV6   Word32 Bool
                        | NodeToNodeVersionV7   Word32 Bool
                        | NodeToNodeVersionV8   Word32 Bool
+                       | NodeToNodeVersionV9   Word32 Bool
                        deriving (Eq, Ord, Show)
 
 keepAliveReqEnc :: NodeVersion -> Word16 -> CBOR.Encoding
@@ -267,6 +269,7 @@ handshakeReqEnc versions =
     encodeVersion (NodeToNodeVersionV6 magic mode) = encodeWithMode 6 magic mode
     encodeVersion (NodeToNodeVersionV7 magic mode) = encodeWithMode 7 magic mode
     encodeVersion (NodeToNodeVersionV8 magic mode) = encodeWithMode 8 magic mode
+    encodeVersion (NodeToNodeVersionV9 magic mode) = encodeWithMode 9 magic mode
 
 
     encodeWithMode :: Word -> Word32 -> Bool -> CBOR.Encoding
@@ -339,6 +342,7 @@ handshakeDec = do
              , version `testBit`  nodeToClientVersionBit ) of
              (7, False) -> decodeWithMode NodeToNodeVersionV7
              (8, False) -> decodeWithMode NodeToNodeVersionV8
+             (9, False) -> decodeWithMode NodeToNodeVersionV9
              (9, True)  -> Right . NodeToClientVersionV9 <$> CBOR.decodeWord32
              (10, True) -> Right . NodeToClientVersionV10 <$> CBOR.decodeWord32
              (11, True) -> Right . NodeToClientVersionV11 <$> CBOR.decodeWord32

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -382,6 +382,7 @@ instance CardanoHardForkConstraints c
   supportedNodeToNodeVersions _ = Map.fromList $
       [ (NodeToNodeV_7, CardanoNodeToNodeVersion5)
       , (NodeToNodeV_8, CardanoNodeToNodeVersion5)
+      , (NodeToNodeV_9, CardanoNodeToNodeVersion5)
       ]
 
   supportedNodeToClientVersions _ = Map.fromList $
@@ -399,7 +400,7 @@ instance CardanoHardForkConstraints c
       , (NodeToClientV_12, CardanoNodeToClientVersion8)
       ]
 
-  latestReleasedNodeVersion _prx = (Just NodeToNodeV_7, Just NodeToClientV_12)
+  latestReleasedNodeVersion _prx = (Just NodeToNodeV_8, Just NodeToClientV_12)
 
 {-------------------------------------------------------------------------------
   ProtocolInfo

--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/TPraos.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/TPraos.hs
@@ -283,7 +283,7 @@ data TPraosChainSelectView c = TPraosChainSelectView {
   , csvIssuer      :: SL.VKey 'SL.BlockIssuer c
   , csvIssueNo     :: Word64
   , csvLeaderVRF   :: VRF.OutputVRF (VRF c)
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Generic, NoThunks)
 
 instance SL.PraosCrypto c => Ord (TPraosChainSelectView c) where
   compare =

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -47,13 +47,9 @@ data instance BlockConfig (ShelleyBlock era) = ShelleyConfig {
       shelleyProtocolVersion  :: !SL.ProtVer
     , shelleySystemStart      :: !SystemStart
     , shelleyNetworkMagic     :: !NetworkMagic
-      -- | When chain selection is comparing two fragments, it will prefer the
-      -- fragment with a tip signed by (one of) its own key(s) (provided that
-      -- the 'BlockNo's and 'SlotNo's of the two tips are equal). For nodes that
-      -- can produce blocks, this should be set to the verification key(s)
-      -- corresponding to the node's signing key(s), to make sure we prefer
-      -- self-issued blocks. For non block producing nodes, this can be set to
-      -- the empty map.
+      -- | For nodes that can produce blocks, this should be set to the
+      -- verification key(s) corresponding to the node's signing key(s). For non
+      -- block producing nodes, this can be set to the empty map.
     , shelleyBlockIssuerVKeys :: !(Map (SL.KeyHash 'SL.BlockIssuer (EraCrypto era))
                                        (SL.VKey 'SL.BlockIssuer (EraCrypto era)))
     }

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
@@ -9,15 +9,11 @@
 
 module Ouroboros.Consensus.Shelley.Ledger.TPraos () where
 
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-
 import           Cardano.Crypto.VRF (certifiedOutput)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Signed
 
-import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import qualified Cardano.Protocol.TPraos.OCert as SL
 
@@ -25,7 +21,7 @@ import qualified Cardano.Protocol.TPraos.API as SL
 import           Ouroboros.Consensus.Protocol.TPraos
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block
-import           Ouroboros.Consensus.Shelley.Ledger.Config
+import           Ouroboros.Consensus.Shelley.Ledger.Config ()
 
 {-------------------------------------------------------------------------------
   Support for Transitional Praos consensus algorithm
@@ -37,10 +33,9 @@ instance (SL.PraosCrypto (EraCrypto era), ShelleyBasedEra era)
   => BlockSupportsProtocol (ShelleyBlock era) where
   validateView _cfg (ShelleyHeader hdr _) = hdr
 
-  selectView cfg hdr@(ShelleyHeader shdr _) = TPraosChainSelectView {
+  selectView _ hdr@(ShelleyHeader shdr _) = TPraosChainSelectView {
         csvChainLength = blockNo hdr
       , csvSlotNo      = blockSlot hdr
-      , csvSelfIssued  = selfIssued
       , csvIssuer      = SL.bheaderVk hdrBody
       , csvIssueNo     = SL.ocertN . SL.bheaderOCert $ hdrBody
       , csvLeaderVRF   = certifiedOutput . SL.bheaderL $ hdrBody
@@ -48,47 +43,6 @@ instance (SL.PraosCrypto (EraCrypto era), ShelleyBasedEra era)
     where
       hdrBody :: SL.BHBody (EraCrypto era)
       hdrBody = SL.bhbody shdr
-
-      issuerVKeys :: Map (SL.KeyHash 'SL.BlockIssuer (EraCrypto era))
-                         (SL.VKey 'SL.BlockIssuer (EraCrypto era))
-      issuerVKeys = shelleyBlockIssuerVKeys cfg
-
-      -- | Premature optimisation: we assume everywhere that 'selectView' is
-      -- cheap, so micro-optimise checking whether the issuer vkey is one of our
-      -- own vkeys.
-      --
-      -- * Equality of vkeys takes roughly 40ns
-      -- * Hashing a vkey takes roughly 850ns
-      -- * Equality of hashes takes roughly 10ns
-      --
-      -- We want to avoid the hashing of a vkey as it is more expensive than
-      -- simply doing a linear search, comparing vkeys for equality. Only when
-      -- we have to do a linear search across a large number of vkeys does it
-      -- become more efficient to first hash the vkey and look up its hash in
-      -- the map.
-      --
-      -- We could try to be clever and estimate the number of keys after which
-      -- we switch from a linear search to hashing + a O(log n) map lookup, but
-      -- we keep it (relatively) simple and optimise for the common case: 0 or 1
-      -- key.
-      selfIssued :: SelfIssued
-      selfIssued = case Map.size issuerVKeys of
-          -- The most common case: a non-block producing node
-          0 -> NotSelfIssued
-          -- A block producing node with a single set of credentials: just do an
-          -- equality check of the single VKey, skipping the more expensive
-          -- computation of the hash.
-          1 | SL.bheaderVk hdrBody `elem` issuerVKeys
-            -> SelfIssued
-            | otherwise
-            -> NotSelfIssued
-          -- When we are running with multiple sets of credentials, which should
-          -- only happen when benchmarking, do a hash lookup, as the number of
-          -- keys can grow to 100-250.
-          _ | SL.hashKey (SL.bheaderVk hdrBody) `Map.member` issuerVKeys
-            -> SelfIssued
-            | otherwise
-            -> NotSelfIssued
 
 -- TODO correct place for these two?
 type instance Signed (Header (ShelleyBlock era)) = SL.BHBody (EraCrypto era)

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -104,6 +104,7 @@ import           Ouroboros.Consensus.Util.STM
 import           Ouroboros.Consensus.Util.Time
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (..))
 import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
@@ -885,7 +886,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   -- ChainDB will reject it as invalid, and
                   -- 'Test.ThreadNet.General.prop_general' will eventually fail
                   -- because of a block rejection.
-                  void $ ChainDB.addBlock chainDB ebb
+                  void $ ChainDB.addBlock chainDB InvalidBlockPunishment.noPunishment ebb
                   pure blk
 
       origBlockForging <- pInfoBlockForging

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -355,7 +355,8 @@ runChainSync securityParam (ClientUpdates clientUpdates)
            chainSyncTracer
            chainDbView
            varCandidates
-           serverId $ \varCandidate -> do
+           serverId
+           maxBound $ \varCandidate -> do
              atomically $ modifyTVar varFinalCandidates $
                Map.insert serverId varCandidate
              (result, _) <-

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -359,7 +359,7 @@ run env@ChainDBEnv { varDB, .. } cmd =
       IteratorNext  it         -> IterResult          <$> iteratorNext (unWithEq it)
       IteratorNextGCed  it     -> iterResultGCed      <$> iteratorNext (unWithEq it)
       IteratorClose it         -> Unit                <$> iteratorClose (unWithEq it)
-      NewFollower              -> follower            =<< newFollower registry allComponents
+      NewFollower              -> follower            =<< newFollower registry SelectedChain allComponents
       FollowerInstruction flr  -> MbChainUpdate       <$> followerInstruction (unWithEq flr)
       FollowerForward flr pts  -> MbPoint             <$> followerForward (unWithEq flr) pts
       FollowerClose flr        -> Unit                <$> followerClose (unWithEq flr)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -85,6 +85,7 @@ import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
 import           Ouroboros.Consensus.Storage.ChainDB hiding
                      (TraceFollowerEvent (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB
                      (ValidationPolicy (ValidateAllChunks))
@@ -379,7 +380,7 @@ run env@ChainDBEnv { varDB, .. } cmd =
     advanceAndAdd :: ChainDBState m blk -> SlotNo -> blk -> m (Point blk)
     advanceAndAdd ChainDBState { chainDB } newCurSlot blk = do
       atomically $ modifyTVar varCurSlot (max newCurSlot)
-      addBlock chainDB blk
+      addBlock chainDB InvalidBlockPunishment.noPunishment blk
 
     wipeVolatileDB :: ChainDBState m blk -> m (Point blk)
     wipeVolatileDB st = do

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -146,7 +146,7 @@ data Cmd blk it flr
   | IteratorNextGCed      it
     -- ^ Only for blocks that may have been garbage collected.
   | IteratorClose         it
-  | NewFollower
+  | NewFollower           ChainType
   | FollowerInstruction   flr
     -- ^ 'followerInstructionBlocking' is excluded, as it requires multiple
     -- threads. Its code path is pretty much the same as 'followerInstruction'
@@ -359,7 +359,7 @@ run env@ChainDBEnv { varDB, .. } cmd =
       IteratorNext  it         -> IterResult          <$> iteratorNext (unWithEq it)
       IteratorNextGCed  it     -> iterResultGCed      <$> iteratorNext (unWithEq it)
       IteratorClose it         -> Unit                <$> iteratorClose (unWithEq it)
-      NewFollower              -> follower            =<< newFollower registry SelectedChain allComponents
+      NewFollower ct           -> follower            =<< newFollower registry ct allComponents
       FollowerInstruction flr  -> MbChainUpdate       <$> followerInstruction (unWithEq flr)
       FollowerForward flr pts  -> MbPoint             <$> followerForward (unWithEq flr) pts
       FollowerClose flr        -> Unit                <$> followerClose (unWithEq flr)
@@ -587,7 +587,11 @@ runPure cfg = \case
     IteratorNext  it         -> ok  IterResult          $ update  (Model.iteratorNext it allComponents)
     IteratorNextGCed it      -> ok  iterResultGCed      $ update  (Model.iteratorNext it allComponents)
     IteratorClose it         -> ok  Unit                $ update_ (Model.iteratorClose it)
-    NewFollower              -> ok  Flr                 $ update   Model.newFollower
+    -- As tentative followers differ from normal followers only during chain
+    -- selection, this test can not distinguish between them due to its
+    -- sequential nature. Hence, we don't add a pure model for tentative
+    -- followers.
+    NewFollower _            -> ok  Flr                 $ update   Model.newFollower
     FollowerInstruction flr  -> err MbChainUpdate       $ updateE (Model.followerInstruction flr allComponents)
     FollowerForward flr pts  -> err MbPoint             $ updateE (Model.followerForward flr pts)
     FollowerClose flr        -> ok  Unit                $ update_ (Model.followerClose flr)
@@ -828,7 +832,7 @@ generator genBlock m@Model {..} = At <$> frequency
     , (if null iterators then 0 else 2, genIteratorClose)
 
     -- Followers
-    , (10, return NewFollower)
+    , (10, genNewFollower)
     , (if null followers then 0 else 10, genFollowerInstruction)
     , (if null followers then 0 else 10, genFollowerForward)
       -- Use a lower frequency for closing, so that the chance increases that
@@ -950,6 +954,8 @@ generator genBlock m@Model {..} = At <$> frequency
       return $ if blockCanBeGCed
         then IteratorNextGCed it
         else IteratorNext     it
+
+    genNewFollower = NewFollower <$> elements [SelectedChain, TentativeChain]
 
     genFollowerInstruction = FollowerInstruction <$> elements followers
     genFollowerForward     = FollowerForward     <$> elements followers

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -463,7 +463,7 @@ data BftWithEBBsSelectView = BftWithEBBsSelectView {
     , bebbChainLength :: ChainLength
     , bebbHash        :: TestHeaderHash
     }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic, NoThunks)
 
 instance Ord BftWithEBBsSelectView where
   compare (BftWithEBBsSelectView lBlockNo lIsEBB lChainLength lHash)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -194,6 +194,7 @@ library
                        -- Storing things on disk
                        Ouroboros.Consensus.Storage.ChainDB
                        Ouroboros.Consensus.Storage.ChainDB.API
+                       Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
                        Ouroboros.Consensus.Storage.ChainDB.Impl
                        Ouroboros.Consensus.Storage.ChainDB.Impl.Args
                        Ouroboros.Consensus.Storage.ChainDB.Impl.Background

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -186,6 +186,7 @@ library
                        Ouroboros.Consensus.Util.Singletons
                        Ouroboros.Consensus.Util.SOP
                        Ouroboros.Consensus.Util.STM
+                       Ouroboros.Consensus.Util.TentativeState
                        Ouroboros.Consensus.Util.Time
                        Ouroboros.Consensus.Util.TraceSize
                        Ouroboros.Consensus.Util.Versioned

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -274,6 +274,9 @@ deriving via LiftNamedNS "OneEraHeader" Header xs
 deriving via LiftNamedNS "OneEraLedgerError" WrapLedgerErr xs
          instance CanHardFork xs => NoThunks (OneEraLedgerError xs)
 
+deriving via LiftNamedNS "OneEraSelectView" WrapSelectView xs
+         instance CanHardFork xs => NoThunks (OneEraSelectView xs)
+
 deriving via LiftNamedNS "OneEraTipInfo" WrapTipInfo xs
          instance CanHardFork xs => NoThunks (OneEraTipInfo xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -1,15 +1,17 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -66,6 +68,7 @@ newtype HardForkSelectView xs = HardForkSelectView {
       getHardForkSelectView :: WithBlockNo OneEraSelectView xs
     }
   deriving (Show, Eq)
+  deriving newtype (NoThunks)
 
 instance CanHardFork xs => Ord (HardForkSelectView xs) where
   compare (HardForkSelectView l) (HardForkSelectView r) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE EmptyCase           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
@@ -21,6 +23,8 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers
 
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Tails (Tails (..))
 
@@ -123,7 +127,7 @@ data WithBlockNo (f :: k -> Type) (a :: k) = WithBlockNo {
       getBlockNo  :: BlockNo
     , dropBlockNo :: f a
     }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic, NoThunks)
 
 mapWithBlockNo :: (f x -> g y) -> WithBlockNo f x -> WithBlockNo g y
 mapWithBlockNo f (WithBlockNo bno fx) = WithBlockNo bno (f fx)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -32,15 +32,18 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 chainSyncHeaderServerFollower
     :: ChainDB m blk
+    -> ChainDB.ChainType
     -> ResourceRegistry m
     -> m (Follower m blk (WithPoint blk (SerialisedHeader blk)))
-chainSyncHeaderServerFollower chainDB registry = ChainDB.newFollower chainDB registry getSerialisedHeaderWithPoint
+chainSyncHeaderServerFollower chainDB chainType registry =
+  ChainDB.newFollower chainDB registry chainType getSerialisedHeaderWithPoint
 
 chainSyncBlockServerFollower
     :: ChainDB m blk
     -> ResourceRegistry m
     -> m (Follower m blk (WithPoint blk (Serialised blk)))
-chainSyncBlockServerFollower chainDB registry = ChainDB.newFollower chainDB registry getSerialisedBlockWithPoint
+chainSyncBlockServerFollower chainDB registry =
+  ChainDB.newFollower chainDB registry ChainDB.SelectedChain getSerialisedBlockWithPoint
 
 -- | Chain Sync Server for block headers for a given a 'ChainDB'.
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -556,7 +556,7 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
       -> m ((), Maybe bBF)
     aBlockFetchClient version controlMessageSTM them channel = do
       labelThisThread "BlockFetchClient"
-      bracketFetchClient (getFetchClientRegistry kernel) them $ \clientCtx ->
+      bracketFetchClient (getFetchClientRegistry kernel) version them $ \clientCtx ->
         runPipelinedPeerWithLimits
           (contramap (TraceLabelPeer them) tBlockFetchTracer)
           (cBlockFetchCodec (mkCodecs version))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -512,7 +512,8 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
             (contramap (TraceLabelPeer them) (Node.chainSyncClientTracer (getTracers kernel)))
             (defaultChainDbView (getChainDB kernel))
             (getNodeCandidates kernel)
-            them $ \varCandidate -> do
+            them
+            version $ \varCandidate -> do
               chainSyncTimeout <- genChainSyncTimeout
               (_, trailing) <-
                 runPipelinedPeerWithLimits

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -537,7 +537,13 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
       labelThisThread "ChainSyncServer"
       chainSyncTimeout <- genChainSyncTimeout
       bracketWithPrivateRegistry
-        (chainSyncHeaderServerFollower (getChainDB kernel))
+        (chainSyncHeaderServerFollower
+           (getChainDB kernel)
+           ( if version >= NodeToNodeV_8
+             then ChainDB.TentativeChain
+             else ChainDB.SelectedChain
+           )
+        )
         ChainDB.followerClose
         $ \flr ->
           runPeerWithLimits

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -47,8 +47,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (MaxSlotNo)
 import           Ouroboros.Network.BlockFetch
-import           Ouroboros.Network.NodeToNode
-                     (MiniProtocolParameters (..))
+import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TxSubmissionMempoolWriter)
 import qualified Ouroboros.Network.TxSubmission.Inbound as Inbound
@@ -83,7 +82,8 @@ import           Ouroboros.Consensus.Util.STM
 
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment (InvalidBlockPunishment)
+import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+                     (InvalidBlockPunishment)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -46,6 +46,7 @@ class ( Show (ChainDepState   p)
       , NoThunks (ConsensusConfig p)
       , NoThunks (ChainDepState   p)
       , NoThunks (ValidationErr   p)
+      , NoThunks (SelectView      p)
       , Typeable p -- so that p can appear in exceptions
       ) => ConsensusProtocol p where
   -- | Protocol-specific state

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -26,6 +26,7 @@ instance ( ConsensusProtocol p
          , Show s
          , Typeable p
          , Typeable s
+         , NoThunks s
          ) => ConsensusProtocol (ModChainSel p s) where
     type SelectView    (ModChainSel p s) = s
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -135,7 +135,7 @@ data PBftSelectView = PBftSelectView {
       pbftSelectViewBlockNo :: BlockNo
     , pbftSelectViewIsEBB   :: IsEBB
     }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic, NoThunks)
 
 mkPBftSelectView :: GetHeader blk => Header blk -> PBftSelectView
 mkPBftSelectView hdr = PBftSelectView {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -54,6 +54,7 @@ module Ouroboros.Consensus.Storage.ChainDB.API (
     -- * Invalid block reason
   , InvalidBlockReason (..)
     -- * Followers
+  , ChainType (..)
   , Follower (..)
   , traverseFollower
     -- * Recovery
@@ -301,6 +302,7 @@ data ChainDB m blk = ChainDB {
       --
     , newFollower ::
            forall b. ResourceRegistry m
+        -> ChainType
         -> BlockComponent blk b
         -> m (Follower m blk b)
 
@@ -620,6 +622,14 @@ instance LedgerSupportsProtocol blk
 {-------------------------------------------------------------------------------
   Followers
 -------------------------------------------------------------------------------}
+
+-- | Chain type
+--
+-- 'Follower's can choose to track changes to the "normal" 'SelectedChain', or
+-- track the 'TentativeChain', which might contain a pipelineable header at the
+-- tip.
+data ChainType = SelectedChain | TentativeChain
+  deriving (Eq, Show, Generic)
 
 -- | Follower
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -79,12 +79,15 @@ import           Ouroboros.Consensus.HeaderStateHistory
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
-import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Util ((..:))
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (WithFingerprint)
 
+import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+                     (InvalidBlockPunishment)
+import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.FS.API.Types (FsError)
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
@@ -132,7 +135,7 @@ data ChainDB m blk = ChainDB {
       -- use 'addBlock' to add the block synchronously.
       --
       -- NOTE: back pressure can be applied when overloaded.
-      addBlockAsync      :: blk -> m (AddBlockPromise m blk)
+      addBlockAsync      :: InvalidBlockPunishment m -> blk -> m (AddBlockPromise m blk)
 
       -- | Get the current chain fragment
       --
@@ -412,22 +415,22 @@ data AddBlockPromise m blk = AddBlockPromise
 
 -- | Add a block synchronously: wait until the block has been written to disk
 -- (see 'blockWrittenToDisk').
-addBlockWaitWrittenToDisk :: IOLike m => ChainDB m blk -> blk -> m Bool
-addBlockWaitWrittenToDisk chainDB blk = do
-    promise <- addBlockAsync chainDB blk
+addBlockWaitWrittenToDisk :: IOLike m => ChainDB m blk -> InvalidBlockPunishment m -> blk -> m Bool
+addBlockWaitWrittenToDisk chainDB punish blk = do
+    promise <- addBlockAsync chainDB punish blk
     atomically $ blockWrittenToDisk promise
 
 -- | Add a block synchronously: wait until the block has been processed (see
 -- 'blockProcessed'). The new tip of the ChainDB is returned.
-addBlock :: IOLike m => ChainDB m blk -> blk -> m (Point blk)
-addBlock chainDB blk = do
-    promise <- addBlockAsync chainDB blk
+addBlock :: IOLike m => ChainDB m blk -> InvalidBlockPunishment m -> blk -> m (Point blk)
+addBlock chainDB punish blk = do
+    promise <- addBlockAsync chainDB punish blk
     atomically $ blockProcessed promise
 
 -- | Add a block synchronously. Variant of 'addBlock' that doesn't return the
 -- new tip of the ChainDB.
-addBlock_ :: IOLike m => ChainDB m blk -> blk -> m ()
-addBlock_  = void .: addBlock
+addBlock_ :: IOLike m => ChainDB m blk -> InvalidBlockPunishment m -> blk -> m ()
+addBlock_  = void ..: addBlock
 
 {-------------------------------------------------------------------------------
   Serialised block/header with its point
@@ -491,7 +494,7 @@ fromChain ::
   -> m (ChainDB m blk)
 fromChain openDB chain = do
     chainDB <- openDB
-    mapM_ (addBlock_ chainDB) $ Chain.toOldestFirst chain
+    mapM_ (addBlock_ chainDB InvalidBlockPunishment.noPunishment) $ Chain.toOldestFirst chain
     return chainDB
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API/Types/InvalidBlockPunishment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API/Types/InvalidBlockPunishment.hs
@@ -1,5 +1,8 @@
-{-# LANGUAGE DataKinds   #-}
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | How to punish the sender of a invalid block
 module Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment (
@@ -7,44 +10,84 @@ module Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment (
     InvalidBlockPunishment
   , enact
     -- * combinators
+  , Invalidity (..)
+  , branch
   , mkPunishThisThread
+  , mkUnlessImproved
   , noPunishment
   ) where
 
 import qualified Control.Exception as Exn
+import           Control.Monad (join, unless)
+import           Data.Functor ((<&>))
 import           NoThunks.Class
 
-import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Block.Abstract (BlockProtocol)
+import           Ouroboros.Consensus.Protocol.Abstract (SelectView)
 
--- | How to handle a discovered invalid block
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.TentativeState
+
+-- | Is the added block itself invalid, or is its prefix invalid?
+data Invalidity =
+    BlockItself
+  | BlockPrefix
+
+-- | How to handle a discovered 'Invalidity'
 --
 -- This type is opaque because the soundness of the punishment is subtle because
 -- of where it is invoked during the chain selection. As a result, arbitrary
 -- monadic actions would be foot guns. Instead, this module defines a small DSL
 -- for punishment that we judge to be sound.
 newtype InvalidBlockPunishment m = InvalidBlockPunishment {
-    enact :: m ()
+    enact :: Invalidity -> m ()
   }
-  -- this type is never actually an accumulator, so the -> NoThunks instance is fine
   deriving NoThunks via
     OnlyCheckWhnfNamed "InvalidBlockPunishment" (InvalidBlockPunishment m)
 
 -- | A noop punishment
 noPunishment :: Applicative m => InvalidBlockPunishment m
-noPunishment = InvalidBlockPunishment $ pure ()
+noPunishment = InvalidBlockPunishment $ \_invalidity -> pure ()
 
 -- | Create a punishment that kills this thread
 mkPunishThisThread :: IOLike m => m (InvalidBlockPunishment m)
 mkPunishThisThread = do
     tid <- myThreadId
-    pure $ InvalidBlockPunishment $ do
+    pure $ InvalidBlockPunishment $ \_invalidity ->
       throwTo tid PeerSentAnInvalidBlockException
 
 -- | Thrown asynchronously to the client thread that added the block whose
 -- processing involved an invalid block.
 --
--- See 'mkPunishThisThread'.
+-- See 'punishThisThread'.
 data PeerSentAnInvalidBlockException = PeerSentAnInvalidBlockException
   deriving (Show)
 
 instance Exn.Exception PeerSentAnInvalidBlockException
+
+-- | Allocate a stateful punishment that performs the given punishment unless
+-- the given header is better than the previous invocation
+mkUnlessImproved :: forall proxy m blk.
+     ( IOLike m
+     , NoThunks (SelectView (BlockProtocol blk))
+     , Ord      (SelectView (BlockProtocol blk))
+     )
+  => proxy blk
+  -> STM m (   SelectView (BlockProtocol blk)
+            -> InvalidBlockPunishment m
+            -> InvalidBlockPunishment m
+           )
+mkUnlessImproved _prx = do
+    var <- newTVar (NoLastInvalidTentative :: TentativeState blk)
+    pure $ \new punish -> InvalidBlockPunishment $ \invalidity -> join $ atomically $ do
+      io <- readTVar var <&> \case
+        NoLastInvalidTentative   -> pure ()
+        LastInvalidTentative old -> unless (new > old) $ do
+          enact punish invalidity
+      writeTVar var $ LastInvalidTentative new
+      pure io
+
+-- | Punish according to the 'Invalidity'
+branch :: (Invalidity -> InvalidBlockPunishment m) -> InvalidBlockPunishment m
+branch f = InvalidBlockPunishment $ \invalidity ->
+    enact (f invalidity) invalidity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API/Types/InvalidBlockPunishment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API/Types/InvalidBlockPunishment.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds   #-}
+{-# LANGUAGE DerivingVia #-}
+
+-- | How to punish the sender of a invalid block
+module Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment (
+    -- * opaque
+    InvalidBlockPunishment
+  , enact
+    -- * combinators
+  , mkPunishThisThread
+  , noPunishment
+  ) where
+
+import qualified Control.Exception as Exn
+import           NoThunks.Class
+
+import           Ouroboros.Consensus.Util.IOLike
+
+-- | How to handle a discovered invalid block
+--
+-- This type is opaque because the soundness of the punishment is subtle because
+-- of where it is invoked during the chain selection. As a result, arbitrary
+-- monadic actions would be foot guns. Instead, this module defines a small DSL
+-- for punishment that we judge to be sound.
+newtype InvalidBlockPunishment m = InvalidBlockPunishment {
+    enact :: m ()
+  }
+  -- this type is never actually an accumulator, so the -> NoThunks instance is fine
+  deriving NoThunks via
+    OnlyCheckWhnfNamed "InvalidBlockPunishment" (InvalidBlockPunishment m)
+
+-- | A noop punishment
+noPunishment :: Applicative m => InvalidBlockPunishment m
+noPunishment = InvalidBlockPunishment $ pure ()
+
+-- | Create a punishment that kills this thread
+mkPunishThisThread :: IOLike m => m (InvalidBlockPunishment m)
+mkPunishThisThread = do
+    tid <- myThreadId
+    pure $ InvalidBlockPunishment $ do
+      throwTo tid PeerSentAnInvalidBlockException
+
+-- | Thrown asynchronously to the client thread that added the block whose
+-- processing involved an invalid block.
+--
+-- See 'mkPunishThisThread'.
+data PeerSentAnInvalidBlockException = PeerSentAnInvalidBlockException
+  deriving (Show)
+
+instance Exn.Exception PeerSentAnInvalidBlockException

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -40,6 +40,7 @@ import           Control.Tracer
 import           Data.Functor ((<&>))
 import           Data.Functor.Identity (Identity)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe.Strict (StrictMaybe (..))
 import           GHC.Stack (HasCallStack)
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -71,6 +72,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Query as Query
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
+import           Ouroboros.Consensus.Util.TentativeState
+                     (TentativeState (NoLastInvalidTentative))
 
 {-------------------------------------------------------------------------------
   Initialization
@@ -164,6 +167,8 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
 
       atomically $ LgrDB.setCurrent lgrDB ledger
       varChain           <- newTVarIO chain
+      varTentativeState  <- newTVarIO NoLastInvalidTentative
+      varTentativeHeader <- newTVarIO SNothing
       varIterators       <- newTVarIO Map.empty
       varFollowers       <- newTVarIO Map.empty
       varNextIteratorKey <- newTVarIO (IteratorKey 0)
@@ -176,6 +181,8 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                     , cdbVolatileDB      = volatileDB
                     , cdbLgrDB           = lgrDB
                     , cdbChain           = varChain
+                    , cdbTentativeState  = varTentativeState
+                    , cdbTentativeHeader = varTentativeHeader
                     , cdbIterators       = varIterators
                     , cdbFollowers       = varFollowers
                     , cdbTopLevelConfig  = cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -23,6 +23,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl (
   , TraceInitChainSelEvent (..)
   , TraceIteratorEvent (..)
   , TraceOpenEvent (..)
+  , TracePipeliningEvent (..)
   , TraceValidationEvent (..)
     -- * Re-exported for convenience
   , Args.RelativeMountPoint (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -197,7 +197,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                     }
       h <- fmap CDBHandle $ newTVarIO $ ChainDbOpen env
       let chainDB = API.ChainDB
-            { addBlockAsync         = getEnv1    h ChainSel.addBlockAsync
+            { addBlockAsync         = getEnv2    h ChainSel.addBlockAsync
             , getCurrentChain       = getEnvSTM  h Query.getCurrentChain
             , getLedgerDB           = getEnvSTM  h Query.getLedgerDB
             , getTipBlock           = getEnv     h Query.getTipBlock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -24,7 +24,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel (
 import           Control.Exception (assert)
 import           Control.Monad.Except
 import           Control.Monad.Trans.State.Strict
-import           Control.Tracer (Tracer, contramap, traceWith)
+import           Control.Tracer (Tracer, contramap, nullTracer, traceWith)
 import           Data.Function (on)
 import           Data.List (partition, sortBy)
 import           Data.List.NonEmpty (NonEmpty)
@@ -208,6 +208,7 @@ initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
             , trace = traceWith
                 (contramap (InitChainSelValidation) tracer)
               -- initial chain selection is not concerned about pipelining
+            , tracePipelining = traceWith nullTracer
             , varTentativeState
             , varTentativeHeader
             , punish = Nothing
@@ -540,6 +541,8 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = do
       , curChainAndLedger     = curChainAndLedger
       , trace                 =
           traceWith (contramap (TraceAddBlockEvent . AddBlockValidation) cdbTracer)
+      , tracePipelining       =
+          traceWith (contramap (TraceAddBlockEvent . PipeliningEvent) cdbTracer)
       , punish                = Just (p, punish)
       }
 
@@ -721,7 +724,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = do
          -- return the event to trace when we switched to the new chain.
       -> m (Point blk)
     switchTo vChainDiff varTentativeHeader mkTraceEvent = do
-        (curChain, newChain, events) <- atomically $ do
+        (curChain, newChain, events, prevTentativeHeader) <- atomically $ do
           curChain  <- readTVar         cdbChain -- Not Query.getCurrentChain!
           curLedger <- LgrDB.getCurrent cdbLgrDB
           case Diff.apply curChain chainDiff of
@@ -740,7 +743,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = do
                              (ledgerState $ LgrDB.ledgerDbCurrent newLedger)
 
               -- Clear the tentative header
-              writeTVar varTentativeHeader SNothing
+              prevTentativeHeader <- swapTVar varTentativeHeader SNothing
 
               -- Update the followers
               --
@@ -751,9 +754,11 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = do
               forM_ followerHandles $ \followerHandle ->
                 fhSwitchFork followerHandle ipoint newChain
 
-              return (curChain, newChain, events)
+              return (curChain, newChain, events, prevTentativeHeader)
 
         trace $ mkTraceEvent events (mkNewTipInfo newLedger) curChain newChain
+        whenJust (strictMaybeToMaybe prevTentativeHeader) $
+          trace . PipeliningEvent . OutdatedTentativeHeader
         traceWith cdbTraceLedger newLedger
 
         return $ castPoint $ AF.headPoint newChain
@@ -800,6 +805,7 @@ getKnownHeaderThroughCache volatileDB hash = gets (Map.lookup hash) >>= \case
 data ChainSelEnv m blk = ChainSelEnv
     { lgrDB                 :: LgrDB m blk
     , trace                 :: TraceValidationEvent blk -> m ()
+    , tracePipelining       :: TracePipeliningEvent blk -> m ()
     , bcfg                  :: BlockConfig blk
     , varInvalid            :: StrictTVar m (WithFingerprint (InvalidBlocks blk))
     , varFutureBlocks       :: StrictTVar m (FutureBlocks m blk)
@@ -928,18 +934,21 @@ chainSelection chainSelEnv chainDiffs =
               -- As we are only extending the existing chain, the intersection
               -- point is not receding, in which case fhSwitchFork is not
               -- necessary.
+              tracePipelining $ SetTentativeHeader tentativeHeader
             pure mTentativeHeader
 
         -- | Clear a tentative header that turned out to be invalid. Also, roll
         -- back the tentative followers.
         clearTentativeHeader :: Header blk -> m ()
-        clearTentativeHeader tentativeHeader = atomically $ do
-            writeTVar varTentativeHeader SNothing
-            writeTVar varTentativeState $
-              LastInvalidTentative (selectView bcfg tentativeHeader)
-            forTentativeFollowers $ \followerHandle -> do
-              let curTipPoint = castPoint $ AF.headPoint curChain
-              fhSwitchFork followerHandle curTipPoint curChain
+        clearTentativeHeader tentativeHeader = do
+            atomically $ do
+              writeTVar varTentativeHeader SNothing
+              writeTVar varTentativeState $
+                LastInvalidTentative (selectView bcfg tentativeHeader)
+              forTentativeFollowers $ \followerHandle -> do
+                let curTipPoint = castPoint $ AF.headPoint curChain
+                fhSwitchFork followerHandle curTipPoint curChain
+            tracePipelining $ TrapTentativeHeader tentativeHeader
           where
             forTentativeFollowers f = getTentativeFollowers >>= mapM_ f
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -56,6 +56,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
   , TraceInitChainSelEvent (..)
   , TraceIteratorEvent (..)
   , TraceOpenEvent (..)
+  , TracePipeliningEvent (..)
   , TraceValidationEvent (..)
   ) where
 
@@ -644,6 +645,11 @@ data TraceAddBlockEvent blk =
     -- This is done for all blocks from the future each time a new block is
     -- added.
   | ChainSelectionForFutureBlock (RealPoint blk)
+
+    -- | The tentative header (in the context of diffusion pipelining) has been
+    -- updated.
+  | PipeliningEvent (TracePipeliningEvent blk)
+
   deriving (Generic)
 
 deriving instance
@@ -695,6 +701,18 @@ deriving instance
   ( Show (Header           blk)
   , LedgerSupportsProtocol blk
   ) => Show (TraceValidationEvent blk)
+
+data TracePipeliningEvent blk =
+    -- | A new tentative header got set.
+    SetTentativeHeader (Header blk)
+    -- | The body of tentative block turned out to be invalid.
+  | TrapTentativeHeader (Header blk)
+    -- | We selected a new (better) chain, which cleared the previous tentative
+    -- header.
+  | OutdatedTentativeHeader (Header blk)
+
+deriving stock instance Eq   (Header blk) => Eq   (TracePipeliningEvent blk)
+deriving stock instance Show (Header blk) => Show (TracePipeliningEvent blk)
 
 data TraceInitChainSelEvent blk =
     StartedInitChainSelection

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -61,6 +61,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
 
 import           Control.Tracer
 import           Data.Map.Strict (Map)
+import           Data.Maybe.Strict (StrictMaybe (..))
 import           Data.Typeable
 import           Data.Void (Void)
 import           Data.Word (Word64)
@@ -101,6 +102,7 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import           Ouroboros.Consensus.Storage.VolatileDB (VolatileDB,
                      VolatileDbSerialiseConstraints)
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
+import           Ouroboros.Consensus.Util.TentativeState (TentativeState (..))
 
 -- | All the serialisation related constraints needed by the ChainDB.
 class ( ImmutableDbSerialiseConstraints blk
@@ -197,6 +199,13 @@ data ChainDbEnv m blk = CDB
     --
     -- Note that the \"immutable\" block will /never/ be /more/ than @k@
     -- blocks back, as opposed to the anchor point of 'cdbChain'.
+  , cdbTentativeState  :: !(StrictTVar m (TentativeState blk))
+  , cdbTentativeHeader :: !(StrictTVar m (StrictMaybe (Header blk)))
+    -- ^ The tentative header. Note that we never read from this; it is only
+    -- maintained for clarity and explicitness.
+    --
+    -- INVARIANT: It fits on top of the current chain, and its body is not known
+    -- to be invalid, but might turn out to be.
   , cdbIterators       :: !(StrictTVar m (Map IteratorKey (m ())))
     -- ^ The iterators.
     --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
@@ -15,6 +15,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Util.IOLike
 
 -- | Restricted interface to the 'ChainDB' used on node initialization
@@ -30,7 +31,8 @@ fromFull ::
      (IsLedger (LedgerState blk), IOLike m)
   => ChainDB m blk -> InitChainDB m blk
 fromFull db = InitChainDB {
-      addBlock         = ChainDB.addBlock_ db
+      addBlock         =
+        ChainDB.addBlock_ db InvalidBlockPunishment.noPunishment
     , getCurrentLedger =
         atomically $ ledgerState <$> ChainDB.getCurrentLedger db
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -146,6 +146,7 @@ deriving instance Show (SelectView    (BlockProtocol blk)) => Show (WrapSelectVi
 deriving instance Show (ValidationErr (BlockProtocol blk)) => Show (WrapValidationErr blk)
 
 deriving instance NoThunks (ChainDepState (BlockProtocol blk)) => NoThunks (WrapChainDepState blk)
+deriving instance NoThunks (SelectView    (BlockProtocol blk)) => NoThunks (WrapSelectView    blk)
 deriving instance NoThunks (ValidationErr (BlockProtocol blk)) => NoThunks (WrapValidationErr blk)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -3,6 +3,7 @@ module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
   , module Ouroboros.Consensus.Util.MonadSTM.StrictMVar
   , newEmptyMVar
   , newMVar
+  , newTVar
   , newTVarIO
     -- * Temporary
   , uncheckedNewEmptyMVar
@@ -30,6 +31,10 @@ import qualified Ouroboros.Consensus.Util.MonadSTM.StrictMVar as Strict
 newTVarIO :: (MonadSTM m, HasCallStack, NoThunks a)
           => a -> m (StrictTVar m a)
 newTVarIO = Strict.newTVarWithInvariantIO (fmap show . unsafeNoThunks)
+
+newTVar :: (MonadSTM m, HasCallStack, NoThunks a)
+          => a -> STM m (StrictTVar m a)
+newTVar = Strict.newTVarWithInvariant (fmap show . unsafeNoThunks)
 
 newMVar :: (MonadSTM m, HasCallStack, NoThunks a)
         => a -> m (StrictMVar m a)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/TentativeState.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/TentativeState.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.Util.TentativeState (
+    TentativeState (..)
+  , preferToLastInvalidTentative
+  ) where
+
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+                     (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.Protocol.Abstract (SelectView,
+                     preferCandidate)
+
+-- | Tentative header state in the context of diffusion pipelining. This is used
+-- to check/enforce the monotonicity requirement on invalid tentative block
+-- bodies.
+--
+--  * During chain selection, we maintain the last invalid tentative header to
+--    ensure that the stream of tentative headers we sent downstream whose
+--    blocks turned out to be invalid are strictly improving.
+--  * In the BlockFetch client, we use it to enforce this property for each
+--    upstream peer.
+data TentativeState blk =
+    LastInvalidTentative !(SelectView (BlockProtocol blk))
+  | NoLastInvalidTentative
+  deriving stock (Generic)
+
+deriving stock    instance Show     (SelectView (BlockProtocol blk)) => Show     (TentativeState blk)
+deriving stock    instance Eq       (SelectView (BlockProtocol blk)) => Eq       (TentativeState blk)
+deriving anyclass instance NoThunks (SelectView (BlockProtocol blk)) => NoThunks (TentativeState blk)
+
+preferToLastInvalidTentative ::
+     forall blk.
+     LedgerSupportsProtocol blk
+  => BlockConfig blk
+  -> TentativeState blk
+  -> Header blk
+  -> Bool
+preferToLastInvalidTentative bcfg ts hdr = case ts of
+    LastInvalidTentative lastInvalid ->
+      preferCandidate
+        (Proxy @(BlockProtocol blk))
+        lastInvalid
+        (selectView bcfg hdr)
+    NoLastInvalidTentative -> True

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -293,7 +293,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
           -- TODO: this currently needs MuxPeerRaw because of the resource
           -- bracket
           MuxPeerRaw $ \channel ->
-          bracketFetchClient registry connectionId $ \clientCtx ->
+          bracketFetchClient registry maxBound connectionId $ \clientCtx ->
             runPipelinedPeer
               nullTracer -- (contramap (show . TraceLabelPeer connectionId) stdoutTracer)
               codecBlockFetch
@@ -315,8 +315,9 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                                        map (maxSlotNoFromWithOrigin . pointSlot) .
                                        Set.elems <$>
                                        getTestFetchedBlocks blockHeap,
-              addFetchedBlock        = \p b -> addTestFetchedBlock blockHeap
-                                         (castPoint p) (blockHeader b),
+              mkAddFetchedBlock        = \_enablePipelining -> do
+                  pure $ \p b ->
+                    addTestFetchedBlock blockHeap (castPoint p) (blockHeader b),
 
               plausibleCandidateChain,
               compareCandidateChains,

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -35,7 +35,7 @@ import           Ouroboros.Network.Block
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
 import           Ouroboros.Network.Mux (ControlMessageSTM)
-import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion (..))
 import           Ouroboros.Network.Protocol.BlockFetch.Type
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -27,6 +27,7 @@ module Ouroboros.Network.BlockFetch.ClientState
   , ChainRange (..)
     -- * Ancillary
   , FromConsensus (..)
+  , WhetherReceivingTentativeBlocks (..)
   ) where
 
 import           Data.List (foldl')
@@ -76,6 +77,12 @@ data FetchClientPolicy header block m =
        addFetchedBlock    :: Point block -> block -> m (),
        blockForgeUTCTime  :: FromConsensus block -> STM m UTCTime
      }
+
+-- | Whether the block fetch peer is sending tentative blocks, which are
+-- understood to possibly be invalid
+data WhetherReceivingTentativeBlocks
+  = ReceivingTentativeBlocks
+  | NotReceivingTentativeBlocks
 
 -- | A set of variables shared between the block fetch logic thread and each
 -- thread executing the client side of the block fetch protocol. That is, these

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1200,7 +1200,7 @@ run tracers tracersExtra args argsExtra apps appsExtra = do
 --
 
 -- | For Node-To-Node protocol, any connection which negotiated at least
--- 'NodeToNodeV_8' version and did not declared 'InitiatorOnlyDiffusionMode'
+-- 'NodeToNodeV_9' version and did not declared 'InitiatorOnlyDiffusionMode'
 -- will run in 'Duplex' mode.   All connections from lower versions or one that
 -- declared themselves as 'InitiatorOnly' will run in 'UnidirectionalMode'
 --
@@ -1208,7 +1208,7 @@ nodeDataFlow :: NodeToNodeVersion
              -> NodeToNodeVersionData
              -> DataFlow
 nodeDataFlow v NodeToNodeVersionData { diffusionMode = InitiatorAndResponderDiffusionMode }
-                 | v >= NodeToNodeV_8
+                 | v >= NodeToNodeV_9
                  = Duplex
 nodeDataFlow _ _ = Unidirectional
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -32,6 +32,10 @@ data NodeToNodeVersion
     | NodeToNodeV_8
     -- ^ Changes:
     --
+    -- * Enable block diffusion pipelining in ChainSync and BlockFetch logic.
+    | NodeToNodeV_9
+    -- ^ Changes:
+    --
     -- * Enable full duplex connections.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
@@ -40,9 +44,11 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
   where
     encodeTerm NodeToNodeV_7 = CBOR.TInt 7
     encodeTerm NodeToNodeV_8 = CBOR.TInt 8
+    encodeTerm NodeToNodeV_9 = CBOR.TInt 9
 
     decodeTerm (CBOR.TInt 7) = Right NodeToNodeV_7
     decodeTerm (CBOR.TInt 8) = Right NodeToNodeV_8
+    decodeTerm (CBOR.TInt 9) = Right NodeToNodeV_9
     decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
                                         <> T.pack (show n)
                                     , Just n

--- a/ouroboros-network/test-cddl/specs/handshake-node-to-node.cddl
+++ b/ouroboros-network/test-cddl/specs/handshake-node-to-node.cddl
@@ -13,7 +13,7 @@ msgRefuse          = [2, refuseReason]
 
 versionTable = { * versionNumber => nodeToNodeVersionData }
 
-versionNumber = 7 / 8
+versionNumber = 7 / 8 / 9
 
 nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
 

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -278,7 +278,7 @@ sampleBlockFetchPolicy1 headerFieldsForgeUTCTime blockHeap currentChain candidat
                                map (maxSlotNoFromWithOrigin . pointSlot) .
                                Set.elems <$>
                                getTestFetchedBlocks blockHeap,
-      addFetchedBlock        = addTestFetchedBlock blockHeap,
+      mkAddFetchedBlock      = \_enablePipelining -> pure $ addTestFetchedBlock blockHeap,
 
       plausibleCandidateChain,
       compareCandidateChains,
@@ -324,7 +324,7 @@ runFetchClient :: (MonadAsync m, MonadFork m, MonadMask m, MonadThrow (STM m),
                    -> PeerPipelined (BlockFetch block point) AsClient BFIdle m a)
                 -> m a
 runFetchClient tracer registry peerid channel client =
-    bracketFetchClient registry peerid $ \clientCtx ->
+    bracketFetchClient registry maxBound peerid $ \clientCtx ->
       fst <$>
         runPipelinedPeerWithLimits tracer codec (byteLimitsBlockFetch (fromIntegral . LBS.length))
           timeLimitsBlockFetch channel (client clientCtx)

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -567,7 +567,7 @@ _unit_bracketSyncWithFetchClient step = do
       let peer  = "thepeer"
           fetch :: m a
           fetch = withFetchTestAction $ \body ->
-                    bracketFetchClient registry peer $ \_ ->
+                    bracketFetchClient registry maxBound peer $ \_ ->
                       body
 
           sync :: m b

--- a/strict-stm/src/Control/Monad/Class/MonadSTM/Strict.hs
+++ b/strict-stm/src/Control/Monad/Class/MonadSTM/Strict.hs
@@ -23,6 +23,7 @@ module Control.Monad.Class.MonadSTM.Strict
   , fromLazyTVar
   , newTVar
   , newTVarIO
+  , newTVarWithInvariant
   , newTVarWithInvariantIO
   , readTVar
   , readTVarIO
@@ -148,6 +149,15 @@ newTVarIO = newTVarWithInvariantIO (const Nothing)
 newTVarM :: MonadSTM m => a -> m (StrictTVar m a)
 newTVarM = newTVarIO
 {-# DEPRECATED newTVarM "Use newTVarIO" #-}
+
+newTVarWithInvariant :: (MonadSTM m, HasCallStack)
+                     => (a -> Maybe String) -- ^ Invariant (expect 'Nothing')
+                     -> a
+                     -> STM m (StrictTVar m a)
+newTVarWithInvariant  invariant !a =
+        checkInvariant (invariant a) $
+        (\tvar -> mkStrictTVar invariant tvar)
+    <$> Lazy.newTVar a
 
 newTVarWithInvariantIO :: (MonadSTM m, HasCallStack)
                        => (a -> Maybe String) -- ^ Invariant (expect 'Nothing')


### PR DESCRIPTION
This PR adds block diffusion pipelining, primarily by finally introducing the long-existing concept of _the tentative chain_ into the code.

Main changes:

- add the tentative chain header to the ChainDB state.

- have the `Follower`s for the Node-To-Node ChainSync server follow the tentative chain instead of only the selected chain, thus sending the tentative header before the underlying block has been validated

- this now means some honest nodes will send us an invalid block, when the block is tentative, so we adjust ChainSync and BlockFetch clients to allow that in limited number of scenarios necessary for the common pipelining scenarios