### PR TITLE
Disable unneeded assertion

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -292,7 +292,6 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                              }
                            _now ->
 
-        assert (peeraddr `KnownPeers.member` knownPeers st) $
         if peeraddr `EstablishedPeers.member` establishedPeers st
           then
             let activePeers' = Set.insert peeraddr activePeers in
@@ -315,7 +314,6 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
               decisionState = st,
               decisionJobs  = []
             }
-
 
 ----------------------------
 -- Active peers above target


### PR DESCRIPTION
# Description

This PR fixes #3778 and #3748. It just disables an unneeded assertion that checks if the peer that is getting promoted is a member of the `KnownPeer` set. The reason this assertion is unneeded is because it is possible to reach that point of the code and the peer is not a member of the set due to race conditions. That's why there's an `if` guard to cover for that case.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested

