### PR TITLE
Fix LedgerDB OnDisk tests block generator

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -227,7 +227,7 @@ genBlocks n pt0 = take (fromIntegral n) (go pt0)
 genBlock ::
      Point TestBlock -> TestBlock
 genBlock pt =
-  mkBlockFrom pt Tx { consumed = Token pt'
+  mkBlockFrom pt Tx { consumed = Token pt
                     , produced = ( Token pt', TValue (pointSlot pt'))
                     }
   where


### PR DESCRIPTION
The block generators consumed the same token that was generated instead
of the input token.

The fix can be confirmed by looking at the length of the chains before a
restore command (see `TagRestore`) or a drop command (see `TagMaxDrop`).

Before the fix:

```
  Storage
    LedgerDB
      OnDisk
        LedgerSimple: OK (0.01s)
          +++ OK, passed 100 tests.

          Tags (228 in total):
           6.6% TagMaxRollback = (k = 2) >> 0
           6.6% TagRestore Nothing = (k = 1) >> 0
           6.1% TagRestore Nothing = (k = 2) >> 0
           5.7% TagMaxDrop = (k = 0)
           5.7% TagMaxDrop = (k = 1) >> 0
           5.7% TagMaxDrop = (k = 3) >> 0
           5.7% TagMaxRollback = (k = 0)
           5.3% TagMaxDrop = (k = 2) >> 0
           5.3% TagMaxRollback = (k = 1) >> 0
           4.8% TagMaxRollback = (k = 3) >> 0
           4.8% TagRestore Nothing = (k = 0)
           4.4% TagMaxRollback = (k = 6) >> 0
           4.4% TagRestore Nothing = (k = 3) >> 0
           4.4% TagRestore Nothing = (k = 6) >> 0
           3.9% TagMaxDrop = (k = 6) >> 0
           3.9% TagRestore Nothing = (k = 5) >> 0
           3.5% TagMaxDrop = (k = 4) >> 0
           3.5% TagMaxDrop = (k = 5) >> 0
           3.5% TagMaxRollback = (k = 5) >> 0
           3.5% TagRestore Nothing = (k = 4) >> 0
           2.6% TagMaxRollback = (k = 4) >> 0
```

