### PR TITLE
Update cardano-base cardano-ledger plutus deps

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -203,8 +203,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 8fe904d629194b1fbaaf2d0a4e0ccd17052e9103
-  --sha256: sha256-5B5lJFfUm4jbCBQtqTMvtiY2AWtnsN/1TYftAglT38A=
+  tag: 631cb6cf1fa01ab346233b610a38b3b4cba6e6ab
+  --sha256: 0944wg2nqazmhlmsynwgdwxxj6ay0hb9qig9l128isb2cjia0hlp
   subdir:
     base-deriving-via
     binary
@@ -220,8 +220,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: ea563c6f036da118954723e7d0788b66939d6ab2
-  --sha256: 0c9v2x06qsjkjlxib788bgy9xfnaamr89k2lqziqysn48i6qjgz8
+  tag: 276338526be609b1d2bceb88e6722d077e95245b
+  --sha256: 02wjsnarpfhkj3jw348285f9as6bwjbv7yph6xfp3qjfyiv2p6hi
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -241,17 +241,17 @@ source-repository-package
     libs/cardano-ledger-core
     libs/cardano-ledger-pretty
     libs/cardano-protocol-tpraos
-    libs/compact-map
     libs/non-integral
     libs/set-algebra
     libs/small-steps
     libs/small-steps-test
+    libs/vector-map
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: ccf5bcb99ffe054dc8cd5626723f64e02708dbae
-  --sha256: 18569bgywilibz7r5jyxj9bid8g4fwr80cc0hd9rcm3jhasbgq8i
+  tag: fec94223a985e34d3b270460c8f150002f41b85b
+  --sha256: 1mwknikvbpv9lj43c3ya24v7wpcbpcsrk0fnh6knpi7ds4rmj9j0
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/nix/ouroboros-network.nix
+++ b/nix/ouroboros-network.nix
@@ -93,19 +93,40 @@ let
 
           # Make sure that libsodium DLLs are available for tests
           packages.ouroboros-consensus-byron-test.components.tests.test.postInstall =
-            "ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
+            ''
+              ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll
+              ln -s ${pkgs.secp256k1}/bin/libsecp256k1-0.dll $out/bin/libsecp256k1-0.dll
+            '';
           packages.ouroboros-consensus-cardano-test.components.tests.test.postInstall =
-            "ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
+            ''
+              ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll
+              ln -s ${pkgs.secp256k1}/bin/libsecp256k1-0.dll $out/bin/libsecp256k1-0.dll
+            '';
           packages.ouroboros-consensus-mock-test.components.tests.test.postInstall =
-            "ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
+            ''
+              ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll
+              ln -s ${pkgs.secp256k1}/bin/libsecp256k1-0.dll $out/bin/libsecp256k1-0.dll
+            '';
           packages.ouroboros-consensus-shelley-test.components.tests.test.postInstall =
-            "ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
+            ''
+              ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll
+              ln -s ${pkgs.secp256k1}/bin/libsecp256k1-0.dll $out/bin/libsecp256k1-0.dll
+            '';
           packages.ouroboros-consensus-test.components.tests.test-consensus.postInstall =
-            "ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
+            ''
+              ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll
+              ln -s ${pkgs.secp256k1}/bin/libsecp256k1-0.dll $out/bin/libsecp256k1-0.dll
+            '';
           packages.ouroboros-consensus-test.components.tests.test-infra.postInstall =
-            "ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
+            ''
+              ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll
+              ln -s ${pkgs.secp256k1}/bin/libsecp256k1-0.dll $out/bin/libsecp256k1-0.dll
+            '';
           packages.ouroboros-consensus-test.components.tests.test-storage.postInstall =
