### PR TITLE
Made ouroboros-network compatible with changes in ShelleyGenesis

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -219,8 +219,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9d5fe3e539605e3bf9d98d73ea892aa467d55058
-  --sha256: 1wxh221q0kxkig6bcnrw6rcnf18p7b8kbb3hjd9jns1g8gkb1drq
+  tag: d6003688a647e8ed32f99171449990be2065f277
+  --sha256: zEpASf6eyxLMNVGcNP54/VL8HCkL3YBFNkoDe3/0SUY=
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -43,6 +43,7 @@ library
 
                      , cardano-binary
                      , cardano-crypto-class
+                     , cardano-data
                      , cardano-ledger-alonzo
                      , cardano-ledger-babbage
                      , cardano-ledger-byron

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -49,6 +49,7 @@ import qualified Codec.CBOR.Encoding as CBOR
 import           Control.Exception (assert)
 import qualified Data.ByteString.Short as Short
 import           Data.Functor.These (These1 (..))
+import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
 import           Data.SOP.Strict hiding (shape, shift)
 import           Data.Word (Word16, Word64)
@@ -820,7 +821,7 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
                   registerGenesisStaking
                     (SL.sgStaking genesisShelley)
                 . registerInitialFunds
-                    (SL.sgInitialFunds genesisShelley)
+                    (ListMap.toMap $ SL.sgInitialFunds genesisShelley)
                 $ Shelley.shelleyLedgerState st
             }
 

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -31,6 +31,7 @@ library
   build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11
                      , cardano-crypto-class
+                     , cardano-data
                      , cardano-ledger-core
                      , cardano-protocol-tpraos
                      , cardano-slotting

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -38,6 +38,7 @@ module Test.ThreadNet.Infra.Shelley (
 import           Control.Monad.Except (throwError)
 import qualified Data.ByteString as BS
 import           Data.Coerce (coerce)
+import qualified Data.ListMap as ListMap
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe.Strict (maybeToStrictMaybe)
@@ -356,8 +357,8 @@ mkGenesisConfig pVer k f d maxLovelaceSupply slotLength kesCfg coreNodes =
       | CoreNode { cnGenesisKey, cnDelegateKey, cnVRF } <- coreNodes
       ]
 
-    initialFunds :: Map (SL.Addr (EraCrypto era)) SL.Coin
-    initialFunds = Map.fromList
+    initialFunds :: ListMap.ListMap (SL.Addr (EraCrypto era)) SL.Coin
+    initialFunds = ListMap.ListMap
       [ (addr, coin)
       | CoreNode { cnDelegateKey, cnStakingKey } <- coreNodes
       , let addr = SL.Addr networkId
@@ -369,14 +370,14 @@ mkGenesisConfig pVer k f d maxLovelaceSupply slotLength kesCfg coreNodes =
     -- In this initial stake, each core node delegates its stake to itself.
     initialStake :: ShelleyGenesisStaking (EraCrypto era)
     initialStake = ShelleyGenesisStaking
-      { sgsPools = Map.fromList
+      { sgsPools = ListMap.ListMap
           [ (pk, pp)
           | pp@(SL.PoolParams { _poolId = pk }) <- Map.elems coreNodeToPoolMapping
           ]
         -- The staking key maps to the key hash of the pool, which is set to the
         -- "delegate key" in order that nodes may issue blocks both as delegates
         -- and as stake pools.
-      , sgsStake = Map.fromList
+      , sgsStake = ListMap.ListMap
           [ ( SL.hashKey . SL.VKey $ deriveVerKeyDSIGN cnStakingKey
             , SL.hashKey . SL.VKey $ deriveVerKeyDSIGN cnDelegateKey
             )

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -41,6 +41,7 @@ module Ouroboros.Consensus.Shelley.Node.TPraos (
 
 import           Control.Monad.Except (Except)
 import           Data.Bifunctor (first)
+import qualified Data.ListMap as ListMap
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.SOP.Strict
@@ -380,6 +381,7 @@ registerGenesisStaking staking nes = nes {
     }
   where
     SL.ShelleyGenesisStaking { sgsPools, sgsStake } = staking
+    sgsStakeMap = ListMap.toMap sgsStake
     SL.NewEpochState { nesEs = epochState } = nes
     ledgerState = SL.esLState epochState
     dpState = SL.lsDPState ledgerState
@@ -393,8 +395,8 @@ registerGenesisStaking staking nes = nes {
           SL._unified = UM.unify
             ( Map.map (const $ SL.Coin 0)
                       . Map.mapKeys SL.KeyHashObj
-                      $ sgsStake)
-            ( Map.mapKeys SL.KeyHashObj sgsStake )
+                      $ sgsStakeMap)
+            ( Map.mapKeys SL.KeyHashObj $ sgsStakeMap )
             mempty
         }
 
@@ -402,7 +404,7 @@ registerGenesisStaking staking nes = nes {
     -- See STS POOL for details
     pState' :: SL.PState (EraCrypto era)
     pState' = (SL.dpsPState dpState) {
-          SL._pParams = sgsPools
+          SL._pParams = ListMap.toMap sgsPools
         }
 
     -- The new stake distribution is made on the basis of a snapshot taken


### PR DESCRIPTION
…-ledger changes

# Description

This PR fixes the errors introduced by a breaking change in `cardano-ledger`. 
The breaking change is introduced by this PR: https://github.com/input-output-hk/cardano-ledger/pull/2871

I also updated the cabal files to point to the commit in `cardano-ledger` that introduces these breaking changes.

# Checklist

- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - [X] New tests are added if needed and existing tests are updated
    - [X] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [X] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [X] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [X] Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [X] Reviewer requested
