### PR TITLE
Provide an 'EpochInfo' that can fail to ledger.

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -50,11 +50,13 @@ import qualified Codec.CBOR.Decoding as CBOR
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (decode, encode)
+import           Control.Arrow (left)
 import qualified Control.Exception as Exception
 import           Control.Monad.Except
 import           Data.Coerce (coerce)
 import           Data.Functor ((<&>))
 import           Data.Functor.Identity
+import qualified Data.Text as Text
 import           Data.Word
 import           GHC.Generics (Generic)
 import           GHC.Records
@@ -156,7 +158,7 @@ mkShelleyLedgerConfig genesis transCtxt epochInfo mmpv =
       , shelleyLedgerGlobals            =
           SL.mkShelleyGlobals
             genesis
-            (HardFork.toPureEpochInfo epochInfo)
+            (hoistEpochInfo (left (Text.pack . show) . runExcept) epochInfo)
             maxMajorPV
       , shelleyLedgerTranslationContext = transCtxt
       }


### PR DESCRIPTION
The ledger now supports an `EpochInfo (Either Text)`, and uses the
`Left` constructor to indicate a horizon error. Unfortunately, while the
epoch info being provided had the correct _type_, it was implemented in
a degenerate way - the `Left` constructor would never be used and
instead a pure error was thrown on failures.

This PR instead provides a correct `EpochInfo` to the ledger, where the
failure is reflected in the `Left` constructor.