### PR TITLE
cardano: bump latestReleasedNodeVersion to include Babbage without having to enable testing features

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -460,7 +460,7 @@ instance CardanoHardForkConstraints c
       , (NodeToClientV_13, CardanoNodeToClientVersion9)
       ]
 
-  latestReleasedNodeVersion _prx = (Just NodeToNodeV_8, Just NodeToClientV_12)
+  latestReleasedNodeVersion _prx = (Just NodeToNodeV_9, Just NodeToClientV_13)
 
 {-------------------------------------------------------------------------------
   ProtocolInfo


### PR DESCRIPTION
While reviewing Marcin's latest PR #3775, we noticed the latest released version was never updated to include Babbage.

This PR updates it, so that Babbage is on by default. The test flag will then only have the effect of enabling P2P.