### PR TITLE
`ChainUpdate`s: model bad peer behavior

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -293,6 +293,7 @@ test-suite test-infra
                        Test.Util.Split.Tests
 
   build-depends:       base
+                     , containers
                      , QuickCheck
                      , tasty
                      , tasty-quickcheck

--- a/ouroboros-consensus-test/src/Test/Util/ChainUpdates.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainUpdates.hs
@@ -95,7 +95,12 @@ data UpdateBehavior =
   | -- | Chain updates involving invalid blocks only arisable by bugs, malice or
     -- incorrect configuration.
     InvalidChainBehavior
-  deriving stock (Show, Eq, Ord, Enum, Bounded)
+  deriving stock (Show, Eq, Enum, Bounded)
+  deriving stock
+    ( -- | Note that this 'Ord' instance (and hence the order of constructors)
+      -- is semantically imporant, cf. 'genChainUpdates'.
+      Ord
+    )
 
 -- | Whether an 'UpdateBehavior' should cause a ChainSync and/or BlockFetch
 -- client to disconnect from its peer.

--- a/ouroboros-consensus-test/src/Test/Util/ChainUpdates.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainUpdates.hs
@@ -72,7 +72,7 @@ data UpdateBehavior =
     -- particular, this includes:
     --
     --  * All blocks involved are valid.
-    --  * Every 'ChainUpdate' improves the chain.
+    --  * No 'ChainUpdate' causes the chain to regress.
     SelectedChainBehavior
   | -- | Chain updates tracking the tentative chain of an honest node (in the
     -- context of diffusion pipelining). This is similiar to

