### PR TITLE
New query to get snapshots

### DIFF
--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -75,6 +75,7 @@ library
                      , strict-containers
                      , text              >=1.2   && <1.3
                      , transformers
+                     , vector-map
 
                        -- cardano-ledger-specs
                      , cardano-ledger-alonzo

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -31,7 +31,7 @@ data ShelleyNodeToClientVersion =
     -- | New queries introduced: GetRewardInfoPools
   | ShelleyNodeToClientVersion5
 
-    -- | New queries introduced: GetPoolState
+    -- | New queries introduced: GetPoolState, GetStakeSnapshot
   | ShelleyNodeToClientVersion6
   deriving (Show, Eq, Ord, Enum, Bounded)
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -31,7 +31,7 @@ data ShelleyNodeToClientVersion =
     -- | New queries introduced: GetRewardInfoPools
   | ShelleyNodeToClientVersion5
 
-    -- | New queries introduced: GetPoolState, GetStakeSnapshot
+    -- | New queries introduced: GetPoolState, GetStakeSnapshots
   | ShelleyNodeToClientVersion6
   deriving (Show, Eq, Ord, Enum, Bounded)
 

--- a/ouroboros-consensus/docs/interface-CHANGELOG.md
+++ b/ouroboros-consensus/docs/interface-CHANGELOG.md
@@ -56,6 +56,13 @@ may appear out of chronological order.
 The internals of each entry are organized similar to
 https://keepachangelog.com/en/1.1.0/, adapted to our plan explained above.
 
+## Circa 2022-07-26
+
+### Added
+
+- `GetPoolState`: Get the pool state for the given stake pool ids
+  New addition to client version `NodeToClientV_14`
+
 ## Circa 2022-07-20
 
 ### Fixed

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -35,7 +35,7 @@ data NodeToClientVersion
     | NodeToClientV_13
     -- ^ enabled @CardanoNodeToClientVersion9@, i.e., Babbage
     | NodeToClientV_14
-    -- ^ added @GetPoolState
+    -- ^ added @GetPoolState, @GetSnapshots
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and


### PR DESCRIPTION
# Description

This introduce a new query `GetStakeSnapshots` which extracts the stake snapshots for all pools or for a specified subset of pools. This query is required to improve the CPU and memory efficiency of the `query stake-snapshot` command in the CLI.

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested

## `cardano-api` changes

The existing query, `QueryDebugLedgerState`, will continue to exist and be slow and use a lot of memory, however, there will be a new `GetStakeSnapshot` which uses a lot less CPU and memory:

```
GetStakeSnapshot
    :: SL.KeyHash 'SL.StakePool (EraCrypto era)
    -> BlockQuery (ShelleyBlock proto era)
                  (StakeSnapshot (EraCrypto era))
```

This query takes a set of pool ids so it is possible to query multiple pools at once.

## `cardano-cli` changes

A existing command `query stake-snapshot` will be be functionally unchanged, but use much less CPU and memory.