### PR TITLE
Bartfrenk/cad 4528/test coverage reports

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -67,5 +67,6 @@ let
       inherit pkgs;
       withHoogle = true;
     };
+    inherit ouroborosNetworkHaskellPackages;
   };
 in self

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -149,6 +149,7 @@ test-suite test-consensus
                        Test.Consensus.Mempool
                        Test.Consensus.Node
                        Test.Consensus.ResourceRegistry
+                       Test.Consensus.Util
                        Test.Consensus.Util.MonadSTM.RAWLock
                        Test.Consensus.Util.Versioned
 

--- a/ouroboros-consensus-test/test-consensus/Main.hs
+++ b/ouroboros-consensus-test/test-consensus/Main.hs
@@ -13,6 +13,7 @@ import qualified Test.Consensus.MiniProtocol.ChainSync.Client (tests)
 import qualified Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests)
 import qualified Test.Consensus.Node (tests)
 import qualified Test.Consensus.ResourceRegistry (tests)
+import qualified Test.Consensus.Util (tests)
 import qualified Test.Consensus.Util.MonadSTM.RAWLock (tests)
 import qualified Test.Consensus.Util.Versioned (tests)
 
@@ -31,6 +32,7 @@ tests =
   , Test.Consensus.ResourceRegistry.tests
   , Test.Consensus.Util.MonadSTM.RAWLock.tests
   , Test.Consensus.Util.Versioned.tests
+  , Test.Consensus.Util.tests
   , testGroup "HardFork" [
         testGroup "History" [
             Test.Consensus.HardFork.Summary.tests

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Util.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Util.hs
@@ -1,0 +1,18 @@
+module Test.Consensus.Util (tests) where
+
+import           Ouroboros.Consensus.Util (chunks)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Utils" [
+    testGroup "chunks" [
+        testProperty "chunks have at most size n" prop_chunksHaveAtMostSizeN
+                       ]
+    ]
+
+
+prop_chunksHaveAtMostSizeN :: Positive Int -> [Int] -> Property
+prop_chunksHaveAtMostSizeN (Positive n) xs = property $ length chunked <= length xs
+  where chunked = chunks n xs
+


### PR DESCRIPTION
# Description

Add nix attribute to generate HPC coverage reports for ouroboros-consensus-* packages.

Resolves https://input-output.atlassian.net/browse/CAD-4528.

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
