### PR TITLE
CAD-4155 UTxO-HD: Ticking and apply now produce diffs

### DIFF
--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -113,9 +113,9 @@ examples = Golden.Examples {
     , exampleQuery            = unlabelled exampleQuery
     , exampleResult           = unlabelled exampleResult
     , exampleAnnTip           = unlabelled exampleAnnTip
-    , exampleLedgerState      = unlabelled $ forgetLedgerStateTables exampleLedgerState
+    , exampleLedgerState      = unlabelled $ forgetLedgerTables exampleLedgerState
     , exampleChainDepState    = unlabelled exampleChainDepState
-    , exampleExtLedgerState   = unlabelled $ forgetLedgerStateTables exampleExtLedgerState
+    , exampleExtLedgerState   = unlabelled $ forgetLedgerTables exampleExtLedgerState
     , exampleSlotNo           = unlabelled exampleSlotNo
     , examplesLedgerTables    = unlabelled NoByronLedgerTables
     }
@@ -133,7 +133,7 @@ exampleBlock =
       (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
       (BlockNo 1)
       (SlotNo 1)
-      (applyChainTick ledgerConfig (SlotNo 1) (forgetLedgerStateTables ledgerStateAfterEBB))
+      (applyChainTick ledgerConfig (SlotNo 1) (forgetLedgerTables ledgerStateAfterEBB))
       [ValidatedByronTx exampleGenTx]
       (fakeMkIsLeader leaderCredentials)
   where
@@ -191,22 +191,20 @@ emptyLedgerState = ByronLedgerState {
 
 ledgerStateAfterEBB :: LedgerState ByronBlock ValuesMK
 ledgerStateAfterEBB =
-      applyDiffsLedgerTables emptyLedgerState
-    . projectLedgerTables
+      applyLedgerTablesDiffs emptyLedgerState
     . reapplyLedgerBlock ledgerConfig exampleEBB
-    . flip applyDiffsLedgerTablesTicked polyEmptyLedgerTables
+    . applyLedgerTablesDiffsTicked emptyLedgerState
     . applyChainTick ledgerConfig (SlotNo 0)
-    . forgetLedgerStateTables
+    . forgetLedgerTables
     $ emptyLedgerState
 
 exampleLedgerState :: LedgerState ByronBlock ValuesMK
 exampleLedgerState =
-      applyDiffsLedgerTables emptyLedgerState
-    . projectLedgerTables
+      applyLedgerTablesDiffs emptyLedgerState
     . reapplyLedgerBlock ledgerConfig exampleBlock
-    . flip applyDiffsLedgerTablesTicked (projectLedgerTables ledgerStateAfterEBB)
+    . applyLedgerTablesDiffsTicked ledgerStateAfterEBB
     . applyChainTick ledgerConfig (SlotNo 1)
-    . forgetLedgerStateTables
+    . forgetLedgerTables
     $ ledgerStateAfterEBB
 
 exampleHeaderState :: HeaderState ByronBlock

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -191,18 +191,20 @@ emptyLedgerState = ByronLedgerState {
 
 ledgerStateAfterEBB :: LedgerState ByronBlock ValuesMK
 ledgerStateAfterEBB =
-      mappendValues (projectLedgerTables emptyLedgerState)
-    . forgetLedgerStateTracking
+      applyDiffsLedgerTables emptyLedgerState
+    . projectLedgerTables
     . reapplyLedgerBlock ledgerConfig exampleEBB
+    . flip applyDiffsLedgerTablesTicked polyEmptyLedgerTables
     . applyChainTick ledgerConfig (SlotNo 0)
     . forgetLedgerStateTables
     $ emptyLedgerState
 
 exampleLedgerState :: LedgerState ByronBlock ValuesMK
 exampleLedgerState =
-      mappendValues (projectLedgerTables ledgerStateAfterEBB)
-    . forgetLedgerStateTracking
+      applyDiffsLedgerTables emptyLedgerState
+    . projectLedgerTables
     . reapplyLedgerBlock ledgerConfig exampleBlock
+    . flip applyDiffsLedgerTablesTicked (projectLedgerTables ledgerStateAfterEBB)
     . applyChainTick ledgerConfig (SlotNo 1)
     . forgetLedgerStateTables
     $ ledgerStateAfterEBB

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -264,7 +264,7 @@ byronPBftParams ByronSpecGenesis{..} =
 instance TxGen DualByronBlock where
   testGenTxs _coreNodeId _numCoreNodes curSlotNo cfg () = \st -> do
       n <- choose (0, 20)
-      go [] n $ mappendValuesTicked (projectLedgerTables st) $ applyChainTick (configLedger cfg) curSlotNo $ forgetLedgerStateTables st
+      go [] n $ flip applyDiffsLedgerTablesTicked (projectLedgerTables st) $ applyChainTick (configLedger cfg) curSlotNo $ forgetLedgerStateTables st
     where
       -- Attempt to produce @n@ transactions
       -- Stops when the transaction generator cannot produce more txs

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -264,7 +264,7 @@ byronPBftParams ByronSpecGenesis{..} =
 instance TxGen DualByronBlock where
   testGenTxs _coreNodeId _numCoreNodes curSlotNo cfg () = \st -> do
       n <- choose (0, 20)
-      go [] n $ flip applyDiffsLedgerTablesTicked (projectLedgerTables st) $ applyChainTick (configLedger cfg) curSlotNo $ forgetLedgerStateTables st
+      go [] n $ applyLedgerTablesDiffsTicked st $ applyChainTick (configLedger cfg) curSlotNo $ forgetLedgerTables st
     where
       -- Attempt to produce @n@ transactions
       -- Stops when the transaction generator cannot produce more txs
@@ -281,7 +281,7 @@ instance TxGen DualByronBlock where
                              curSlotNo
                              tx
                              st of
-            Right (st', _vtx) -> go (tx:acc) (n - 1) (mapOverLedgerTablesTicked valuesTrackingMK st')
+            Right (st', _vtx) -> go (tx:acc) (n - 1) (forgetLedgerTablesDiffsTicked st')
             Left _            -> error "testGenTxs: unexpected invalid tx"
 
 -- | Generate transaction

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -194,12 +194,13 @@ instance TableStuff (LedgerState ByronBlock) where
   projectLedgerTables _st                 = NoByronLedgerTables
   withLedgerTables st NoByronLedgerTables = convertMapKind st
 
-  pureLedgerTables     _f                                         = NoByronLedgerTables
-  mapLedgerTables      _f                     NoByronLedgerTables = NoByronLedgerTables
-  traverseLedgerTables _f                     NoByronLedgerTables = pure NoByronLedgerTables
-  zipLedgerTables      _f NoByronLedgerTables NoByronLedgerTables = NoByronLedgerTables
-  foldLedgerTables     _f                     NoByronLedgerTables = mempty
-  foldLedgerTables2    _f NoByronLedgerTables NoByronLedgerTables = mempty
+  pureLedgerTables     _f                                                             = NoByronLedgerTables
+  mapLedgerTables      _f                                         NoByronLedgerTables = NoByronLedgerTables
+  traverseLedgerTables _f                                         NoByronLedgerTables = pure NoByronLedgerTables
+  zipLedgerTables      _f                     NoByronLedgerTables NoByronLedgerTables = NoByronLedgerTables
+  zipLedgerTables2     _f NoByronLedgerTables NoByronLedgerTables NoByronLedgerTables = NoByronLedgerTables
+  foldLedgerTables     _f                                         NoByronLedgerTables = mempty
+  foldLedgerTables2    _f                     NoByronLedgerTables NoByronLedgerTables = mempty
 
 instance SufficientSerializationForAnyBackingStore (LedgerState ByronBlock) where
     codecLedgerTables = NoByronLedgerTables

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -192,7 +192,7 @@ instance ShelleyBasedHardForkConstraints era1 era2
         $ \_cfg1 cfg2 ->
           HFC.TranslateLedgerState {
             translateLedgerStateWith =  \_epochNo ->
-                noNewTickingValues
+                noNewTickingDiffs
               . unFlip
               . unComp
               . SL.translateEra'
@@ -200,12 +200,13 @@ instance ShelleyBasedHardForkConstraints era1 era2
               . Comp
               . Flip
           , translateLedgerTablesWith =
-            \ShelleyLedgerTables { shelleyUTxOTable = ApplyValuesMK (HD.UtxoValues vals) } -> ShelleyLedgerTables {
-                shelleyUTxOTable = ApplyValuesMK
-                                 . HD.UtxoValues
-                                 . fmap ( unTxOutWrapper
-                                        . SL.translateEra' (shelleyLedgerTranslationContext (unwrapLedgerConfig cfg2))
-                                        . TxOutWrapper)
+            \ShelleyLedgerTables { shelleyUTxOTable = ApplyDiffMK (HD.UtxoDiff vals) } -> ShelleyLedgerTables {
+                shelleyUTxOTable = ApplyDiffMK
+                                 . HD.UtxoDiff
+                                 . fmap (\(HD.UtxoEntryDiff x y) -> HD.UtxoEntryDiff ( unTxOutWrapper
+                                                                                     . SL.translateEra' (shelleyLedgerTranslationContext (unwrapLedgerConfig cfg2))
+                                                                                     . TxOutWrapper
+                                                                                     $ x) y)
                                  $ vals
               }
         }

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Tele
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig, LedgerState,
                      TickedLedgerState, ValuesMK, applyChainTick,
-                     projectLedgerTables, forgetLedgerStateTables, applyDiffsLedgerTablesTicked)
+                     forgetLedgerTables, applyLedgerTablesDiffsTicked)
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 
 import           Cardano.Crypto (toVerification)
@@ -227,9 +227,9 @@ migrateUTxO migrationInfo curSlot lcfg lst
     mbUTxO =
           fmap getUTxOShelley
         . ejectShelleyTickedLedgerState
-        . flip applyDiffsLedgerTablesTicked (projectLedgerTables lst)
+        . applyLedgerTablesDiffsTicked lst
         . applyChainTick lcfg curSlot
-        . forgetLedgerStateTables
+        . forgetLedgerTables
         $ lst
 
     MigrationInfo

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Tele
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig, LedgerState,
                      TickedLedgerState, ValuesMK, applyChainTick,
-                     mappendValuesTicked, projectLedgerTables, forgetLedgerStateTables)
+                     projectLedgerTables, forgetLedgerStateTables, applyDiffsLedgerTablesTicked)
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 
 import           Cardano.Crypto (toVerification)
