### PR TITLE
Remove NodeToClientV_8 and below

### DIFF
--- a/docs/interface-CHANGELOG.md
+++ b/docs/interface-CHANGELOG.md
@@ -5,6 +5,11 @@ team.  See [consensus
 CHANGELOG](../ouroboros-consensus/docs/interface-CHANGELOG.md) file for how
 this changelog is supposed to be used.
 
+## Circa 2022-05-19
+
+- removed `node-to-client` versions `1` to `8`.  The lowest supported version is
+  `NodeToClientV_9` introduced before the Alonzo hard-fork.
+
 ## Circa 2022-05-16
 
 - `io-classes`, `io-sim` and `strict-stm` were moved to
@@ -12,6 +17,7 @@ this changelog is supposed to be used.
 
 - `typed-protocols`, `typed-protocols-cborg` and `typed-protocols` were moved
   to https://github.com/input-output-hk/typed-protocols
+
 
 ## Circa 2022-04-06
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
@@ -35,10 +35,10 @@ instance SupportedNetworkProtocolVersion ByronBlock where
       , (NodeToNodeV_8, ByronNodeToNodeVersion1)
       ]
   supportedNodeToClientVersions _ = Map.fromList [
-        (NodeToClientV_1, ByronNodeToClientVersion1)
-        -- Enable the LocalStateQuery protocol, no serialisation changes
-      , (NodeToClientV_2, ByronNodeToClientVersion1)
-        -- V_3 enables the hard fork, not supported by Byron-only.
+        (NodeToClientV_9,  ByronNodeToClientVersion1)
+      , (NodeToClientV_10, ByronNodeToClientVersion1)
+      , (NodeToClientV_11, ByronNodeToClientVersion1)
+      , (NodeToClientV_12, ByronNodeToClientVersion1)
       ]
 
   latestReleasedNodeVersion = latestReleasedNodeVersionDefault

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -452,16 +452,8 @@ instance CardanoHardForkConstraints c
       , (NodeToNodeV_10, CardanoNodeToNodeVersion6)
       ]
 
