### PR TITLE
Fix GH Actions Windows CI caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,10 @@ jobs:
 
         ghc --version
         cabal --version
-        echo "::set-output name=cabal-store::$(cabal --help | tail -1 | tr -d ' ' | rev | cut -d '/' -f2- | rev)\\store"
+        echo "::set-output name=cabal-store::$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store"
 
     - name: Set cache version
-      run: echo "CACHE_VERSION=9w76Z3Q" >> $GITHUB_ENV
+      run: echo "CACHE_VERSION=20220719" >> $GITHUB_ENV
 
     - name: "LINUX: Install build environment (apt-get)"
       if: runner.os == 'Linux'


### PR DESCRIPTION
# Description

In #3901, the store path used for caching was `C:\cabal\config\store` instead of the correct `C:\cabal\store`. This was due a mix up of the path separators (`/` vs `\`).

Also, we bump the cache version as we want to override the previous (empty) cache.

For evidence that this works, see [this run](https://github.com/input-output-hk/ouroboros-network/runs/7417675263?check_suite_focus=true), in particular how the `Build dependencies` and the `Build projects [build]` finish almost instantly.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
