### PR TITLE
Test trap tentative header monotonicity 

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -287,6 +287,7 @@ test-suite test-infra
   hs-source-dirs:      test-infra
   main-is:             Main.hs
   other-modules:
+                       Ouroboros.Consensus.Util.Tests
                        Test.ThreadNet.Util.Tests
                        Test.Util.ChainUpdates.Tests
                        Test.Util.Schedule.Tests

--- a/ouroboros-consensus-test/test-infra/Main.hs
+++ b/ouroboros-consensus-test/test-infra/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import           Test.Tasty
 
+import qualified Ouroboros.Consensus.Util.Tests (tests)
 import qualified Test.ThreadNet.Util.Tests (tests)
 import qualified Test.Util.ChainUpdates.Tests (tests)
 import qualified Test.Util.Schedule.Tests (tests)
@@ -15,7 +16,8 @@ main = defaultMainWithTestEnv defaultTestEnvConfig tests
 tests :: TestTree
 tests =
   testGroup "test-infra"
-  [ Test.ThreadNet.Util.Tests.tests
+  [ Ouroboros.Consensus.Util.Tests.tests
+  , Test.ThreadNet.Util.Tests.tests
   , Test.Util.ChainUpdates.Tests.tests
   , Test.Util.Schedule.Tests.tests
   , Test.Util.Split.Tests.tests

--- a/ouroboros-consensus-test/test-infra/Ouroboros/Consensus/Util/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Ouroboros/Consensus/Util/Tests.hs
@@ -1,0 +1,16 @@
+module Ouroboros.Consensus.Util.Tests (tests) where
+
+import           Ouroboros.Consensus.Util
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Consensus.Util" $
+    [ testProperty "split" prop_split
+    ]
+
+prop_split :: Fun Int Bool -> [Int] -> Property
+prop_split (Fun _ p) as =
+    concat (split p as) === filter (not . p) as .&&.
+    length (split p as) === length (filter p as) + 1


### PR DESCRIPTION
# Description

Closes [CAD-4194](https://input-output.atlassian.net/browse/CAD-4194).

Removing the call to `preferToLastInvalidTentative` makes the test fail.

```diff
diff --git a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
index 419185e8a..a5e903bc0 100644
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -1264,7 +1264,7 @@ isPipelineable ::
 isPipelineable bcfg tentativeState ChainDiff {..}
   | -- we apply exactly one header
     AF.Empty _ :> hdr <- getSuffix
-  , preferToLastInvalidTentative bcfg tentativeState hdr
+  , True || preferToLastInvalidTentative bcfg tentativeState hdr
     -- ensure that the diff is applied to the chain tip
   , getRollback == 0
   = SJust hdr
```

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
