### PR TITLE
Fix the reference to the range extension paper

### DIFF
--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/VRF.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/VRF.hs
@@ -99,7 +99,7 @@ hashVRF _ use certVRF =
         SVRFNonce  -> castHash $ hashWith id $ "N" <> vrfOutputAsBytes
 
 -- | Range-extend a VRF output to be used for leader checks from the relevant
--- hash. See section 2.1 of the linked paper for details.
+-- hash. See section 4.1 of the linked paper for details.
 vrfLeaderValue ::
   forall c proxy.
   Crypto c =>
@@ -112,7 +112,7 @@ vrfLeaderValue p cvrf =
     (bytesToNatural . hashToBytes $ hashVRF p SVRFLeader cvrf)
 
 -- | Range-extend a VRF output to be used for the evolving nonce. See section
--- 2.1 of the linked paper for details.
+-- 4.1 of the linked paper for details.
 vrfNonceValue ::
   forall c proxy.
   Crypto c =>


### PR DESCRIPTION
Two-character PR! :v:

The `vrfLeaderValue` and `vrfNonceValue` functions both reference the VRF range extension paper in the haddock comment. The correct section to reference, however, is 4.1, not 2.1.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
