### PR TITLE
CAD-4535 use correct ledger state in mempool revalidation

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -175,13 +175,23 @@ data Mempool m blk idx = Mempool {
     , getSnapshot    :: STM m (MempoolSnapshot blk idx)
 
       -- | Get a snapshot of the mempool state that is valid with respect to
-      -- the returned ledger state when it's ticked to the given slot
+      -- the returned ledger state when it's ticked to the given slot.
+      --
+      -- This returns the ledger state that was retrieved from the LedgerDB (for
+      -- ticking its ChainDepState to see if we have to forge), the ticked
+      -- ledger state that was used for mempool revalidation, and a snapshot of
+      -- the mempool. In particular given '(a, b, _)' as a result, 'b == tick
+      -- (ledgerState a)'.
       --
       -- This does not update the state of the mempool.
     , getLedgerAndSnapshotFor ::
            Point blk
         -> SlotNo
-        -> m (Maybe (ExtLedgerState blk EmptyMK, MempoolSnapshot blk idx))
+        -> m (Maybe ( ExtLedgerState blk EmptyMK
+                    , TickedLedgerState blk TrackingMK
+                    , MempoolSnapshot blk idx
+                    )
+             )
 
       -- | Get the mempool's capacity in bytes.
       --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -17,7 +17,7 @@ module Ouroboros.Consensus.Mempool.API (
     -- * Mempool Snapshot
   , ForgeLedgerState (..)
   , MempoolSnapshot (..)
-  , withLedgerTablesFLS
+  , forgeLedgerState
     -- * Mempool size and capacity
   , MempoolCapacityBytes (..)
   , MempoolCapacityBytesOverride (..)
@@ -303,12 +303,12 @@ addTxsHelper mempool wti = \txs -> do
 -- ledger: the update system might be updated, scheduled delegations might be
 -- applied, etc., and such changes should take effect before we validate any
 -- transactions.
-data ForgeLedgerState blk mk =
+data ForgeLedgerState blk =
     -- | The slot number of the block is known
     --
     -- This will only be the case when we realized that we are the slot leader
     -- and we are actually producing a block.
-    ForgeInKnownSlot SlotNo (TickedLedgerState blk mk)
+    ForgeInKnownSlot SlotNo (LedgerState blk ValuesMK)
 
     -- | The slot number of the block is not yet known
     --
@@ -316,18 +316,11 @@ data ForgeLedgerState blk mk =
     -- will end up, we have to make an assumption about which slot number to use
     -- for 'applyChainTick' to prepare the ledger state; we will assume that
     -- they will end up in the slot after the slot at the tip of the ledger.
-  | ForgeInUnknownSlot (LedgerState blk mk)
+  | ForgeInUnknownSlot (LedgerState blk ValuesMK)
 
-withLedgerTablesFLS ::
-     (TickedTableStuff (LedgerState blk), IsApplyMapKind mk)
-  => ForgeLedgerState blk any
-  -> LedgerTables (LedgerState blk) mk
-  -> ForgeLedgerState blk mk
-withLedgerTablesFLS flst tables = case flst of
-    ForgeInKnownSlot slot tickedLst ->
-      ForgeInKnownSlot slot $ withLedgerTablesTicked tickedLst tables
-    ForgeInUnknownSlot lst ->
-      ForgeInUnknownSlot $ withLedgerTables lst tables
+forgeLedgerState :: ForgeLedgerState blk -> LedgerState blk ValuesMK
+forgeLedgerState (ForgeInKnownSlot _ ls) = ls
+forgeLedgerState (ForgeInUnknownSlot ls) = ls
 
 {-------------------------------------------------------------------------------
   Mempool capacity in bytes
@@ -405,9 +398,6 @@ data MempoolSnapshot blk idx = MempoolSnapshot {
 
     -- | The block number of the "virtual block" under construction
   , snapshotSlotNo      :: SlotNo
-
-    -- | The ledger state after all transactions in the snapshot
-  , snapshotLedgerState :: TickedLedgerState blk ValuesMK
   }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -125,14 +125,14 @@ mkMempool mpEnv = Mempool
         case mbPair of
           Nothing        -> pure Nothing
           Just (is, ls') -> do
-            let snapshot =
-                  pureGetSnapshotFor
+            let (ticked, snapshot) =
+                  pureGetSnapshotAndTickedFor
                     cfg
                     (ForgeInKnownSlot slot $ ledgerState ls')
                     capacityOverride
                     is
             atomically $ putTMVar istate is
-            pure $ Just (forgetLedgerTables ls', snapshot)
+            pure $ Just (forgetLedgerTables ls', ticked, snapshot)
     , getCapacity    = isCapacity <$> readTMVar istate
     , getTxSize      = txSize
     , zeroIdx        = zeroTicketNo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -128,11 +128,7 @@ mkMempool mpEnv = Mempool
             let snapshot =
                   pureGetSnapshotFor
                     cfg
-                    (ForgeInKnownSlot slot
-                      $ applyLedgerTablesDiffsTicked (ledgerState ls')
-                      $ applyChainTick cfg slot
-                      $ forgetLedgerTables
-                      $ ledgerState ls')
+                    (ForgeInKnownSlot slot $ ledgerState ls')
                     capacityOverride
                     is
             atomically $ putTMVar istate is

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -14,7 +14,7 @@ module Ouroboros.Consensus.Mempool.Impl.Pure (
     -- * Mempool
     SyncWithLedger (..)
   , TryAddTxs (..)
-  , pureGetSnapshotFor
+  , pureGetSnapshotAndTickedFor
   , pureRemoveTxs
   , pureSyncWithLedger
   , pureTryAddTxs
@@ -25,6 +25,7 @@ module Ouroboros.Consensus.Mempool.Impl.Pure (
   ) where
 
 import           Control.Exception (assert)
+import           Data.Bifunctor (second)
 import           Data.Maybe (isJust, isNothing)
 import qualified Data.Set as Set
 
@@ -226,7 +227,7 @@ pureSyncWithLedger istate lstate lcfg capacityOverride =
 
 -- | Get a snapshot of the mempool state that is valid with respect to
 -- the given ledger state
-pureGetSnapshotFor
+pureGetSnapshotAndTickedFor
   :: forall blk.
      ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
@@ -236,10 +237,11 @@ pureGetSnapshotFor
   -> ForgeLedgerState blk
   -> MempoolCapacityBytesOverride
   -> InternalState blk
-  -> MempoolSnapshot blk TicketNo
-pureGetSnapshotFor cfg blockLedgerState capacityOverride =
-      implSnapshotFromIS
-    . internalStateFromVR
+  -> (TickedLedgerState blk TrackingMK, MempoolSnapshot blk TicketNo)
+pureGetSnapshotAndTickedFor cfg blockLedgerState capacityOverride =
+      second ( implSnapshotFromIS
+            . internalStateFromVR
+            )
     . validateStateFor capacityOverride cfg blockLedgerState
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -233,7 +233,7 @@ pureGetSnapshotFor
      , ValidateEnvelope blk
      )
   => LedgerConfig blk
-  -> ForgeLedgerState blk ValuesMK
+  -> ForgeLedgerState blk
   -> MempoolCapacityBytesOverride
   -> InternalState blk
   -> MempoolSnapshot blk TicketNo
@@ -258,7 +258,6 @@ implSnapshotFromIS is = MempoolSnapshot {
     , snapshotHasTx       = implSnapshotHasTx          is
     , snapshotMempoolSize = implSnapshotGetMempoolSize is
     , snapshotSlotNo      = isSlotNo                   is
-    , snapshotLedgerState = isLedgerState              is
     }
  where
   implSnapshotGetTxs :: InternalState blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -584,7 +584,6 @@ forkBlockForging IS{..} blockForging =
 
         -- force the mempool's computation before the tracer event
         _ <- evaluate (length txs)
-        _ <- evaluate (snapshotLedgerState mempoolSnapshot)
         -- trace $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
 
         -- Actually produce the block


### PR DESCRIPTION
The "no need to revalidate" case on `validateStateFor` was dropping `ValuesMK` that were newly provided in the ledger state and not present in the previous state the mempool was revalidated for. To solve this, the solution is to keep the `DiffMK` produced by applying the transactions, and re-apply them on the provided ledger state.

The way this was solved in order to not repeat the differences of ticking, was by carrying an unticked ledger state in `ForgeInKnownSlot` so that it is only ticked if we go the `otherwise` route, and applying the differences from ticking and from the transactions on it would be sound.

Also, the retrieved ledger state was being ticked both in the mempool and in the forging loop. By having the mempool return the ticked state, we saved one of those ticks.

# Checklist

- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - [X] New tests are added if needed and existing tests are updated
    - [X] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [X] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [X] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [X] Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [X] Reviewer requested
