### PR TITLE
CAD-4667 Flush every +100th block on sync

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -204,9 +204,9 @@ type ModernLedgerDB l = DbChangelog l
 data LedgerDB (l :: LedgerStateKind) = LedgerDB {
       -- | Legacy LedgerDB. If specified, this will be @Nothing@ and we will
       -- just run the modern database.
-      ledgerDbCheckpoints :: Maybe (LegacyLedgerDB l)
+      ledgerDbCheckpoints :: !(Maybe (LegacyLedgerDB l))
       -- | Modern database
-    , ledgerDbChangelog   :: ModernLedgerDB l
+    , ledgerDbChangelog   :: !(ModernLedgerDB l)
     }
   deriving (Generic)
 


### PR DESCRIPTION
Flushing every block imposes an unacceptable overhead. This changes it so that it flushes no less than every 100 blocks.

# Checklist

- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - [X] New tests are added if needed and existing tests are updated
    - [X] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [X] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [X] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [X] Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [X] Reviewer requested
