### PR TITLE
Remove the use of ledgerDbCurrentValues in the ThreadNet tests

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -241,7 +241,7 @@ instance ShelleyCompatible proto era => QueryLedger (ShelleyBlock proto era) whe
           SL.poolsByTotalStakeFraction globals st
         GetUTxOByAddress addrs ->
           SL.getFilteredUTxO st addrs
-        GetUTxOWhole ->
+        GetUTxOWhole -> -- FIXME:  if we never match this case then we should probaly clarify this to avoid confusions when reading this part of the code.
           SL.getUTxO st
         DebugEpochState ->
           getEpochState st

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -345,7 +345,7 @@ getLedgerDB ::
 getLedgerDB cfg m@Model{..} =
       ledgerDbPrune (SecurityParam (maxActualRollback k m))
     $ ledgerDbPushMany' ledgerDbCfg blks
-    $ ledgerDbWithAnchor RunBoth initLedger
+    $ ledgerDbWithAnchor RunOnlyNew initLedger
   where
     blks = Chain.toOldestFirst $ currentChain m
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -39,13 +39,8 @@ import           Codec.CBOR.Encoding (Encoding)
 import           Codec.CBOR.Read (DeserialiseFailure)
 import           Codec.Serialise (Serialise)
 
-import qualified Control.Exception as Exn
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
-import qualified Data.Map as Map
-import           Data.Monoid (Sum (..))
-import           Data.Semigroup (Max (..))
-import qualified Data.Set as Set
 import           Data.Void (Void)
 
 import           Network.TypedProtocol.Codec
@@ -73,7 +68,6 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
@@ -87,9 +81,6 @@ import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
 import qualified Ouroboros.Consensus.Node.Tracers as Node
 import           Ouroboros.Consensus.NodeKernel
-import qualified Ouroboros.Consensus.Storage.LedgerDB.HD as HD
-import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore as BackingStore
-import qualified Ouroboros.Consensus.Storage.LedgerDB.InMemory as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
 import           Ouroboros.Consensus.Util (ShowProxy, StaticEither (..))
 import           Ouroboros.Consensus.Util.IOLike
@@ -144,137 +135,16 @@ mkHandlers NodeKernelArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
           localStateQueryServer
             (ExtLedgerCfg cfg)
             (\seP -> do
-                let mkDLV (LedgerDB.LedgerBackingStoreValueHandle seqNo vh, ldb, close) =
-                      DiskLedgerView
-                        (LedgerDB.ledgerDbCurrent ldb)
-                        (\ks -> do
-                           let chlog = LedgerDB.ledgerDbChangelog ldb
-                               rew   = LedgerDB.rewindTableKeySets chlog ks
-                           unfwd <-
-                             LedgerDB.readKeySetsVH
-                               (\ks' -> (,) seqNo <$> BackingStore.bsvhRead vh ks')
-                               rew
-                           case LedgerDB.forwardTableKeySets chlog unfwd of
-                             Left _err -> error "impossible!"
-                             Right vs  -> pure vs
-                        )
-                        (\rq -> do
-                            let chlog = LedgerDB.ledgerDbChangelog ldb
-                                diffs =
-                                    maybe
-                                      id
-                                      (zipLedgerTables doDropLTE)
-                                      (BackingStore.rqPrev rq)
-                                  $ mapLedgerTables prj
-                                  $ changelogDiffs chlog
-                            let -- (1) ensure that we never delete everything
-                                --     read from disk (ie if our result is
-                                --     non-empty then it contains something read
-                                --     from disk)
-                                -- (2) also, read one additional key, which we
-                                --     will not include in the result but need
-                                --     in order to know which in-memory
-                                --     insertions to include
-                                maxDeletes =
-                                    maybe 0 getMax
-                                  $ foldLedgerTables (Just . Max . numDeletesDiffMK) diffs
-                                nrequested = 1 + max (BackingStore.rqCount rq) (1 + maxDeletes)
-                                rq'        = rq{BackingStore.rqCount = nrequested}
-                            values <- BackingStore.bsvhRangeRead vh rq'
-                            pure $ zipLedgerTables (doFixupReadResult nrequested) diffs values
-                        )
-                        close
                 se <- ChainDB.getLedgerBackingStoreValueHandle getChainDB rreg seP
                 case se of
                   StaticRight (Left p)  -> pure $ StaticRight (Left p)
-                  StaticLeft         x  -> pure $ StaticLeft  $         mkDLV x
-                  StaticRight (Right x) -> pure $ StaticRight $ Right $ mkDLV x
+                  StaticLeft         x  -> pure $ StaticLeft  $         LedgerDB.mkDiskLedgerView x
+                  StaticRight (Right x) -> pure $ StaticRight $ Right $ LedgerDB.mkDiskLedgerView x
             )
       , hTxMonitorServer =
           localTxMonitorServer
             getMempool
       }
