### PR TITLE
Add a consensus-level BlockFetch client test 

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -78,6 +78,7 @@ library
 
   build-depends:       base              >=4.9 && <4.15
                      , base16-bytestring
+                     , binary
                      , bytestring        >=0.10  && <0.11
                      , cardano-crypto-class
                      , cardano-prelude

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -143,6 +143,7 @@ test-suite test-consensus
                        Test.Consensus.HardFork.Combinator
                        Test.Consensus.HardFork.Combinator.A
                        Test.Consensus.HardFork.Combinator.B
+                       Test.Consensus.MiniProtocol.BlockFetch.Client
                        Test.Consensus.MiniProtocol.ChainSync.Client
                        Test.Consensus.MiniProtocol.LocalStateQuery.Server
                        Test.Consensus.Mempool
@@ -162,6 +163,7 @@ test-suite test-consensus
                      , contra-tracer
                      , directory
                      , generics-sop
+                     , hashable
                      , mtl
                      , nothunks
                      , QuickCheck
@@ -174,6 +176,7 @@ test-suite test-consensus
                      , tasty-quickcheck
                      , temporary
                      , time
+                     , transformers
                      , tree-diff
 
                      , io-classes

--- a/ouroboros-consensus-test/test-consensus/Main.hs
+++ b/ouroboros-consensus-test/test-consensus/Main.hs
@@ -8,6 +8,7 @@ import qualified Test.Consensus.HardFork.Forecast (tests)
 import qualified Test.Consensus.HardFork.History (tests)
 import qualified Test.Consensus.HardFork.Summary (tests)
 import qualified Test.Consensus.Mempool (tests)
+import qualified Test.Consensus.MiniProtocol.BlockFetch.Client (tests)
 import qualified Test.Consensus.MiniProtocol.ChainSync.Client (tests)
 import qualified Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests)
 import qualified Test.Consensus.Node (tests)
