### PR TITLE
Update cardano-base and cardano-ledger. Removed VRF10 crypto

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -202,8 +202,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 631cb6cf1fa01ab346233b610a38b3b4cba6e6ab
-  --sha256: 0944wg2nqazmhlmsynwgdwxxj6ay0hb9qig9l128isb2cjia0hlp
+  tag: 0f3a867493059e650cda69e20a5cbf1ace289a57
+  --sha256: 0p0az3sbkhb7njji8xxdrfb0yx2gc8fmrh872ffm8sfip1w29gg1
   subdir:
     base-deriving-via
     binary
@@ -219,8 +219,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: e290bf8d0ea272a51e9acd10adc96b4e12e00d37
-  --sha256: 1pmdg80a8irrqgdhbp46a9jx628mjbrj0k89xv5nb5dy37z5ig5f
+  tag: 52da70e5a0472cd4433876289f1aebaa0c6e5c85
+  --sha256: 0aiislbwx5yqdidwd66zqqpskvay84iwkgsgi5l96rbfcsf0n8lq
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Crypto.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Crypto.hs
@@ -2,28 +2,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Module defining the crypto primitives used throughout Shelley based eras.
-module Ouroboros.Consensus.Shelley.Crypto (
-    StandardCrypto
-  , VRF10Crypto
-  ) where
+module Ouroboros.Consensus.Shelley.Crypto (StandardCrypto) where
 
-import           Cardano.Crypto.DSIGN (Ed25519DSIGN)
-import           Cardano.Crypto.Hash (Blake2b_256)
-import           Cardano.Crypto.KES (CompactSum7KES)
-import           Cardano.Crypto.VRF.PraosBatchCompat (PraosBatchCompatVRF)
-import           Cardano.Ledger.Crypto (Crypto (..), StandardCrypto)
-
--- | Crypto to be used from the Babbage era onwards. This incorporates a few
--- changes from 'StandardCrypto':
---
--- - Update to IETF VRF draft 10
--- - Use a smaller KES proof
-
-data VRF10Crypto
-
-instance Crypto VRF10Crypto where
-  type ADDRHASH _ = ADDRHASH StandardCrypto
-  type HASH _ = HASH StandardCrypto
-  type DSIGN _ = DSIGN StandardCrypto
-  type VRF _ = PraosBatchCompatVRF
-  type KES _ = CompactSum7KES Ed25519DSIGN Blake2b_256
+import           Cardano.Ledger.Crypto (StandardCrypto)


### PR DESCRIPTION
VRF10 has not passed the full audit yet, as such it has been disabled in: https://github.com/input-output-hk/cardano-base/pull/281

This PR removes the unused `VRF10Crypto` type (which should have been defined in ledger anyways)

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
