### PR TITLE
Augment `db-analyser` backingstore CLI with LMDB `mapsize` option.

### DIFF
--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -322,6 +321,15 @@ storeLedgerStateAt slotNo AnalysisEnv { db, backing, initLedger, cfg, ledgerDbFS
         -- blocks. We use this flush to push all the remaining differences into
         -- the backing store. First, we must update the @DbChangeLog@ such that
         -- it reflects the fact that we are flushing all remaining differences.
+        -- That is, we move the volatile part into the immutable part, such that
+        -- from the perspective of the changelog, the diffs we are flushing are
+        -- in the immutable part. See Note [Behaviour of OnDisk.flush] in the
+        -- @ouroboros-consensus@, which explains why this is necessary.
+
+        -- TODO(jdral): We might want to look into not using @'OnDisk.flush'@
+        -- directly. We could add a new @DbChangelogFlushPolicy@, and use
+        -- @InMemory.ledgerDbFlush@ instead, because then we don't have to
+        -- look under the hood of the @'DbChangeLog'@ here.
 
         let
           DbChangelog {
@@ -331,16 +339,12 @@ storeLedgerStateAt slotNo AnalysisEnv { db, backing, initLedger, cfg, ledgerDbFS
             , changelogVolatileStates
             } = ledgerDbChangelog ldb
 
-          imm = changelogImmutableStates
-          vol = changelogVolatileStates
-
-          imm'    = AS.unsafeJoin imm vol
-          vol'    = AS.Empty $ AS.anchor imm'
+          imm'    = AS.unsafeJoin changelogImmutableStates changelogVolatileStates
           ldb'    = DbChangelog {
               changelogDiffAnchor
             , changelogDiffs
             , changelogImmutableStates = imm'
-            , changelogVolatileStates  = vol'
+            , changelogVolatileStates  = AS.Empty $ AS.anchor imm'
             }
 
         OnDisk.flush backingStore ldb'

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,6 +24,7 @@ import           Data.Proxy
 import           Data.Word (Word16, Word64)
 import qualified Debug.Trace as Debug
 
+import qualified Ouroboros.Network.AnchoredSeq as AS
 import           Ouroboros.Network.Point (WithOrigin (At))
 
 import           Ouroboros.Consensus.Util.IOLike
@@ -69,8 +71,7 @@ data AnalysisName =
 
 runAnalysis ::
      forall blk .
-     ( LgrDbSerialiseConstraints blk
-     , HasAnalysis blk)
+     HasAnalysis blk
   => AnalysisName -> Analysis blk
 runAnalysis analysisName env@AnalysisEnv{ tracer } = do
   traceWith tracer (StartedEvent analysisName)
@@ -309,7 +310,7 @@ storeLedgerStateAt slotNo AnalysisEnv { db, backing, initLedger, cfg, ledgerDbFS
              tracer'
              configLedgerDb
              backingStore
-             (mkStream (\b -> if blockSlot b >= slotNo
+             (mkStream (\b -> if blockSlot b > slotNo
                               then return NoMoreBlocks
                               else return $ NextBlock b) GetBlock db)
              initDb
@@ -319,8 +320,30 @@ storeLedgerStateAt slotNo AnalysisEnv { db, backing, initLedger, cfg, ledgerDbFS
       Right (ldb, _) -> do
         -- The replay performed above leaves the DbChangelog at @tip - k@
         -- blocks. We use this flush to push all the remaining differences into
-        -- the backing store.
-        OnDisk.flush backingStore $ ledgerDbChangelog ldb
+        -- the backing store. First, we must update the @DbChangeLog@ such that
+        -- it reflects the fact that we are flushing all remaining differences.
+
+        let
+          DbChangelog {
+              changelogDiffAnchor
+            , changelogDiffs
+            , changelogImmutableStates
+            , changelogVolatileStates
+            } = ledgerDbChangelog ldb
+
+          imm = changelogImmutableStates
+          vol = changelogVolatileStates
+
+          imm'    = AS.unsafeJoin imm vol
+          vol'    = AS.Empty $ AS.anchor imm'
+          ldb'    = DbChangelog {
+              changelogDiffAnchor
+            , changelogDiffs
+            , changelogImmutableStates = imm'
+            , changelogVolatileStates  = vol'
+            }
+
+        OnDisk.flush backingStore ldb'
 
         writeSnapshot
           ledgerDbFS

--- a/ouroboros-consensus-cardano/tools/db-analyser/Documentation.md
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Documentation.md
@@ -24,6 +24,9 @@ Usage: db-analyser --db PATH
                     --show-ebbs |
 					--store-ledger SLOT_NUMBER]
                    [--num-blocks-to-process INT]
+                   [--inmem-backingstore | --lmdb-backingstore
+                     [--mapsize NR_BYTES]]
+
   Simple framework used to analyse a Chain DB
 
 ```
@@ -108,3 +111,11 @@ Lastly the user must provide the analysis they want to run on the chain. They mu
 * `--store-ledger SLOT_NUMBER` Will store a snapshot of a ledger state under `DB_PATH/ledger/SLOT_NUMBER_db-analyser`. If there is no block under requested slot number, it will create one on the next available slot number (and issue a warning about this fact).
 
 * `--count-blocks` Will print out the number of blocks it saw on the chain
+
+### --inmem-backingstore and --lmdb-backingstore MAP_SIZE
+
+```
+[--inmem-backingstore | --lmdb-backingstore [--mapsize NR_BYTES]]
+```
+
+UTxO HD introduces optional functionality to store parts of the ledger state, such as the UTxO, on disk. The user can choose whether to store these parts of the ledger state in memory by providing the `--inmem-backingstore` flag, or use the functionality to store the ledger state on disk using the `--lmdb-backingstore` flag. In case the latter flag is provided, the `--mapsize NR_BYTES` option defines the maxmimum size of the on-disk database in nr. of bytes `NR_BYTES`. Note that the `NR_BYTES` should be a multiple of the OS page size. The maximum database size defaults to ~`6_000_000` bytes if this option is not provided. By default, `db-analyser` uses the in-memory backing store.

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -9,6 +10,7 @@
 module Main (main) where
 
 import           Data.Foldable (asum)
+import           Data.Maybe (fromMaybe)
 import           Options.Applicative
 import           System.IO
 
@@ -30,7 +32,7 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
                      (SnapshotInterval (..), defaultDiskPolicy)
 import           Ouroboros.Consensus.Storage.LedgerDB.HD.LMDB
-                     (defaultLMDBLimits)
+                     (defaultLMDBLimits, mapSize)
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
                      (BackingStoreSelector (..), DiskSnapshot (..))
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
@@ -53,7 +55,7 @@ data SelectDB =
     SelectChainDB
   | SelectImmutableDB (Maybe DiskSnapshot)
 
-data BackingStore = LMDB | MEM
+data BackingStore = LMDB (Maybe Int) | MEM
   deriving Eq
 
 data CmdLine = CmdLine {
@@ -97,10 +99,27 @@ parseCmdLine = CmdLine
     <*> parseSelector
 
 parseSelector :: Parser BackingStore
-parseSelector = (\x -> if x == "MEM" then MEM else LMDB) <$> strOption
-  (  long "backend"
-  <> metavar "BACKEND"
-  <> help "Choose a backend for the LedgerDB (MEM|LMDB), default: LMDB" )
+parseSelector = fromMaybe MEM <$> parseMaybe (asum [
+      MEM <$ parseMEM
+    , LMDB <$ parseLMDB <*> parseMapSize
+    ])
+  where
+    parseMEM :: Parser ()
+    parseMEM = flag' () $ mconcat [
+        long "inmem-backingstore"
+      , help "Choose the in-memory backing store for the LedgerDB."
+      ]
+    parseLMDB :: Parser ()
+    parseLMDB = flag' () $ mconcat [
+        long "lmdb-backingstore"
+      , help "Choose the LMDB backing store for the LedgerDB."
+      ]
+    parseMapSize :: Parser (Maybe Int)
+    parseMapSize = optional $ read <$> strOption (mconcat [
+        long "mapsize"
+      , metavar "NR_BYTES"
+      , help "The maximum database size defined in nr. of bytes NR_BYTES. NR_BYTES must be a multiple of the OS page size."
+      ])
 
 parseSelectDB :: Parser SelectDB
 parseSelectDB = asum [
@@ -265,8 +284,12 @@ analyse CmdLine {..} args =
                                 Just snapshot -> Left snapshot
 
           let bs = case bsSelector of
-                MEM -> InMemoryBackingStore
-                _   -> LMDBBackingStore defaultLMDBLimits
+                MEM          -> InMemoryBackingStore
+                LMDB mapsize ->
+                  maybe
+                    (LMDBBackingStore defaultLMDBLimits)
+                    (\n -> LMDBBackingStore (defaultLMDBLimits { mapSize = n }))
+                    mapsize
 
           ImmutableDB.withDB (ImmutableDB.openDB immutableDbArgs runWithTempRegistry) $ \immutableDB -> do
             runAnalysis analysis $ AnalysisEnv {


### PR DESCRIPTION
Changes:
* Update the flags/options in `db-analyser` for picking UTxO HD backing stores.
* Add an option to set the `mapsize` of the LMDB backing store in case `db-analyser` uses the LMDB backing store.
* Elaborated on the flags/options in `db-analyser/Documentation.md`.

Why:
* Adding the option to set the LMDB `mapsize` allows us to profile the LMDB backing store WRT to changes in the `mapsize` value.

Bugfixes:
* `--store-ledger` was flushing inconsistent state to the backing store.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