@@ -22,6 +23,7 @@ tests :: TestTree
 tests =
   testGroup "ouroboros-consensus"
   [ Test.Consensus.BlockchainTime.Simple.tests
+  , Test.Consensus.MiniProtocol.BlockFetch.Client.tests
   , Test.Consensus.MiniProtocol.ChainSync.Client.tests
   , Test.Consensus.MiniProtocol.LocalStateQuery.Server.tests
   , Test.Consensus.Mempool.tests

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -1,0 +1,439 @@
+{-# LANGUAGE BlockArguments             #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+
+-- | A test for the consensus-specific parts of the BlockFetch client.
+--
+-- When adding a block to the ChainDB, we allocate potential punishments, which
+-- are later invoked after block validation, crucially allowing us to kill the
+-- BlockFetch client and hence disconnect from malicious peers.
+--
+-- This test spins up several BlockFetch clients, which download randomly
+-- generated chains and add them to the ChainDB, which will enact these
+-- punishments on validation. Right now, we only ensure that doing so for chains
+-- originating from honest behavior do not cause any disconnects, but we plan to
+-- also model malicious/erroneous behavior.
+module Test.Consensus.MiniProtocol.BlockFetch.Client (tests) where
+
+import           Control.Monad (replicateM)
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Control.Tracer (Tracer (..), nullTracer, traceWith)
+import           Data.Bifunctor (first)
+import           Data.Hashable (Hashable)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Traversable (for)
+
+import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
+
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
+                     BlockFetchConsensusInterface, FetchMode (..),
+                     blockFetchLogic, bracketFetchClient,
+                     bracketKeepAliveClient, bracketSyncWithFetchClient,
+                     newFetchClientRegistry)
+import           Ouroboros.Network.BlockFetch.Client (blockFetchClient)
+import           Ouroboros.Network.Channel (createConnectedChannels)
+import qualified Ouroboros.Network.Driver.Simple as Driver
+import           Ouroboros.Network.MockChain.Chain (Chain)
+import qualified Ouroboros.Network.MockChain.Chain as Chain
+import qualified Ouroboros.Network.Mux as Mux
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
+import           Ouroboros.Network.Protocol.BlockFetch.Codec (codecBlockFetchId)
+import           Ouroboros.Network.Protocol.BlockFetch.Server
+                     (BlockFetchBlockSender (SendMsgNoBlocks, SendMsgStartBatch),
+                     BlockFetchSendBlocks (SendMsgBatchDone, SendMsgBlock),
+                     BlockFetchServer (..), blockFetchServerPeer)
+import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..),
+                     Message (MsgBlock))
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Fragment.InFuture
+                     (CheckInFuture (CheckInFuture))
+import           Ouroboros.Consensus.Fragment.Validated
+                     (ValidatedFragment (validatedFragment))
+import           Ouroboros.Consensus.HardFork.History.EraParams
+                     (EraParams (eraEpochSize))
+import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import           Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDBImpl
+import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (SomeHasFS))
+import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+                     (SnapshotInterval (DefaultSnapshotInterval),
+                     defaultDiskPolicy)
+import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry
+import           Ouroboros.Consensus.Util.STM (blockUntilJust,
+                     forkLinkedWatcher)
+
+import           Test.Util.ChainUpdates
+import qualified Test.Util.FS.Sim.MockFS as MockFS
+import           Test.Util.FS.Sim.STM (simHasFS)
+import           Test.Util.LogicalClock (Tick (..))
+import qualified Test.Util.LogicalClock as LogicalClock
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.Schedule
+import           Test.Util.TestBlock
+import           Test.Util.Time (dawnOfTime)
+import           Test.Util.Tracer (recordingTracerTVar)
+
+tests :: TestTree
+tests = testGroup "BlockFetchClient"
+    [ testProperty "blockFetch" prop_blockFetch
+    ]
+
+prop_blockFetch :: BlockFetchClientTestSetup -> Property
+prop_blockFetch bfcts@BlockFetchClientTestSetup{..} =
+    counterexample ("Trace:\n" <> unlines (ppTrace <$> bfcoTrace)) $
+    counterexample (condense bfcts) $
+    conjoin $
+      [ noException ("BlockFetch client " <> condense peerId) res
+      | (peerId, res) <- Map.toList bfcoBlockFetchResults
+      ] <>
+      [ Map.keysSet bfcoBlockFetchResults === Map.keysSet peerUpdates
+      , counterexample ("Fetched blocks per peer: " <> condense bfcoFetchedBlocks) $
+        property $ all (> 0) bfcoFetchedBlocks
+      ]
+  where
+    BlockFetchClientOutcome{..} = runSimOrThrow $ runBlockFetchTest bfcts
+
+    noException msg = \case
+      Right () -> property ()
+      Left ex  ->
+        counterexample (msg <> ": exception: " <> displayException ex) False
+
+    ppTrace (Tick tick, ev) = show tick <> ": " <> ev
+
+{-------------------------------------------------------------------------------
+  Running a test involving the consensus BlockFetch interface
+-------------------------------------------------------------------------------}
+
+data BlockFetchClientOutcome = BlockFetchClientOutcome {
+    bfcoBlockFetchResults :: Map PeerId (Either SomeException ())
+  , bfcoFetchedBlocks     :: Map PeerId Word
+  , bfcoTrace             :: [(Tick, String)]
+  }
+
+runBlockFetchTest ::
+     forall m.
+     (IOLike m, MonadTime m)
+  => BlockFetchClientTestSetup
+  -> m BlockFetchClientOutcome
+runBlockFetchTest BlockFetchClientTestSetup{..} = withRegistry \registry -> do
+    varChains           <- uncheckedNewTVarM Map.empty
+    varControlMessage   <- uncheckedNewTVarM Mux.Continue
+    varFetchedBlocks    <- uncheckedNewTVarM (0 <$ peerUpdates)
+
+    fetchClientRegistry <- newFetchClientRegistry
+    clock               <- LogicalClock.new registry $
+      LogicalClock.sufficientTimeFor $ lastTick <$> Map.elems peerUpdates
+    (tracer, getTrace)  <-
+      first (LogicalClock.tickTracer clock) <$> recordingTracerTVar
+    chainDbView         <- mkChainDbView registry tracer
+
+    let getCandidates = Map.map chainToAnchoredFragment <$> readTVar varChains
+
+        blockFetchConsensusInterface =
+          mkTestBlockFetchConsensusInterface
+            (Map.map (AF.mapAnchoredFragment getHeader) <$> getCandidates)
+            chainDbView
+
+    _ <- forkLinkedThread registry "BlockFetchLogic" $
+      blockFetchLogic
+        nullTracer
+        nullTracer
+        blockFetchConsensusInterface
+        fetchClientRegistry
+        blockFetchCfg
+
+    let runBlockFetchClient peerId =
+          bracketFetchClient fetchClientRegistry ntnVersion peerId \clientCtx -> do
+            let bfClient = blockFetchClient
+                    ntnVersion
+                    (readTVar varControlMessage)
+                    nullTracer
+                    clientCtx
+                bfServer =
+                    blockFetchServerPeer $ mockBlockFetchServer getCurrentChain
+                  where
+                    getCurrentChain = atomically $ (Map.! peerId) <$> getCandidates
+
+                blockFetchTracer = Tracer \case
+                    (Driver.Client, ev) -> do
+                      atomically case ev of
+                        Driver.TraceRecvMsg (AnyMessageAndAgency _ (MsgBlock _)) ->
+                           modifyTVar varFetchedBlocks $ Map.adjust (+ 1) peerId
+                        _ -> pure ()
+                      traceWith tracer $
+                        show peerId <> ": BlockFetchClient: " <> show ev
+                    _ -> pure ()
+            fst <$> Driver.runConnectedPeersPipelined
+              createConnectedChannels
+              blockFetchTracer
+              codecBlockFetchId
+              bfClient
+              bfServer
+
+        -- On every tick, we schedule updates to the shared chain fragment
+        -- (mocking ChainSync).
+        forkTicking peerId =
+            forkLinkedWatcher registry ("TickWatcher " <> condense peerId) $
+              LogicalClock.tickWatcher clock \tick -> atomically do
+                let updates = toChainUpdates $
+                      Map.findWithDefault [] tick $
+                        getSchedule $ peerUpdates Map.! peerId
+                    updateChain chain =
+                      case Chain.applyChainUpdates updates chain of
+                        Just chain' -> chain'
+                        Nothing     -> error "Chain update failed"
+                -- Block until our "ChainSync" thread registered itself to the
+                -- FetchClientRegistry, see 'forkChainSync' below.
+                _ <- blockUntilJust $ Map.lookup peerId <$> readTVar varChains
+                modifyTVar varChains $ Map.adjust updateChain peerId
+
+        forkChainSync peerId =
+          forkLinkedThread registry ("BracketSync" <> condense peerId) $
+            bracketSyncWithFetchClient fetchClientRegistry peerId $ do
+              let modifyChains = atomically . modifyTVar varChains
+              bracket_
+                (modifyChains $ Map.insert peerId Chain.Genesis)
+                (modifyChains $ Map.delete peerId)
+                (forkTicking peerId >>= waitThread)
+
+        -- The BlockFetch logic requires initializing the KeepAlive
+        -- miniprotocol, even if it does not do anything.
+        forkKeepAlive peerId =
+          forkLinkedThread registry "KeepAlive" $
+            bracketKeepAliveClient fetchClientRegistry peerId \_ ->
+              infiniteDelay
+
+    blockFetchThreads <- Map.fromList <$> for peerIds \peerId -> do
+      _ <- forkChainSync peerId
+      _ <- forkKeepAlive peerId
+      fmap (peerId,) $
+        forkThread registry ("BlockFetch " <> condense peerId) $
+          try $ runBlockFetchClient peerId
+
+    LogicalClock.waitUntilDone clock
+    atomically $ writeTVar varControlMessage Mux.Terminate
+
+    bfcoBlockFetchResults <- traverse waitThread blockFetchThreads
+    bfcoFetchedBlocks     <- readTVarIO varFetchedBlocks
+    bfcoTrace             <- getTrace
+    pure BlockFetchClientOutcome {..}
+  where
+    peerIds = Map.keys peerUpdates
+
+    numCoreNodes = NumCoreNodes $ fromIntegral $ Map.size peerUpdates + 1
+
+    mkChainDbView ::
+         ResourceRegistry m
+      -> Tracer m String
+      -> m (BlockFetchClientInterface.ChainDbView m TestBlock)
+    mkChainDbView registry tracer = do
+        chainDbArgs <- do
+          cdbHasFSImmutableDB <- mockedHasFS
+          cdbHasFSVolatileDB  <- mockedHasFS
+          cdbHasFSLgrDB       <- mockedHasFS
+          let cdbImmutableDbValidation  = ImmutableDB.ValidateAllChunks
+              cdbVolatileDbValidation   = VolatileDB.ValidateAll
+              cdbMaxBlocksPerFile       = VolatileDB.mkBlocksPerFile 4
+              cdbDiskPolicy             =
+                defaultDiskPolicy securityParam DefaultSnapshotInterval
+              cdbTopLevelConfig         = topLevelConfig
+              cdbChunkInfo              = ImmutableDB.simpleChunkInfo epochSize
+              cdbCheckIntegrity _blk    = True
+              cdbGenesis                = pure testInitExtLedger
+              cdbCheckInFuture          = CheckInFuture checkInFuture
+              cdbImmutableDbCacheConfig = ImmutableDB.CacheConfig 2 60
+              cdbTraceLedger            = nullTracer
+              cdbRegistry               = registry
+              cdbBlocksToAddSize        = 1
+              -- not relevant for this test
+              cdbGcDelay                = 1
+              cdbGcInterval             = 1
+          pure ChainDbArgs {..}
+        (_, (chainDB, ChainDBImpl.Internal{intAddBlockRunner})) <-
+          allocate
+            registry
+            (\_ -> ChainDBImpl.openDBInternal chainDbArgs False)
+            (ChainDB.closeDB . fst)
+        _ <- forkLinkedThread registry "AddBlockRunner" intAddBlockRunner
+
+        let -- Always return the empty chain such that the BlockFetch logic
+            -- downloads all chains.
+            getCurrentChain           = pure $ AF.Empty AF.AnchorGenesis
+            getIsFetched              = ChainDB.getIsFetched chainDB
+            getMaxSlotNo              = ChainDB.getMaxSlotNo chainDB
+            addBlockWaitWrittenToDisk = ChainDB.addBlockWaitWrittenToDisk chainDB
+        pure BlockFetchClientInterface.ChainDbView {..}
+      where
+        -- Needs to be larger than any chain length in this test, to ensure that
+        -- switching to any chain is never too deep.
+        securityParam  = SecurityParam 1000
+        topLevelConfig = singleNodeTestConfigWithK securityParam
+        epochSize      = eraEpochSize $ topLevelConfigLedger topLevelConfig
+
+        mockedHasFS = SomeHasFS . simHasFS <$> newTVarIO MockFS.empty
+
+        cdbTracer = Tracer \case
+            ChainDBImpl.TraceAddBlockEvent ev ->
+              traceWith tracer $ "ChainDB: " <> show ev
+            _ -> pure ()
+
+        -- TODO generate more interesting behavior here
+        checkInFuture vf = pure (validatedFragment vf, [])
+
+    mkTestBlockFetchConsensusInterface ::
+         STM m (Map PeerId (AnchoredFragment (Header TestBlock)))
+      -> BlockFetchClientInterface.ChainDbView m TestBlock
+      -> BlockFetchConsensusInterface PeerId (Header TestBlock) TestBlock m
+    mkTestBlockFetchConsensusInterface getCandidates chainDbView =
+        BlockFetchClientInterface.mkBlockFetchConsensusInterface
+          (TestBlockConfig numCoreNodes)
+          chainDbView
+          getCandidates
+          (\_hdr -> 1000) -- header size, only used for peer prioritization
+          slotForgeTime
+          (pure blockFetchMode)
+      where
+        -- Bogus implementation; this is fine as this is only used for
+        -- enriching tracing information ATM.
+        slotForgeTime :: BlockFetchClientInterface.SlotForgeTimeOracle m blk
+        slotForgeTime _ = pure dawnOfTime
+
+mockBlockFetchServer ::
+     forall m blk.
+     (Monad m, HasHeader blk)
+  => m (AnchoredFragment blk)
+  -> BlockFetchServer blk (Point blk) m ()
+mockBlockFetchServer getCurrentChain = idle
+  where
+    idle :: BlockFetchServer blk (Point blk) m ()
+    idle = flip BlockFetchServer () \(ChainRange from to) -> do
+        curChain <- getCurrentChain
+        pure case AF.sliceRange curChain from to of
+          Nothing    -> SendMsgNoBlocks (pure idle)
+          Just slice -> SendMsgStartBatch $ sendBlocks (AF.toOldestFirst slice)
+
+    sendBlocks :: [blk] -> m (BlockFetchSendBlocks blk (Point blk) m ())
+    sendBlocks = pure . \case
+      []         -> SendMsgBatchDone (pure idle)
+      blk : blks -> SendMsgBlock blk (sendBlocks blks)
+
+ntnVersion :: NodeToNodeVersion
+ntnVersion = maxBound
+
+{-------------------------------------------------------------------------------
+  BlockFetchClientTestSetup
+-------------------------------------------------------------------------------}
+
+data BlockFetchClientTestSetup = BlockFetchClientTestSetup {
+    -- | A 'Schedule' of 'ChainUpdate's for every peer. This emulates
+    -- the candidate fragments provided by the ChainSync client.
+    peerUpdates    :: Map PeerId (Schedule ChainUpdate)
+    -- | BlockFetch 'FetchMode'
+  , blockFetchMode :: FetchMode
+  , blockFetchCfg  :: BlockFetchConfiguration
+  }
+  deriving stock (Show)
+
+instance Condense BlockFetchClientTestSetup where
+  condense BlockFetchClientTestSetup{..} = unlines
+      [ "Number of peers: "
+          <> show (Map.size peerUpdates)
+      , "Chain updates:\n"
+          <> ppPerPeer peerUpdates
+      , "BlockFetch mode: " <> show blockFetchMode
+      , "BlockFetch cfg: " <> show blockFetchCfg
+      ]
+    where
+      ppPerPeer peerMap = unlines
+        [ "  " <> show peerId <> ": " <> valLine
+        | (peerId, val) <- Map.toAscList peerMap
+        , valLine       <- lines $ condense val
+        ]
+
+instance Arbitrary BlockFetchClientTestSetup where
+  arbitrary = do
+      numPeers <- chooseInt (1, 3)
+      let peerIds = PeerId <$> [1 .. numPeers]
+      peerUpdates <-
+            Map.fromList . zip peerIds
+        <$> replicateM numPeers genUpdateSchedule
+      blockFetchMode <- elements [FetchModeBulkSync, FetchModeDeadline]
+      blockFetchCfg  <- do
+        let -- ensure that we can download blocks from all peers
+            bfcMaxConcurrencyBulkSync = fromIntegral numPeers
+            bfcMaxConcurrencyDeadline = fromIntegral numPeers
+            -- This is used to introduce a minimal delay between BlockFetch
+            -- logic iterations in case the monitored state vars change too
+            -- fast, which we don't have to worry about in this test.
+            bfcDecisionLoopInterval   = 0
+        bfcMaxRequestsInflight <- chooseEnum (2, 10)
+        bfcSalt                <- arbitrary
+        pure BlockFetchConfiguration {..}
+      pure BlockFetchClientTestSetup {..}
+    where
+      genUpdateSchedule =
+        genChainUpdates TentativeChainBehavior maxRollback 20 >>= genSchedule
+
+      -- Only use a small k to avoid rolling forward by a big chain.
+      maxRollback = SecurityParam 5
+
+  shrink BlockFetchClientTestSetup{..} =
+      -- If we have multiple peers, check if removing the peer still
+      -- yields an error
+      [ BlockFetchClientTestSetup {
+            peerUpdates = Map.delete peerId peerUpdates
+          , ..
+          }
+      | length peerIds > 1
+      , peerId <- peerIds
+      ] <>
+      -- Shrink the schedules for all peers simultaneously
+      [ BlockFetchClientTestSetup {
+            peerUpdates = Map.insert peerId updates peerUpdates
+          , ..
+          }
+      | peerId <- peerIds
+      , updates <-
+          filter (not . null . joinSchedule) $
+            shrinkSchedule (peerUpdates Map.! peerId)
+      ]
+    where
+      peerIds = Map.keys peerUpdates
+
+newtype PeerId = PeerId Int
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Condense, Hashable, Enum, Bounded)
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+infiniteDelay :: MonadSTM m => m a
+infiniteDelay = atomically retry
+
+chainToAnchoredFragment :: HasHeader blk => Chain blk -> AnchoredFragment blk
+chainToAnchoredFragment =
+    AF.fromOldestFirst AF.AnchorGenesis . Chain.toOldestFirst

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -129,6 +129,7 @@ library
                        Ouroboros.Consensus.Mempool.Impl.Types
                        Ouroboros.Consensus.Mempool.TxLimits
                        Ouroboros.Consensus.Mempool.TxSeq
