### PR TITLE
CAD-4307 LMDB exception handling

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
@@ -87,7 +87,7 @@ data TraceDb
   | TDBValueHandle Int TraceValueHandle
   | TDBTableOp     TraceTableOp
   | TDBInitialisingFromLMDB !FS.FsPath
-  | TDBInitialisingFromLMDBDone !FS.FsPath
+  | TDBInitialisedFromLMDBD !FS.FsPath
   deriving (Show, Eq)
 
 data TraceTableOp = TTO
@@ -467,14 +467,10 @@ initFromLMDBs tracer limits shfs from0 to0 = do
     from <- guardDbDir GDDMustExist shfs from0
     to <- guardDbDirWithRetry GDDMustNotExist shfs to0
     bracket
-      -- TODO assess limits, in particular this could fail if the db is too big
-      -- TODO(jdral): Should we read from some configuration/settings file what
-      -- the limits of the "from" database are? Do we want to support
-      -- interoperablity between databases with different limits?
       (liftIO $ LMDB.openEnvironment from limits)
       (liftIO . LMDB.closeEnvironment)
       (flip (lmdbCopy tracer) to)
-    Trace.traceWith tracer $ TDBInitialisingFromLMDBDone to0
+    Trace.traceWith tracer $ TDBInitialisedFromLMDBD to0
 
 lmdbCopy :: MonadIO m
   => Trace.Tracer m TraceDb


### PR DESCRIPTION
This PR comes up with a strategy for exception handling in the `LedgerDB.HD.LMDB` module.

#### Error propagation

The `LMDB` module uses `Control.Exception.throw` to throw exceptions, which will be propagated up to the nearest handler or kill the thread. Using `ExceptT` instead would force us to act on exceptions, so it might be beneficial to let (parts of) the `LMDB` module run in `ExceptT DbErr`. This depends in part on the following:

There is no meaningful way to recover from most exceptions from within the `LMDB` module. Most should be fatal for the node as well: If we can't find a UTxO on-disk while we are trying to read it, then the node probably has no meaningful way to recover from this exception. However, when we try to replay a snapshot and encounter a "fatal" exception, we could instead discard the current snapshot and try a different one. The question is whether it would be better to let the node die anyway, since the snapshot could still be there on the next node startup.

- [x] Decide which errors should be "fatal".
- [x] Depending on the previous, decide whether it makes sense to have parts run in  `ExceptT DbErr`. 

#### Other

- [x] Decide whether we should store the database settings in the database itself.
- [x] Decide on a strategy for `LMDBLimits`.