### PR TITLE
CAD-4648 Document that protocol versions for eras do not have to be successive.

### DIFF
--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -205,6 +205,10 @@ instance Aeson.FromJSON CardanoConfig where
             $           (fmap TriggerHardForkAtEpoch <$> (v Aeson..:? nm))
               Aeson..!= (TriggerHardForkAtVersion majProtVer)
 
+      -- Note: we must skip major protocol version 6, which coincides with the
+      -- era between the Alonzo intra-era hard-fork and Babbage hard-fork. The
+      -- intra-era hard-fork only introduced changes at the ledger level and
+      -- not at the consensus level, so protocol version 6 can be skipped.
       stas <- hsequence' $
         f "TestShelleyHardForkAtEpoch" 2 (\_ -> ()) :*
         f "TestAllegraHardForkAtEpoch" 3 (\_ -> ()) :*

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -177,6 +177,13 @@ instance
     LedgerSupportsProtocol (ShelleyBlock proto era)
   ) => SingleEraBlock (ShelleyBlock proto era) where
   singleEraTransition pcfg _eraParams _eraStart ledgerState =
+      -- TODO(jdral): When fixing a bug in @db-analyser@ related to hard-forks,
+      -- we replaced the matched expression below with @traceShowId $
+      -- shelleyTriggerHardFork pcf@ to debug the hard-fork functionality.
+      -- The trace of @db-analyser@ shows that the expression is printed thrice
+      -- for every @reapplyBlock@ of a Shelley block. Does this mean that we
+      -- evaluate this function thrice for every @reapplyBlock@? It would be
+      -- useful to investigate whether this is problematic behaviour.
       case shelleyTriggerHardFork pcfg of
         TriggerHardForkNever                         -> Nothing
         TriggerHardForkAtEpoch   epoch               -> Just epoch

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -177,13 +177,13 @@ instance
     LedgerSupportsProtocol (ShelleyBlock proto era)
   ) => SingleEraBlock (ShelleyBlock proto era) where
   singleEraTransition pcfg _eraParams _eraStart ledgerState =
-      -- TODO(jdral): When fixing a bug in @db-analyser@ related to hard-forks,
-      -- we replaced the matched expression below with @traceShowId $
-      -- shelleyTriggerHardFork pcf@ to debug the hard-fork functionality.
-      -- The trace of @db-analyser@ shows that the expression is printed thrice
-      -- for every @reapplyBlock@ of a Shelley block. Does this mean that we
-      -- evaluate this function thrice for every @reapplyBlock@? It would be
-      -- useful to investigate whether this is problematic behaviour.
+      -- TODO: We might be evaluating 'singleEraTransition' more than once when
+      -- replaying blocks. We should investigate if this is the case, and if so,
+      -- whether this is the desired behaviour. If it is not, then we need to
+      -- fix it.
+      --
+      -- For evidence of this behaviour, replace the cased-on expression by:
+      -- > @traceShowId $ shelleyTriggerHardFork pcf@
       case shelleyTriggerHardFork pcfg of
         TriggerHardForkNever                         -> Nothing
         TriggerHardForkAtEpoch   epoch               -> Just epoch

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Simple.hs
@@ -13,6 +13,10 @@ import           Cardano.Slotting.Slot (EpochNo)
 data TriggerHardFork =
     -- | Trigger the transition when the on-chain protocol major version (from
     -- the ledger state) reaches this number.
+    --
+    -- Note: Consensus does not enforce protocol versions to be successive.
+    -- That is, the ledger state is not restricted to transition from version
+    -- @x@ to @x+1@.
     TriggerHardForkAtVersion !Word16
     -- | For testing only, trigger the transition at a specific hard-coded
     -- epoch, irrespective of the ledger state.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Simple.hs
@@ -14,9 +14,8 @@ data TriggerHardFork =
     -- | Trigger the transition when the on-chain protocol major version (from
     -- the ledger state) reaches this number.
     --
-    -- Note: Consensus does not enforce protocol versions to be successive.
-    -- That is, the ledger state is not restricted to transition from version
-    -- @x@ to @x+1@.
+    -- Note: The HFC logic does not require the trigger version for one era to
+    -- be the successor of the trigger version for the previous era.
     TriggerHardForkAtVersion !Word16
     -- | For testing only, trigger the transition at a specific hard-coded
     -- epoch, irrespective of the ledger state.


### PR DESCRIPTION
A recent bug in `db-analyser` was caused by misconfiguring the era transition from Alonzo to Babbage: It was set to be triggered at protocol version 6, while it should be triggered at protocol version 7. This implies that we can skip protocol versions, i.e., protocol version 6. This PR aims to document that:
* From the view of consensus, protocol versions do not have to be successive.
* The Babbage hard-fork should be triggered at protocol version 7, and not 6.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
