### PR TITLE
Hydra: don't run style checks on mingwW64

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -92,10 +92,6 @@ let
       ([ "exes" ] ++ path)
       ([ "haskellPackages" (head path) "components" "exes" ] ++ (tail path))
     ];
-    stylePaths = path: [
-      ([ "checks" "styles" ] ++ path)
-      ([ "haskellPackages" (head path) "checks" ] ++ (tail path))
-    ];
   in [ [ "shell" ] ] ++ (optionals (!withProblematicWindowsTests)
     ((checksPaths [ "ouroboros-network" "test" ])
       ++ (checksPaths [ "Win32-network" "test" ])
@@ -109,8 +105,7 @@ let
         [ "haskellPackages" "ouroboros-network-testing" "coverageReport" ]
       ])) ++ (testsPaths [ "ouroboros-network" "cddl" ])
   ++ (checksPaths [ "ouroboros-network" "cddl" ])
-  ++ (exesPaths [ "network-mux" "cardano-ping" ])
-  ++ (stylePaths [ "check-nixfmt" "check-stylish" "check-stylish-network" ])
+  ++ (exesPaths [ "network-mux" "cardano-ping" ]) ++ [[ "checks" "styles" ]]
   ++ onlyBuildOnDefaultSystem;
 
   # Remove build jobs for which cross compiling does not make sense.


### PR DESCRIPTION
Previously, the `styles.check-nixfmt` check also ran when cross-compiling to mingwW64 (which is of course unnecessary). This failed, as some dependencies of nixfmt can't be cross-compiled, but the job was not marked as required, so it didn't prevent `hydra:required` from going green.

This check was never supposed to run on mingwW64, but it was not properly excluded due to what seems to be a copy-paste error of `stylePaths` in `noCrossBuild`. This PR fixes this by excluding `checks.styles.*` from being cross-compiled.