### PR TITLE
CAD-4696 Optimise `OnDisk` tests

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
@@ -114,7 +114,7 @@ initLMDB mayLimits = do
     emptyInit :: LMDB.LMDBInit l
     emptyInit = LMDB.LIInitialiseFromMemory Origin polyEmptyLedgerTables
   bs <- LMDB.newLMDBBackingStore
-    (show `Trace.contramap` Trace.stdoutTracer)
+    Trace.nullTracer
     limits fs emptyInit
   pure (tmpdir, bs)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -1555,14 +1555,14 @@ data Bucket = Bucket {
 
 -- | Given a bucket size, and value, compute the bucket that the value falls in.
 bucketise :: Int -> Int -> Bucket
-bucketise bucketSize value = Bucket {..}
+bucketise bucketSize value = Bucket bucketNo bucketSize
   where
     bucketNo = value `div` bucketSize
 
 -- We can calculate the shape of the bucket (e.g., "[0,9]" or "[30,39]") just
 -- from the @'bucketNo'@ and @'bucketSize'@.
 instance Show Bucket where
-  show Bucket{..} = mconcat [
+  show Bucket{bucketNo, bucketSize} = mconcat [
     "["
     , show $ bucketNo * bucketSize
     , ","


### PR DESCRIPTION
# Description

## Problem description
The running time of the `Storage.LedgerDB.OnDisk.SimpleLedger` test is increased significantly when using the LMDB backing store instead of the InMemory one. That is, running a `1000` tests locally using the InMemory backing store takes roughly `0.18s`, while running the same number of tests using the LMDB backing store takes `135.04s`.

## Goal
This PR aims to reduce the running time of the LMDB-variant of the test by a constant factor. We also pick a suitable number of tests to run, which depends on at least the following: i) we should generate enough tests of suitable lengths such that we test interesting command sequences, and ii) the tests should run within in a "reasonable" amount of time. What is *reasonable*? The tentative answer is a bit arbitrary: Less than a couple of minutes.

Possibly, we could look into nightly tests if we prefer to run more tests once in a while.

## Results

We opted to change the distribution of generated commands for the LMDB variant of the test. The added overhead results in a ~1.25x increase in running time for the in-memory variant of the test, but a ~2.5x decrease in running time for the LMDB variant of the test. An overview of the results can be found below:

### Baseline (47588c5379f8bd05d4d72cdb877b5d4575901e19)

In-memory:
```
Up to date
ouroboros-storage
  Storage
    LedgerDB
      OnDisk
        LedgerSimple-InMem: OK (60.05s)
          +++ OK, passed 100000 tests.

All 1 tests passed (60.05s)
	Command being timed: "cabal run -j1 ouroboros-consensus-test:test-storage -- -p LedgerSimple-InMem"
	User time (seconds): 60.50
	System time (seconds): 0.11
	Percent of CPU this job got: 100%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:00.51
```
LMDB:
```
Warning: Requested index-state 2022-02-18T00:00:00Z is newer than
'hackage.haskell.org'! Falling back to older state (2022-02-17T23:17:49Z).
Resolving dependencies...
Up to date
ouroboros-storage
  Storage
    LedgerDB
      OnDisk
        LedgerSimple-LMDB: OK (257.48s)
          +++ OK, passed 2000 tests.

All 1 tests passed (257.48s)
	Command being timed: "cabal run -j1 ouroboros-consensus-test:test-storage -- -p LedgerSimple-LMDB"
	User time (seconds): 21.86
	System time (seconds): 24.13
	Percent of CPU this job got: 17%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 4:22.18
```

### Feature (7a1184a88e92b59d38856db4cd4fa32f1ac6e48a)
In-memory:
```
Warning: Requested index-state 2022-02-18T00:00:00Z is newer than
'hackage.haskell.org'! Falling back to older state (2022-02-17T23:17:49Z).
Resolving dependencies...
Up to date
ouroboros-storage
  Storage
    LedgerDB
      OnDisk
        LedgerSimple-InMem: OK (70.92s)
          +++ OK, passed 100000 tests.
          
          Bucketised length of generated command sequence (100000 in total):
          32.625% [0,9]
          19.139% [10,19]
          13.941% [20,29]
          10.610% [30,39]
           8.140% [40,49]
           6.093% [50,59]
           4.367% [60,69]
           2.839% [70,79]
           1.675% [80,89]
           0.571% [90,99]

          Types of commands (2473190 in total):
          14.20712% CTagPush
          14.20635% CTagDrop
          14.18763% CTagRestore
          14.18330% CTagSwitch
          14.18031% CTagFlush
          14.17210% CTagSnap
          14.15387% CTagCurrent
           0.70933% CTagCorrupt

All 1 tests passed (70.92s)
	Command being timed: "cabal run -j1 ouroboros-consensus-test:test-storage -- -p LedgerSimple-InMem"
	User time (seconds): 75.19
	System time (seconds): 0.27
	Percent of CPU this job got: 100%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:15.37
```
LMDB:
```
Warning: Requested index-state 2022-02-18T00:00:00Z is newer than
'hackage.haskell.org'! Falling back to older state (2022-02-17T23:17:49Z).
Resolving dependencies...
Up to date
ouroboros-storage
  Storage
    LedgerDB
      OnDisk
        LedgerSimple-LMDB: OK (96.29s)
          +++ OK, passed 2000 tests.
          
          Bucketised length of generated command sequence (2000 in total):
          31.80% [0,9]
          19.50% [10,19]
          13.35% [20,29]
          10.85% [30,39]
           8.05% [40,49]
           6.20% [50,59]
           4.75% [60,69]
           3.05% [70,79]
           2.00% [80,89]
           0.45% [90,99]
          
          Types of commands (50587 in total):
          34.539% CTagPush
          34.266% CTagCurrent
          17.085% CTagFlush
           3.525% CTagSwitch
           3.416% CTagDrop
           3.378% CTagSnap
           3.368% CTagRestore
           0.423% CTagCorrupt

All 1 tests passed (96.29s)
	Command being timed: "cabal run -j1 ouroboros-consensus-test:test-storage -- -p LedgerSimple-LMDB"
	User time (seconds): 11.26
	System time (seconds): 7.65
	Percent of CPU this job got: 18%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:40.76
```

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
