### PR TITLE
Keep and forward keys when applying a block

### DIFF
--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -128,12 +128,13 @@ instance TableStuff (LedgerState ByronSpecBlock) where
   projectLedgerTables _st                     = NoByronSpecLedgerTables
   withLedgerTables st NoByronSpecLedgerTables = convertMapKind st
 
-  pureLedgerTables     _f                                                 = NoByronSpecLedgerTables
-  mapLedgerTables      _f                         NoByronSpecLedgerTables = NoByronSpecLedgerTables
-  traverseLedgerTables _f                         NoByronSpecLedgerTables = pure NoByronSpecLedgerTables
-  zipLedgerTables      _f NoByronSpecLedgerTables NoByronSpecLedgerTables = NoByronSpecLedgerTables
-  foldLedgerTables     _f                         NoByronSpecLedgerTables = mempty
-  foldLedgerTables2    _f NoByronSpecLedgerTables NoByronSpecLedgerTables = mempty
+  pureLedgerTables     _f                                                                         = NoByronSpecLedgerTables
+  mapLedgerTables      _f                                                 NoByronSpecLedgerTables = NoByronSpecLedgerTables
+  traverseLedgerTables _f                                                 NoByronSpecLedgerTables = pure NoByronSpecLedgerTables
+  zipLedgerTables      _f                         NoByronSpecLedgerTables NoByronSpecLedgerTables = NoByronSpecLedgerTables
+  zipLedgerTables2     _f NoByronSpecLedgerTables NoByronSpecLedgerTables NoByronSpecLedgerTables = NoByronSpecLedgerTables
+  foldLedgerTables     _f                                                 NoByronSpecLedgerTables = mempty
+  foldLedgerTables2    _f                         NoByronSpecLedgerTables NoByronSpecLedgerTables = mempty
 
 instance SufficientSerializationForAnyBackingStore (LedgerState ByronSpecBlock) where
     codecLedgerTables = NoByronSpecLedgerTables

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -383,12 +383,13 @@ instance ShelleyBasedHardForkConstraints era1 era2
           hfstate
           tables
 