-  supportedNodeToClientVersions _ = Map.fromList
-      [ (NodeToClientV_1 , CardanoNodeToClientVersion1)
-      , (NodeToClientV_2 , CardanoNodeToClientVersion1)
-      , (NodeToClientV_3 , CardanoNodeToClientVersion2)
-      , (NodeToClientV_4 , CardanoNodeToClientVersion3)
-      , (NodeToClientV_5 , CardanoNodeToClientVersion4)
-      , (NodeToClientV_6 , CardanoNodeToClientVersion5)
-      , (NodeToClientV_7 , CardanoNodeToClientVersion6)
-      , (NodeToClientV_8 , CardanoNodeToClientVersion6)
-      , (NodeToClientV_9 , CardanoNodeToClientVersion7)
+  supportedNodeToClientVersions _ = Map.fromList $
+      [ (NodeToClientV_9 , CardanoNodeToClientVersion7)
       , (NodeToClientV_10, CardanoNodeToClientVersion7)
       , (NodeToClientV_11, CardanoNodeToClientVersion8)
       , (NodeToClientV_12, CardanoNodeToClientVersion8)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -43,18 +43,10 @@ instance SupportedNetworkProtocolVersion (ShelleyBlock proto era) where
       , (NodeToNodeV_8, ShelleyNodeToNodeVersion1)
       ]
   supportedNodeToClientVersions _ = Map.fromList [
-        (NodeToClientV_1, ShelleyNodeToClientVersion1)
-        -- Enable the LocalStateQuery protocol, no serialisation changes
-      , (NodeToClientV_2, ShelleyNodeToClientVersion1)
-        -- V_3 enables the hard fork to Shelley, which didn't affect
-        -- Shelley-only when introduced. However, we have retroactively claimed
-        -- V_3 to enable 'ShelleyNodeToClientVersion2'.
-      , (NodeToClientV_3, ShelleyNodeToClientVersion2)
-        -- V_4 enables the hard fork to Allegra, which didn't affect
-        -- Shelley-only when introduced. However, we have retroactively claimed
-        -- V_4 to enable 'ShelleyNodeToClientVersion3'.
-      , (NodeToClientV_4, ShelleyNodeToClientVersion3)
-      , (NodeToClientV_5, ShelleyNodeToClientVersion5)
+        (NodeToClientV_9,  ShelleyNodeToClientVersion5)
+      , (NodeToClientV_10, ShelleyNodeToClientVersion5)
+      , (NodeToClientV_11, ShelleyNodeToClientVersion5)
+      , (NodeToClientV_12, ShelleyNodeToClientVersion5)
       ]
 
   latestReleasedNodeVersion = latestReleasedNodeVersionDefault

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -227,9 +227,8 @@ instance ( blockVersion ~ BlockNodeToClientVersion blk
       -- This case statement will cause a warning when we add a new top
       -- level query and hence a new QueryVersion. In that case we should
       -- support such top level `Query` constructors in this Arbitrary instance.
-      Query.TopLevelQueryDisabled -> arbitraryBlockQuery queryVersion
-      Query.QueryVersion1         -> genTopLevelQuery1
-      Query.QueryVersion2         -> genTopLevelQuery2
+      Query.QueryVersion1 -> genTopLevelQuery1
+      Query.QueryVersion2 -> genTopLevelQuery2
     where
       mkEntry :: QueryVersion
         -> Query blk query

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query/Version.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query/Version.hs
@@ -11,13 +11,8 @@ import           Ouroboros.Network.NodeToClient.Version
 -- Multiple top level queries are now supported. The encoding now has
 -- constructor tags for the different top level queries for QueryVersion1 onwards.
 data QueryVersion
-    -- | Only the 'BlockQuery' constructor of 'Query' is supported. The binary
-    -- encoding is backwards compatible: it does not introduce any constructor
-    -- tag around the 'BlockQuery'.
-  = TopLevelQueryDisabled
-
   -- Adds support for 'GetSystemStart'.
-  | QueryVersion1
+  = QueryVersion1
 
   -- Adds support for 'GetChainBlockNo' and 'GetChainPoint'.
   | QueryVersion2
@@ -26,14 +21,6 @@ data QueryVersion
 -- | Get the @QueryVersion@ supported by this @NodeToClientVersion@.
 nodeToClientVersionToQueryVersion :: NodeToClientVersion -> QueryVersion
 nodeToClientVersionToQueryVersion x = case x of
-  NodeToClientV_1  -> TopLevelQueryDisabled
-  NodeToClientV_2  -> TopLevelQueryDisabled
-  NodeToClientV_3  -> TopLevelQueryDisabled
-  NodeToClientV_4  -> TopLevelQueryDisabled
-  NodeToClientV_5  -> TopLevelQueryDisabled
-  NodeToClientV_6  -> TopLevelQueryDisabled
-  NodeToClientV_7  -> TopLevelQueryDisabled
-  NodeToClientV_8  -> TopLevelQueryDisabled
   NodeToClientV_9  -> QueryVersion1
   NodeToClientV_10 -> QueryVersion2
   NodeToClientV_11 -> QueryVersion2

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -206,7 +206,6 @@ defaultCodecs ccfg version networkVersion = Codecs {
 
     , cStateQueryCodec =
         codecLocalStateQuery
-          (networkVersion >= NodeToClientV_8)
           (encodePoint (encodeRawHash p))
           (decodePoint (decodeRawHash p))
           (queryEncodeNodeToClient ccfg queryVersion version . SomeSecond)
@@ -266,7 +265,6 @@ clientCodecs ccfg version networkVersion = Codecs {
 
     , cStateQueryCodec =
         codecLocalStateQuery
-          (networkVersion >= NodeToClientV_8)
           (encodePoint (encodeRawHash p))
           (decodePoint (decodeRawHash p))
           (queryEncodeNodeToClient ccfg queryVersion version . SomeSecond)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -174,9 +174,6 @@ nodeToClientProtocols protocols version =
           , localTxSubmissionMiniProtocol localTxSubmissionProtocol
           ] <>
           [ localStateQueryMiniProtocol localStateQueryProtocol
-          | case version of
-              NodeToClientV_1 -> False
-              _               -> True
           ] <>
           [ localTxMonitorMiniProtocol localTxMonitorProtocol
           | version >= NodeToClientV_12

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -24,22 +24,7 @@ import           Ouroboros.Network.Protocol.Handshake.Version (Accept (..),
 -- | Enumeration of node to client protocol versions.
 --
 data NodeToClientVersion
-    = NodeToClientV_1
-    | NodeToClientV_2
-    -- ^ added local-query mini-protocol
-    | NodeToClientV_3
-    -- ^ enabled @CardanoNodeToClientVersion2@
-    | NodeToClientV_4
-    -- ^ enabled @CardanoNodeToClientVersion3@, adding more queries
-    | NodeToClientV_5
-    -- ^ enabled @CardanoNodeToClientVersion4@, i.e., Allegra
-    | NodeToClientV_6
-    -- ^ enabled @CardanoNodeToClientVersion5@, i.e., Mary
-    | NodeToClientV_7
-    -- ^ enabled @CardanoNodeToClientVersion6@, adding a query
-    | NodeToClientV_8
-    -- ^ 'LocalStateQuery' protocol codec change, allows to acquire tip point.
-    | NodeToClientV_9
+    = NodeToClientV_9
     -- ^ enabled @CardanoNodeToClientVersion7@, i.e., Alonzo
     | NodeToClientV_10
     -- ^ added 'GetChainBlockNo' and 'GetChainPoint' queries
@@ -61,14 +46,6 @@ data NodeToClientVersion
 nodeToClientVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToClientVersion
 nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     where
-      encodeTerm NodeToClientV_1  = CBOR.TInt 1
-      encodeTerm NodeToClientV_2  = CBOR.TInt (2  `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_3  = CBOR.TInt (3  `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_4  = CBOR.TInt (4  `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_5  = CBOR.TInt (5  `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_6  = CBOR.TInt (6  `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_7  = CBOR.TInt (7  `setBit` nodeToClientVersionBit)
-      encodeTerm NodeToClientV_8  = CBOR.TInt (8  `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_9  = CBOR.TInt (9  `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_10 = CBOR.TInt (10 `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_11 = CBOR.TInt (11 `setBit` nodeToClientVersionBit)
@@ -79,14 +56,6 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
        case ( tag `clearBit` nodeToClientVersionBit
             , tag `testBit`  nodeToClientVersionBit
             ) of
-        (1, False) -> Right NodeToClientV_1
-        (2, True)  -> Right NodeToClientV_2
-        (3, True)  -> Right NodeToClientV_3
-        (4, True)  -> Right NodeToClientV_4
-        (5, True)  -> Right NodeToClientV_5
-        (6, True)  -> Right NodeToClientV_6
-        (7, True)  -> Right NodeToClientV_7
-        (8, True)  -> Right NodeToClientV_8
         (9, True)  -> Right NodeToClientV_9
         (10, True) -> Right NodeToClientV_10
         (11, True) -> Right NodeToClientV_11

--- a/ouroboros-network/test-cddl/Main.hs
+++ b/ouroboros-network/test-cddl/Main.hs
@@ -293,7 +293,7 @@ localTxMonitorCodec =
 localStateQueryCodec :: Codec (LocalStateQuery Block (Point Block) LocalStateQuery.Query)
                               CBOR.DeserialiseFailure IO BL.ByteString
 localStateQueryCodec =
-    LocalStateQuery.codec True
+    LocalStateQuery.codec
 
 
 --
@@ -418,7 +418,7 @@ instance Arbitrary (AnyMessageAndAgency (Handshake NodeToClientVersion CBOR.Term
         ]
       where
         genVersion :: Gen NodeToClientVersion
-        genVersion = elements [NodeToClientV_1 ..]
+        genVersion = elements [minBound .. maxBound]
 
         genData :: Gen NodeToClientVersionData
         genData = NodeToClientVersionData

--- a/ouroboros-network/test-cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network/test-cddl/specs/handshake-node-to-client.cddl
@@ -13,8 +13,9 @@ msgRefuse          = [2, refuseReason]
 
 versionTable = { * versionNumber => nodeToClientVersionData }
 
-; from version 2 we set 15th bit to 1
-versionNumber = 1 / 32770 / 32771 / 32772 / 32773 / 32774 / 32775 / 32776 / 32777 / 32778 / 32779 / 32780 / 32781
+; as of version 2 (which is no longer supported) we set 15th bit to 1
+;               9     / 10    / 11    / 12    / 13
+versionNumber = 32777 / 32778 / 32779 / 32780 / 32781
 
 nodeToClientVersionData = networkMagic
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/NodeToClient/Version.hs
@@ -24,7 +24,7 @@ data VersionAndVersionData =
 instance Arbitrary VersionAndVersionData where
     arbitrary =
       VersionAndVersionData
-        <$> elements [ NodeToClientV_1, NodeToClientV_2, NodeToClientV_3 ]
+        <$> elements [ minBound .. maxBound]
         <*> (NodeToClientVersionData . NetworkMagic <$> arbitrary)
 
 prop_nodeToClientCodec :: VersionAndVersionData -> Bool

--- a/ouroboros-network/test/Test/Version.hs
+++ b/ouroboros-network/test/Test/Version.hs
@@ -7,7 +7,8 @@ module Test.Version (tests) where
 import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.NodeToClient (NodeToClientVersion (..),
                      nodeToClientVersionCodec)
-import           Ouroboros.Network.NodeToNode (nodeToNodeVersionCodec)
+import           Ouroboros.Network.NodeToNode (NodeToNodeVersion (..),
+                     nodeToNodeVersionCodec)
 
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
@@ -23,19 +24,16 @@ tests =
                  (crossFailurePropAll
                    nodeToClientVersionCodec
                    nodeToNodeVersionCodec
-                   ([NodeToClientV_2 .. maxBound] :: [NodeToClientVersion]))
+                   ([minBound .. maxBound] :: [NodeToClientVersion]))
       ]
     , testGroup "NodeToNodeVersion"
       [ testCase "NodeToNodeVersion round-trip codec property"
                  (roundTripPropAll nodeToNodeVersionCodec)
-      -- TODO: enable this test when `NodeToClientV_1` is removed:
-      {--
-        - , testCase "NodeToNodeVersion should not deserialise as NodeToClient"
-        -            (crossFailurePropAll
-        -              nodeToNodeVersionCodec
-        -              nodeToClientVersionCodec
-        -              ([minBound .. maxBound] :: [NodeToNodeVersion]))
-        --}
+      , testCase "NodeToNodeVersion should not deserialise as NodeToClient"
+                 (crossFailurePropAll
+                   nodeToNodeVersionCodec
+                   nodeToClientVersionCodec
+                   ([minBound .. maxBound] :: [NodeToNodeVersion]))
       ]
     ]
 


### PR DESCRIPTION
[NodeToClientV_9](https://input-output-hk.github.io/ouroboros-network/ouroboros-network/Ouroboros-Network-NodeToClient.html#t:NodeToClientVersion)
was introduced before the Alonzo hard fork.
