### PR TITLE
Fix LMDB for mingwW64 cross compilation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -280,11 +280,11 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/haskell-lmdb
-  tag: 774fee77940591108a7142f8f1d3d41a1afd6e06
-  --sha256: sha256-JRqYxbHZbOHXF4PqAairfQD7T00sTN+YtjOO6oKojH0=
+  tag: d9ba8e382161aec999de12ae46e98c0eb83096b9
+  --sha256: 173dbqpn9czyjib6lnqa8f7ai66n3r4k44h5hvyl321ljychn5fm
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/lmdb-simple
   tag: 5b2c622c1cf43deca081139b2d1d1eb9fc991064
-  --sha256: sha256-xb/YBlhc4M3UZSV08fr9YioBTskYAw1uCI3a06s3d3w=
+  --sha256: 0n96rzj4901y0q2l1fb6ffjp1kvgqchliig9id6jaq05xn4v386s

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -40,6 +40,16 @@ let
         })
       # And, of course, our haskell-nix-ified cabal project:
       (import ./pkgs.nix)
+      # for LMDB cross compilation
+      # remove once our nixpkgs pin contains https://github.com/NixOS/nixpkgs/pull/171686
+      (self: super:
+        super.lib.optionalAttrs super.stdenv.hostPlatform.isWindows {
+          lmdb = super.lmdb.overrideAttrs (oldAttrs: {
+            makeFlags = oldAttrs.makeFlags ++ [ "SOEXT=.dll" "BINEXT=.exe" ];
+            buildInputs = [ super.windows.pthreads ];
+            patches = [ ./lmdb-mingw.patch ];
+          });
+        })
     ] ++ [
       # This overlay adds a field localConfig to the pkgs that will be used
       # afterwards to retrieve the locally defined values for building the

--- a/nix/lmdb-mingw.patch
+++ b/nix/lmdb-mingw.patch
@@ -1,0 +1,21 @@
+diff --git a/libraries/liblmdb/Makefile b/libraries/liblmdb/Makefile
+index 612484e..2e6b562 100644
+--- a/libraries/liblmdb/Makefile
++++ b/libraries/liblmdb/Makefile
+@@ -27,6 +27,7 @@ CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
+ LDLIBS	=
+ SOLIBS	=
+ SOEXT	= .so
++BINEXT  =
+ prefix	= /usr/local
+ exec_prefix = $(prefix)
+ bindir = $(exec_prefix)/bin
+@@ -49,7 +50,7 @@ install: $(ILIBS) $(IPROGS) $(IHDRS)
+ 	mkdir -p $(DESTDIR)$(libdir)
+ 	mkdir -p $(DESTDIR)$(includedir)
+ 	mkdir -p $(DESTDIR)$(mandir)/man1
+-	for f in $(IPROGS); do cp $$f $(DESTDIR)$(bindir); done
++	for f in $(IPROGS); do cp $$f$(BINEXT) $(DESTDIR)$(bindir); done
+ 	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
+ 	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
+ 	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
@@ -116,9 +116,11 @@ initLMDB mayLimits = do
     limits fs emptyInit
   pure (tmpdir, bs)
 
--- | Remove a temporary directory that was created for an @`LMDBBackingStore`@.
-cleanupLMDB :: (FilePath, b) -> IO ()
-cleanupLMDB (tmpdir, _) = do
+-- | Close the 'LMDB.LMDBBackingStore' and remove the temporary
+-- directory containing the LMDB files.
+cleanupLMDB :: (FilePath, LMDB.LMDBBackingStore l IO) -> IO ()
+cleanupLMDB (tmpdir, bs) = do
+  HD.bsClose bs
   Dir.removeDirectoryRecursive tmpdir
 
 someHasFSIO :: FilePath -> SomeHasFS IO


### PR DESCRIPTION
 - This patches the `lmdb` package in nixpkgs for cross-compilation to suceed. This is already upstreamed (see https://github.com/NixOS/nixpkgs/pull/171686), but it will take some time until this reaches our nixpkgs pin.
 - We update haskell-lmdb such that it includes https://github.com/input-output-hk/haskell-lmdb/pull/1. Also, update the hash of lmdb-simple, which was incorrect before (causing Hydra eval to fail).
 - We now close the `LMDBBackingStore` before removing its storage dir, such that this test does no longer error on cleanup on Windows.
