### PR TITLE
CAD-3915 config flags in node

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -111,7 +111,7 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index as Index
 import qualified Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy as LgrDB
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
-                     (RunAlsoLegacy (RunBoth), ledgerDbCurrentValues)
+                     (RunAlsoLegacy (RunOnlyNew), ledgerDbCurrentValues)
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
                      (BackingStoreSelector (..), LedgerDB')
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
@@ -714,7 +714,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
         -- Misc
         , cdbTracer                 = instrumentationTracer <> nullDebugTracer
         , cdbTraceLedger            = nullDebugTracer
-        , cdbLedgerRunAlsoLegacy    = RunBoth
+        , cdbLedgerRunAlsoLegacy    = RunOnlyNew
         , cdbRegistry               = registry
           -- TODO vary these
         , cdbGcDelay                = 0

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -243,7 +243,7 @@ initLgrDB k chain = do
       , lgrGenesis              = return testInitExtLedger
       , lgrTracer               = nullTracer
       , lgrTraceLedger          = nullTracer
-      , lgrRunAlsoLegacy        = LgrDB.RunBoth
+      , lgrRunAlsoLegacy        = LgrDB.RunOnlyNew
       , lgrBackingStoreSelector = TECHDEBT.InMemoryBackingStore
       }
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1694,7 +1694,7 @@ mkArgs cfg (MaxClockSkew maxClockSkew) chunkInfo initLedger tracer registry varC
     , cdbGcInterval             = 1
 
       -- UTxO HD scaffolding
-    , cdbLedgerRunAlsoLegacy    = RunBoth
+    , cdbLedgerRunAlsoLegacy    = RunOnlyNew
     , cdbBackingStoreSelector   = LedgerDB.InMemoryBackingStore
     }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -186,7 +186,7 @@ defaultArgs lgrHasFS diskPolicy bss = LgrDbArgs {
     , lgrTopLevelConfig = NoDefault
     , lgrTraceLedger    = nullTracer
     , lgrTracer         = nullTracer
-    , lgrRunAlsoLegacy  = RunBoth
+    , lgrRunAlsoLegacy  = RunOnlyNew
     , lgrBackingStoreSelector = bss
     }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
@@ -14,6 +14,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.HD.LMDB (
   , LMDBBackingStore
   , LMDBInit (..)
   , LMDBLimits
+  , LMDB.mapSize
   , LMDBValueHandle
   , TraceDb (..)
   , defaultLMDBLimits

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -945,6 +945,7 @@ data TraceReplayEvent blk =
         (ReplayGoal blk)  -- ^ the block at the tip of the ImmutableDB
   deriving (Generic, Eq, Show)
 
+-- | The backing store selector
 data BackingStoreSelector m where
   LMDBBackingStore :: MonadIO m => !LMDB.LMDBLimits -> BackingStoreSelector m
   InMemoryBackingStore :: BackingStoreSelector m


### PR DESCRIPTION
- `DISABLE_DUAL_LEDGER` removed.
- `RunAlsoLegacy` defaulted to `RunOnlyNew` always.
- New `BackingStoreSelectorFlag` datatype to be able to parse them without the `m` monad.