### PR TITLE
Some formatting niceties

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,7 @@ consensus layer. Start with the
 The consensus team uses `stylish-haskell` >= 0.11.0.0 to format its code. This
 is enforced by CI.
 
-Either enable editor integration or run the following command to manually
-format all of the consensus code (but not the network code):
-
-```bash
-stylish-haskell -i `git ls-files -- 'ouroboros-consensus*/*.hs' | grep -v Setup.hs`
-```
-
-Alternatively, call the script used by CI itself:
-https://github.com/input-output-hk/ouroboros-network/blob/master/scripts/ci/check-stylish.sh
+Either enable editor integration or call the script used by CI itself:
 
 ```bash
 ./scripts/ci/check-stylish.sh

--- a/nix/check-nixfmt.nix
+++ b/nix/check-nixfmt.nix
@@ -1,8 +1,11 @@
-{ runCommand, fd, nixfmt }:
+{ runCommand, fd, nixfmt, haskell-nix }:
 
 runCommand "check-nixfmt" {
   buildInputs = [ fd nixfmt ];
-  src = ./..;
+  src = haskell-nix.haskellLib.cleanGit {
+    name = "ouroboros-network-src";
+    src = ../.;
+  };
 } ''
   unpackPhase
   cd $sourceRoot

--- a/nix/check-stylish-network.nix
+++ b/nix/check-stylish-network.nix
@@ -10,15 +10,7 @@ runCommand "check-stylish-network" {
 } ''
   unpackPhase
   cd $sourceRoot
-  export LC_ALL=C.UTF-8
-  fd -p io-sim -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-  fd -p io-classes -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-  fd -p strict-stm -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-  fd -p typed-protocols -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-  fd -p network-mux -e hs -E Setup.hs -E network-mux/src/Network/Mux/TCPInfo.hs -E network-mux/src/Network/Mux/Bearer/Pipe.hs -E network-mux/src/Network/Mux/Channel.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-  fd -p ouroboros-network-framework -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-  fd . './ouroboros-network' -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-  fd -p cardano-client -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
+  bash ./scripts/ci/check-stylish-network.sh
   diff -ru $src .
 
   EXIT_CODE=$?

--- a/nix/check-stylish-network.nix
+++ b/nix/check-stylish-network.nix
@@ -1,9 +1,12 @@
-{ runCommand, fd, lib, stylish-haskell }:
+{ runCommand, fd, lib, stylish-haskell, haskell-nix }:
 
 runCommand "check-stylish-network" {
   meta.platforms = with lib.platforms; [ linux ];
   buildInputs = [ fd stylish-haskell ];
-  src = ./..;
+  src = haskell-nix.haskellLib.cleanGit {
+    name = "ouroboros-network-src";
+    src = ../.;
+  };
 } ''
   unpackPhase
   cd $sourceRoot

--- a/nix/check-stylish.nix
+++ b/nix/check-stylish.nix
@@ -10,7 +10,7 @@ runCommand "check-stylish" {
 } ''
   unpackPhase
   cd $sourceRoot
-  fd -p ouroboros-consensus -e hs -E Setup.hs -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs -X stylish-haskell -c .stylish-haskell.yaml -i
+  bash ./scripts/ci/check-stylish.sh
   diff -ru $src .
 
   EXIT_CODE=$?

--- a/nix/check-stylish.nix
+++ b/nix/check-stylish.nix
@@ -1,9 +1,12 @@
-{ runCommand, fd, lib, stylish-haskell }:
+{ runCommand, fd, lib, stylish-haskell, haskell-nix }:
 
 runCommand "check-stylish" {
   meta.platforms = with lib.platforms; [ linux ];
   buildInputs = [ fd stylish-haskell ];
-  src = ./..;
+  src = haskell-nix.haskellLib.cleanGit {
+    name = "ouroboros-network-src";
+    src = ../.;
+  };
 } ''
   unpackPhase
   cd $sourceRoot

--- a/scripts/ci/check-stylish-network.sh
+++ b/scripts/ci/check-stylish-network.sh
@@ -2,13 +2,13 @@
 
 set -euo pipefail
 
+export LC_ALL=C.UTF-8
 fd -p io-sim -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 fd -p io-classes -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 fd -p strict-stm -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 fd -p typed-protocols -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 # TODO CPP pragmas in export lists are not supported by stylish-haskell
-fd -p network-mux -e hs -E Setup.hs -E network-mux/src/Network/Mux/Bearer/Pipe.hs -E network-mux/src/Network/Mux/Channel.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd -p ouroboros-network* -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
+fd -p network-mux -e hs -E Setup.hs -E network-mux/src/Network/Mux/TCPInfo.hs -E network-mux/src/Network/Mux/Bearer/Pipe.hs -E network-mux/src/Network/Mux/Channel.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
+fd -p ouroboros-network-framework -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
+fd . './ouroboros-network' -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 fd -p cardano-client -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
-
-git diff --exit-code

--- a/scripts/ci/check-stylish.sh
+++ b/scripts/ci/check-stylish.sh
@@ -2,5 +2,6 @@
 
 set -euo pipefail
 
+export LC_ALL=C.UTF-8
 # TODO the export of the <= operator TxLimits crashes stylish-haskell
 fd -p ouroboros-consensus -e hs -E Setup.hs -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs -X stylish-haskell -c .stylish-haskell.yaml -i

--- a/scripts/ci/check-stylish.sh
+++ b/scripts/ci/check-stylish.sh
@@ -3,6 +3,4 @@
 set -euo pipefail
 
 # TODO the export of the <= operator TxLimits crashes stylish-haskell
-fd -p ouroboros-consensus -e hs -E Setup.hs -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs -X stylish-haskell -i
-
-git diff --exit-code
+fd -p ouroboros-consensus -e hs -E Setup.hs -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs -X stylish-haskell -c .stylish-haskell.yaml -i


### PR DESCRIPTION
This includes some small things of #3720 not included in #3722.

 - We use `cleanGit` to only copy the git-tracked files to the nix store. Previously, the entire local development directory would be copied (easily >1GB). This subsumes #3669.
 - We reuse the scripts in `scripts/ci` such that people can easily run stylish-haskell in the same way as it is checked in CI.
 - This sets `export LC_ALL=C.UTF-8` for the consensus stylish-haskell check, which hopefully fixes errors like https://hydra.iohk.io/build/14684287/nixlog/1