### PR TITLE
Fix GetUTxOBy(Address|TxIn)

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -62,7 +62,8 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
-import           Ouroboros.Consensus.Ledger.Basics (ValuesMK)
+import           Ouroboros.Consensus.Ledger.Basics (StowableLedgerTables (..),
+                     ValuesMK, forgetLedgerTables)
 import           Ouroboros.Consensus.Ledger.Extended
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -816,9 +817,20 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
 
         register ::
              (EraCrypto era ~ c, ShelleyBasedEra era)
-          => Flip LedgerState mk (ShelleyBlock proto era)
-          -> Flip LedgerState mk (ShelleyBlock proto era)
-        register (Flip st) = Flip st {
+          => Flip LedgerState ValuesMK (ShelleyBlock proto era)
+          -> Flip LedgerState ValuesMK (ShelleyBlock proto era)
+        -- Due to UTxO-HD there is a subtlety here. The functions that register
+        -- the initial funds work on the UTxO inside the LedgerState instead of
+        -- on the tables. This implies that we have to first stow the tables,
+        -- modify the values and then unstow them. However because
+        -- 'unstowLedgerTables' expects an 'EmptyMK' state, we have to
+        -- 'forgetLedgerTables' just to make the types match.
+        --
+        -- It doesn't seem wise to modify the type of 'unstowLedgerTables' to
+        -- accept any 'mk' as now we get the guarantee that whenever we are
+        -- unstowing, we are doing it on an EmptyMK and only in this case (which
+        -- must happen only on tests) we do this trickery.
+        register (Flip st) = Flip $ unstowLedgerTables $ forgetLedgerTables $ st {
               Shelley.shelleyLedgerState =
                 -- We must first register the initial funds, because the stake
                 -- information depends on it.
@@ -826,7 +838,9 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
                     (SL.sgStaking genesisShelley)
                 . registerInitialFunds
                     (ListMap.toMap (SL.sgInitialFunds genesisShelley))
-                $ Shelley.shelleyLedgerState st
+                . Shelley.shelleyLedgerState
+                . stowLedgerTables
+                $ st
             }
 
     -- | For each element in the list, a block forging thread will be started.

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -239,10 +239,10 @@ instance ShelleyCompatible proto era => QueryLedger (ShelleyBlock proto era) whe
           getProposedPPUpdates st
         GetStakeDistribution ->
           SL.poolsByTotalStakeFraction globals st
-        GetUTxOByAddress addrs ->
-          SL.getFilteredUTxO st addrs
-        GetUTxOWhole -> -- FIXME:  if we never match this case then we should probaly clarify this to avoid confusions when reading this part of the code.
-          SL.getUTxO st
+        GetUTxOByAddress{} ->
+          error "This code path should be unreachable as we should not answer a WholeL query directly but incrementally"
+        GetUTxOWhole ->
+          error "This code path should be unreachable as we should not answer a WholeL query directly but incrementally"
         DebugEpochState ->
           getEpochState st
         GetCBOR query' ->
@@ -304,10 +304,7 @@ instance ShelleyCompatible proto era => QueryLedger (ShelleyBlock proto era) whe
           id
       GetUTxOWhole           ->
         IncrementalQueryHandler
-          (\st ->
-             let ShelleyLedgerTables (ApplyValuesMK (HD.UtxoValues vs)) = projectLedgerTables st
-             in SL.UTxO vs
-          )
+          (SL.getUTxO . shelleyLedgerState)
           emptyUtxo
           combUtxo
           id

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -303,8 +303,8 @@ answerWholeBlockQueryIfCurrent =
   where
     go :: All SingleEraBlock xs'
        => (forall st.
-              (LedgerState (HardForkBlock xs') ValuesMK -> Either (MismatchEraInfo xs') st)
-           -> (LedgerState (HardForkBlock xs)  ValuesMK -> Either (MismatchEraInfo xs)  st)
+              (LedgerState (HardForkBlock xs') EmptyMK -> Either (MismatchEraInfo xs') st)
+           -> (LedgerState (HardForkBlock xs)  EmptyMK -> Either (MismatchEraInfo xs)  st)
           )
        -> QueryIfCurrent xs' WholeL result
        -> IncrementalQueryHandler


### PR DESCRIPTION
# Description

There were three crucial problems fixed in this PR:
1. GetUtxoByAddress combined the UTxO inside the retrieved ledger states and not the tables. An `stowLedgerTables` and some magic was required.
2. GetUtxoByTxIn suffered from a very similar problem
3. `sgInitialFunds` were being lost because we updated the UTxO inside the genesis ledger state but then never combined that with the values that already existed outside the ledger state in the tables.

# Checklist

- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - [X] New tests are added if needed and existing tests are updated
    - [X] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [X] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [X] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [X] Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [X] Reviewer requested
