### PR TITLE
gitignore: more specific pattern for excluding nix output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ dist/
 *~
 \#*
 *_flymake.hs
-result*
+result
+result-[0-9]*
 **/tags
 **/TAGS
 .stack-to-nix.cache


### PR DESCRIPTION
# Description

Otherwise, in setups with case insensitivity, new golden test files (starting
with `Result_`) are ignored by git, which can easily cause confusion.

To test this, run `git config core.ignoreCase true`. Then, create a file called
`Result_foo` and compare `git status` before and after this change.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