-            "ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
+            ''
+              ln -s ${libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll
+              ln -s ${pkgs.secp256k1}/bin/libsecp256k1-0.dll $out/bin/libsecp256k1-0.dll
+            '';
         })
       # Options for when not compiling to windows:
       ({ pkgs, ... }:

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -38,7 +38,6 @@ library
                      , cardano-crypto-wrapper
                      , cardano-slotting
                      , containers
-                     , compact-map
                      , mtl
                      , QuickCheck
                      , sop-core

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -56,7 +56,6 @@ import           Ouroboros.Consensus.Cardano.Block (CardanoEras, GenTx (..),
 import           Ouroboros.Consensus.Cardano.Node (CardanoHardForkConstraints)
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 
-import qualified Data.Compact.SplitMap as SplitMap
 import qualified Test.ThreadNet.Infra.Shelley as Shelley
 import           Test.ThreadNet.TxGen
 
@@ -142,8 +141,7 @@ migrateUTxO migrationInfo curSlot lcfg lst
     | Just utxo <- mbUTxO =
 
     let picked :: Map (SL.TxIn c) (SL.TxOut (ShelleyEra c))
-        picked = SplitMap.toMap $
-            SplitMap.filter pick $ SL.unUTxO utxo
+        picked = Map.filter pick $ SL.unUTxO utxo
           where
             pick (SL.TxOut addr _) =
                 addr == SL.AddrBootstrap (SL.BootstrapAddress byronAddr)

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -64,7 +64,6 @@ library
                      , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
-                     , compact-map
                      , containers        >=0.5   && <0.7
                      , data-default-class
                      , deepseq

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -74,7 +74,6 @@ import qualified Cardano.Protocol.TPraos.API as SL
 import qualified Cardano.Protocol.TPraos.OCert as Absolute (KESPeriod (..))
 
 import qualified Cardano.Protocol.TPraos.OCert as SL
-import qualified Data.Compact.SplitMap as SplitMap
 import qualified Data.UMap as UM
 import           Ouroboros.Consensus.Protocol.Ledger.HotKey (HotKey)
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
@@ -466,7 +465,7 @@ registerInitialFunds initialFunds nes = nes {
     reserves     = SL._reserves      accountState
 
     initialFundsUtxo :: SL.UTxO era
-    initialFundsUtxo = SL.UTxO $ SplitMap.fromList [
+    initialFundsUtxo = SL.UTxO $ Map.fromList [
           (txIn, txOut)
         | (addr, amount) <- Map.toList initialFunds
         ,  let txIn  = SL.initialFundsPseudoTxIn addr
@@ -498,7 +497,7 @@ registerInitialFunds initialFunds nes = nes {
          HasCallStack
       => SL.UTxO era -> SL.UTxO era -> SL.UTxO era
     mergeUtxoNoOverlap (SL.UTxO m1) (SL.UTxO m2) = SL.UTxO $
-        SplitMap.unionWithKey
+        Map.unionWithKey
           (\k _ _ -> error $ "initial fund part of UTxO: " <> show k)
           m1
           m2

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
@@ -804,6 +804,7 @@ hardForkEpochInfo ArbitraryChain{..} for =
                , epochInfoEpoch_ = \_ -> throw err
 
                , epochInfoSlotToRelativeTime_ = \_ -> throw err
+               , epochInfoSlotLength_         = \_ -> throw err
                }
            , "<out of range>"
            , "<out of range>"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
@@ -37,6 +37,8 @@ interpreterToEpochInfo i = EpochInfo {
 
     , epochInfoSlotToRelativeTime_ = \s ->
         interpretQuery' (fst <$> slotToWallclock s)
+
+    , epochInfoSlotLength_ = \s -> interpretQuery' (slotToSlotLength s)
     }
   where
     interpretQuery' :: HasCallStack => Qry a -> Except PastHorizonException a
@@ -51,6 +53,7 @@ dummyEpochInfo = EpochInfo {
     , epochInfoFirst_              = \_ -> error "dummyEpochInfo used"
     , epochInfoEpoch_              = \_ -> error "dummyEpochInfo used"
     , epochInfoSlotToRelativeTime_ = \_ -> error "dummyEpochInfo used"
+    , epochInfoSlotLength_         = \_ -> error "dummyEpochInfo used"
     }
 
 -- | Interpret the 'PastHorizonException' as a _pure exception_ via 'throw'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
@@ -34,6 +34,7 @@ module Ouroboros.Consensus.HardFork.History.Qry (
   , epochToSlot'
   , slotToEpoch
   , slotToEpoch'
+  , slotToSlotLength
   , slotToWallclock
   , wallclockToSlot
   ) where
@@ -480,6 +481,11 @@ slotToWallclock :: SlotNo -> Qry (RelativeTime, SlotLength)
 slotToWallclock absSlot =
     qryFromExpr (slotToWallclockExpr absSlot)
 
+-- | Acquire a slot's length
+slotToSlotLength :: SlotNo -> Qry SlotLength
+slotToSlotLength absSlot =
+    qryFromExpr (slotToSlotLengthExpr absSlot)
+
 -- | Convert 'SlotNo' to 'EpochNo' and the relative slot within the epoch
 slotToEpoch' :: SlotNo -> Qry (EpochNo, Word64)
 slotToEpoch' absSlot =
@@ -532,6 +538,9 @@ slotToWallclockExpr absSlot =
     EPair
       (ERelToAbsTime (ERelSlotToTime (EAbsToRelSlot (ELit absSlot))))
       (ESlotLength (ELit absSlot))
+
+slotToSlotLengthExpr :: SlotNo -> Expr f SlotLength
+slotToSlotLengthExpr absSlot = ESlotLength (ELit absSlot)
 
 slotToEpochExpr' :: SlotNo -> Expr f (EpochNo, SlotInEpoch)
 slotToEpochExpr' absSlot =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Util.hs
@@ -12,6 +12,7 @@ import           Data.Word
 import           GHC.Stack
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Util.RedundantConstraints
 
 {-------------------------------------------------------------------------------
   Adding and subtracting slots/epochs
@@ -29,7 +30,11 @@ addEpochs n (EpochNo x) = EpochNo (x + n)
 -- | @countSlots to fr@ counts the slots from @fr@ to @to@ (@to >= fr@)
 countSlots :: HasCallStack => SlotNo -> SlotNo -> Word64
 countSlots (SlotNo to) (SlotNo fr) = assert (to >= fr) $ to - fr
+  where
+    _ = keepRedundantConstraint (Proxy :: Proxy HasCallStack)
 
 -- | @countEpochs to fr@ counts the epochs from @fr@ to @to@ (@to >= fr@)
 countEpochs :: HasCallStack => EpochNo -> EpochNo -> Word64
 countEpochs (EpochNo to) (EpochNo fr) = assert (to >= fr) $ to - fr
+  where
+    _ = keepRedundantConstraint (Proxy :: Proxy HasCallStack)


### PR DESCRIPTION
This finishes off and squashes PR #3751. Thanks to @Jimbo4350 and @lehins for opening that.

With a few small patch commits (which I shared with Jordan), I was able to build `exe:cardano` with this, branching off of `cf3e0c75e - (origin/jordan/dep-bump-protocol-in-block)` in `cardano-node`.

Changes:

* Ledger removed the `SplitMap` type
* Ledger renamed their `compact-map` package to `vector-map`
* `cardano-base` added `epochInfoSlotLength_` to `EpochInfo`

```
$ git lg -15
dedec0d8f - (HEAD -> nfrisby/dep-bump-protocol-in-block, origin/nfrisby/dep-bump-protocol-in-block) node: SplitMap was removed, use normal Map (28 minutes ago) <Nicolas Frisby>
66d9efa58 - api: SplitMap was removed, use normal Map (31 minutes ago) <Nicolas Frisby>
1c04ea6c2 - api: Babbage has _coinsPerUTxOByte instead of _coinsPerUTxOWord (32 minutes ago) <Nicolas Frisby>
591dee9b3 - api: Data.VMap instead of Data.Compact.Map (32 minutes ago) <Nicolas Frisby>
cf3e0c75e - (origin/jordan/dep-bump-protocol-in-block) Further cabal.project file changes. Merge with initial cabal.project file commit (70 minutes ago) <Jordan Millar>
```