@@ -227,7 +227,7 @@ migrateUTxO migrationInfo curSlot lcfg lst
     mbUTxO =
           fmap getUTxOShelley
         . ejectShelleyTickedLedgerState
-        . mappendValuesTicked (projectLedgerTables lst)
+        . flip applyDiffsLedgerTablesTicked (projectLedgerTables lst)
         . applyChainTick lcfg curSlot
         . forgetLedgerStateTables
         $ lst

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -716,8 +716,8 @@ translateLedgerStateByronToShelleyWrapper =
     $ \_ (WrapLedgerConfig cfgShelley) ->
         TranslateLedgerState {
             translateLedgerStateWith = \epochNo ledgerByron ->
-                trackingTablesToDiffs
-              . flip (zipOverLedgerTables calculateDifference) polyEmptyLedgerTables
+                forgetLedgerTablesValues
+              . calculateAdditions
               . unstowLedgerTables
               $ ShelleyLedgerState {
                     shelleyLedgerTip =

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -296,7 +296,7 @@ storeLedgerStateAt slotNo (AnalysisEnv { db, registry, initLedger, cfg, limit, l
       let ledgerCfg     = ExtLedgerCfg cfg
           appliedResult = tickThenApplyLedgerResult ledgerCfg blk oldLedger
           newLedger     =
-              either (error . show) (forgetLedgerStateTracking . lrResult)
+              either (error . show) (applyDiffsLedgerTables oldLedger . projectLedgerTables . lrResult)
             $ runExcept $ appliedResult
       when (blockSlot blk >= slotNo) $ storeLedgerState blk newLedger
       when (blockSlot blk > slotNo) $ issueWarning blk
@@ -371,7 +371,7 @@ checkNoThunksEvery
       let ledgerCfg     = ExtLedgerCfg cfg
           appliedResult = tickThenApplyLedgerResult ledgerCfg blk oldLedger
           newLedger     =
-              either (error . show) (forgetLedgerStateTracking . lrResult)
+              either (error . show) (applyDiffsLedgerTables oldLedger . projectLedgerTables . lrResult)
             $ runExcept $ appliedResult
           bn            = blockNo blk
       when (unBlockNo bn `mod` nBlocks == 0 ) $ checkNoThunks bn newLedger
@@ -408,7 +408,7 @@ traceLedgerProcessing
       let ledgerCfg     = ExtLedgerCfg cfg
           appliedResult = tickThenApplyLedgerResult ledgerCfg blk oldLedger
           newLedger     =
-              either (error . show) (forgetLedgerStateTracking . lrResult)
+              either (error . show) (applyDiffsLedgerTables oldLedger . projectLedgerTables . lrResult)
             $ runExcept $ appliedResult
           traces        =
             (HasAnalysis.emitTraces $

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -296,7 +296,7 @@ storeLedgerStateAt slotNo (AnalysisEnv { db, registry, initLedger, cfg, limit, l
       let ledgerCfg     = ExtLedgerCfg cfg
           appliedResult = tickThenApplyLedgerResult ledgerCfg blk oldLedger
           newLedger     =
-              either (error . show) (applyDiffsLedgerTables oldLedger . projectLedgerTables . lrResult)
+              either (error . show) (applyLedgerTablesDiffs oldLedger . lrResult)
             $ runExcept $ appliedResult
       when (blockSlot blk >= slotNo) $ storeLedgerState blk newLedger
       when (blockSlot blk > slotNo) $ issueWarning blk
@@ -371,7 +371,7 @@ checkNoThunksEvery
       let ledgerCfg     = ExtLedgerCfg cfg
           appliedResult = tickThenApplyLedgerResult ledgerCfg blk oldLedger
           newLedger     =
-              either (error . show) (applyDiffsLedgerTables oldLedger . projectLedgerTables . lrResult)
+              either (error . show) (applyLedgerTablesDiffs oldLedger . lrResult)
             $ runExcept $ appliedResult
           bn            = blockNo blk
       when (unBlockNo bn `mod` nBlocks == 0 ) $ checkNoThunks bn newLedger
@@ -408,7 +408,7 @@ traceLedgerProcessing
       let ledgerCfg     = ExtLedgerCfg cfg
           appliedResult = tickThenApplyLedgerResult ledgerCfg blk oldLedger
           newLedger     =
-              either (error . show) (applyDiffsLedgerTables oldLedger . projectLedgerTables . lrResult)
+              either (error . show) (applyLedgerTablesDiffs oldLedger . lrResult)
             $ runExcept $ appliedResult
           traces        =
             (HasAnalysis.emitTraces $

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -64,7 +64,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (MockShelley h)) where
 
       | otherwise               = do
       n <- choose (0, 20)
-      go [] n $ flip applyDiffsLedgerTablesTicked (projectLedgerTables lst) $ applyChainTick lcfg curSlotNo $ forgetLedgerStateTables lst
+      go [] n $ applyLedgerTablesDiffsTicked lst $ applyChainTick lcfg curSlotNo $ forgetLedgerTables lst
     where
       ShelleyTxGenExtra
         { stgeGenEnv
@@ -86,7 +86,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (MockShelley h)) where
           Just tx -> case runExcept $ fst <$> applyTx lcfg DoNotIntervene curSlotNo tx st of
               -- We don't mind generating invalid transactions
               Left  _   -> go (tx:acc) (n - 1) st
-              Right st' -> go (tx:acc) (n - 1) (mapOverLedgerTablesTicked valuesTrackingMK st')
+              Right st' -> go (tx:acc) (n - 1) (forgetLedgerTablesDiffsTicked st')
 
 genTx
   :: forall h. HashAlgorithm h

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -64,7 +64,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (MockShelley h)) where
 
       | otherwise               = do
       n <- choose (0, 20)
-      go [] n $ mappendValuesTicked (projectLedgerTables lst) $ applyChainTick lcfg curSlotNo $ forgetLedgerStateTables lst
+      go [] n $ flip applyDiffsLedgerTablesTicked (projectLedgerTables lst) $ applyChainTick lcfg curSlotNo $ forgetLedgerStateTables lst
     where
       ShelleyTxGenExtra
         { stgeGenEnv

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -602,13 +602,10 @@ applyHelper f cfg blk stBefore = do
     let track ::
              LedgerState (ShelleyBlock era) ValuesMK
           -> LedgerState (ShelleyBlock era) TrackingMK
-        track stAfter =
-          zipOverLedgerTables
-            (\after before -> calculateDifference before after)
-            stAfter
-            (projectLedgerTablesTicked stBefore)
+        track = calculateDifference stBefore
 
-    return $ ledgerResult <&> \newNewEpochState -> trackingTablesToDiffs $ track $ unstowLedgerTables $ ShelleyLedgerState {
+
+    return $ ledgerResult <&> \newNewEpochState -> forgetLedgerTablesValues $ track $ unstowLedgerTables $ ShelleyLedgerState {
         shelleyLedgerTip = NotOrigin ShelleyTip {
             shelleyTipBlockNo = blockNo   blk
           , shelleyTipSlotNo  = blockSlot blk

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -579,7 +579,7 @@ applyHelper :: forall m era.
   -> TickedLedgerState (ShelleyBlock era) ValuesMK
   -> m (LedgerResult
           (LedgerState (ShelleyBlock era))
-          (LedgerState (ShelleyBlock era) TrackingMK))
+          (LedgerState (ShelleyBlock era) DiffMK))
 applyHelper f cfg blk stBefore = do
     let TickedShelleyLedgerState{
             tickedShelleyLedgerTransition
@@ -608,7 +608,7 @@ applyHelper f cfg blk stBefore = do
             stAfter
             (projectLedgerTablesTicked stBefore)
 
-    return $ ledgerResult <&> \newNewEpochState -> track $ unstowLedgerTables $ ShelleyLedgerState {
+    return $ ledgerResult <&> \newNewEpochState -> trackingTablesToDiffs $ track $ unstowLedgerTables $ ShelleyLedgerState {
         shelleyLedgerTip = NotOrigin ShelleyTip {
             shelleyTipBlockNo = blockNo   blk
           , shelleyTipSlotNo  = blockSlot blk

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -256,13 +256,7 @@ applyShelleyTx cfg wti slot (ShelleyTx _ tx) st0 = do
         st3 = ShelleyLedger.cnv $ unstowLedgerTables $ ShelleyLedger.vnc st2
 
         st4 :: TickedLedgerState (ShelleyBlock era) TrackingMK
-        st4 =
-          overLedgerTablesTicked
-            (zipLedgerTables
-               calculateDifference
-               (projectLedgerTablesTicked st0)
-            )
-            st3
+        st4 = calculateDifferenceTicked st0 st3
 
     pure (st4, mkShelleyValidatedTx vtx)
 
@@ -284,12 +278,7 @@ reapplyShelleyTx cfg slot vgtx st0 = do
           (SL.mkMempoolState innerSt)
           vtx
 
-    let st2 =
-            overLedgerTablesTicked
-              (zipLedgerTables
-                 calculateDifference
-                 (projectLedgerTablesTicked st0)
-              )
+    let st2 = calculateDifferenceTicked st0
           $ ShelleyLedger.cnv $ unstowLedgerTables $ ShelleyLedger.vnc
           $ set theLedgerLens mempoolState' st1
 

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -343,7 +343,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
         v <-
             uncheckedNewTVarM
           $ VDown Genesis
-          $ forgetLedgerStateTables ledgerState
+          $ forgetLedgerTables ledgerState
         pure (nid, v)
 
     -- fork the directed edges, which also allocates their status variables
@@ -861,7 +861,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                     Right st -> pure $ applyChainTick
                                         (configLedger pInfoConfig)
                                         currentSlot
-                                        (forgetLedgerStateTables st)
+                                        (forgetLedgerTables st)
 
                   -- forge the block usings the ledger state that includes
                   -- the EBB

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -491,6 +491,7 @@ instance PayloadSemantics ptype
     = case applyPayload payloadDependentState tbPayload of
         Left err  -> throwError $ InvalidPayload err
         Right st' -> return     $ pureLedgerResult
+                                $ forgetLedgerTablesValues
                                 $ TestLedger {
                                     lastAppliedPoint      = Chain.blockPoint tb
                                   , payloadDependentState = st'
@@ -500,6 +501,7 @@ instance PayloadSemantics ptype
     case applyPayload payloadDependentState tbPayload of
         Left err  -> error $ "Found an error when reapplying a block: " ++ show err
         Right st' ->              pureLedgerResult
+                                $ forgetLedgerTablesValues
                                 $ TestLedger {
                                     lastAppliedPoint      = Chain.blockPoint tb
                                   , payloadDependentState = st'
@@ -570,7 +572,7 @@ instance PayloadSemantics ptype => IsLedger (LedgerState (TestBlockWith ptype)) 
 
   applyChainTickLedgerResult _ _ = pureLedgerResult
                                  . TickedTestLedger
-                                 . noNewTickingValues
+                                 . noNewTickingDiffs
 
 instance PayloadSemantics ptype => UpdateLedger (TestBlockWith ptype)
 

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -320,6 +320,7 @@ class ( Typeable ptype
       , NoThunks ptype
 
       , Eq        (PayloadDependentState ptype EmptyMK)
+      , Eq        (PayloadDependentState ptype DiffMK)
       , Eq        (PayloadDependentState ptype ValuesMK)
 
       , forall mk'. Show (PayloadDependentState ptype (ApplyMapKind' mk'))
@@ -330,6 +331,7 @@ class ( Typeable ptype
       , NoThunks  (PayloadDependentState ptype EmptyMK)
       , NoThunks  (PayloadDependentState ptype ValuesMK)
       , NoThunks  (PayloadDependentState ptype SeqDiffMK)
+      , NoThunks  (PayloadDependentState ptype DiffMK)
 
       , TickedTableStuff     (LedgerState (TestBlockWith ptype))
       , StowableLedgerTables (LedgerState (TestBlockWith ptype))
@@ -526,6 +528,8 @@ deriving stock instance Eq (PayloadDependentState ptype EmptyMK)
   => Eq (LedgerState (TestBlockWith ptype) EmptyMK)
 deriving stock instance Eq (PayloadDependentState ptype ValuesMK)
   => Eq (LedgerState (TestBlockWith ptype) ValuesMK)
+deriving stock instance Eq (PayloadDependentState ptype DiffMK)
+  => Eq (LedgerState (TestBlockWith ptype) DiffMK)
 
 deriving stock instance Generic (LedgerState (TestBlockWith ptype) mk)
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -257,7 +257,7 @@ instance IsLedger (LedgerState BlockA) where
 
   applyChainTickLedgerResult _ _ = pureLedgerResult
                                  . TickedLedgerStateA
-                                 . noNewTickingValues
+                                 . noNewTickingDiffs
 
 instance ApplyBlock (LedgerState BlockA) BlockA where
   applyBlockLedgerResult cfg blk =

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -230,7 +230,7 @@ instance IsLedger (LedgerState BlockB) where
 
   applyChainTickLedgerResult _ _ = pureLedgerResult
                                  . TickedLedgerStateB
-                                 . noNewTickingValues
+                                 . noNewTickingDiffs
 
 instance ApplyBlock (LedgerState BlockB) BlockB where
   applyBlockLedgerResult   = \_ b _ -> return $ pureLedgerResult $ LgrB (blockPoint b)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -750,7 +750,7 @@ runMock cmd initMock =
     push b = do
         ls <- State.get
         l' <- State.lift $ tickThenApply (ledgerDbCfg cfg) b (cur ls)
-        State.put ((b, forgetLedgerStateTracking l'):ls)
+        State.put ((b, applyDiffsLedgerTables (cur ls) $ projectLedgerTables l'):ls)
 
     switch :: Word64
            -> [TestBlock]

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -558,7 +558,7 @@ instance IsLedger (LedgerState TestBlock) where
 
   applyChainTickLedgerResult _ _ = pureLedgerResult
                                  . TickedTestLedger
-                                 . noNewTickingValues
+                                 . noNewTickingDiffs
 
 instance ShowLedgerState (LedgerState TestBlock) where
   showsLedgerState _sing = shows

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -94,6 +94,9 @@ deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock
 deriving stock   instance CanHardFork xs => Eq       (LedgerState (HardForkBlock xs) ValuesMK)
 deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs) ValuesMK)
 
+deriving stock   instance CanHardFork xs => Eq       (LedgerState (HardForkBlock xs) DiffMK)
+deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs) DiffMK)
+
 deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs) SeqDiffMK)
 
 instance (SingI mk, CanHardFork xs) => Show (LedgerState (HardForkBlock xs) (ApplyMapKind' mk)) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -210,14 +210,14 @@ injectInitialExtLedgerState cfg extLedgerState0 =
 
     targetEraLedgerState :: LedgerState (HardForkBlock (x ': xs)) ValuesMK
     targetEraLedgerState =
-          mappendValues ( projectLedgerTables
-                        . HardForkLedgerState
-                        . initHardForkState
-                        . Flip
-                        . ledgerState
-                        $ extLedgerState0
-                        )
-        $ HardForkLedgerState
+          applyDiffsLedgerTables ( HardForkLedgerState
+                                 . initHardForkState
+                                 . Flip
+                                 . ledgerState
+                                 $ extLedgerState0
+                                 )
+        . projectLedgerTables
+        . HardForkLedgerState
           -- We can immediately extend it to the right slot, executing any
           -- scheduled hard forks in the first slot
         $ State.extendToSlot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -210,20 +210,15 @@ injectInitialExtLedgerState cfg extLedgerState0 =
 
     targetEraLedgerState :: LedgerState (HardForkBlock (x ': xs)) ValuesMK
     targetEraLedgerState =
-          applyDiffsLedgerTables ( HardForkLedgerState
-                                 . initHardForkState
-                                 . Flip
-                                 . ledgerState
-                                 $ extLedgerState0
-                                 )
-        . projectLedgerTables
-        . HardForkLedgerState
-          -- We can immediately extend it to the right slot, executing any
-          -- scheduled hard forks in the first slot
-        $ State.extendToSlot
-            (configLedger cfg)
-            (SlotNo 0)
-            (initHardForkState $ Flip $ forgetLedgerStateTables $ ledgerState extLedgerState0)
+       applyLedgerTablesDiffs
+         (HardForkLedgerState . initHardForkState . Flip . ledgerState $ extLedgerState0)
+         (HardForkLedgerState
+           -- We can immediately extend it to the right slot, executing any
+           -- scheduled hard forks in the first slot
+             (State.extendToSlot
+                (configLedger cfg)
+                (SlotNo 0)
+                (initHardForkState $ Flip $ forgetLedgerTables $ ledgerState extLedgerState0)))
 
     firstEraChainDepState :: HardForkChainDepState (x ': xs)
     firstEraChainDepState =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -201,11 +201,11 @@ tickOne :: SingleEraBlock blk
 tickOne ei slot sopIdx partialCfg st =
       Comp
     . fmap ( FlipTickedLedgerState
-           . prependDiffsTicked (unFlip st)
+           . prependLedgerTablesDiffsTicked (unFlip st)
            )
     . embedLedgerResult (injectLedgerEvent sopIdx)
     . applyChainTickLedgerResult (completeLedgerConfig' ei partialCfg) slot
-    . forgetLedgerStateTables
+    . forgetLedgerTables
     . unFlip
     $ st
 
@@ -511,7 +511,7 @@ instance CanHardFork' xs => LedgerSupportsProtocol (HardForkBlock xs) where
           , currentState = AnnForecast {
                 annForecast      = mapForecast WrapTickedLedgerView $
                                      ledgerViewForecastAt cfg' st
-              , annForecastState = forgetLedgerStateTables st
+              , annForecastState = forgetLedgerTables st
               , annForecastTip   = ledgerTipSlot st
               , annForecastEnd   = History.mkUpperBound params start <$>
                                      singleEraTransition' cfg params start st

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -247,14 +247,14 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
                              -- just be a no-op. See the haddock for
                              -- 'translateLedgerTablesWith' for more
                              -- information).
-                             . prependDiffs' ( translateLedgerTablesWith f
-                                               . projectLedgerTables
-                                               . unFlip
-                                               . currentState
-                                               $ cur
+                             . prependLedgerTablesDiffsRaw ( translateLedgerTablesWith f
+                                             . projectLedgerTables
+                                             . unFlip
+                                             . currentState
+                                             $ cur
                                              )
                              . translateLedgerStateWith f (History.boundEpoch currentEnd)
-                             . forgetLedgerStateTables
+                             . forgetLedgerTables
                              . unFlip
                              . currentState
                              $ cur

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -30,7 +30,7 @@ import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.History (Bound)
-import           Ouroboros.Consensus.Ledger.Basics (LedgerState, EmptyMK, ValuesMK, LedgerTables)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerState, DiffMK, EmptyMK, LedgerTables)
 import           Ouroboros.Consensus.Ticked
 
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
@@ -112,7 +112,7 @@ data TranslateLedgerState x y = TranslateLedgerState {
         translateLedgerStateWith ::
             EpochNo
          -> LedgerState x EmptyMK
-         -> LedgerState y ValuesMK
+         -> LedgerState y DiffMK
 
         -- | How to translate tables on an era transition.
         --
@@ -128,8 +128,8 @@ data TranslateLedgerState x y = TranslateLedgerState {
         -- hole and allows us to promote tables from one era into tables from
         -- the next era.
       , translateLedgerTablesWith ::
-            LedgerTables (LedgerState x) ValuesMK
-         -> LedgerTables (LedgerState y) ValuesMK
+            LedgerTables (LedgerState x) DiffMK
+         -> LedgerTables (LedgerState y) DiffMK
     }
 
 -- | Knowledge in a particular era of the transition to the next era

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -168,7 +168,7 @@ fromChain cfg initState chain =
     anchorSnapshot NE.:| snapshots =
           fmap headerState
         . NE.scanl
-            (\st blk -> applyDiffsLedgerTables st $ projectLedgerTables $ tickThenReapply (ExtLedgerCfg cfg) blk st)
+            (\st blk -> applyLedgerTablesDiffs st $ tickThenReapply (ExtLedgerCfg cfg) blk st)
             initState
         . Chain.toOldestFirst
         $ chain

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -168,7 +168,7 @@ fromChain cfg initState chain =
     anchorSnapshot NE.:| snapshots =
           fmap headerState
         . NE.scanl
-            (\st blk -> forgetLedgerStateTracking $ tickThenReapply (ExtLedgerCfg cfg) blk st)
+            (\st blk -> applyDiffsLedgerTables st $ projectLedgerTables $ tickThenReapply (ExtLedgerCfg cfg) blk st)
             initState
         . Chain.toOldestFirst
         $ chain

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -63,16 +63,12 @@ module Ouroboros.Consensus.Ledger.Basics (
   , MapKind
   , SMapKind
   , Sing (..)
-  , calculateDifference
-  , diffKeysMK
-  , diffTrackingMK
   , emptyAppliedMK
   , mapValuesAppliedMK
   , sMapKind
   , sMapKind'
   , showsApplyMapKind
   , toSMapKind
-  , valuesTrackingMK
     -- *** Mediators
   , CodecMK (..)
   , DiffMK
@@ -89,16 +85,21 @@ module Ouroboros.Consensus.Ledger.Basics (
   , DiskLedgerView (..)
   , FootprintL (..)
     -- ** Convenience aliases
-  , applyDiffsLedgerTables
   , emptyLedgerTables
-  , forgetLedgerStateTables
-  , forgetLedgerStateTracking
-  , forgetTickedLedgerStateTracking
   , polyEmptyLedgerTables
-  , trackingTablesToDiffs
-  , mappendValues
-  , mappendValuesTicked
-  , mappendTracking
+  , forgetLedgerTables
+  , forgetLedgerTablesValues
+  , forgetLedgerTablesDiffs
+  , forgetLedgerTablesDiffsTicked
+  , prependLedgerTablesDiffsRaw
+  , prependLedgerTablesDiffs
+  , prependLedgerTablesDiffsTicked
+  , prependLedgerTablesDiffsFromTicked
+  , applyLedgerTablesDiffs
+  , applyLedgerTablesDiffsTicked
+  , calculateAdditions
+  , calculateDifference
+  , calculateDifferenceTicked
     -- ** Special classes of ledger states
   , InMemory (..)
   , StowableLedgerTables (..)
@@ -121,7 +122,10 @@ module Ouroboros.Consensus.Ledger.Basics (
   , youngestImmutableSlotDbChangelog
     -- ** Misc
   , ShowLedgerState (..)
-  , applyDiffsLedgerTablesTicked, prependDiffs', prependDiffs, prependDiffsTicked) where
+    -- * Exported only for testing
+  , rawCalculateDifference
+  , rawApplyDiffs
+  ) where
 
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
@@ -135,7 +139,6 @@ import           Data.Typeable (Typeable)
 import           Data.Word (Word8)
 import           GHC.Generics (Generic)
 import           GHC.Show (showCommaSpace, showSpace)
-import           GHC.Stack (HasCallStack)
 import           NoThunks.Class (NoThunks (..), OnlyCheckWhnfNamed (..))
 import qualified NoThunks.Class as NoThunks
 
@@ -234,6 +237,8 @@ class ( -- Requirements on the ledger state itself
 --      , forall mk. (IsApplyMapKind mk, Typeable mk) => NoThunks (l mk)
       , Eq       (l EmptyMK)
       , NoThunks (l EmptyMK)
+      , Eq       (l DiffMK)
+      , NoThunks (l DiffMK)
       , Eq       (l ValuesMK)
       , NoThunks (l ValuesMK)
       , NoThunks (l SeqDiffMK)
@@ -322,6 +327,10 @@ applyChainTick ::
   -> l EmptyMK
   -> Ticked1 l DiffMK
 applyChainTick = lrResult ..: applyChainTickLedgerResult
+
+{-------------------------------------------------------------------------------
+ [Ticked]TableStuff
+-------------------------------------------------------------------------------}
 
 -- | When applying a block that is not on an era transition, ticking won't
 -- generate new values, so this function can be used to wrap the call to the
@@ -469,22 +478,6 @@ zipOverLedgerTables f l tables2 =
       (\tables1 -> zipLedgerTables f tables1 tables2)
       l
 
--- | Mappend the values in the tables and in the ledger state
-mappendValues ::
-     TableStuff l
-  => LedgerTables l ValuesMK
-  -> l ValuesMK
-  -> l ValuesMK
-mappendValues = flip (zipOverLedgerTables (\(ApplyValuesMK v1) (ApplyValuesMK v2) -> ApplyValuesMK $ v1 <> v2))
-
--- | Mappend the differences in the tables and in the ledger state
-mappendTracking ::
-     TableStuff l
-  => LedgerTables l TrackingMK
-  -> l TrackingMK
-  -> l TrackingMK
-mappendTracking = flip (zipOverLedgerTables (\(ApplyTrackingMK v1 d1) (ApplyTrackingMK _ d2) -> ApplyTrackingMK v1 (d2 <> d1)))
-
 -- Separate so that we can have a 'TableStuff' instance for 'Ticked1' without
 -- involving double-ticked types.
 class TableStuff l => TickedTableStuff (l :: LedgerStateKind) where
@@ -530,51 +523,9 @@ zipOverLedgerTablesTicked f l tables2 =
       (\tables1 -> zipLedgerTables f tables1 tables2)
       l
 
--- | Mappend the values in the tables and in the ticked ledger state
-mappendValuesTicked ::
-     TickedTableStuff l
-  => LedgerTables l ValuesMK
-  -> Ticked1      l ValuesMK
-  -> Ticked1      l ValuesMK
-mappendValuesTicked = flip (zipOverLedgerTablesTicked (\(ApplyValuesMK v1) (ApplyValuesMK v2) -> ApplyValuesMK $ v1 <> v2))
-
-applyDiffsLedgerTablesTicked ::
-     (TickedTableStuff l)
-  => Ticked1      l DiffMK
-  -> LedgerTables l ValuesMK
-  -> Ticked1      l ValuesMK
-applyDiffsLedgerTablesTicked =
-  zipOverLedgerTablesTicked (\(ApplyDiffMK diffs') (ApplyValuesMK vals') -> ApplyValuesMK (forwardValues vals' diffs'))
-
-prependDiffs' ::
-     (TableStuff l)
-  => LedgerTables l DiffMK
-  -> l DiffMK
-  -> l DiffMK
-prependDiffs' ticked applied =
-  zipOverLedgerTables
-    (\(ApplyDiffMK (UtxoDiff d1)) (ApplyDiffMK (UtxoDiff d2)) -> ApplyDiffMK (UtxoDiff (d1 <> d2)))
-    applied
-    ticked
-
-prependDiffs ::
-     (TickedTableStuff l)
-  => Ticked1 l DiffMK
-  -> l DiffMK
-  -> l DiffMK
-prependDiffs = prependDiffs' . projectLedgerTablesTicked
-
-prependDiffsTicked ::
-     (TickedTableStuff l)
-  => l DiffMK
-  -> Ticked1 l DiffMK
-  -> Ticked1 l DiffMK
-prependDiffsTicked ticked1 ticked2 =
-  zipOverLedgerTablesTicked
-    (\(ApplyDiffMK (UtxoDiff d2)) (ApplyDiffMK (UtxoDiff d1)) -> ApplyDiffMK (UtxoDiff (d1 <> d2)))
-    ticked2
-    (projectLedgerTables ticked1)
-
+{-------------------------------------------------------------------------------
+  Serialization Codecs
+-------------------------------------------------------------------------------}
 
 -- | This class provides a 'CodecMK' that can be used to encode/decode keys and
 -- values on @'LedgerTables' l mk@
@@ -634,40 +585,79 @@ emptyLedgerTables :: TableStuff l => LedgerTables l EmptyMK
 emptyLedgerTables = polyEmptyLedgerTables
 
 -- | Empty values for every table
-polyEmptyLedgerTables :: forall mk l.
-  (TableStuff l, IsApplyMapKind mk) => LedgerTables l mk
-polyEmptyLedgerTables =
-    pureLedgerTables $ emptyAppliedMK sMapKind
+polyEmptyLedgerTables :: forall mk l. (TableStuff l, IsApplyMapKind mk) => LedgerTables l mk
+polyEmptyLedgerTables = pureLedgerTables $ emptyAppliedMK sMapKind
 
-forgetLedgerStateTracking :: TableStuff l => l TrackingMK -> l ValuesMK
-forgetLedgerStateTracking = mapOverLedgerTables valuesTrackingMK
+-- Forget all
 
-forgetLedgerStateTables :: TableStuff l => l mk -> l EmptyMK
-forgetLedgerStateTables l = withLedgerTables l emptyLedgerTables
+forgetLedgerTables :: TableStuff l => l mk -> l EmptyMK
+forgetLedgerTables l = withLedgerTables l emptyLedgerTables
 
--- | Used only for the dual ledger
-applyDiffsLedgerTables ::
-     (TableStuff l, HasCallStack)
-  => l ValuesMK
-  -> LedgerTables l DiffMK
-  -> l ValuesMK
-applyDiffsLedgerTables =
-    zipOverLedgerTables f
-  where
-    f ::
-         Ord k
-      => ValuesMK k v
-      -> DiffMK   k v
-      -> ValuesMK k v
-    f (ApplyValuesMK values) (ApplyDiffMK diff) =
-      ApplyValuesMK (forwardValues values diff)
+-- Forget values
 
-trackingTablesToDiffs :: TableStuff l => l TrackingMK -> l DiffMK
-trackingTablesToDiffs = mapOverLedgerTables diffTrackingMK
+rawForgetValues :: TrackingMK k v -> DiffMK k v
+rawForgetValues (ApplyTrackingMK _values diff) = ApplyDiffMK diff
 
-forgetTickedLedgerStateTracking ::
-  TickedTableStuff l => Ticked1 l TrackingMK -> Ticked1 l ValuesMK
-forgetTickedLedgerStateTracking = mapOverLedgerTablesTicked valuesTrackingMK
+forgetLedgerTablesValues :: TableStuff l => l TrackingMK -> l DiffMK
+forgetLedgerTablesValues = mapOverLedgerTables rawForgetValues
+
+-- Forget diffs
+
+rawForgetDiffs :: TrackingMK k v -> ValuesMK k v
+rawForgetDiffs (ApplyTrackingMK values _diff) = ApplyValuesMK values
+
+forgetLedgerTablesDiffs       ::       TableStuff l =>         l TrackingMK ->         l ValuesMK
+forgetLedgerTablesDiffsTicked :: TickedTableStuff l => Ticked1 l TrackingMK -> Ticked1 l ValuesMK
+forgetLedgerTablesDiffs       = mapOverLedgerTables rawForgetDiffs
+forgetLedgerTablesDiffsTicked = mapOverLedgerTablesTicked rawForgetDiffs
+
+-- Prepend diffs
+
+rawPrependDiffs ::
+     Ord k
+  => DiffMK k v -- ^ Earlier differences
+  -> DiffMK k v -- ^ Later differences
+  -> DiffMK k v
+rawPrependDiffs (ApplyDiffMK (UtxoDiff d1)) (ApplyDiffMK (UtxoDiff d2)) = ApplyDiffMK (UtxoDiff (d1 `Map.union` d2))
+
+prependLedgerTablesDiffsRaw        ::       TableStuff l => LedgerTables l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffs           ::       TableStuff l =>              l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffsFromTicked :: TickedTableStuff l => Ticked1      l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffsTicked     :: TickedTableStuff l =>              l DiffMK -> Ticked1 l DiffMK -> Ticked1 l DiffMK
+prependLedgerTablesDiffsRaw        = flip (zipOverLedgerTables rawPrependDiffs)
+prependLedgerTablesDiffs           = prependLedgerTablesDiffsRaw . projectLedgerTables
+prependLedgerTablesDiffsFromTicked = prependLedgerTablesDiffsRaw . projectLedgerTablesTicked
+prependLedgerTablesDiffsTicked     = flip (zipOverLedgerTablesTicked rawPrependDiffs) . projectLedgerTables
+
+-- Apply diffs
+
+rawApplyDiffs ::
+     Ord k
+  => ValuesMK k v -- ^ Values to which differences are applied
+  -> DiffMK   k v -- ^ Differences to apply
+  -> ValuesMK k v
+rawApplyDiffs (ApplyValuesMK vals) (ApplyDiffMK diffs) = ApplyValuesMK (forwardValues vals diffs)
+
+applyLedgerTablesDiffs       ::       TableStuff l => l ValuesMK ->         l DiffMK ->         l ValuesMK
+applyLedgerTablesDiffsTicked :: TickedTableStuff l => l ValuesMK -> Ticked1 l DiffMK -> Ticked1 l ValuesMK
+applyLedgerTablesDiffs       = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . projectLedgerTables
+applyLedgerTablesDiffsTicked = flip (zipOverLedgerTablesTicked $ flip rawApplyDiffs) . projectLedgerTables
+
+-- Calculate differences
+
+rawCalculateDifference ::
+     Ord k
+  => ValuesMK   k v
+  -> ValuesMK   k v
+  -> TrackingMK k v
+rawCalculateDifference (ApplyValuesMK before) (ApplyValuesMK after) = ApplyTrackingMK after (differenceUtxoValues before after)
+
+calculateAdditions        ::       TableStuff l =>         l ValuesMK ->                               l TrackingMK
+calculateDifference       :: TickedTableStuff l => Ticked1 l ValuesMK ->         l ValuesMK ->         l TrackingMK
+calculateDifferenceTicked :: TickedTableStuff l => Ticked1 l ValuesMK -> Ticked1 l ValuesMK -> Ticked1 l TrackingMK
+calculateAdditions               after = zipOverLedgerTables       (flip rawCalculateDifference) after polyEmptyLedgerTables
+calculateDifference       before after = zipOverLedgerTables       (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
+calculateDifferenceTicked before after = zipOverLedgerTablesTicked (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
 
 {-------------------------------------------------------------------------------
   Concrete ledger tables
@@ -746,15 +736,6 @@ mapValuesAppliedMK f = \case
 
   ApplyQueryAllMK         -> ApplyQueryAllMK
   ApplyQuerySomeMK ks     -> ApplyQuerySomeMK (castUtxoKeys ks)
-
-diffKeysMK :: DiffMK k v -> KeysMK k v
-diffKeysMK (ApplyDiffMK diff) = ApplyKeysMK $ keysUtxoDiff diff
-
-diffTrackingMK :: TrackingMK k v -> DiffMK k v
-diffTrackingMK (ApplyTrackingMK _values diff) = ApplyDiffMK diff
-
-valuesTrackingMK :: TrackingMK k v -> ValuesMK k v
-valuesTrackingMK (ApplyTrackingMK values _diff) = ApplyValuesMK values
 
 instance (Ord k, Eq v) => Eq (ApplyMapKind' mk k v) where
   ApplyEmptyMK          == _                     = True
@@ -933,14 +914,6 @@ instance FromCBOR (Sing SeqDiffMK')  where fromCBOR = SSeqDiffMK  <$ CBOR.decode
 instance FromCBOR (Sing RewoundMK')  where fromCBOR = SRewoundMK  <$ CBOR.decodeNull
 instance FromCBOR (Sing QueryMK')    where fromCBOR = SQueryMK    <$ CBOR.decodeNull
 
-calculateDifference ::
-     Ord k
-  => ValuesMK k v
-  -> ValuesMK k v
-  -> TrackingMK k v
-calculateDifference (ApplyValuesMK before) (ApplyValuesMK after) =
-    ApplyTrackingMK after (differenceUtxoValues before after)
-
 {-------------------------------------------------------------------------------
   Link block to its ledger
 -------------------------------------------------------------------------------}
@@ -1110,8 +1083,8 @@ extendDbChangelog dblog newState =
       , changelogVolatileStates
       } = dblog
 
-    l'         = forgetLedgerStateTables newState
-    tablesDiff = projectLedgerTables     newState
+    l'         = forgetLedgerTables  newState
+    tablesDiff = projectLedgerTables newState
 
     slot = case getTipSlot l' of
       Origin -> error "impossible! extendDbChangelog"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -938,7 +938,7 @@ applyMaybeBlock :: UpdateLedger blk
                 -> Maybe blk
                 -> TickedLedgerState blk ValuesMK
                 -> LedgerState blk EmptyMK
-                -> Except (LedgerError blk) (LedgerState blk TrackingMK)
+                -> Except (LedgerError blk) (LedgerState blk DiffMK)
 applyMaybeBlock _   Nothing      _   st =
     -- if there is no block, then are no changes to track
     return $ st `withLedgerTables` polyEmptyLedgerTables
@@ -953,7 +953,7 @@ reapplyMaybeBlock :: UpdateLedger blk
                   -> Maybe blk
                   -> TickedLedgerState blk ValuesMK
                   -> LedgerState blk EmptyMK
-                  -> LedgerState blk TrackingMK
+                  -> LedgerState blk DiffMK
 reapplyMaybeBlock _   Nothing      _   st =
     -- if there is no block, then are no changes to track
     st `withLedgerTables` polyEmptyLedgerTables

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -374,7 +374,7 @@ instance Bridge m a => IsLedger (LedgerState (DualBlock m a)) where
                                            slot
                                           dualLedgerStateAux
         , tickedDualLedgerStateAuxOrig =
-            forgetLedgerStateTables dualLedgerStateAux
+            forgetLedgerTables dualLedgerStateAux
         , tickedDualLedgerStateBridge  = dualLedgerStateBridge
         }
     where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -128,14 +128,14 @@ mkMempool mpEnv = Mempool
                   pureGetSnapshotFor
                     cfg
                     (ForgeInKnownSlot slot
-                      $ flip applyDiffsLedgerTablesTicked (projectLedgerTables $ ledgerState ls')
+                      $ applyLedgerTablesDiffsTicked (ledgerState ls')
                       $ applyChainTick cfg slot
-                      $ forgetLedgerStateTables
+                      $ forgetLedgerTables
                       $ ledgerState ls')
                     capacityOverride
                     is
             atomically $ putTMVar istate is
-            pure $ Just (forgetLedgerStateTables ls', snapshot)
+            pure $ Just (forgetLedgerTables ls', snapshot)
     , getCapacity    = isCapacity <$> readTMVar istate
     , getTxSize      = txSize
     , zeroIdx        = zeroTicketNo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -128,7 +128,7 @@ mkMempool mpEnv = Mempool
                   pureGetSnapshotFor
                     cfg
                     (ForgeInKnownSlot slot
-                      $ mappendValuesTicked (projectLedgerTables $ ledgerState ls')
+                      $ flip applyDiffsLedgerTablesTicked (projectLedgerTables $ ledgerState ls')
                       $ applyChainTick cfg slot
                       $ forgetLedgerStateTables
                       $ ledgerState ls')

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
@@ -335,7 +335,7 @@ tickLedgerState
   -> (SlotNo, TickedLedgerState blk ValuesMK)
 tickLedgerState _cfg (ForgeInKnownSlot slot st) = (slot, st)
 tickLedgerState  cfg (ForgeInUnknownSlot st) =
-    (slot, mappendValuesTicked (projectLedgerTables st)
+    (slot, flip applyDiffsLedgerTablesTicked (projectLedgerTables st)
          $ applyChainTick cfg slot
          $ forgetLedgerStateTables st
     )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
@@ -208,7 +208,7 @@ extendVRPrevApplied cfg txTicket vr =
                       }
       Right st' -> vr { vrValid      = vrValid :> txTicket
                       , vrValidTxIds = Set.insert (txId (txForgetValidated tx)) vrValidTxIds
-                      , vrAfter      = forgetTickedLedgerStateTracking st'
+                      , vrAfter      = forgetLedgerTablesDiffsTicked st'
                       }
   where
     TxTicket { txTicketTx = tx } = txTicket
@@ -241,7 +241,7 @@ extendVRNew cfg txSize wti tx vr = assert (isNothing vrNewValid) $
         , vr { vrValid        = vrValid :> TxTicket vtx nextTicketNo (txSize tx)
              , vrValidTxIds   = Set.insert (txId tx) vrValidTxIds
              , vrNewValid     = Just vtx
-             , vrAfter        = forgetTickedLedgerStateTracking st'
+             , vrAfter        = forgetLedgerTablesDiffsTicked st'
              , vrLastTicketNo = nextTicketNo
              }
         )
@@ -335,10 +335,7 @@ tickLedgerState
   -> (SlotNo, TickedLedgerState blk ValuesMK)
 tickLedgerState _cfg (ForgeInKnownSlot slot st) = (slot, st)
 tickLedgerState  cfg (ForgeInUnknownSlot st) =
-    (slot, flip applyDiffsLedgerTablesTicked (projectLedgerTables st)
-         $ applyChainTick cfg slot
-         $ forgetLedgerStateTables st
-    )
+    (slot, applyLedgerTablesDiffsTicked st $ applyChainTick cfg slot (forgetLedgerTables st))
   where
     -- Optimistically assume that the transactions will be included in a block
     -- in the next available slot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -516,7 +516,7 @@ forkBlockForging IS{..} blockForging =
         trace $ TraceNodeIsLeader currentSlot
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
-        let tickedLedgerState :: TickedLedgerState blk ValuesMK
+        let tickedLedgerState :: TickedLedgerState blk DiffMK
             tickedLedgerState =
               applyChainTick
                 (configLedger cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -383,7 +383,7 @@ initLedgerDB replayTracer
           initDb        =
             case runAlsoLegacy of
               RunBoth    -> ledgerDbWithAnchor runAlsoLegacy (stowLedgerTables genesisLedger)
-              RunOnlyNew -> ledgerDbWithAnchor runAlsoLegacy (forgetLedgerStateTables genesisLedger)
+              RunOnlyNew -> ledgerDbWithAnchor runAlsoLegacy (forgetLedgerTables genesisLedger)
       backingStore <- newBackingStore hasFS (projectLedgerTables genesisLedger) -- TODO: needs to go into ResourceRegistry
       eDB <- runExceptT $ replayStartingWith
                             replayTracer'


### PR DESCRIPTION
In the light of the Shelley to Allegra transition requiring to delete
values, it was decided that both operations on the ledger would return
differences, and we would inject the AVVMs in the shelley -> allegra
transition.