-  pureLedgerTables     f                                                                           = ShelleyBasedHardForkLedgerTables f
-  mapLedgerTables      f                                      (ShelleyBasedHardForkLedgerTables x) = ShelleyBasedHardForkLedgerTables (f x)
-  traverseLedgerTables f                                      (ShelleyBasedHardForkLedgerTables x) = ShelleyBasedHardForkLedgerTables <$> f x
-  zipLedgerTables      f (ShelleyBasedHardForkLedgerTables l) (ShelleyBasedHardForkLedgerTables r) = ShelleyBasedHardForkLedgerTables (f l r)
-  foldLedgerTables     f                                      (ShelleyBasedHardForkLedgerTables x) = f x
-  foldLedgerTables2    f (ShelleyBasedHardForkLedgerTables l) (ShelleyBasedHardForkLedgerTables r) = f l r
+  pureLedgerTables     f                                                                                                                = ShelleyBasedHardForkLedgerTables f
+  mapLedgerTables      f                                                                           (ShelleyBasedHardForkLedgerTables x) = ShelleyBasedHardForkLedgerTables (f x)
+  traverseLedgerTables f                                                                           (ShelleyBasedHardForkLedgerTables x) = ShelleyBasedHardForkLedgerTables <$> f x
+  zipLedgerTables      f                                      (ShelleyBasedHardForkLedgerTables l) (ShelleyBasedHardForkLedgerTables r) = ShelleyBasedHardForkLedgerTables (f l r)
+  zipLedgerTables2     f (ShelleyBasedHardForkLedgerTables l) (ShelleyBasedHardForkLedgerTables c) (ShelleyBasedHardForkLedgerTables r) = ShelleyBasedHardForkLedgerTables (f l c r)
+  foldLedgerTables     f                                                                           (ShelleyBasedHardForkLedgerTables x) = f x
+  foldLedgerTables2    f                                      (ShelleyBasedHardForkLedgerTables l) (ShelleyBasedHardForkLedgerTables r) = f l r
 
 instance ShelleyBasedHardForkConstraints era1 era2
       => SufficientSerializationForAnyBackingStore (LedgerState (ShelleyBasedHardForkBlock era1 era2)) where

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -501,12 +501,13 @@ instance CardanoHardForkConstraints c => TableStuff (LedgerState (CardanoBlock c
           hfstate
           tables
 
-  pureLedgerTables     f                                                 = CardanoLedgerTables f
-  mapLedgerTables      f                         (CardanoLedgerTables x) = CardanoLedgerTables (f x)
-  traverseLedgerTables f                         (CardanoLedgerTables x) = CardanoLedgerTables <$> f x
-  zipLedgerTables      f (CardanoLedgerTables l) (CardanoLedgerTables r) = CardanoLedgerTables (f l r)
-  foldLedgerTables     f                         (CardanoLedgerTables x) = f x
-  foldLedgerTables2    f (CardanoLedgerTables l) (CardanoLedgerTables r) = f l r
+  pureLedgerTables     f                                                                         = CardanoLedgerTables f
+  mapLedgerTables      f                                                 (CardanoLedgerTables x) = CardanoLedgerTables (f x)
+  traverseLedgerTables f                                                 (CardanoLedgerTables x) = CardanoLedgerTables <$> f x
+  zipLedgerTables      f                         (CardanoLedgerTables l) (CardanoLedgerTables r) = CardanoLedgerTables (f l r)
+  zipLedgerTables2     f (CardanoLedgerTables l) (CardanoLedgerTables c) (CardanoLedgerTables r) = CardanoLedgerTables (f l c r)
+  foldLedgerTables     f                                                 (CardanoLedgerTables x) = f x
+  foldLedgerTables2    f                         (CardanoLedgerTables l) (CardanoLedgerTables r) = f l r
 
 instance CardanoHardForkConstraints c
       => SufficientSerializationForAnyBackingStore (LedgerState (CardanoBlock c)) where

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -393,12 +393,13 @@ instance (SimpleCrypto c, Typeable ext) => TableStuff (LedgerState (SimpleBlock 
   projectLedgerTables _st                                = NoMockTables
   withLedgerTables    (SimpleLedgerState x) NoMockTables = SimpleLedgerState x
 
-  pureLedgerTables     _f                           = NoMockTables
-  mapLedgerTables      _f              NoMockTables = NoMockTables
-  traverseLedgerTables _f              NoMockTables = pure NoMockTables
-  zipLedgerTables      _f NoMockTables NoMockTables = NoMockTables
-  foldLedgerTables     _f              NoMockTables = mempty
-  foldLedgerTables2    _f NoMockTables NoMockTables = mempty
+  pureLedgerTables     _f                                        = NoMockTables
+  mapLedgerTables      _f                           NoMockTables = NoMockTables
+  traverseLedgerTables _f                           NoMockTables = pure NoMockTables
+  zipLedgerTables      _f              NoMockTables NoMockTables = NoMockTables
+  zipLedgerTables2     _f NoMockTables NoMockTables NoMockTables = NoMockTables
+  foldLedgerTables     _f                           NoMockTables = mempty
+  foldLedgerTables2    _f              NoMockTables NoMockTables = mempty
 
 instance (SimpleCrypto c, Typeable ext) => TickedTableStuff (LedgerState (SimpleBlock c ext)) where
   projectLedgerTablesTicked _st                                 = NoMockTables

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
@@ -39,7 +39,6 @@ module Ouroboros.Consensus.Shelley.Eras (
 import           Control.Exception (Exception, throw)
 import           Control.Monad.Except
 import           Data.Default.Class (Default)
-import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import           Data.Void (Void)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -93,7 +93,6 @@ import qualified Cardano.Ledger.Chain as Chain
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Core
 import qualified Cardano.Ledger.Shelley.API as SL
-import qualified Cardano.Ledger.Shelley.LedgerState as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL (makeHeaderView)
 import qualified Control.State.Transition.Extended as STS
 
@@ -284,6 +283,13 @@ instance ShelleyBasedEra era => TableStuff (LedgerState (ShelleyBlock era)) wher
 
   zipLedgerTables f (ShelleyLedgerTables utxoL) (ShelleyLedgerTables utxoR) =
       ShelleyLedgerTables (f utxoL utxoR)
+
+  zipLedgerTables2
+    f
+    (ShelleyLedgerTables utxoL)
+    (ShelleyLedgerTables utxoM)
+    (ShelleyLedgerTables utxoR) =
+      ShelleyLedgerTables (f utxoL utxoM utxoR)
 
   foldLedgerTables f (ShelleyLedgerTables utxo) = f utxo
 

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -191,7 +191,7 @@ instance Condense TestHash where
 
 instance InMemory.ReadsKeySets Identity (LedgerState TestBlock) where
   readDb (InMemory.RewoundTableKeySets seqNo NoTestLedgerTables) =
-      pure $ InMemory.UnforwardedReadSets seqNo NoTestLedgerTables
+      pure $ InMemory.UnforwardedReadSets seqNo NoTestLedgerTables NoTestLedgerTables
 
 -- | Test block parametrized on the payload type
 --
@@ -456,12 +456,13 @@ instance TableStuff (LedgerState TestBlock) where
   projectLedgerTables _                  = NoTestLedgerTables
   withLedgerTables st NoTestLedgerTables = convertMapKind st
 
-  pureLedgerTables     _                                       = NoTestLedgerTables
-  mapLedgerTables      _ NoTestLedgerTables                    = NoTestLedgerTables
-  traverseLedgerTables _ NoTestLedgerTables                    = pure NoTestLedgerTables
-  zipLedgerTables      _ NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
-  foldLedgerTables     _ NoTestLedgerTables                    = mempty
-  foldLedgerTables2    _ NoTestLedgerTables NoTestLedgerTables = mempty
+  pureLedgerTables     _                                                          = NoTestLedgerTables
+  mapLedgerTables      _                                       NoTestLedgerTables = NoTestLedgerTables
+  traverseLedgerTables _                                       NoTestLedgerTables = pure NoTestLedgerTables
+  zipLedgerTables      _                    NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
+  zipLedgerTables2     _ NoTestLedgerTables NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
+  foldLedgerTables     _                                       NoTestLedgerTables = mempty
+  foldLedgerTables2    _                    NoTestLedgerTables NoTestLedgerTables = mempty
 
 instance SufficientSerializationForAnyBackingStore (LedgerState TestBlock) where
     codecLedgerTables = NoTestLedgerTables

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -373,12 +373,13 @@ instance TableStuff (LedgerState (HardForkBlock '[BlockA, BlockB])) where
   projectLedgerTables _st            = NoAbTables
   withLedgerTables    st  NoAbTables = convertMapKind st
 
-  pureLedgerTables     _f                       = NoAbTables
-  mapLedgerTables      _f            NoAbTables = NoAbTables
-  traverseLedgerTables _f            NoAbTables = pure NoAbTables
-  zipLedgerTables      _f NoAbTables NoAbTables = NoAbTables
-  foldLedgerTables     _f            NoAbTables = mempty
-  foldLedgerTables2    _f NoAbTables NoAbTables = mempty
+  pureLedgerTables     _f                                  = NoAbTables
+  mapLedgerTables      _f                       NoAbTables = NoAbTables
+  traverseLedgerTables _f                       NoAbTables = pure NoAbTables
+  zipLedgerTables      _f            NoAbTables NoAbTables = NoAbTables
+  zipLedgerTables2     _f NoAbTables NoAbTables NoAbTables = NoAbTables
+  foldLedgerTables     _f                       NoAbTables = mempty
+  foldLedgerTables2    _f            NoAbTables NoAbTables = mempty
 
 instance SufficientSerializationForAnyBackingStore (LedgerState (HardForkBlock '[BlockA, BlockB])) where
     codecLedgerTables = NoAbTables

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -215,12 +215,13 @@ instance TableStuff (LedgerState BlockA) where
   projectLedgerTables _st           = NoATables
   withLedgerTables    st  NoATables = convertMapKind st
 
-  pureLedgerTables     _f                     = NoATables
-  mapLedgerTables      _f           NoATables = NoATables
-  traverseLedgerTables _f           NoATables = pure NoATables
-  zipLedgerTables      _f NoATables NoATables = NoATables
-  foldLedgerTables     _f           NoATables = mempty
-  foldLedgerTables2    _f NoATables NoATables = mempty
+  pureLedgerTables     _f                               = NoATables
+  mapLedgerTables      _f                     NoATables = NoATables
+  traverseLedgerTables _f                     NoATables = pure NoATables
+  zipLedgerTables      _f           NoATables NoATables = NoATables
+  zipLedgerTables2     _f NoATables NoATables NoATables = NoATables
+  foldLedgerTables     _f                     NoATables = mempty
+  foldLedgerTables2    _f           NoATables NoATables = mempty
 
 instance SufficientSerializationForAnyBackingStore (LedgerState BlockA) where
     codecLedgerTables = NoATables

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -176,12 +176,13 @@ instance TableStuff (LedgerState BlockB) where
   projectLedgerTables _st           = NoBTables
   withLedgerTables    st  NoBTables = convertMapKind st
 
-  pureLedgerTables     _f                     = NoBTables
-  mapLedgerTables      _f           NoBTables = NoBTables
-  traverseLedgerTables _f           NoBTables = pure NoBTables
-  zipLedgerTables      _f NoBTables NoBTables = NoBTables
-  foldLedgerTables     _f           NoBTables = mempty
-  foldLedgerTables2    _f NoBTables NoBTables = mempty
+  pureLedgerTables     _f                               = NoBTables
+  mapLedgerTables      _f                     NoBTables = NoBTables
+  traverseLedgerTables _f                     NoBTables = pure NoBTables
+  zipLedgerTables      _f           NoBTables NoBTables = NoBTables
+  zipLedgerTables2     _f NoBTables NoBTables NoBTables = NoBTables
+  foldLedgerTables     _f                     NoBTables = mempty
+  foldLedgerTables2    _f           NoBTables NoBTables = mempty
 
 instance SufficientSerializationForAnyBackingStore (LedgerState BlockB) where
     codecLedgerTables = NoBTables

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -238,15 +238,12 @@ instance TableStuff (LedgerState TestBlock) where
 
   pureLedgerTables = TokenToTValue
 
-  mapLedgerTables      f (TokenToTValue x)                   = TokenToTValue    (f x)
-
-  traverseLedgerTables f (TokenToTValue x)                   = TokenToTValue <$> f x
-
-  zipLedgerTables      f (TokenToTValue x) (TokenToTValue y) = TokenToTValue    (f x y)
-
-  foldLedgerTables     f (TokenToTValue x)                   =                   f x
-
-  foldLedgerTables2    f (TokenToTValue x) (TokenToTValue y) =                   f x y
+  mapLedgerTables      f                                     (TokenToTValue x) = TokenToTValue    (f x)
+  traverseLedgerTables f                                     (TokenToTValue x) = TokenToTValue <$> f x
+  zipLedgerTables      f                   (TokenToTValue x) (TokenToTValue y) = TokenToTValue    (f x y)
+  zipLedgerTables2     f (TokenToTValue x) (TokenToTValue y) (TokenToTValue z) = TokenToTValue    (f x y z)
+  foldLedgerTables     f                                     (TokenToTValue x) =                   f x
+  foldLedgerTables2    f                   (TokenToTValue x) (TokenToTValue y) =                   f x y
 
 deriving newtype  instance Eq       (LedgerTables (LedgerState TestBlock) EmptyMK)
 deriving newtype  instance Eq       (LedgerTables (LedgerState TestBlock) DiffMK)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -123,7 +123,7 @@ import           Test.Util.Orphans.SignableRepresentation ()
 
 instance InMemory.ReadsKeySets Identity (LedgerState TestBlock) where
   readDb (InMemory.RewoundTableKeySets seqNo NoTestLedgerTables) =
-      pure $ InMemory.UnforwardedReadSets seqNo NoTestLedgerTables
+      pure $ InMemory.UnforwardedReadSets seqNo NoTestLedgerTables NoTestLedgerTables
 
 data TestBlock = TestBlock {
       testHeader :: !TestHeader
@@ -571,12 +571,13 @@ instance TableStuff (LedgerState TestBlock) where
   projectLedgerTables _st                    = NoTestLedgerTables
   withLedgerTables    st  NoTestLedgerTables = convertMapKind st
 
-  pureLedgerTables     _                                       = NoTestLedgerTables
-  mapLedgerTables      _                    NoTestLedgerTables = NoTestLedgerTables
-  traverseLedgerTables _                    NoTestLedgerTables = pure NoTestLedgerTables
-  zipLedgerTables      _ NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
-  foldLedgerTables     _                    NoTestLedgerTables = mempty
-  foldLedgerTables2    _ NoTestLedgerTables NoTestLedgerTables = mempty
+  pureLedgerTables     _                                                          = NoTestLedgerTables
+  mapLedgerTables      _                                       NoTestLedgerTables = NoTestLedgerTables
+  traverseLedgerTables _                                       NoTestLedgerTables = pure NoTestLedgerTables
+  zipLedgerTables      _                    NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
+  zipLedgerTables2     _ NoTestLedgerTables NoTestLedgerTables NoTestLedgerTables = NoTestLedgerTables
+  foldLedgerTables     _                                       NoTestLedgerTables = mempty
+  foldLedgerTables2    _                    NoTestLedgerTables NoTestLedgerTables = mempty
 
 instance SufficientSerializationForAnyBackingStore (LedgerState TestBlock) where
     codecLedgerTables = NoTestLedgerTables

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -227,6 +227,7 @@ instance (SingleEraBlock x, TableStuff (LedgerState x)) => TableStuff (LedgerSta
   pureLedgerTables  f = coerce $ pureLedgerTables  @(LedgerState x) f
   mapLedgerTables   f = coerce $ mapLedgerTables   @(LedgerState x) f
   zipLedgerTables   f = coerce $ zipLedgerTables   @(LedgerState x) f
+  zipLedgerTables2  f = coerce $ zipLedgerTables2  @(LedgerState x) f
   foldLedgerTables  f = coerce $ foldLedgerTables  @(LedgerState x) f
   foldLedgerTables2 f = coerce $ foldLedgerTables2 @(LedgerState x) f
 
@@ -338,10 +339,10 @@ instance ( CanHardFork xs
       $ hczipWith proxySingle f hardForkInjectLedgerTablesKeysMK ns
     where
       f ::
-           SingleEraBlock                                    x
-        => InjectLedgerTables xs                             x
-        -> I                                                 x
-        -> K (TableKeySets (LedgerState (HardForkBlock xs))) x
+           SingleEraBlock                                           x
+        => InjectLedgerTables xs                                    x
+        -> I                                                        x
+        -> K (LedgerTables (LedgerState (HardForkBlock xs)) KeysMK) x
       f inj (I blk) = K $ applyInjectLedgerTables inj $ getBlockKeySets blk
 
 apply :: SingleEraBlock blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -279,7 +279,7 @@ prepareQueryIfCurrent ::
   forall xs result.
      (All SingleEraBlock xs, LedgerTablesCanHardFork xs)
   => QueryIfCurrent xs LargeL result
-  -> TableKeySets (LedgerState (HardForkBlock xs))
+  -> LedgerTables (LedgerState (HardForkBlock xs)) KeysMK
 prepareQueryIfCurrent =
     \qic -> go qic hardForkInjectLedgerTablesKeysMK
   where
@@ -287,7 +287,7 @@ prepareQueryIfCurrent =
          All SingleEraBlock ys
       => QueryIfCurrent ys LargeL result
       -> NP (InjectLedgerTables xs) ys
-      -> TableKeySets (LedgerState (HardForkBlock xs))
+      -> LedgerTables (LedgerState (HardForkBlock xs)) KeysMK
     go (QS qic) (_   :* injs) = go qic injs
     go (QZ bq)  (inj :* _)    =
       applyInjectLedgerTables inj $ prepareBlockQuery bq

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -131,10 +131,10 @@ instance CanHardFork' xs => LedgerSupportsMempool (HardForkBlock xs) where
       $ hczipWith proxySingle f hardForkInjectLedgerTablesKeysMK ns
     where
       f ::
-           SingleEraBlock                                    x
-        => InjectLedgerTables xs                             x
-        -> GenTx                                             x
-        -> K (TableKeySets (LedgerState (HardForkBlock xs))) x
+           SingleEraBlock                                           x
+        => InjectLedgerTables xs                                    x
+        -> GenTx                                                    x
+        -> K (LedgerTables (LedgerState (HardForkBlock xs)) KeysMK) x
       f inj tx = K $ applyInjectLedgerTables inj $ getTransactionKeySets tx
 
 -- | A private type used only to clarify the parameterization of 'applyHelper'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -115,7 +115,7 @@ class ( IsLedger l
   -- TODO: this might not be the best place to define this function. Maybe we
   -- want to make the on-disk ledger state storage concern orthogonal to the
   -- ledger state transformation concern.
-  getBlockKeySets :: blk -> TableKeySets l
+  getBlockKeySets :: blk -> LedgerTables l KeysMK
 
 -- | Interaction with the ledger layer
 class (ApplyBlock (LedgerState blk) blk, TickedTableStuff (LedgerState blk)) => UpdateLedger blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -89,8 +89,6 @@ module Ouroboros.Consensus.Ledger.Basics (
   , DiskLedgerView (..)
   , FootprintL (..)
     -- ** Convenience aliases
-  , TableKeySets
-  , TableReadSets
   , applyDiffsLedgerTables
   , emptyLedgerTables
   , forgetLedgerStateTables
@@ -402,6 +400,19 @@ class ( ShowLedgerState (LedgerTables l)
     -> LedgerTables l mk1
     -> LedgerTables l mk2
     -> LedgerTables l mk3
+
+  zipLedgerTables2 ::
+       (forall k v.
+            Ord k
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> mk4 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> LedgerTables l mk4
 
   foldLedgerTables ::
        Monoid m
@@ -922,8 +933,6 @@ data DiskLedgerView m l =
       (RangeQuery (LedgerTables l KeysMK) -> m (LedgerTables l ValuesMK))   -- TODO will be unacceptably coarse once we have multiple tables
       (m ())
 
-type TableKeySets l = LedgerTables l KeysMK
-
 {-------------------------------------------------------------------------------
   Special classes of ledger states
 
@@ -940,8 +949,6 @@ class InMemory (l :: LedgerStateKind) where
   -- This function is useful to combine functions that operate on functions that
   -- transform the map kind on a ledger state (eg applyChainTickLedgerResult).
   convertMapKind :: l mk -> l mk'
-
-type TableReadSets l = LedgerTables l ValuesMK
 
 -- | TODO Once we remove the dual ledger, we won't need this anymore
 class StowableLedgerTables (l :: LedgerStateKind) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -427,6 +427,15 @@ instance Bridge m a => TableStuff (LedgerState (DualBlock m a)) where
         (zipLedgerTables f mainL mainR)
         (zipLedgerTables f auxL  auxR)
 
+  zipLedgerTables2
+    f
+    (DualBlockLedgerTables mainL auxL)
+    (DualBlockLedgerTables mainM auxM)
+    (DualBlockLedgerTables mainR auxR) =
+      DualBlockLedgerTables
+        (zipLedgerTables2 f mainL mainM mainR)
+        (zipLedgerTables2 f auxL  auxM  auxR)
+
   foldLedgerTables f (DualBlockLedgerTables main aux) =
        foldLedgerTables f main
     <> foldLedgerTables f aux

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -190,6 +190,7 @@ instance (LedgerSupportsProtocol blk, TableStuff (LedgerState blk)) => TableStuf
   pureLedgerTables  f = coerce $ pureLedgerTables  @(LedgerState blk) f
   mapLedgerTables   f = coerce $ mapLedgerTables   @(LedgerState blk) f
   zipLedgerTables   f = coerce $ zipLedgerTables   @(LedgerState blk) f
+  zipLedgerTables2  f = coerce $ zipLedgerTables2  @(LedgerState blk) f
   foldLedgerTables  f = coerce $ foldLedgerTables  @(LedgerState blk) f
   foldLedgerTables2 f = coerce $ foldLedgerTables2 @(LedgerState blk) f
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -290,7 +290,7 @@ answerQuery cfg query st = case query of
   GetChainBlockNo -> headerStateBlockNo (headerState st)
   GetChainPoint -> headerStatePoint (headerState st)
 
-prepareQuery :: QueryLedger blk => Query blk LargeL result -> TableKeySets (LedgerState blk)
+prepareQuery :: QueryLedger blk => Query blk LargeL result -> LedgerTables (LedgerState blk) KeysMK
 prepareQuery (BlockQuery query) = prepareBlockQuery query
 
 class QuerySat (mk :: MapKind) (fp :: FootprintL)
@@ -311,13 +311,13 @@ class IsQuery (BlockQuery blk) => QueryLedger blk where
   -- | Answer the given query about the extended ledger state.
   answerBlockQuery :: QuerySat mk fp => ExtLedgerCfg blk -> BlockQuery blk fp result -> ExtLedgerState blk mk -> result
 
-  prepareBlockQuery :: BlockQuery blk LargeL result -> TableKeySets (LedgerState blk)
+  prepareBlockQuery :: BlockQuery blk LargeL result -> LedgerTables (LedgerState blk) KeysMK
 
   answerWholeBlockQuery :: BlockQuery blk WholeL result -> IncrementalQueryHandler blk result
 
   -- This method need not be defined for a @'BlockQuery' blk@ that only contains
   -- 'SmallL' queries.
-  default prepareBlockQuery :: SmallQuery (BlockQuery blk) => BlockQuery blk LargeL result -> TableKeySets (LedgerState blk)
+  default prepareBlockQuery :: SmallQuery (BlockQuery blk) => BlockQuery blk LargeL result -> LedgerTables (LedgerState blk) KeysMK
   prepareBlockQuery query = proveNotLargeQuery query
 
   -- This method need not be defined for a @'BlockQuery' blk@ that only contains

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -630,6 +630,9 @@ readKeySetsVH readKeys (RewoundTableKeySets _seqNo rew) = do
     pure UnforwardedReadSets {
         ursSeqNo  = slot
       , ursValues = zipLedgerTables comb rew values
+      , ursKeys   = mapLedgerTables
+                      (\(ApplyRewoundMK rew') -> ApplyKeysMK (HD.rkAbsent rew'))
+                      rew
     }
   where
     prj :: ApplyMapKind RewoundMK k v -> ApplyMapKind KeysMK k v


### PR DESCRIPTION
Keys were being dropped and therefore applying a block would fail. This
keeps them in `UnforwardedReadSets`.