### PR TITLE
Add coverage reports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Ouroboros-Network
+
+## Coverage Reports
+
+### Generating Coverage Reports
+
+A haskell.nix project with coverage enabled for all project packages is exposed under the `coveredProject` attribute of `default.nix`:
+
+```
+nix-build default.nix -A coveredProject
+```
+
+A coverage report for the entire project can be generated and viewed with:
+
+```
+nix-build default.nix -A coveredProject.projectCoverageReport
+xdg-open ./result/share/hpc/vanilla/html/index.html
+```
+
+Coverage reports for each individual package can be generated with:
+
+```
+nix-build default.nix -A coveredProject.hsPkgs.$pkg.coverageReport
+xdg-open ./result/share/hpc/vanilla/html/index.html
+```
+
+Although individual package reports are also available in the entire project coverage report.
+
+### Debugging Coverage Reports
+
+The Nix derivation used to generate coverage reports can be debugged with:
+
+```
+nix-shell default.nix -A coveredProject.projectCoverageReport
+OR nix-shell default.nix -A coveredProject.hsPkgs.$pkg.coverageReport
+cd $(mktemp -d)
+out=$(pwd) genericBuild
+```
+
+Build logs are written to stdout and artifacts written to the current directory.

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,8 @@ let
     # the Haskell.nix package set, reduced to local packages.
     (selectProjectPackages ouroborosNetworkHaskellPackages);
 
+  coveredProject = ouroborosNetworkHaskellPackages.appendModule { coverage = true; };
+
   validate-mainnet = import ./nix/validate-mainnet.nix {
     inherit pkgs;
     byron-db-converter =
@@ -27,7 +29,7 @@ let
   };
 
   self = {
-    inherit haskellPackages network-docs consensus-docs;
+    inherit haskellPackages network-docs consensus-docs coveredProject;
 
     inherit (haskellPackages.ouroboros-network.identifier) version;
 

--- a/nix/ouroboros-network.nix
+++ b/nix/ouroboros-network.nix
@@ -17,7 +17,17 @@ let
 
   # This creates the Haskell package set.
   # https://input-output-hk.github.io/haskell.nix/user-guide/projects/
-  pkgSet = haskell-nix.cabalProject {
+  pkgSet = haskell-nix.cabalProject [
+    ({ lib, pkgs, buildProject, ... }: {
+      options = {
+        coverage = lib.mkOption {
+          type = lib.types.bool;
+          description = "Enable Haskell Program Coverage for ouroboros-network libraries and test suites.";
+          default = false;
+        };
+      };
+    })
+    ({ config, ...}: {
     inherit compiler-nix-name src;
     modules = [
 
@@ -25,6 +35,13 @@ let
         # Compile all local packages with -Werror:
         packages = lib.genAttrs projectPackages
           (name: { configureFlags = [ "--ghc-option=-Werror" ]; });
+      }
+      {
+        packages = lib.genAttrs projectPackages (name: {
+          # Enable Haskell Program Coverage for all local libraries
+          # and test suites.
+          doCoverage = config.coverage;
+        });
       }
       {
         # Apply profiling arg to all library components in the build:
@@ -80,5 +97,5 @@ let
             [ "-fexternal-interpreter" ];
         })
     ];
-  };
+  })];
 in pkgSet

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -18,10 +18,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4e01f345439c89bc2a5616ceda08a979a01bc15e",
-        "sha256": "02n3ag3zcig60x93hh9v2vnhyw6qmzr9qg8dpnr4ac4ym8cyifc9",
+        "rev": "0dca71e2f3f3d63eeab01136138e0e1ceab5320d",
+        "sha256": "1icav8bx2hzppm8nzkf9i9a5yx9m8r7p6ys3zl1g7qara0j2nsvr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/4e01f345439c89bc2a5616ceda08a979a01bc15e.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/0dca71e2f3f3d63eeab01136138e0e1ceab5320d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "962ecfed3a4fb656b5a91d89159291e00ed766bc"
     },


### PR DESCRIPTION
# Description

Adds coverage reports to the ouroboros-network repository and includes documentation on how to generate and debug them.

Alternative to https://github.com/input-output-hk/ouroboros-network/pull/3899, feel free to take what you need from this PR and merge it into the #3899.