### PR TITLE
Strict map operations on UTxO-HD tables

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD.hs
@@ -104,7 +104,7 @@ emptyUtxoValues :: UtxoValues k v
 emptyUtxoValues = UtxoValues Map.empty
 
 mapUtxoValues :: (v -> v') -> UtxoValues k v -> UtxoValues k v'
-mapUtxoValues f (UtxoValues vs) = UtxoValues $ fmap f vs
+mapUtxoValues f (UtxoValues vs) = UtxoValues $ Map.map f vs
 
 {-------------------------------------------------------------------------------
   Difference of maps
@@ -176,7 +176,7 @@ emptyUtxoDiff = UtxoDiff Map.empty
 -- value is uniquely determined by context).
 mapUtxoDiff :: (v -> v') -> UtxoDiff k v -> UtxoDiff k v'
 mapUtxoDiff f (UtxoDiff m) =
-    UtxoDiff $ fmap g m
+    UtxoDiff $ Map.map g m
   where
     g (UtxoEntryDiff v diffstate) = UtxoEntryDiff (f v) diffstate
 


### PR DESCRIPTION
We were using `fmap` which is lazy. `NoThunks` discovered thunks in the values. This fixes it.

# Checklist

- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [X] Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [X] Reviewer requested