```
ouroboros-storage
  Storage
    LedgerDB
      OnDisk
        LedgerSimple: OK (0.03s)
          +++ OK, passed 100 tests.

          Tags (253 in total):
           5.5% TagMaxRollback = (k = 0)
           2.4% TagMaxDrop = (k = 0)
           2.0% TagMaxRollback = (k = 1) >> 0
           1.6% TagMaxDrop = (k = 0) >> 2
           1.6% TagMaxDrop = (k = 3) >> 1
           1.6% TagMaxDrop = (k = 4) >> 3
           1.6% TagMaxRollback = (k = 1)
           1.6% TagMaxRollback = (k = 3) >> 0
           1.2% TagMaxDrop = (k = 1) >> 0
           1.2% TagMaxDrop = (k = 2) >> 1
           1.2% TagMaxDrop = (k = 4) >> 2
           1.2% TagMaxDrop = (k = 5) >> 0
           1.2% TagMaxDrop = (k = 6) >> 0
           1.2% TagMaxRollback = (k = 2)
           1.2% TagMaxRollback = (k = 2) >> 0
           1.2% TagMaxRollback = (k = 3) >> 2
           1.2% TagMaxRollback = (k = 4)
           1.2% TagMaxRollback = (k = 5) >> 2
           1.2% TagMaxRollback = (k = 6) >> 0
           1.2% TagMaxRollback = (k = 6) >> 1
           1.2% TagMaxRollback = (k = 6) >> 3
           1.2% TagMaxRollback = (k = 6) >> 4
           1.2% TagRestore Nothing = (k = 0) >> 1
           1.2% TagRestore Nothing = (k = 0) >> 3
           1.2% TagRestore Nothing = (k = 1) >> 0
           1.2% TagRestore Nothing = (k = 3) >> 0
           1.2% TagRestore Nothing = (k = 3) >> 1
           1.2% TagRestore Nothing = (k = 3) >> 2
           1.2% TagRestore Nothing = (k = 4)
           1.2% TagRestore Nothing = (k = 4) >> 0
           1.2% TagRestore Nothing = (k = 6)
           1.2% TagRestore Nothing = (k = 6) >> 2
           0.8% TagMaxDrop = (k = 0) >> 3
           0.8% TagMaxDrop = (k = 0) >> 4
           0.8% TagMaxDrop = (k = 1)
           0.8% TagMaxDrop = (k = 1) <  7
           0.8% TagMaxDrop = (k = 2)
           0.8% TagMaxDrop = (k = 2) >> 4
           0.8% TagMaxDrop = (k = 3)
           0.8% TagMaxDrop = (k = 5) <  12
           0.8% TagMaxDrop = (k = 5) >> 1
           0.8% TagMaxDrop = (k = 6) <  13
           0.8% TagMaxDrop = (k = 6) >  1
           0.8% TagMaxRollback = (k = 3) >> 1
           0.8% TagMaxRollback = (k = 4) >> 1
           0.8% TagMaxRollback = (k = 4) >> 2
           0.8% TagMaxRollback = (k = 4) >> 3
           0.8% TagMaxRollback = (k = 5)
           0.8% TagMaxRollback = (k = 5) >> 4
           0.8% TagMaxRollback = (k = 6) >> 2
           0.8% TagRestore (Just SnapOk) = (k = 1) >> 2
           0.8% TagRestore (Just SnapOk) = (k = 1) >> 3
           0.8% TagRestore (Just SnapOk) ≈ (k = 0) << 8
           0.8% TagRestore (Just SnapOk) ≈ (k = 1) << 9
           0.8% TagRestore Nothing = (k = 0) >> 2
           0.8% TagRestore Nothing = (k = 1) <  6
           0.8% TagRestore Nothing = (k = 2)
           0.8% TagRestore Nothing = (k = 2) >> 0
           0.8% TagRestore Nothing = (k = 2) >> 1
           0.8% TagRestore Nothing = (k = 3)
           0.8% TagRestore Nothing = (k = 4) >> 2
           0.8% TagRestore Nothing = (k = 5) >> 2
           0.8% TagRestore Nothing = (k = 5) >> 3
           0.8% TagRestore Nothing = (k = 6) <  13
           0.8% TagRestore Nothing = (k = 6) >> 3
           0.8% TagRestore Nothing ≈ (k = 6) << 14
           0.4% TagMaxDrop = (k = 0) >> 1
           0.4% TagMaxDrop = (k = 1) <  6
           0.4% TagMaxDrop = (k = 1) >> 2
           0.4% TagMaxDrop = (k = 1) >> 4
           0.4% TagMaxDrop = (k = 2) >> 0
           0.4% TagMaxDrop = (k = 3) <  11
           0.4% TagMaxDrop = (k = 3) <  9
           0.4% TagMaxDrop = (k = 3) >> 0
           0.4% TagMaxDrop = (k = 3) >> 2
           0.4% TagMaxDrop = (k = 4) <  12
           0.4% TagMaxDrop = (k = 4) <  9
           0.4% TagMaxDrop = (k = 4) >> 0
           0.4% TagMaxDrop = (k = 4) >> 1
           0.4% TagMaxDrop = (k = 5) >> 3
           0.4% TagMaxDrop = (k = 6)
           0.4% TagMaxDrop = (k = 6) <  15
           0.4% TagMaxDrop = (k = 6) >> 1
           0.4% TagMaxDrop = (k = 6) >> 2
           0.4% TagMaxDrop = (k = 6) >> 3
           0.4% TagMaxDrop = (k = 6) >> 4
           0.4% TagMaxDrop ≈ (k = 0) << 16
           0.4% TagMaxRollback = (k = 2) >> 1
           0.4% TagMaxRollback = (k = 3)
           0.4% TagMaxRollback = (k = 4) >> 0
           0.4% TagMaxRollback = (k = 5) >> 1
           0.4% TagMaxRollback = (k = 6)
           0.4% TagRestore (Just SnapCorrupted) = (k = 0) >> 4
           0.4% TagRestore (Just SnapCorrupted) = (k = 1) >> 2
           0.4% TagRestore (Just SnapCorrupted) = (k = 4)
           0.4% TagRestore (Just SnapCorrupted) = (k = 5) <  15
           0.4% TagRestore (Just SnapCorrupted) ≈ (k = 0) << 8
           0.4% TagRestore (Just SnapCorrupted) ≈ (k = 1) << 9
           0.4% TagRestore (Just SnapCorrupted) ≈ (k = 3) << 11
           0.4% TagRestore (Just SnapCorrupted) ≈ (k = 6) << 14
           0.4% TagRestore (Just SnapOk) = (k = 0) <  5
           0.4% TagRestore (Just SnapOk) = (k = 0) >> 1
           0.4% TagRestore (Just SnapOk) = (k = 0) >> 2
           0.4% TagRestore (Just SnapOk) = (k = 2) <  7
           0.4% TagRestore (Just SnapOk) = (k = 3) <  8
           0.4% TagRestore (Just SnapOk) = (k = 4) <  11
           0.4% TagRestore (Just SnapOk) = (k = 4) <  12
           0.4% TagRestore (Just SnapOk) = (k = 5) <  11
           0.4% TagRestore (Just SnapOk) = (k = 5) <  15
           0.4% TagRestore (Just SnapOk) = (k = 6) <  15
           0.4% TagRestore (Just SnapOk) = (k = 6) <  16
           0.4% TagRestore (Just SnapOk) ≈ (k = 3) << 11
           0.4% TagRestore (Just SnapOk) ≈ (k = 5) << 21
           0.4% TagRestore Nothing = (k = 0)
           0.4% TagRestore Nothing = (k = 0) <  5
           0.4% TagRestore Nothing = (k = 0) >> 4
           0.4% TagRestore Nothing = (k = 1)
           0.4% TagRestore Nothing = (k = 1) <  7
           0.4% TagRestore Nothing = (k = 1) >> 3
           0.4% TagRestore Nothing = (k = 1) >> 4
           0.4% TagRestore Nothing = (k = 2) <  7
           0.4% TagRestore Nothing = (k = 2) <  8
           0.4% TagRestore Nothing = (k = 2) >> 3
           0.4% TagRestore Nothing = (k = 3) <  8
           0.4% TagRestore Nothing = (k = 4) <  13
           0.4% TagRestore Nothing = (k = 4) <  9
           0.4% TagRestore Nothing = (k = 4) >> 1
           0.4% TagRestore Nothing = (k = 5) <  11
           0.4% TagRestore Nothing = (k = 5) <  12
           0.4% TagRestore Nothing = (k = 5) <  13
           0.4% TagRestore Nothing = (k = 5) >> 1
           0.4% TagRestore Nothing = (k = 6) >> 0
           0.4% TagRestore Nothing ≈ (k = 0) << 8
           0.4% TagRestore Nothing ≈ (k = 5) << 13
```

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
