### PR TITLE
Inbound governor idle timeout

### DIFF
--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -268,7 +268,7 @@ withBidirectionalConnectionManager snocket socket
                     serverInboundGovernorTracer = ("inbound-governor",) `contramap` debugTracer,
                     serverConnectionLimits = AcceptedConnectionsLimit maxBound maxBound 0,
                     serverConnectionManager = connectionManager,
-                    serverInboundIdleTimeout = protocolIdleTimeout,
+                    serverInboundIdleTimeout = Just protocolIdleTimeout,
                     serverControlChannel = inbgovControlChannel,
                     serverObservableStateVar = observableStateVar
                   }

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server2.hs
@@ -80,7 +80,7 @@ data ServerArguments (muxMode  :: MuxMode) socket peerAddr versionNumber bytes m
       -- | Time for which all protocols need to be idle to trigger
       -- 'DemotedToCold' transition.
       --
-      serverInboundIdleTimeout    :: DiffTime,
+      serverInboundIdleTimeout    :: Maybe DiffTime,
 
       -- | Server control var is passed as an argument; this allows to use the
       -- server to run and manage responders which needs to be started on

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -567,7 +567,7 @@ withBidirectionalConnectionManager name timeouts
                       WithName name `contramap` inboundTracer, -- InboundGovernorTrace
                     serverConnectionLimits = acceptedConnLimit,
                     serverConnectionManager = connectionManager,
-                    serverInboundIdleTimeout = tProtocolIdleTimeout timeouts,
+                    serverInboundIdleTimeout = Just (tProtocolIdleTimeout timeouts),
                     serverControlChannel = inbgovControlChannel,
                     serverObservableStateVar = observableStateVar
                   }

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -724,7 +724,7 @@ runM Interfaces
                             serverTracer                = dtLocalServerTracer,
                             serverTrTracer              = nullTracer, -- TODO: issue #3320
                             serverInboundGovernorTracer = dtLocalInboundGovernorTracer,
-                            serverInboundIdleTimeout    = local_PROTOCOL_IDLE_TIMEOUT,
+                            serverInboundIdleTimeout    = Nothing,
                             serverConnectionLimits      = localConnectionLimits,
                             serverConnectionManager     = localConnectionManager,
                             serverControlChannel        = localControlChannel,
@@ -1018,7 +1018,7 @@ runM Interfaces
                                   serverInboundGovernorTracer = dtInboundGovernorTracer,
                                   serverConnectionLimits      = daAcceptedConnectionsLimit,
                                   serverConnectionManager     = connectionManager,
-                                  serverInboundIdleTimeout    = daProtocolIdleTimeout,
+                                  serverInboundIdleTimeout    = Just daProtocolIdleTimeout,
                                   serverControlChannel        = controlChannel,
                                   serverObservableStateVar    = observableStateVar
                                 })


### PR DESCRIPTION
For local connections the inbound governor should not force the idleness
timeout.  Some clients relay letting the connection idle after it was
negotiated and before any mini-protocol is started.

We keep the connection manager idle timeout, this is only used for
outbound connections, and thus not related to `node-to-client` protocol.

Fixes #3843
