### PR TITLE
Extract generation of `ChainUpdate`s from the ChainSync client test

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -36,6 +36,7 @@ library
 
                        Test.Util.Blob
                        Test.Util.BoolProps
+                       Test.Util.ChainUpdates
                        Test.Util.ChunkInfo
                        Test.Util.Classify
                        Test.Util.Corruption
@@ -62,6 +63,7 @@ library
                        Test.Util.QuickCheck
                        Test.Util.Range
                        Test.Util.RefEnv
+                       Test.Util.Schedule
                        Test.Util.Serialisation.Golden
                        Test.Util.Serialisation.Roundtrip
                        Test.Util.Shrink
@@ -280,6 +282,8 @@ test-suite test-infra
   main-is:             Main.hs
   other-modules:
                        Test.ThreadNet.Util.Tests
+                       Test.Util.ChainUpdates.Tests
+                       Test.Util.Schedule.Tests
                        Test.Util.Split.Tests
 
   build-depends:       base

--- a/ouroboros-consensus-test/src/Test/Util/ChainUpdates.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainUpdates.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE LambdaCase         #-}
+
+-- | Generate sequences of updates to model an evolving chain
+module Test.Util.ChainUpdates (
+    ChainUpdate (..)
+  , UpdateBehavior (..)
+  , genChainUpdates
+  , toChainUpdates
+    -- * Tests
+  , prop_genChainUpdates
+  ) where
+
+import           Control.Monad.State.Strict
+
+import           Test.QuickCheck
+
+import           Ouroboros.Network.MockChain.Chain (Chain (Genesis))
+import qualified Ouroboros.Network.MockChain.Chain as Chain
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+
+import           Test.Util.TestBlock
+
+data ChainUpdate =
+    AddBlock TestBlock
+    -- | Roll back to the given 'Point', and then /immediately/ roll
+    -- forward by the given 'TestBlock's.
+  | SwitchFork (Point TestBlock) [TestBlock]
+  deriving stock (Eq, Show)
+
+instance Condense ChainUpdate where
+  condense = \case
+    AddBlock b -> "AddBlock " <> condense b
+    SwitchFork p bs -> "SwitchFork <- " <> condense p <> " -> " <>
+      unwords (map condense bs)
+
+toChainUpdates :: [ChainUpdate] -> [Chain.ChainUpdate TestBlock TestBlock]
+toChainUpdates = concatMap $ \case
+    SwitchFork pt bs -> Chain.RollBack pt : map Chain.AddBlock bs
+    AddBlock b       -> Chain.AddBlock b  : []
+
+{-------------------------------------------------------------------------------
+  Generating ChainUpdates
+-------------------------------------------------------------------------------}
+
+-- | We need some state to generate @ChainUpdate@s
+data ChainUpdateState = ChainUpdateState
+  { cusCurrentChain :: !(Chain TestBlock)
+    -- ^ The current chain, obtained by applying all the 'cusUpdates' in reverse
+    -- order.
+  , cusUpdates      :: ![ChainUpdate]
+    -- ^ The updates that have been generated so far, in reverse order: the
+    -- first update in the list is the last update to apply.
+  } deriving stock (Show)
+
+emptyUpdateState :: ChainUpdateState
+emptyUpdateState = ChainUpdateState
+  { cusCurrentChain = Genesis
+  , cusUpdates      = []
+  }
+
+getChainUpdates :: ChainUpdateState -> [ChainUpdate]
+getChainUpdates = reverse . cusUpdates
+
+-- | Different strategies how to generate a sequence of 'ChainUpdate's.
+data UpdateBehavior =
+    -- | Chain updates tracking the selected chain of an honest node. In
+    -- particular, this includes:
+    --
+    --  * All blocks involved are valid.
+    --  * Every 'ChainUpdate' improves the chain.
+    SelectedChainBehavior
+  | -- | Chain updates tracking the tentative chain of an honest node (in the
+    -- context of diffusion pipelining). This is similiar to
+    -- 'SelectedChainBehavior', but allows for the following sequence of
+    -- 'ChainUpdates':
+    --
+    --  1. @'AddBlock' blk@ for @blk@ invalid
+    --  2. @'SwitchFork' (prevPoint blk) [blk']@ where @blk'@ is preferable to
+    --     @blk@.
+    TentativeChainBehavior
+  deriving stock (Show, Eq, Enum, Bounded)
+
+genChainUpdates
+  :: UpdateBehavior
+  -> SecurityParam
+  -> Int  -- ^ The number of updates to generate
+  -> Gen [ChainUpdate]
+genChainUpdates updateBehavior securityParam n =
+        getChainUpdates
+    <$> genChainUpdateState updateBehavior securityParam n emptyUpdateState
+
+genChainUpdateState ::
+     UpdateBehavior
+  -> SecurityParam
+  -> Int
+  -> ChainUpdateState
+  -> Gen ChainUpdateState
+genChainUpdateState updateBehavior securityParam n =
+    execStateT (replicateM_ n genChainUpdate)
+  where
+    -- Modify the state
+    addUpdate u cus = cus { cusUpdates = u : cusUpdates cus }
+    setChain  c cus = cus { cusCurrentChain = c }
+
+    k = fromIntegral $ maxRollbacks securityParam
+
+    genChainUpdate = do
+      ChainUpdateState { cusCurrentChain = chain } <- get
+      let genValid =
+            frequency'
+              [ (3, genAddBlock Valid)
+              , ( if Chain.null chain then 0 else 1
+                , genSwitchFork (choose (1, k))
+                )
+              ]
+      frequency' $
+        (5, replicateM_ 2 genValid) :
+        [ (1, genInvalidBlock) | updateBehavior == TentativeChainBehavior ]
+
+    genBlockToAdd validity = do
+        ChainUpdateState { cusCurrentChain = chain } <- get
+        block <- lift $ case Chain.head chain of
+          Nothing      -> setValidity . firstBlock <$> genForkNo
+          Just curHead -> do
+            forkNo <- case validity of
+              Valid   ->  genForkNo
+              Invalid -> pure 3
+            return
+              . modifyFork (const forkNo)
+              . setValidity
+              $ successorBlock curHead
+        modify $ setChain (Chain.addBlock block chain)
+        return block
+      where
+        setValidity b = b { tbValid = validity }
+        genForkNo = case validity of
+          Valid -> frequency
+            [ (1, return 0)
+            , (1, choose (1, 2))
+            ]
+          -- Blocks with equal hashes have to have equal validity, so we reserve
+          -- a specific ForkNo for invalid blocks to ensure this.
+          Invalid -> pure 3
+
+    genAddBlock validity = do
+      block <- genBlockToAdd validity
+      modify $ addUpdate (AddBlock block)
+
+    genSwitchFork genRollBackBlocks = do
+      ChainUpdateState { cusCurrentChain = chain } <- get
+      rollBackBlocks <- lift genRollBackBlocks
+      let chain' = Chain.drop rollBackBlocks chain
+      modify $ setChain chain'
+      blocks <- replicateM rollBackBlocks (genBlockToAdd Valid)
+      modify $ addUpdate (SwitchFork (Chain.headPoint chain') blocks)
+
+    genInvalidBlock = do
+      genAddBlock Invalid
+      genSwitchFork (pure 1)
+
+-- | Variant of 'frequency' that allows for transformers of 'Gen'
+frequency' :: (MonadTrans t, Monad (t Gen)) => [(Int, t Gen a)] -> t Gen a
+frequency' [] = error "frequency' used with empty list"
+frequency' xs0 = lift (choose (1, tot)) >>= (`pick` xs0)
+  where
+    tot = sum (map fst xs0)
+
+    pick n ((k,x):xs)
+      | n <= k    = x
+      | otherwise = pick (n-k) xs
+    pick _ _  = error "pick used with empty list"
+
+-- | Test that applying the generated updates gives us the same chain
+-- as @cusCurrentChain@.
+prop_genChainUpdates :: SecurityParam -> Int -> Property
+prop_genChainUpdates securityParam n =
+    forAll genCUS $ \cus ->
+      Chain.applyChainUpdates (toChainUpdates (getChainUpdates cus)) Genesis ===
+      Just (cusCurrentChain cus)
+  where
+    genCUS = do
+      behavior <- chooseEnum (minBound, maxBound)
+      genChainUpdateState behavior securityParam n emptyUpdateState

--- a/ouroboros-consensus-test/src/Test/Util/Schedule.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Schedule.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RankNTypes         #-}
+
+-- | Utilities to schedule actions per 'Tick'.
+module Test.Util.Schedule (
+    Schedule (..)
+  , genSchedule
+  , joinSchedule
+  , lastTick
+  , shrinkSchedule
+  ) where
+
+import           Data.List (intercalate, unfoldr)
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+
+import           Test.QuickCheck
+
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+
+import           Test.Util.LogicalClock (Tick (..))
+
+-- | A schedule plans actions on certain times.
+--
+-- TODO Note that a schedule can't express delays between the actions
+-- within a single tick. Generating such delays may expose more (most
+-- likely concurrency-related) bugs.
+newtype Schedule a = Schedule { getSchedule :: Map Tick [a] }
+  deriving stock (Show, Eq)
+
+instance Condense a => Condense (Schedule a) where
+  condense =
+        unlines
+      . map (uncurry showEntry)
+      . filter (not . null . snd)
+      . Map.toAscList
+      . getSchedule
+    where
+      showEntry (Tick tick) as = show tick <> ": " <>
+        intercalate ", " (map condense as)
+
+-- | Return the last tick at which an update is planned, if no updates
+-- are planned, return 0.
+lastTick :: Schedule a -> Tick
+lastTick = fromMaybe (Tick 0) . maxKey . getSchedule
+  where
+    maxKey :: forall k v. Map k v -> Maybe k
+    maxKey = fmap (fst . fst) . Map.maxViewWithKey
+
+-- | Spread out elements over a schedule, i.e. schedule a number of
+-- elements to be processed on each tick. Most ticks will have no
+-- associated elements.
+genSchedule :: [a] -> Gen (Schedule a)
+genSchedule = fmap Schedule . go Map.empty 1
+  where
+    go :: Map Tick [a]
+       -> Tick
+       -> [a]
+       -> Gen (Map Tick [a])
+    go !schedule tick as
+      | null as = return schedule
+      | otherwise    = do
+        nbAs <- frequency [ (2, return 0), (1, choose (1, 5)) ]
+        let (this, rest) = splitAt nbAs as
+        go (Map.insert tick this schedule) (succ tick) rest
+
+-- | Repeatedly remove the last entry (highest 'Tick')
+shrinkSchedule :: Schedule a -> [Schedule a]
+shrinkSchedule =
+      unfoldr (fmap (\(_, m) -> (Schedule m, m)) . Map.maxView)
+    . getSchedule
+
+-- | Inverse of 'genSchedule'
+joinSchedule :: Schedule a -> [a]
+joinSchedule = concatMap snd . Map.toAscList . getSchedule

--- a/ouroboros-consensus-test/test-infra/Main.hs
+++ b/ouroboros-consensus-test/test-infra/Main.hs
@@ -3,6 +3,8 @@ module Main (main) where
 import           Test.Tasty
 
 import qualified Test.ThreadNet.Util.Tests (tests)
+import qualified Test.Util.ChainUpdates.Tests (tests)
+import qualified Test.Util.Schedule.Tests (tests)
 import qualified Test.Util.Split.Tests (tests)
 
 main :: IO ()
@@ -12,5 +14,7 @@ tests :: TestTree
 tests =
   testGroup "test-infra"
   [ Test.ThreadNet.Util.Tests.tests
+  , Test.Util.ChainUpdates.Tests.tests
+  , Test.Util.Schedule.Tests.tests
   , Test.Util.Split.Tests.tests
   ]

--- a/ouroboros-consensus-test/test-infra/Test/Util/ChainUpdates/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Test/Util/ChainUpdates/Tests.hs
@@ -1,0 +1,16 @@
+module Test.Util.ChainUpdates.Tests (tests) where
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Test.Util.ChainUpdates
+
+import           Ouroboros.Consensus.Config
+
+tests :: TestTree
+tests = testGroup "Test.Util.ChainUpdates"
+    [ testProperty "genChainUpdates" $ prop_genChainUpdates k updatesToGenerate
+    ]
+  where
+    k = SecurityParam 3
+    updatesToGenerate = 100

--- a/ouroboros-consensus-test/test-infra/Test/Util/Schedule/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Test/Util/Schedule/Tests.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Util.Schedule.Tests (tests) where
+
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Test.Util.Schedule
+
+tests :: TestTree
+tests = testGroup "Test.Util.Schedule"
+    [ testProperty "joinSchedule/genSchedule" $ prop_joinSchedule_genSchedule
+    ]
+
+prop_joinSchedule_genSchedule :: Property
+prop_joinSchedule_genSchedule =
+    forAll genElementsAndSpread $ \(as, spread) ->
+      joinSchedule spread === as
+  where
+    genElementsAndSpread = do
+      -- generate elements of some type with an Ord instance
+      as :: [Int] <- arbitrary
+      spread      <- genSchedule as
+      return (as, spread)


### PR DESCRIPTION
Closes [CAD-4313](https://input-output.atlassian.net/browse/CAD-4313).

This will be used by the upcoming consensus-level BlockFetch client tests.