### PR TITLE
Update ledger

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -219,8 +219,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 70dbfc9f12283666e29f8492aff5da9b1c8c5a7f
-  --sha256: 0mjrmc49nr9b54dxzb6b8487dys83c0jkk1d5vr0d9v2a8mfpram
+  tag: 1db68a3ec0a2dcb5751004beb22b906162474f23
+  --sha256: 03pv2jvskbi65dwaddp6a8bxbbcw674csjxhg8xbqd6q1kfpc41a
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite


### PR DESCRIPTION
This PR updates ledger to the most recent version.

The update adds two new ledger events
* an event for all Plutus scripts which are executed
* a `RestrainedRewards` event to be used by db-sync

It also adds some small changes to the Babbage era.