--- a/ouroboros-consensus-test/src/Test/Util/Schedule.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Schedule.hs
@@ -5,6 +5,7 @@
 -- | Utilities to schedule actions per 'Tick'.
 module Test.Util.Schedule (
     Schedule (..)
+  , SchedulingStrategy (..)
   , genSchedule
   , joinSchedule
   , lastTick
@@ -49,11 +50,22 @@ lastTick = fromMaybe (Tick 0) . maxKey . getSchedule
     maxKey :: forall k v. Map k v -> Maybe k
     maxKey = fmap (fst . fst) . Map.maxViewWithKey
 
+-- | A scheduling strategy specifies how to distribute elements across a
+-- sequence of ticks.
+data SchedulingStrategy =
+     -- | The default strategy. Most ticks will have no associated elements, but
+     -- if they do, there can be multiple.
+     DefaultSchedulingStrategy
+   | -- | Like 'DefaultSchedulingStrategy', but with at most one element per
+     -- tick.
+     SingleItemPerTickStrategy
+  deriving stock (Show, Eq, Ord, Enum, Bounded)
+
 -- | Spread out elements over a schedule, i.e. schedule a number of
 -- elements to be processed on each tick. Most ticks will have no
 -- associated elements.
-genSchedule :: [a] -> Gen (Schedule a)
-genSchedule = fmap Schedule . go Map.empty 1
+genSchedule :: SchedulingStrategy -> [a] -> Gen (Schedule a)
+genSchedule strat = fmap Schedule . go Map.empty 1
   where
     go :: Map Tick [a]
        -> Tick
@@ -62,9 +74,14 @@ genSchedule = fmap Schedule . go Map.empty 1
     go !schedule tick as
       | null as = return schedule
       | otherwise    = do
-        nbAs <- frequency [ (2, return 0), (1, choose (1, 5)) ]
+        nbAs <- genNumElemsPerTick
         let (this, rest) = splitAt nbAs as
         go (Map.insert tick this schedule) (succ tick) rest
+
+    genNumElemsPerTick = case strat of
+        DefaultSchedulingStrategy ->
+          frequency [ (2, return 0), (1, choose (1, 5)) ]
+        SingleItemPerTickStrategy -> elements [0, 1]
 
 -- | Repeatedly remove the last entry (highest 'Tick')
 shrinkSchedule :: Schedule a -> [Schedule a]

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -149,7 +149,8 @@ prop_blockFetch bfcts@BlockFetchClientTestSetup{..} =
 data BlockFetchClientOutcome = BlockFetchClientOutcome {
     bfcoPeerOutcomes  :: Map PeerId PeerOutcome
   , bfcoFetchedBlocks :: Map PeerId Word
-  , bfcoTrace         :: [(Tick, String)]
+  , -- | Trace messages, only used for debugging.
+    bfcoTrace         :: [(Tick, String)]
   }
 
 data PeerOutcome = PeerOutcome {

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -367,7 +367,8 @@ instance Arbitrary BlockFetchClientTestSetup where
       pure BlockFetchClientTestSetup {..}
     where
       genUpdateSchedule =
-        genChainUpdates TentativeChainBehavior maxRollback 20 >>= genSchedule
+        genChainUpdates TentativeChainBehavior maxRollback 20
+          >>= genSchedule DefaultSchedulingStrategy
 
       -- Only use a small k to avoid rolling forward by a big chain.
       maxRollback = SecurityParam 5

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -499,9 +499,9 @@ computeHeaderStateHistory cfg =
 data ChainSyncClientSetup = ChainSyncClientSetup
   { securityParam :: SecurityParam
   , clientUpdates :: ClientUpdates
-    -- ^ Depends on 'securityParam' and 'clientUpdates'
+    -- ^ Depends on 'securityParam' and 'serverUpdates'
   , serverUpdates :: ServerUpdates
-    -- ^ Depends on 'securityParam' and 'clientUpdates'
+    -- ^ Depends on 'securityParam'.
   , startTick     :: Tick
     -- ^ Depends on 'clientUpdates' and 'serverUpdates'
   , invalidBlocks :: InvalidBlocks

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE TypeApplications    #-}
 module Test.Consensus.MiniProtocol.ChainSync.Client (tests) where
 
-import           Control.Monad.Class.MonadThrow (Handler (..), catches)
 import           Control.Monad.State.Strict
 import           Control.Tracer (contramap, nullTracer)
 import           Data.Bifunctor (first)
@@ -62,6 +61,7 @@ import           Ouroboros.Consensus.Storage.ChainDB.API
                      (InvalidBlockReason (ValidationError))
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.Exception
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
@@ -426,12 +426,6 @@ runChainSync securityParam (ClientUpdates clientUpdates)
       [ lastTick clientUpdates
       , lastTick serverUpdates
       , startSyncingAt
-      ]
-
-    catchAlsoLinked :: Exception e => m a -> (e -> m a) -> m a
-    catchAlsoLinked ma handler = ma `catches`
-      [ Handler handler
-      , Handler $ \(ExceptionInLinkedThread _ ex) -> throwIO ex `catch` handler
       ]
 
 updateClientState :: [ChainUpdate] -> Chain TestBlock -> Chain TestBlock

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -73,8 +73,7 @@ import qualified Test.Util.LogicalClock as LogicalClock
 import           Test.Util.LogicalClock (NumTicks (..), Tick (..))
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.Schedule (Schedule (..), genSchedule, joinSchedule,
-                     lastTick, shrinkSchedule)
+import           Test.Util.Schedule
 import qualified Test.Util.TestBlock as TestBlock
 import           Test.Util.TestBlock
 import           Test.Util.Tracer (recordingTracerTVar)
@@ -525,7 +524,8 @@ instance Arbitrary ChainSyncClientSetup where
           | AddBlock b <- joinSchedule (getServerUpdates serverUpdates)
           , tbValid b == Invalid
           ]
-    invalidBlocks <- InvalidBlocks <$> (genSchedule =<< shuffle trapBlocks)
+    invalidBlocks <- InvalidBlocks <$>
+      (genSchedule DefaultSchedulingStrategy =<< shuffle trapBlocks)
     return ChainSyncClientSetup {..}
   shrink cscs@ChainSyncClientSetup {..} =
     -- We don't shrink 'securityParam' because the updates depend on it
@@ -606,7 +606,8 @@ genUpdateSchedule
   -> SecurityParam
   -> Gen (Schedule ChainUpdate)
 genUpdateSchedule updateBehavior securityParam =
-    genChainUpdates updateBehavior securityParam 10 >>= genSchedule
+    genChainUpdates updateBehavior securityParam 10
+      >>= genSchedule DefaultSchedulingStrategy
 
 {-------------------------------------------------------------------------------
   Pretty-printing

--- a/ouroboros-consensus-test/test-infra/Test/Util/ChainUpdates/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Test/Util/ChainUpdates/Tests.hs
@@ -1,16 +1,85 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE RecordWildCards    #-}
+
 module Test.Util.ChainUpdates.Tests (tests) where
+
+import qualified Data.Map.Strict as Map
 
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Test.Util.ChainUpdates
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Util (allEqual)
+import           Ouroboros.Consensus.Util.Condense
+
+import           Test.Util.ChainUpdates
+import           Test.Util.QuickCheck
+import           Test.Util.TestBlock
 
 tests :: TestTree
 tests = testGroup "Test.Util.ChainUpdates"
-    [ testProperty "genChainUpdates" $ prop_genChainUpdates k updatesToGenerate
+    [ testProperty "genChainUpdates" $
+        prop_genChainUpdates securityParam 100
+    , testProperty "consistency"
+        prop_consistency
     ]
+
+securityParam :: SecurityParam
+securityParam = SecurityParam 3
+
+data ChainUpdatesTestSetup = ChainUpdatesTestSetup {
+    -- | The 'UpdateBehavior' used to generate the 'chainUpdates'.
+    updateBehavior :: UpdateBehavior
+  , chainUpdates   :: [ChainUpdate]
+  }
+  deriving stock (Show, Eq)
+
+instance Condense ChainUpdatesTestSetup where
+  condense ChainUpdatesTestSetup{..} =
+         "Update behavior: " <> show updateBehavior <> "\n"
+      <> "Updates: " <> condense chainUpdates
+
+instance Arbitrary ChainUpdatesTestSetup where
+  arbitrary = do
+      numUpdates     <- chooseInt (5, 100)
+      updateBehavior <- chooseEnum (minBound, maxBound)
+      chainUpdates   <- genChainUpdates updateBehavior securityParam numUpdates
+      pure ChainUpdatesTestSetup {..}
+
+  shrink ChainUpdatesTestSetup{..} =
+      [ ChainUpdatesTestSetup{chainUpdates = init chainUpdates, ..}
+      | not $ null chainUpdates
+      ]
+
+prop_consistency :: ChainUpdatesTestSetup -> Property
+prop_consistency cuts@ChainUpdatesTestSetup{..} =
+    counterexample (condense cuts) $
+    collect updateBehavior $
+    conjoin
+      [ hashValidityConsistency
+      , classificationConsistency
+      ]
   where
-    k = SecurityParam 3
-    updatesToGenerate = 100
+    -- | Ensure that blocks with the same hash actually have the same validity
+    -- (also see the comment on 'tbValid').
+    hashValidityConsistency =
+        counterexample "hash validity inconsistency" $
+        property $ all allEqual validityByHash
+      where
+        allBlocks = chainUpdates >>= \case
+          AddBlock blk      -> [blk]
+          SwitchFork _ blks -> blks
+        validityByHash = Map.fromListWith (<>)
+          [ (blockHash blk, [tbValid blk]) | blk <- allBlocks ]
+
+    -- | Ensure that classifying the updates generated for a specific behavior
+    -- yields this or a more narrow behavior.
+    classificationConsistency =
+        counterexample "classification inconsistency" $
+        tabulate "classified vs. requested behavior"
+        [show (classifiedBehavior, updateBehavior)] $
+        classifiedBehavior `le` updateBehavior
+      where
+        classifiedBehavior = classifyBehavior chainUpdates

--- a/ouroboros-consensus-test/test-infra/Test/Util/Schedule/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Test/Util/Schedule/Tests.hs
@@ -19,7 +19,7 @@ prop_joinSchedule_genSchedule =
       joinSchedule spread === as
   where
     genElementsAndSpread = do
-      strat       <- chooseEnum (minBound, maxBound)
+      strat       <- arbitraryBoundedEnum
       -- generate elements of some type with an Ord instance
       as :: [Int] <- arbitrary
       spread      <- genSchedule strat as

--- a/ouroboros-consensus-test/test-infra/Test/Util/Schedule/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Test/Util/Schedule/Tests.hs
@@ -19,7 +19,8 @@ prop_joinSchedule_genSchedule =
       joinSchedule spread === as
   where
     genElementsAndSpread = do
+      strat       <- chooseEnum (minBound, maxBound)
       -- generate elements of some type with an Ord instance
       as :: [Int] <- arbitrary
-      spread      <- genSchedule as
+      spread      <- genSchedule strat as
       return (as, spread)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -175,6 +175,7 @@ library
                        Ouroboros.Consensus.Util.Counting
                        Ouroboros.Consensus.Util.DepPair
                        Ouroboros.Consensus.Util.EarlyExit
+                       Ouroboros.Consensus.Util.Exception
                        Ouroboros.Consensus.Util.FileLock
                        Ouroboros.Consensus.Util.Enclose
                        Ouroboros.Consensus.Util.HList

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Exception.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Exception.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Ouroboros.Consensus.Util.Exception (catchAlsoLinked) where
 
+import qualified Control.Exception as E
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Consensus.Util.IOLike
@@ -13,6 +17,7 @@ catchAlsoLinked ::
 catchAlsoLinked ma handler =
     ma `catches`
       [ Handler handler
-      , Handler $ \(ExceptionInLinkedThread _ ex) ->
-          throwIO ex `catch` handler
+      , Handler $ \case
+          (ExceptionInLinkedThread _ (E.fromException -> Just ex)) -> handler ex
+          ex                                                       -> throwIO ex
       ]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Exception.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Exception.hs
@@ -1,0 +1,18 @@
+module Ouroboros.Consensus.Util.Exception (catchAlsoLinked) where
+
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Consensus.Util.IOLike
+
+-- | Catch @e@ as well as @'ExceptionInLinkedThread' _ (ex :: e)@.
+catchAlsoLinked ::
+     (MonadCatch m, Exception e)
+  => m a
+  -> (e -> m a)
+  -> m a
+catchAlsoLinked ma handler =
+    ma `catches`
+      [ Handler handler
+      , Handler $ \(ExceptionInLinkedThread _ ex) ->
+          throwIO ex `catch` handler
+      ]


### PR DESCRIPTION
# Description

Closes [CAD-4314](https://input-output.atlassian.net/browse/CAD-4314)

Previously, we did not generate any `ChainUpdate` behavior modeling a malicious or ill-configured peer. This meant that existing tests could only check that our disconnection routines are not overly restrictive, but not that they are strict enough.

This PR adds this possibility, namely by randomly toggling some blocks to be invalid. As the result is not necessarily modeling bad behavior, we add a function to "classify" a sequence of chain updates after the fact.

Concerning the BlockFetch client test: as certain invalid behavior is only caught by the ChainSync client, we now also run it in the background.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