-  where
-    prj ::
-         Ord k
-      => ApplyMapKind SeqDiffMK k v
-      -> ApplyMapKind DiffMK k v
-    prj (ApplySeqDiffMK sq) = ApplyDiffMK (HD.cumulativeDiffSeqUtxoDiff sq)
-
-    numDeletesDiffMK :: ApplyMapKind DiffMK k v -> Int
-    numDeletesDiffMK (ApplyDiffMK (HD.UtxoDiff m)) =
-      getSum $ foldMap (Sum . oneIfDel) m
-
-    oneIfDel (HD.UtxoEntryDiff _v diffstate) = case diffstate of
-      HD.UedsDel       -> 1
-      HD.UedsIns       -> 0
-      HD.UedsInsAndDel -> 0
-
-    -- remove all diff elements that are <= to the greatest given key
-    doDropLTE ::
-         Ord k
-      => ApplyMapKind KeysMK k v
-      -> ApplyMapKind DiffMK k v
-      -> ApplyMapKind DiffMK k v
-    doDropLTE (ApplyKeysMK (HD.UtxoKeys ks)) (ApplyDiffMK (HD.UtxoDiff ds)) =
-        ApplyDiffMK
-      $ HD.UtxoDiff
-      $ case Set.lookupMax ks of
-          Nothing -> ds
-          Just k  -> Map.filterWithKey (\dk _dv -> dk > k) ds
-
-    -- INVARIANT: nrequested > 0
-    --
-    -- (1) if we reached the end of the store, then simply yield the given diff
-    --     applied to the given values
-    -- (2) otherwise, the readset must be non-empty, since 'rqCount' is positive
-    -- (3) remove the greatest read key
-    -- (4) remove all diff elements that are >= the greatest read key
-    -- (5) apply the remaining diff
-    -- (6) (the greatest read key will be the first fetched if the yield of this
-    --     result is next passed as 'rqPrev')
-    --
-    -- Note that if the in-memory changelog contains the greatest key, then
-    -- we'll return that in step (1) above, in which case the next passed
-    -- 'rqPrev' will contain it, which will cause 'doDropLTE' to result in an
-    -- empty diff, which will result in an entirely empty range query result,
-    -- which is the termination case.
-    --
-    -- TODO this @definitelyNoMoreToFetch@ logic leads to an extra roundtrip
-    -- when the changelog contains the greatest key. That'll be rare, and should
-    -- be in-expensive since the requisite pages would have been fetched by the
-    -- previous roundtrip (which was fruitful). But it seems sloppy. Switching
-    -- from 'rqPrev' to 'rqStart' would eliminate the extra rountrip and
-    -- simplify this code. However, it would also complicate the return type,
-    -- since the " next " range query wouldn't be defined by the keys of the "
-    -- previous " range query's results: we'd have to explicitly include the "
-    -- new next key " in the result of the range query. So maybe this should
-    -- stay as-is? Maybe some existing general wisdom out there about range
-    -- queries could guide us here.
-    doFixupReadResult ::
-         Ord k
-      => Int
-      -> ApplyMapKind DiffMK   k v
-      -> ApplyMapKind ValuesMK k v
-      -> ApplyMapKind ValuesMK k v
-    doFixupReadResult
-      nrequested
-      (ApplyDiffMK (HD.UtxoDiff ds))
-      (ApplyValuesMK (HD.UtxoValues vs)) =
-        let definitelyNoMoreToFetch = Map.size vs < nrequested
-            includingAllKeys        =
-              HD.forwardValues (HD.UtxoValues vs) (HD.UtxoDiff ds)
-        in
-        ApplyValuesMK
-      $ case Map.maxViewWithKey vs of
-          Nothing             ->
-              Exn.assert definitelyNoMoreToFetch
-            $ includingAllKeys
-          Just ((k, _v), vs') ->
-            if definitelyNoMoreToFetch then includingAllKeys else
-            HD.forwardValues
-              (HD.UtxoValues vs')
-              (HD.UtxoDiff $ Map.filterWithKey (\dk _dv -> dk < k) ds)
 
 {-------------------------------------------------------------------------------
   Codecs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -349,6 +349,12 @@ data ChainDB m blk = ChainDB {
       -- not on current chain, so that 'LedgerDB' is unavailable.
       --
       -- The value handle is allocated in the given registry.
+      --
+      -- TODO: we need to comment what does the input value mean.
+      --
+      -- TODO: We need to comment on the rationale for the complex return type.
+      --
+      -- TODO: We should probably wrap this triple in a data type.
     , getLedgerBackingStoreValueHandle ::
         forall b.
              ResourceRegistry m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/BackingStore.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/BackingStore.hs
@@ -104,6 +104,9 @@ data RangeQuery keys = RangeQuery {
       -- has not reached the last key. The only crucial invariant is that the
       -- query only returns an empty map if there are no more keys to read on
       -- disk.
+      --
+      -- FIXME: can we satisfy this invariant if we read keys from disk but all
+      -- of them were deleted in the changelog?
     , rqCount :: !Int
     }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
@@ -11,10 +11,10 @@
 
 module Ouroboros.Consensus.Storage.LedgerDB.HD.LMDB (
     DbErr
+  , LMDB.mapSize
   , LMDBBackingStore
   , LMDBInit (..)
   , LMDBLimits
-  , LMDB.mapSize
   , LMDBValueHandle
   , TraceDb (..)
   , defaultLMDBLimits

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -152,6 +152,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
   , LedgerBackingStore (..)
   , LedgerBackingStoreValueHandle (..)
   , flush
+  , mkDiskLedgerView
   , readKeySets
   , readKeySetsVH
     -- * Snapshots
@@ -185,12 +186,15 @@ module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
 import qualified Codec.CBOR.Write as CBOR
 import           Codec.Serialise.Decoding (Decoder)
 import           Codec.Serialise.Encoding (Encoding)
+import qualified Control.Exception as Exn
 import           Control.Monad.Except
 import           Control.Tracer
 import qualified Data.List as List
 import qualified Data.Map as Map
 import           Data.Maybe (isJust, mapMaybe)
+import           Data.Monoid (Sum (..))
 import           Data.Ord (Down (..))
+import           Data.Semigroup (Max (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
@@ -218,7 +222,7 @@ import           Ouroboros.Consensus.Storage.FS.API.Types
 
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD as HD
-import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore as HD
+import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore as BackingStore
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.LMDB as LMDB
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
 
@@ -534,16 +538,18 @@ restoreBackingStore someHasFs snapshot bss = do
 
     store <- case bss of
       LMDBBackingStore limits -> LMDB.newLMDBBackingStore mempty limits someHasFs (LMDB.LIInitialiseFromLMDB loadPath)
-      InMemoryBackingStore -> HD.newTVarBackingStore
+      InMemoryBackingStore -> BackingStore.newTVarBackingStore
                (zipLedgerTables lookup_)
-               (\rq values -> case HD.rqPrev rq of
-                   Nothing   -> mapLedgerTables (rangeRead0_ (HD.rqCount rq))      values
-                   Just keys -> zipLedgerTables (rangeRead_  (HD.rqCount rq)) keys values
+               (\rq values -> case BackingStore.rqPrev rq of
+                   Nothing   ->
+                     mapLedgerTables (rangeRead0_ (BackingStore.rqCount rq))      values
+                   Just keys ->
+                     zipLedgerTables (rangeRead_  (BackingStore.rqCount rq)) keys values
                )
                (zipLedgerTables applyDiff_)
                valuesMKEncoder
                valuesMKDecoder
-               (Left (someHasFs, HD.BackingStorePath loadPath))
+               (Left (someHasFs, BackingStore.BackingStorePath loadPath))
     pure (LedgerBackingStore store)
   where
     loadPath = snapshotToTablesPath snapshot
@@ -567,11 +573,13 @@ newBackingStore tracer bss someHasFS tables = do
       limits
       someHasFS
       (LMDB.LIInitialiseFromMemory Origin tables)
-    InMemoryBackingStore -> HD.newTVarBackingStore
+    InMemoryBackingStore -> BackingStore.newTVarBackingStore
                (zipLedgerTables lookup_)
-               (\rq values -> case HD.rqPrev rq of
-                   Nothing   -> mapLedgerTables (rangeRead0_ (HD.rqCount rq))      values
-                   Just keys -> zipLedgerTables (rangeRead_  (HD.rqCount rq)) keys values
+               (\rq values -> case BackingStore.rqPrev rq of
+                   Nothing   ->
+                     mapLedgerTables (rangeRead0_ (BackingStore.rqCount rq))      values
+                   Just keys ->
+                     zipLedgerTables (rangeRead_  (BackingStore.rqCount rq)) keys values
                )
                (zipLedgerTables applyDiff_)
                valuesMKEncoder
@@ -617,7 +625,7 @@ applyDiff_ (ApplyValuesMK values) (ApplyDiffMK diff) =
 
 -- | A handle to the backing store for the ledger tables
 newtype LedgerBackingStore m l = LedgerBackingStore
-    (HD.BackingStore m
+    (BackingStore.BackingStore m
       (LedgerTables l KeysMK)
       (LedgerTables l ValuesMK)
       (LedgerTables l DiffMK)
@@ -627,7 +635,7 @@ newtype LedgerBackingStore m l = LedgerBackingStore
 -- | A handle to the backing store for the ledger tables
 data LedgerBackingStoreValueHandle m l = LedgerBackingStoreValueHandle
     !(WithOrigin SlotNo)
-    !(HD.BackingStoreValueHandle m
+    !(BackingStore.BackingStoreValueHandle m
       (LedgerTables l KeysMK)
       (LedgerTables l ValuesMK)
     )
@@ -636,13 +644,147 @@ data LedgerBackingStoreValueHandle m l = LedgerBackingStoreValueHandle
 
 type LedgerBackingStore' m blk = LedgerBackingStore m (ExtLedgerState blk)
 
+mkDiskLedgerView ::
+     (GetTip (l EmptyMK), IOLike m, TableStuff l)
+  => (LedgerBackingStoreValueHandle m l, LedgerDB l, m ())
+  -> DiskLedgerView m l
+mkDiskLedgerView (LedgerBackingStoreValueHandle seqNo vh, ldb, close) =
+    DiskLedgerView
+      (ledgerDbCurrent ldb)
+      (\ks -> do
+          let chlog = ledgerDbChangelog ldb
+              rew   = rewindTableKeySets chlog ks
+          unfwd <- readKeySetsVH
+                     (\ks' -> (,) seqNo <$> BackingStore.bsvhRead vh ks')
+                     rew
+          case forwardTableKeySets chlog unfwd of
+              Left _err -> error "impossible!"
+              Right vs  -> pure vs
+      )
+      (\rq -> do
+          let chlog = ledgerDbChangelog ldb
+              -- Get the differences without the keys that are greater or equal
+              -- than the maximum previously seen key.
+              diffs =
+                maybe
+                  id
+                  (zipLedgerTables doDropLTE)
+                  (BackingStore.rqPrev rq)
+                  $ mapLedgerTables prj
+                  $ changelogDiffs chlog
+              -- (1) Ensure that we never delete everything read from disk (ie
+              --     if our result is non-empty then it contains something read
+              --     from disk).
+              --
+              -- (2) Also, read one additional key, which we will not include in
+              --     the result but need in order to know which in-memory
+              --     insertions to include.
+              maxDeletes = maybe 0 getMax
+                         $ foldLedgerTables (Just . Max . numDeletesDiffMK) diffs
+              nrequested = 1 + max (BackingStore.rqCount rq) (1 + maxDeletes)
+
+          values <- BackingStore.bsvhRangeRead vh (rq{BackingStore.rqCount = nrequested})
+          pure $ zipLedgerTables (doFixupReadResult nrequested) diffs values
+      )
+      close
+  where
+    prj ::
+         Ord k
+      => ApplyMapKind SeqDiffMK k v
+      -> ApplyMapKind DiffMK k v
+    prj (ApplySeqDiffMK sq) = ApplyDiffMK (HD.cumulativeDiffSeqUtxoDiff sq)
+
+    -- remove all diff elements that are <= to the greatest given key
+    doDropLTE ::
+         Ord k
+      => ApplyMapKind KeysMK k v
+      -> ApplyMapKind DiffMK k v
+      -> ApplyMapKind DiffMK k v
+    doDropLTE (ApplyKeysMK (HD.UtxoKeys ks)) (ApplyDiffMK (HD.UtxoDiff ds)) =
+        ApplyDiffMK
+      $ HD.UtxoDiff
+      $ case Set.lookupMax ks of
+          Nothing -> ds
+          Just k  -> Map.filterWithKey (\dk _dv -> dk > k) ds
+
+    -- NOTE: this is counting the deletions wrt disk.
+    numDeletesDiffMK :: ApplyMapKind DiffMK k v -> Int
+    numDeletesDiffMK (ApplyDiffMK (HD.UtxoDiff m)) =
+      getSum $ foldMap (Sum . oneIfDel) m
+      where
+        oneIfDel (HD.UtxoEntryDiff _v diffstate) = case diffstate of
+          HD.UedsDel       -> 1
+          HD.UedsIns       -> 0
+          HD.UedsInsAndDel -> 0
+
+    -- INVARIANT: nrequested > 0
+    --
+    -- (1) if we reached the end of the store, then simply yield the given diff
+    --     applied to the given values
+    -- (2) otherwise, the readset must be non-empty, since 'rqCount' is positive
+    -- (3) remove the greatest read key
+    -- (4) remove all diff elements that are >= the greatest read key
+    -- (5) apply the remaining diff
+    -- (6) (the greatest read key will be the first fetched if the yield of this
+    --     result is next passed as 'rqPrev')
+    --
+    -- Note that if the in-memory changelog contains the greatest key, then
+    -- we'll return that in step (1) above, in which case the next passed
+    -- 'rqPrev' will contain it, which will cause 'doDropLTE' to result in an
+    -- empty diff, which will result in an entirely empty range query result,
+    -- which is the termination case.
+    --
+    -- TODO this @definitelyNoMoreToFetch@ logic leads to an extra roundtrip
+    -- when the changelog contains the greatest key. That'll be rare, and should
+    -- be in-expensive since the requisite pages would have been fetched by the
+    -- previous roundtrip (which was fruitful). But it seems sloppy. Switching
+    -- from 'rqPrev' to 'rqStart' would eliminate the extra rountrip and
+    -- simplify this code. However, it would also complicate the return type,
+    -- since the " next " range query wouldn't be defined by the keys of the "
+    -- previous " range query's results: we'd have to explicitly include the "
+    -- new next key " in the result of the range query. So maybe this should
+    -- stay as-is? Maybe some existing general wisdom out there about range
+    -- queries could guide us here.
+    doFixupReadResult ::
+         Ord k
+      => Int
+      -- ^ TODO: what is this?
+      -> ApplyMapKind DiffMK   k v
+      -- ^ TODO: what is this?
+      -> ApplyMapKind ValuesMK k v
+      -- ^ TODO: what is this?
+      -> ApplyMapKind ValuesMK k v
+    doFixupReadResult
+      nrequested
+      (ApplyDiffMK (HD.UtxoDiff ds))
+      (ApplyValuesMK (HD.UtxoValues vs)) = -- TODO: it's hard to see where the fundef begins
+        let definitelyNoMoreToFetch = Map.size vs < nrequested
+            includingAllKeys        =
+              HD.forwardValues (HD.UtxoValues vs) (HD.UtxoDiff ds)
+        in
+        ApplyValuesMK
+      $ case Map.maxViewWithKey vs of
+          Nothing             ->
+              assertDefinitelyNoMoreToFetch
+            $ includingAllKeys
+          Just ((k, _v), vs') ->
+            if definitelyNoMoreToFetch then includingAllKeys else
+            HD.forwardValues
+              (HD.UtxoValues vs')
+              (HD.UtxoDiff $ Map.filterWithKey (\dk _dv -> dk < k) ds)
+      where
+        assertDefinitelyNoMoreToFetch =
+          if Map.size vs < nrequested
+          then id
+          else error $ "Size of values " <> show (Map.size vs) <> ", nrequested " <> show nrequested
+
 readKeySets :: forall m l.
      IOLike m
   => LedgerBackingStore m l
   -> RewoundTableKeySets l
   -> m (UnforwardedReadSets l)
 readKeySets (LedgerBackingStore backingStore) rew = do
-    readKeySetsVH (HD.bsRead backingStore) rew
+    readKeySetsVH (BackingStore.bsRead backingStore) rew
 
 readKeySetsVH :: forall m l.
      IOLike m
@@ -669,7 +811,7 @@ flush (LedgerBackingStore backingStore) dblog =
     case youngestImmutableSlotDbChangelog dblog of
       Origin  -> pure ()   -- the diff is necessarily empty
       At slot ->
-        HD.bsWrite
+        BackingStore.bsWrite
           backingStore
           slot
           (mapLedgerTables prj $ changelogDiffs dblog)
@@ -820,10 +962,10 @@ writeSnapshot (SomeHasFS hasFS) backingStore encLedger snapshot cs = do
     createDirectory hasFS (snapshotToDirPath snapshot)
     withFile hasFS (snapshotToStatePath snapshot) (WriteMode MustBeNew) $ \h ->
       void $ hPut hasFS h $ CBOR.toBuilder (encode cs)
-    HD.bsCopy
+    BackingStore.bsCopy
       (let LedgerBackingStore store = backingStore in store)
       (SomeHasFS hasFS)
-      (HD.BackingStorePath (snapshotToTablesPath snapshot))
+      (BackingStore.BackingStorePath (snapshotToTablesPath snapshot))
   where
     encode :: ExtLedgerState blk EmptyMK -> Encoding
     encode = encodeSnapshot encLedger


### PR DESCRIPTION
We now make use of a range query that fetches the whole UTxO from the given `DiskLedgerView`.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