+                       Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
                        Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
                        Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                        Ouroboros.Consensus.MiniProtocol.ChainSync.Server

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -1,0 +1,307 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+-- | Initialization of the 'BlockFetchConsensusInterface'
+module Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface (
+    ChainDbView (..)
+  , SlotForgeTimeOracle
+  , defaultChainDbView
+  , initSlotForgeTimeOracle
+  , mkBlockFetchConsensusInterface
+  , readFetchModeDefault
+  ) where
+
+import           Control.Monad
+import           Data.Map.Strict (Map)
+import           Data.Proxy
+import           Data.Time.Clock (UTCTime)
+import           GHC.Stack (HasCallStack)
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (MaxSlotNo)
+import           Ouroboros.Network.BlockFetch
+
+import           Ouroboros.Consensus.Block hiding (blockMatchesHeader)
+import qualified Ouroboros.Consensus.Block as Block
+import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.Config
+import qualified Ouroboros.Consensus.Config.SupportsNode as SupportsNode
+import qualified Ouroboros.Consensus.HardFork.Abstract as History
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.AnchoredFragment
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.Orphans ()
+
+import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+                     (InvalidBlockPunishment)
+import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
+
+-- | Abstract over the ChainDB
+data ChainDbView m blk = ChainDbView {
+     getCurrentChain           :: STM m (AnchoredFragment (Header blk))
+   , getIsFetched              :: STM m (Point blk -> Bool)
+   , getMaxSlotNo              :: STM m MaxSlotNo
+   , addBlockWaitWrittenToDisk :: InvalidBlockPunishment m -> blk -> m Bool
+   }
+
+defaultChainDbView :: IOLike m => ChainDB m blk -> ChainDbView m blk
+defaultChainDbView chainDB = ChainDbView {
+    getCurrentChain           = ChainDB.getCurrentChain chainDB
+  , getIsFetched              = ChainDB.getIsFetched chainDB
+  , getMaxSlotNo              = ChainDB.getMaxSlotNo chainDB
+  , addBlockWaitWrittenToDisk = ChainDB.addBlockWaitWrittenToDisk chainDB
+  }
+
+-- | How to get the wall-clock time of a slot. Note that this is a very
+-- non-trivial operation in the context of the HFC, cf. 'headerForgeUTCTime'.
+type SlotForgeTimeOracle m blk = RealPoint blk -> STM m UTCTime
+
+-- | Create a HFC-enabled 'SlotForgeTimeOracle'. Note that its semantics are
+-- rather tricky, cf. 'headerForgeUTCTime'.
+initSlotForgeTimeOracle ::
+     forall m blk.
+     ( IOLike m
+     , BlockSupportsProtocol blk
+     , History.HasHardForkHistory blk
+     , SupportsNode.ConfigSupportsNode blk
+     , IsLedger (LedgerState blk)
+     )
+  => TopLevelConfig blk
+  -> ChainDB m blk
+  -> m (SlotForgeTimeOracle m blk)
+initSlotForgeTimeOracle cfg chainDB = do
+    cache <-
+      History.runWithCachedSummary
+        (toSummary <$> ChainDB.getCurrentLedger chainDB)
+    let slotForgeTime rp =
+              fmap
+                (either errMsg toAbsolute)
+            $ History.cachedRunQuery
+                cache
+                (fst <$> History.slotToWallclock (realPointSlot rp))
+          where
+            -- This @cachedRunQuery@ fail for the following reasons.
+            --
+            -- By the PRECONDITIONs documented in the 'headerForgeUTCTime', we
+            -- can assume that the given header was validated by the ChainSync
+            -- client. This means its slot was, at some point, within the ledger
+            -- view forecast range of the ledger state of our contemporary
+            -- intersection with the header itself (and that intersection
+            -- extended our contemporary immutable tip). A few additional facts
+            -- ensure that we will always be able to thereafter correctly
+            -- convert that header's slot using our current chain's ledger
+            -- state.
+            --
+            --   o For under-developed reasons, the ledger view forecast range
+            --     is equivalent to the time forecast range, ie " Definition
+            --     17.2 (Forecast range) " from The Consensus Report.
+            --
+            --   o Because rollback is bounded, our currently selected chain
+            --     will always be an evolution (ie " switch(n, bs) ") of that
+            --     intersection point. (This one is somewhat obvious in
+            --     retrospect, but we're being explicit here in order to
+            --     emphasize the relation to the " chain evolution " jargon.)
+            --
+            --   o Because " stability itself is stable ", the HFC satisfies "
+            --     Property 17.3 (Time conversions stable under chain evolution)
+            --     " from The Consensus Report.
+            errMsg err =
+              error $
+                 "Consensus could not determine forge UTCTime!"
+              <> " " <> show rp
+              <> " " <> show err
+    pure slotForgeTime
+  where
+    toSummary ::
+         ExtLedgerState blk
+      -> History.Summary (History.HardForkIndices blk)
+    toSummary = History.hardForkSummary (configLedger cfg) . ledgerState
+
+    toAbsolute :: RelativeTime -> UTCTime
+    toAbsolute =
+        fromRelativeTime (SupportsNode.getSystemStart (configBlock cfg))
+
+readFetchModeDefault ::
+     (MonadSTM m, HasHeader blk)
+  => BlockchainTime m
+  -> STM m (AnchoredFragment blk)
+  -> STM m FetchMode
+readFetchModeDefault btime getCurrentChain = do
+    mCurSlot <- getCurrentSlot btime
+    case mCurSlot of
+      -- The current chain's tip far away from "now", so use bulk sync mode.
+      CurrentSlotUnknown  -> return FetchModeBulkSync
+      CurrentSlot curSlot -> do
+        curChainSlot <- AF.headSlot <$> getCurrentChain
+        let slotsBehind = case curChainSlot of
+              -- There's nothing in the chain. If the current slot is 0, then
+              -- we're 1 slot behind.
+              Origin         -> unSlotNo curSlot + 1
+              NotOrigin slot -> unSlotNo curSlot - unSlotNo slot
+            maxSlotsBehind = 1000
+        return $ if slotsBehind < maxSlotsBehind
+          -- When the current chain is near to "now", use deadline mode,
+          -- when it is far away, use bulk sync mode.
+          then FetchModeDeadline
+          else FetchModeBulkSync
+
+mkBlockFetchConsensusInterface ::
+     forall m peer blk.
+     ( IOLike m
+     , BlockSupportsProtocol blk
+     )
+  => BlockConfig blk
+  -> ChainDbView m blk
+  -> STM m (Map peer (AnchoredFragment (Header blk)))
+  -> (Header blk -> SizeInBytes)
+  -> SlotForgeTimeOracle m blk
+     -- ^ Slot forge time, see 'headerForgeUTCTime' and 'blockForgeUTCTime'.
+  -> STM m FetchMode
+     -- ^ See 'readFetchMode'.
+  -> BlockFetchConsensusInterface peer (Header blk) blk m
+mkBlockFetchConsensusInterface
+  bcfg chainDB getCandidates blockFetchSize slotForgeTime readFetchMode =
+    BlockFetchConsensusInterface {..}
+  where
+    blockMatchesHeader :: Header blk -> blk -> Bool
+    blockMatchesHeader = Block.blockMatchesHeader
+
+    readCandidateChains :: STM m (Map peer (AnchoredFragment (Header blk)))
+    readCandidateChains = getCandidates
+
+    readCurrentChain :: STM m (AnchoredFragment (Header blk))
+    readCurrentChain = getCurrentChain chainDB
+
+    readFetchedBlocks :: STM m (Point blk -> Bool)
+    readFetchedBlocks = getIsFetched chainDB
+
+    -- See 'mkAddFetchedBlock_'
+    mkAddFetchedBlock ::
+         WhetherReceivingTentativeBlocks
+      -> STM m (Point blk -> blk -> m ())
+    mkAddFetchedBlock enabledPipelining = do
+      unlessImproved <- InvalidBlockPunishment.mkUnlessImproved (Proxy @blk)
+      pure $ mkAddFetchedBlock_ unlessImproved enabledPipelining
+
+    -- Waits until the block has been written to disk, but not until chain
+    -- selection has processed the block.
+    mkAddFetchedBlock_ ::
+         (   SelectView (BlockProtocol blk)
+          -> InvalidBlockPunishment m
+          -> InvalidBlockPunishment m
+         )
+      -> WhetherReceivingTentativeBlocks
+      -> Point blk
+      -> blk
+      -> m ()
+    mkAddFetchedBlock_ unlessImproved enabledPipelining _pt blk = void $ do
+       disconnect <- InvalidBlockPunishment.mkPunishThisThread
+       -- A BlockFetch peer can either send an entire range or none of the
+       -- range; anything else will incur a disconnect. And in 'FetchDeadline'
+       -- mode, which is the relevant case for this kind of DoS attack (because
+       -- in bulk sync, our honest peers will be streaming a very dense chain
+       -- very quickly, meaning the adversary only has very small windows during
+       -- which we're interested in its chains), the node only requests whole
+       -- suffixes from peers: the BlockFetch decision logic does not avoid
+       -- requesting a block that is already in-flight from other peers. Thus
+       -- the adversary cannot send us blocks out-of-order (during
+       -- 'FetchDeadline'), even if they control more than one of our peers.
+       --
+       -- Therefore, the following punishment logic only needs to cover the
+       -- "whole chain received in-order from a single-peer" case. Which it
+       -- currently does.
+       --
+       -- TODO maintain the context of which ChainSync candidate incurring this
+       -- fetch request, and disconnect immediately if the invalid block is not
+       -- the tip of that candidate. As-is, in 'FetchDeadline' they must also
+       -- send the next block, but they might be able to wait long enough that
+       -- it is not desirable when it arrives, and therefore not be disconnected
+       -- from. So their choices are: cause a disconnect or else do nothing for
+       -- long enough. Both are fine by us, from a DoS mitigation perspective.
+       let punishment = InvalidBlockPunishment.branch $ \case
+             -- invalid parents always cause a disconnect
+             InvalidBlockPunishment.BlockPrefix -> disconnect
+             -- when pipelining, we forgive an invalid block itself if it's
+             -- better than the previous invalid block this peer delivered
+             InvalidBlockPunishment.BlockItself -> case enabledPipelining of
+               NotReceivingTentativeBlocks -> disconnect
+               ReceivingTentativeBlocks    ->
+                 unlessImproved (selectView bcfg (getHeader blk)) disconnect
+       addBlockWaitWrittenToDisk
+         chainDB
+         punishment
+         blk
+
+    readFetchedMaxSlotNo :: STM m MaxSlotNo
+    readFetchedMaxSlotNo = getMaxSlotNo chainDB
+
+    -- Note that @ours@ comes from the ChainDB and @cand@ from the ChainSync
+    -- client.
+    --
+    -- Fragments are proxies for their corresponding chains; it is possible, in
+    -- principle, that an empty fragment corresponds to the chain we want to
+    -- adopt, and should therefore be preferred over other fragments (whose
+    -- blocks we therefore do not want to download). The precondition to
+    -- 'preferAnchoredCandidates' is designed precisely to rule out this
+    -- possibility (for details, see the Consensus Report), but unfortunately we
+    -- cannot always satisfy this precondition: although the chain sync client
+    -- preserves an invariant that relates our current chain to the candidate
+    -- fragment, by the time the block fetch download logic considers the
+    -- fragment, our current chain might have changed.
+    plausibleCandidateChain :: HasCallStack
+                            => AnchoredFragment (Header blk)
+                            -> AnchoredFragment (Header blk)
+                            -> Bool
+    plausibleCandidateChain ours cand
+      -- 1. The ChainDB maintains the invariant that the anchor of our fragment
+      --    corresponds to the immutable tip.
+      --
+      -- 2. The ChainSync client locally maintains the invariant that our
+      --    fragment and the candidate fragment have the same anchor point. This
+      --    establishes the precondition required by @preferAnchoredCandidate@.
+      --
+      -- 3. However, by the time that the BlockFetch logic processes a fragment
+      --    presented to it by the ChainSync client, our current fragment might
+      --    have changed, and they might no longer be anchored at the same
+      --    point. This means that we are no longer guaranteed that the
+      --    precondition holds.
+      --
+      -- 4. Our chain's anchor can only move forward. We can detect this by
+      --    looking at the block numbers of the anchors.
+      --
+      | AF.anchorBlockNo cand < AF.anchorBlockNo ours  -- (4)
+      = case (AF.null ours, AF.null cand) of
+          -- Both are non-empty, the precondition trivially holds.
+          (False, False) -> preferAnchoredCandidate bcfg ours cand
+          -- The candidate is shorter than our chain and, worse, we'd have to
+          -- roll back past our immutable tip (the anchor of @cand@).
+          (_,     True)  -> False
+          -- As argued above we can only reach this case when our chain's anchor
+          -- has changed (4).
+          --
+          -- It is impossible for our chain to change /and/ still be empty: the
+          -- anchor of our chain only changes when a new block becomes
+          -- immutable. For a new block to become immutable, we must have
+          -- extended our chain with at least @k + 1@ blocks. Which means our
+          -- fragment can't be empty.
+          (True,  _)     -> error "impossible"
+
+      | otherwise
+      = preferAnchoredCandidate bcfg ours cand
+
+    compareCandidateChains :: AnchoredFragment (Header blk)
+                           -> AnchoredFragment (Header blk)
+                           -> Ordering
+    compareCandidateChains = compareAnchoredFragments bcfg
+
+    headerForgeUTCTime = slotForgeTime . headerRealPoint . unFromConsensus
+    blockForgeUTCTime  = slotForgeTime . blockRealPoint  . unFromConsensus

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -36,8 +36,6 @@ import           Data.Map.Strict (Map)
 import           Data.Maybe (isJust, mapMaybe)
 import           Data.Proxy
 import qualified Data.Text as Text
-import           Data.Time.Clock (UTCTime)
-import           GHC.Stack (HasCallStack)
 import           System.Random (StdGen)
 
 import           Control.Tracer
@@ -45,7 +43,6 @@ import           Control.Tracer
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (MaxSlotNo)
 import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
 import           Ouroboros.Network.TxSubmission.Inbound
@@ -59,10 +56,7 @@ import           Ouroboros.Consensus.Block hiding (blockMatchesHeader)
 import qualified Ouroboros.Consensus.Block as Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-import qualified Ouroboros.Consensus.Config.SupportsNode as SupportsNode
 import           Ouroboros.Consensus.Forecast
-import qualified Ouroboros.Consensus.HardFork.Abstract as History
-import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
@@ -70,10 +64,10 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
+import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.AnchoredFragment
 import           Ouroboros.Consensus.Util.EarlyExit
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -82,8 +76,6 @@ import           Ouroboros.Consensus.Util.STM
 
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
-                     (InvalidBlockPunishment)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
@@ -220,239 +212,20 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
     let getCandidates :: STM m (Map remotePeer (AnchoredFragment (Header blk)))
         getCandidates = readTVar varCandidates >>= traverse readTVar
 
-    blockFetchInterface <-
-      initBlockFetchConsensusInterface
-        cfg
-        chainDB
-        getCandidates
-        blockFetchSize
-        btime
-    let _ = blockFetchInterface :: BlockFetchConsensusInterface remotePeer (Header blk) blk m
+    slotForgeTimeOracle <- BlockFetchClientInterface.initSlotForgeTimeOracle cfg chainDB
+    let readFetchMode = BlockFetchClientInterface.readFetchModeDefault
+          btime
+          (ChainDB.getCurrentChain chainDB)
+        blockFetchInterface :: BlockFetchConsensusInterface remotePeer (Header blk) blk m
+        blockFetchInterface = BlockFetchClientInterface.mkBlockFetchConsensusInterface
+          (configBlock cfg)
+          (BlockFetchClientInterface.defaultChainDbView chainDB)
+          getCandidates
+          blockFetchSize
+          slotForgeTimeOracle
+          readFetchMode
 
     return IS {..}
-
-initBlockFetchConsensusInterface
-    :: forall m peer blk.
-       ( IOLike m
-       , BlockSupportsProtocol blk
-       , SupportsNode.ConfigSupportsNode blk
-       , History.HasHardForkHistory blk
-       , IsLedger (LedgerState blk)
-       )
-    => TopLevelConfig blk
-    -> ChainDB m blk
-    -> STM m (Map peer (AnchoredFragment (Header blk)))
-    -> (Header blk -> SizeInBytes)
-    -> BlockchainTime m
-    -> m (BlockFetchConsensusInterface peer (Header blk) blk m)
-initBlockFetchConsensusInterface cfg chainDB getCandidates blockFetchSize btime = do
-    cache <-
-      History.runWithCachedSummary
-        (toSummary <$> ChainDB.getCurrentLedger chainDB)
-    let slotToUTCTime rp =
-              fmap
-                (either errMsg toAbsolute)
-            $ History.cachedRunQuery
-                cache
-                (fst <$> History.slotToWallclock (realPointSlot rp))
-          where
-            -- This @cachedRunQuery@ fail for the following reasons.
-            --
-            -- By the PRECONDITIONs documented in the 'headerForgeUTCTime', we
-            -- can assume that the given header was validated by the ChainSync
-            -- client. This means its slot was, at some point, within the ledger
-            -- view forecast range of the ledger state of our contemporary
-            -- intersection with the header itself (and that intersection
-            -- extended our contemporary immutable tip). A few additional facts
-            -- ensure that we will always be able to thereafter correctly
-            -- convert that header's slot using our current chain's ledger
-            -- state.
-            --
-            --   o For under-developed reasons, the ledger view forecast range
-            --     is equivalent to the time forecast range, ie " Definition
-            --     17.2 (Forecast range) " from The Consensus Report.
-            --
-            --   o Because rollback is bounded, our currently selected chain
-            --     will always be an evolution (ie " switch(n, bs) ") of that
-            --     intersection point. (This one is somewhat obvious in
-            --     retrospect, but we're being explicit here in order to
-            --     emphasize the relation to the " chain evolution " jargon.)
-            --
-            --   o Because " stability itself is stable ", the HFC satisfies "
-            --     Property 17.3 (Time conversions stable under chain evolution)
-            --     " from The Consensus Report.
-            errMsg err =
-              error $
-                 "Consensus could not determine forge UTCTime!"
-              <> " " <> show rp
-              <> " " <> show err
-        headerForgeUTCTime = slotToUTCTime . headerRealPoint . unFromConsensus
-        blockForgeUTCTime  = slotToUTCTime . blockRealPoint  . unFromConsensus
-
-    pure BlockFetchConsensusInterface {..}
-  where
-    toSummary ::
-         ExtLedgerState blk
-      -> History.Summary (History.HardForkIndices blk)
-    toSummary = History.hardForkSummary (configLedger cfg) . ledgerState
-
-    toAbsolute :: RelativeTime -> UTCTime
-    toAbsolute =
-        fromRelativeTime (SupportsNode.getSystemStart (configBlock cfg))
-
-    bcfg :: BlockConfig blk
-    bcfg = configBlock cfg
-
-    blockMatchesHeader :: Header blk -> blk -> Bool
-    blockMatchesHeader = Block.blockMatchesHeader
-
-    readCandidateChains :: STM m (Map peer (AnchoredFragment (Header blk)))
-    readCandidateChains = getCandidates
-
-    readCurrentChain :: STM m (AnchoredFragment (Header blk))
-    readCurrentChain = ChainDB.getCurrentChain chainDB
-
-    readFetchMode :: STM m FetchMode
-    readFetchMode = do
-      mCurSlot <- getCurrentSlot btime
-      case mCurSlot of
-        -- The current chain's tip far away from "now", so use bulk sync mode.
-        CurrentSlotUnknown  -> return FetchModeBulkSync
-        CurrentSlot curSlot -> do
-          curChainSlot <- AF.headSlot <$> ChainDB.getCurrentChain chainDB
-          let slotsBehind = case curChainSlot of
-                -- There's nothing in the chain. If the current slot is 0, then
-                -- we're 1 slot behind.
-                Origin         -> unSlotNo curSlot + 1
-                NotOrigin slot -> unSlotNo curSlot - unSlotNo slot
-              maxSlotsBehind = 1000
-          return $ if slotsBehind < maxSlotsBehind
-            -- When the current chain is near to "now", use deadline mode,
-            -- when it is far away, use bulk sync mode.
-            then FetchModeDeadline
-            else FetchModeBulkSync
-
-    readFetchedBlocks :: STM m (Point blk -> Bool)
-    readFetchedBlocks = ChainDB.getIsFetched chainDB
-
-    -- See 'mkAddFetchedBlock_'
-    mkAddFetchedBlock ::
-         WhetherReceivingTentativeBlocks
-      -> STM m (Point blk -> blk -> m ())
-    mkAddFetchedBlock enabledPipelining = do
-      unlessImproved <- InvalidBlockPunishment.mkUnlessImproved (Proxy @blk)
-      pure $ mkAddFetchedBlock_ unlessImproved enabledPipelining
-
-    -- Waits until the block has been written to disk, but not until chain
-    -- selection has processed the block.
-    mkAddFetchedBlock_ ::
-         (   SelectView (BlockProtocol blk)
-          -> InvalidBlockPunishment m
-          -> InvalidBlockPunishment m
-         )
-      -> WhetherReceivingTentativeBlocks
-      -> Point blk
-      -> blk
-      -> m ()
-    mkAddFetchedBlock_ unlessImproved enabledPipelining _pt blk = void $ do
-       disconnect <- InvalidBlockPunishment.mkPunishThisThread
-       -- A BlockFetch peer can either send an entire range or none of the
-       -- range; anything else will incur a disconnect. And in 'FetchDeadline'
-       -- mode, which is the relevant case for this kind of DoS attack (because
-       -- in bulk sync, our honest peers will be streaming a very dense chain
-       -- very quickly, meaning the adversary only has very small windows during
-       -- which we're interested in its chains), the node only requests whole
-       -- suffixes from peers: the BlockFetch decision logic does not avoid
-       -- requesting a block that is already in-flight from other peers. Thus
-       -- the adversary cannot send us blocks out-of-order (during
-       -- 'FetchDeadline'), even if they control more than one of our peers.
-       --
-       -- Therefore, the following punishment logic only needs to cover the
-       -- "whole chain received in-order from a single-peer" case. Which it
-       -- currently does.
-       --
-       -- TODO maintain the context of which ChainSync candidate incurring this
-       -- fetch request, and disconnect immediately if the invalid block is not
-       -- the tip of that candidate. As-is, in 'FetchDeadline' they must also
-       -- send the next block, but they might be able to wait long enough that
-       -- it is not desirable when it arrives, and therefore not be disconnected
-       -- from. So their choices are: cause a disconnect or else do nothing for
-       -- long enough. Both are fine by us, from a DoS mitigation perspective.
-       let punishment = InvalidBlockPunishment.branch $ \case
-             -- invalid parents always cause a disconnect
-             InvalidBlockPunishment.BlockPrefix -> disconnect
-             -- when pipelining, we forgive an invalid block itself if it's
-             -- better than the previous invalid block this peer delivered
-             InvalidBlockPunishment.BlockItself -> case enabledPipelining of
-               NotReceivingTentativeBlocks -> disconnect
-               ReceivingTentativeBlocks    ->
-                 unlessImproved (selectView bcfg (getHeader blk)) disconnect
-       ChainDB.addBlockWaitWrittenToDisk
-         chainDB
-         punishment
-         blk
-
-    readFetchedMaxSlotNo :: STM m MaxSlotNo
-    readFetchedMaxSlotNo = ChainDB.getMaxSlotNo chainDB
-
-    -- Note that @ours@ comes from the ChainDB and @cand@ from the ChainSync
-    -- client.
-    --
-    -- Fragments are proxies for their corresponding chains; it is possible, in
-    -- principle, that an empty fragment corresponds to the chain we want to
-    -- adopt, and should therefore be preferred over other fragments (whose
-    -- blocks we therefore do not want to download). The precondition to
-    -- 'preferAnchoredCandidates' is designed precisely to rule out this
-    -- possibility (for details, see the Consensus Report), but unfortunately we
-    -- cannot always satisfy this precondition: although the chain sync client
-    -- preserves an invariant that relates our current chain to the candidate
-    -- fragment, by the time the block fetch download logic considers the
-    -- fragment, our current chain might have changed.
-    plausibleCandidateChain :: HasCallStack
-                            => AnchoredFragment (Header blk)
-                            -> AnchoredFragment (Header blk)
-                            -> Bool
-    plausibleCandidateChain ours cand
-      -- 1. The ChainDB maintains the invariant that the anchor of our fragment
-      --    corresponds to the immutable tip.
-      --
-      -- 2. The ChainSync client locally maintains the invariant that our
-      --    fragment and the candidate fragment have the same anchor point. This
-      --    establishes the precondition required by @preferAnchoredCandidate@.
-      --
-      -- 3. However, by the time that the BlockFetch logic processes a fragment
-      --    presented to it by the ChainSync client, our current fragment might
-      --    have changed, and they might no longer be anchored at the same
-      --    point. This means that we are no longer guaranteed that the
-      --    precondition holds.
-      --
-      -- 4. Our chain's anchor can only move forward. We can detect this by
-      --    looking at the block numbers of the anchors.
-      --
-      | AF.anchorBlockNo cand < AF.anchorBlockNo ours  -- (4)
-      = case (AF.null ours, AF.null cand) of
-          -- Both are non-empty, the precondition trivially holds.
-          (False, False) -> preferAnchoredCandidate bcfg ours cand
-          -- The candidate is shorter than our chain and, worse, we'd have to
-          -- roll back past our immutable tip (the anchor of @cand@).
-          (_,     True)  -> False
-          -- As argued above we can only reach this case when our chain's anchor
-          -- has changed (4).
-          --
-          -- It is impossible for our chain to change /and/ still be empty: the
-          -- anchor of our chain only changes when a new block becomes
-          -- immutable. For a new block to become immutable, we must have
-          -- extended our chain with at least @k + 1@ blocks. Which means our
-          -- fragment can't be empty.
-          (True,  _)     -> error "impossible"
-
-      | otherwise
-      = preferAnchoredCandidate bcfg ours cand
-
-    compareCandidateChains :: AnchoredFragment (Header blk)
-                           -> AnchoredFragment (Header blk)
-                           -> Ordering
-    compareCandidateChains = compareAnchoredFragments bcfg
 
 forkBlockForging
     :: forall m remotePeer localPeer blk.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -254,6 +254,7 @@ data BlockFetchConfiguration =
          -- | Salt used when comparing peers
          bfcSalt                   :: !Int
      }
+     deriving (Show)
 
 -- | Execute the block fetch logic. It monitors the current chain and candidate
 -- chains. It decided which block bodies to fetch and manages the process of


### PR DESCRIPTION
Closes [CAD-4193](https://input-output.atlassian.net/browse/CAD-4193)

See the module description for an overview.

Possible ways to add bugs to see how failures/shrinking behavior look like include setting `n2nVersion` to `minBound` (such that pipelining is not enabled, which will result in disconnections despite honest peer behavior), or adapting `Test.Util.ChainUpdates` to sometimes include invalid blocks in a regular roll forward (see [CAD-4314](https://input-output.atlassian.net/browse/CAD-4314) for upcoming work to model such behavior as part of regular property tests).