### PR TITLE
CAD-4303 merge test suites

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -223,6 +223,8 @@ test-suite test-storage
                        Test.Ouroboros.Storage.ImmutableDB.StateMachine
                        Test.Ouroboros.Storage.LedgerDB
                        Test.Ouroboros.Storage.LedgerDB.DiskPolicy
+                       Test.Ouroboros.Storage.LedgerDB.HD
+                       Test.Ouroboros.Storage.LedgerDB.HD.LMDB
                        Test.Ouroboros.Storage.LedgerDB.InMemory
                        Test.Ouroboros.Storage.LedgerDB.OnDisk
                        Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary
@@ -269,40 +271,6 @@ test-suite test-storage
                      , ouroboros-network
                      , ouroboros-consensus
                      , ouroboros-consensus-test
-
-  default-language:    Haskell2010
-  ghc-options:         -Wall
-                       -Wcompat
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wpartial-fields
-                       -Widentities
-                       -Wredundant-constraints
-                       -Wmissing-export-lists
-                       -Wno-unticked-promoted-constructors
-                       -fno-ignore-asserts
-                       -threaded
-
-test-suite test-lmdb-bs
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test-lmdb-bs
-  main-is:             Main.hs
-  other-modules:
-
-  build-depends:       base
-                     , QuickCheck
-                     , tasty
-                     , tasty-quickcheck
-                     , tasty-hunit
-                     , ouroboros-consensus
-                     , cardano-binary
-                     , cardano-slotting
-                     , ouroboros-consensus-test
-                     , directory
-                     , temporary
-                     , text
-                     , containers
-                     , contra-tracer
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
@@ -3,12 +3,14 @@ module Test.Ouroboros.Storage.LedgerDB (tests) where
 import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage.LedgerDB.DiskPolicy as DiskPolicy
+import qualified Test.Ouroboros.Storage.LedgerDB.HD as HD
 import qualified Test.Ouroboros.Storage.LedgerDB.InMemory as InMemory
 import qualified Test.Ouroboros.Storage.LedgerDB.OnDisk as OnDisk
 
 tests :: TestTree
 tests = testGroup "LedgerDB" [
-      InMemory.tests
+      HD.tests
+    , InMemory.tests
     , OnDisk.tests
     , DiskPolicy.tests
     ]

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD.hs
@@ -1,0 +1,9 @@
+module Test.Ouroboros.Storage.LedgerDB.HD (tests) where
+
+import qualified Test.Ouroboros.Storage.LedgerDB.HD.LMDB as LMDB
+import           Test.Tasty (TestTree, testGroup)
+
+tests :: TestTree
+tests = testGroup "HD" [
+      LMDB.tests
+    ]

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Simple unit tests for the LMDB backing store.
-module Main (main) where
+module Test.Ouroboros.Storage.LedgerDB.HD.LMDB (tests) where
 
 import qualified Control.Tracer as Trace
 import           Data.Maybe
@@ -20,7 +20,7 @@ import           Data.Text (Text)
 import qualified System.Directory as Dir
 import           System.IO.Temp
 
-import           Test.Tasty (TestTree)
+import           Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty as Tasty
 import qualified Test.Tasty.HUnit as Tasty
 
@@ -39,8 +39,10 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.LMDB as LMDB
 
 import           Test.Util.TestBlock ()
 
-main :: IO ()
-main = Tasty.defaultMain test1
+tests :: TestTree
+tests = testGroup "LMDB" [
+    test1
+  ]
 
 {-------------------------------------------------------------------------------
   Unit tests


### PR DESCRIPTION
LMDB backing store tests now run in the `test-lmdb-storage` hierarchy at
"ouroboros-storage ; Storage ; LedgerDB ; HD ; LMDB".

Why: The LMDB backing store tests include only a single unit test, so it
may not be necessary to have it live in its own test-suite.

Note: The LMDB backing store tests can be run separately from the rest
of the test-suite using:
`cabal run ouroboros-consensus-test:test-storage -- -p "HD"`