### PR TITLE
CAD-4473 Decrease `withMaxSuccess` for `OnDisk` tests to ensure tests pass.

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -1346,8 +1346,13 @@ sm secParam db = StateMachine {
         dbCleanup $ dbEnv db
     }
 
+-- FIXME(jdral): @withMaxSuccess@ has temporarily been decreased from @1000000@
+-- to @1000@, since the LMDB version of this property test takes an unreasonable
+-- amount of time to finish. At the moment, a 1000 property tests that exercise
+-- an LMDB backing store will take ~3 minutes to run. Code line to restore:
+-- > prop_sequential mkDbEnv secParam = QC.withMaxSuccess 100000
 prop_sequential :: (SecurityParam -> IO (DbEnv IO)) -> SecurityParam -> QC.Property
-prop_sequential mkDbEnv secParam = QC.withMaxSuccess 100000 $
+prop_sequential mkDbEnv secParam = QC.withMaxSuccess 1000 $
   forAllCommands (sm secParam dbUnused) Nothing $ \cmds ->
     QC.monadicIO $ QC.run (mkDbEnv secParam) >>= \e -> propCmds e cmds
 


### PR DESCRIPTION
Note: I've decreased the amount of `OnDisk` tests we perform because it was semi-blocking "CAD-4473: Ensuring that all tests pass" -- It was taking >2.5 hours to finish. 

`withMaxSuccess` has temporarily been decreased from `1000000` to `1000`, since the LMDB version of this property test takes an unreasonable amount of time to finish. At the moment, a 1000 property tests that exercise an LMDB backing store will take ~3 minutes to run. Running a number of tests in the order of `1000000` will take at least an hour up to a few hours.

Since we are still in the process of enabling/fixing CI on the "CAD-4180-rebase-lmdb-branch" branch, we did a local sanity check of whether relevant tests are passing. I've tested using:

`cabal test ouroboros-consensus-test ouroboros-consensus-byron-test ouroboros-consensus-cardano-test ouroboros-consensus-mock-test ouroboros-consensus-shelley-test`

Two log-files are included below: The first was tested using the old `withMaxSuccess` parameter, the second was tested using the new parameter.

[lmdb-tests-large.log](https://github.com/input-output-hk/ouroboros-network/files/8798420/lmdb-tests-large.log)
[lmdb-tests-small.log](https://github.com/input-output-hk/ouroboros-network/files/8798421/lmdb-tests-small.log)


