### PR TITLE
PeerMetrics: interpolate results when inserting a new peer

### DIFF
--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -24,6 +24,7 @@ import           Text.Printf
 import           Control.Exception hiding (throwIO)
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
+import           Data.Bifunctor (Bifunctor (..))
 import           Data.Word
 import           GHC.Generics (Generic (..))
 import           Quiet (Quiet (..))
@@ -100,6 +101,9 @@ handleIOException errorMsg e = throwIO MuxError {
 --
 data TraceLabelPeer peerid a = TraceLabelPeer peerid a
   deriving (Eq, Functor, Show)
+
+instance Bifunctor TraceLabelPeer where
+  bimap f g (TraceLabelPeer a b) = TraceLabelPeer (f a) (g b)
 
 -- | Type used for tracing mux events.
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -348,7 +348,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
         nodeKernel <- initNodeKernel nodeKernelArgs
         rnNodeKernelHook registry nodeKernel
 
-        peerMetrics <- newPeerMetric
+        peerMetrics <- newPeerMetric Diffusion.peerMetricsConfiguration
         let ntnApps = mkNodeToNodeApps   nodeKernelArgs nodeKernel peerMetrics
             ntcApps = mkNodeToClientApps nodeKernelArgs nodeKernel
             (apps, appsExtra) = mkDiffusionApplications

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -67,6 +67,7 @@ import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
 import qualified Ouroboros.Network.Diffusion as Diffusion
 import qualified Ouroboros.Network.Diffusion.NonP2P as NonP2P
 import qualified Ouroboros.Network.Diffusion.P2P as P2P
+import qualified Ouroboros.Network.Diffusion.Policies as Diffusion
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.NodeToClient (ConnectionId, LocalAddress,
                      LocalSocket, NodeToClientVersionData (..), combineVersions,
@@ -77,7 +78,7 @@ import           Ouroboros.Network.NodeToNode (DiffusionMode (..),
                      defaultMiniProtocolParameters)
 import           Ouroboros.Network.PeerSelection.LedgerPeers
                      (LedgerPeersConsensusInterface (..))
-import           Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics (..),
+import           Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics,
                      newPeerMetric, reportMetric)
 import           Ouroboros.Network.Protocol.Limits (shortWait)
 import           Ouroboros.Network.RethrowPolicy
@@ -389,7 +390,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
           (NTN.defaultCodecs codecConfig version)
           NTN.byteLimits
           llrnChainSyncTimeout
-          (reportMetric peerMetrics)
+          (reportMetric Diffusion.peerMetricsConfiguration peerMetrics)
           (NTN.mkHandlers nodeKernelArgs nodeKernel)
 
     mkNodeToClientApps

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -569,5 +569,5 @@ data InboundGovernorTrace peerAddr
     | TrRemoteState                  !(Map (ConnectionId peerAddr) RemoteSt)
     | TrUnexpectedlyFalseAssertion   !(IGAssertionLocation peerAddr)
     -- ^ This case is unexpected at call site.
-    | TrInboundGovernorError  !SomeException
+    | TrInboundGovernorError         !SomeException
   deriving Show

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/Data/Script.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/Data/Script.hs
@@ -10,6 +10,8 @@ module Ouroboros.Network.Testing.Data.Script
   , initScript
   , stepScript
   , stepScriptSTM
+  , stepScriptOrFinish
+  , stepScriptOrFinishSTM
   , initScript'
   , stepScript'
   , stepScriptSTM'
@@ -26,6 +28,7 @@ module Ouroboros.Network.Testing.Data.Script
   , interpretPickScript
   ) where
 
+import           Data.Functor (($>))
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Set (Set)
@@ -76,6 +79,20 @@ stepScriptSTM scriptVar = do
       x':xs' -> LazySTM.writeTVar scriptVar (Script (x' :| xs'))
     return x
 
+-- | Return 'Left' if it was the last step, return 'Right' if the script can
+-- continue.
+--
+stepScriptOrFinish :: MonadSTM m => TVar m (Script a) -> m (Either a a)
+stepScriptOrFinish scriptVar = atomically (stepScriptOrFinishSTM scriptVar)
+
+stepScriptOrFinishSTM :: MonadSTM m => TVar m (Script a) -> STM m (Either a a)
+stepScriptOrFinishSTM scriptVar = do
+    Script (x :| xs) <- LazySTM.readTVar scriptVar
+    case xs of
+      []     -> return (Left x)
+      x':xs' -> writeTVar scriptVar (Script (x' :| xs'))
+             $> Right x
+
 initScript' :: MonadSTM m => Script a -> m (TVar m (Script a))
 initScript' = newTVarIO
 
@@ -110,7 +127,7 @@ instance Arbitrary a => Arbitrary (Script a) where
 
 type TimedScript a = Script (a, ScriptDelay)
 
-data ScriptDelay = NoDelay | ShortDelay | LongDelay
+data ScriptDelay = NoDelay | ShortDelay | LongDelay | Delay DiffTime
   deriving (Eq, Show)
 
 instance Arbitrary ScriptDelay where
@@ -121,6 +138,7 @@ instance Arbitrary ScriptDelay where
   shrink LongDelay  = [NoDelay, ShortDelay]
   shrink ShortDelay = [NoDelay]
   shrink NoDelay    = []
+  shrink (Delay _)  = []
 
 playTimedScript :: (MonadAsync m, MonadTimer m)
                 => Tracer m a -> TimedScript a -> m (TVar m a)
@@ -135,9 +153,10 @@ playTimedScript tracer (Script ((x0,d0) :| script)) = do
                      | (x,d) <- script ]
     return v
   where
-    interpretScriptDelay NoDelay    = 0
-    interpretScriptDelay ShortDelay = 1
-    interpretScriptDelay LongDelay  = 3600
+    interpretScriptDelay NoDelay       = 0
+    interpretScriptDelay ShortDelay    = 1
+    interpretScriptDelay LongDelay     = 3600
+    interpretScriptDelay (Delay delay) = delay
 
 
 --

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -298,6 +298,7 @@ test-suite test
                        Test.Ouroboros.Network.PeerSelection.Json
                        Test.Ouroboros.Network.PeerSelection.MockEnvironment
                        Test.Ouroboros.Network.PeerSelection.PeerGraph
+                       Test.Ouroboros.Network.PeerSelection.PeerMetric
                        Test.Ouroboros.Network.NodeToNode.Version
                        Test.Ouroboros.Network.NodeToClient.Version
                        Test.Ouroboros.Network.ShrinkCarefully

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -95,7 +95,7 @@ import           Ouroboros.Network.PeerSelection.Governor.Types
                      PeerSelectionCounters (..), TracePeerSelection (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers
                      (UseLedgerAfter (..), withLedgerPeers)
-import           Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics (..))
+import           Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics)
 import           Ouroboros.Network.PeerSelection.PeerStateActions
                      (PeerConnectionHandle, PeerSelectionActionsTrace (..),
                      PeerStateActionsArguments (..), withPeerStateActions)

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -231,6 +231,20 @@ data ArgumentsExtra m = ArgumentsExtra {
       -- is using @TIME_WAIT@.
       --
     , daTimeWaitTimeout :: DiffTime
+
+      -- | Churn interval between churn events in deadline mode.  A small fuzz
+      -- is added (max 10 minutes) so that not all nodes churn at the same time.
+      --
+      -- By default it is set to 3300 seconds.
+      --
+    , daDeadlineChurnInterval :: DiffTime
+
+      -- | Churn interval between churn events in bulk sync mode.  A small fuzz
+      -- is added (max 1 minute) so that not all nodes churn at the same time.
+      --
+      -- By default it is set to 300 seconds.
+      --
+    , daBulkChurnInterval :: DiffTime
     }
 
 --
@@ -606,6 +620,8 @@ runM Interfaces
        , daReadUseLedgerAfter
        , daProtocolIdleTimeout
        , daTimeWaitTimeout
+       , daDeadlineChurnInterval
+       , daBulkChurnInterval
        }
      Applications
        { daApplicationInitiatorMode
@@ -879,6 +895,8 @@ runM Interfaces
                           Async.withAsync
                           (Governor.peerChurnGovernor
                             dtTracePeerSelectionTracer
+                            daDeadlineChurnInterval
+                            daBulkChurnInterval
                             daPeerMetrics
                             churnModeVar
                             churnRng
@@ -1026,6 +1044,8 @@ runM Interfaces
                                   Async.withAsync
                                     (Governor.peerChurnGovernor
                                       dtTracePeerSelectionTracer
+                                      daDeadlineChurnInterval
+                                      daBulkChurnInterval
                                       daPeerMetrics
                                       churnModeVar
                                       churnRng

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -34,7 +34,7 @@ deactivateTimeout = 300
 -- | Timeout for 'spsCloseConnectionTimeout'.
 --
 -- This timeout depends on 'KeepAlive' and 'TipSample' timeouts.  'KeepAlive'
--- keeps agancy most of the time, but 'TipSample' can give away its agency for
+-- keeps agency most of the time, but 'TipSample' can give away its agency for
 -- longer periods of time.  Here we allow it to get 6 blocks (assuming a new
 -- block every @20s@).
 --
@@ -103,7 +103,7 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
              . Map.assocs
              $ available'
 
-    -- Randomly pick peers to demote, peeers with knownPeerTepid set are twice
+    -- Randomly pick peers to demote, peers with knownPeerTepid set are twice
     -- as likely to be demoted.
     warmDemotionPolicy :: PickPolicy peerAddr m
     warmDemotionPolicy _ _ isTepid available pickNum = do

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -9,6 +9,8 @@ import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
 
 import           Data.List (sortOn, unfoldr)
+import qualified Data.Map.Merge.Strict as Map
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Word (Word32)
@@ -51,6 +53,19 @@ peerMetricsConfiguration :: PeerMetricsConfiguration
 peerMetricsConfiguration = PeerMetricsConfiguration {
     maxEntriesToTrack = 180
   }
+
+-- | Merge two dictionaries where values of the first one are obligatory, while
+-- the second one are optional.
+--
+optionalMerge
+    :: Ord k
+    => Map k a
+    -> Map k b
+    -> Map k (a, Maybe b)
+optionalMerge = Map.merge (Map.mapMissing (\_ a -> (a, Nothing)))
+                           Map.dropMissing
+                          (Map.zipWithMatched (\_ a b -> (a, Just b)))
+
 
 
 simplePeerSelectionPolicy :: forall m peerAddr.
@@ -99,18 +114,27 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
         mode <- getChurnMode
         scores <- case mode of
                        ChurnModeNormal -> do
+                           jpm <- joinedPeerMetricAt metrics
                            hup <- upstreamyness metrics
                            bup <- fetchynessBlocks metrics
-                           return $ Map.unionWith (+) hup bup
+                           return $ Map.unionWith (+) hup bup `optionalMerge` jpm
 
-                       ChurnModeBulkSync ->
-                           fetchynessBytes metrics
+                       ChurnModeBulkSync -> do
+                           jpm <- joinedPeerMetricAt metrics
+                           bup <- fetchynessBytes metrics
+                           return $ bup `optionalMerge` jpm
+
         available' <- addRand available (,)
         return $ Set.fromList
              . map fst
              . take pickNum
+               -- order the results, resolve the ties using slot number when
+               -- a peer joined the leader board.
+               --
+               -- note: this will prefer to preserve newer peers, whose results
+               -- less certain than peers who entered leader board earlier.
              . sortOn (\(peer, rn) ->
-                          (Map.findWithDefault 0 peer scores, rn))
+                          (Map.findWithDefault (0, Nothing) peer scores, rn))
              . Map.assocs
              $ available'
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -88,12 +88,12 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
         mode <- getChurnMode
         scores <- case mode of
                        ChurnModeNormal -> do
-                           hup <- upstreamyness <$> getHeaderMetrics metrics
-                           bup <- fetchynessBlocks <$> getFetchedMetrics metrics
+                           hup <- upstreamyness metrics
+                           bup <- fetchynessBlocks metrics
                            return $ Map.unionWith (+) hup bup
 
                        ChurnModeBulkSync ->
-                           fetchynessBytes <$> getFetchedMetrics metrics
+                           fetchynessBytes metrics
         available' <- addRand available (,)
         return $ Set.fromList
              . map fst

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -42,6 +42,17 @@ closeConnectionTimeout :: DiffTime
 closeConnectionTimeout = 120
 
 
+-- | Number of events tracked by 'PeerMetrics'.  This corresponds to one hour of
+-- blocks on mainnet.
+--
+-- TODO: issue #3866
+--
+peerMetricsConfiguration :: PeerMetricsConfiguration
+peerMetricsConfiguration = PeerMetricsConfiguration {
+    maxEntriesToTrack = 180
+  }
+
+
 simplePeerSelectionPolicy :: forall m peerAddr.
                              ( MonadSTM m
                              , Ord peerAddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -657,8 +657,7 @@ peerChurnGovernor tracer _metrics churnModeVar inRng getFetchMode base peerSelec
       -- Short delay, we may have no active peers right now
       threadDelay 1
 
-      -- Pick new active peer(s) based on the best performing established
-      -- peers.
+      -- Pick new active peer(s).
       atomically $ increaseActivePeers churnMode
 
       -- Give the promotion process time to start

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -593,8 +593,11 @@ data TracePeerSelection peeraddr =
      | TracePromoteColdDone    Int Int peeraddr
      -- | target active, actual active, selected peers
      | TracePromoteWarmPeers   Int Int (Set peeraddr)
-     -- | local per-group (target active, actual active), selected peers
-     | TracePromoteWarmLocalPeers [(Int, Int)] (Set peeraddr)
+     -- | Promote local peers to warm
+     | TracePromoteWarmLocalPeers
+         [(Int, Int)]   -- ^ local per-group `(target active, actual active)`,
+                        -- only limited to groups which are below their target.
+         (Set peeraddr) -- ^ selected peers
      -- | target active, actual active, peer, reason
      | TracePromoteWarmFailed  Int Int peeraddr SomeException
      -- | target active, actual active, peer

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
@@ -11,6 +11,7 @@ module Ouroboros.Network.PeerSelection.PeerMetric
   , PeerMetricsConfiguration (..)
   , newPeerMetric
     -- * Metric calculations
+  , joinedPeerMetricAt
   , upstreamyness
   , fetchynessBytes
   , fetchynessBlocks
@@ -375,6 +376,24 @@ metricsTracer getMetrics writeMetrics PeerMetricsConfiguration { maxEntriesToTra
                 then return ()
                 else writeMetrics (IntPSQ.insert (slotToInt slot) slot (peer, time) metrics)
 
+
+joinedPeerMetricAt
+    :: forall p m.
+       MonadSTM m
+    => Ord p
+    => PeerMetrics m p
+    -> STM m (Map p SlotNo)
+joinedPeerMetricAt PeerMetrics {peerMetricsVar} =
+    joinedPeerMetricAtImpl <$> readTVar peerMetricsVar
+
+
+joinedPeerMetricAtImpl
+    :: forall p.
+       Ord p
+    => PeerMetricsState p
+    -> Map p SlotNo
+joinedPeerMetricAtImpl PeerMetricsState { peerRegistry } =
+    OrdPSQ.fold' (\p slotNo _ m -> Map.insert p slotNo m) Map.empty peerRegistry
 
 --
 -- Metrics

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
@@ -34,6 +34,10 @@ import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as IntPSQ
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import           Data.Monoid (Sum (..))
+import           Data.OrdPSQ (OrdPSQ)
+import qualified Data.OrdPSQ as OrdPSQ
 
 import           Cardano.Slotting.Slot (SlotNo (..))
 import           Ouroboros.Network.DeltaQ (SizeInBytes)
@@ -51,7 +55,20 @@ newtype PeerMetricsConfiguration = PeerMetricsConfiguration {
     }
 
 
+-- | Integer based metric ordered by 'SlotNo' which holds the peer and time.
+--
+-- The `p` parameter is truly polymorphic.  For `upstreamyness` and we use peer
+-- address, and for `fetchyness` it is a pair of peer id and bytes downloaded.
+--
 type SlotMetric p = IntPSQ SlotNo (p, Time)
+
+-- | Peer registry ordered by slot when a peer joined the peer metric.
+--
+type PeerRegistry p = OrdPSQ p SlotNo AverageMetrics
+
+-- | Peer registry ordered by slot when a peer was last seen.
+--
+type LastSeenRegistry p = OrdPSQ p SlotNo ()
 
 -- | Mutable peer metrics state accessible via 'STM'.
 --
@@ -62,14 +79,51 @@ newtype PeerMetrics m p = PeerMetrics {
 -- | Internal state
 --
 data PeerMetricsState p = PeerMetricsState {
-    headerMetrics  :: SlotMetric p
-  , fetchedMetrics :: SlotMetric (p, SizeInBytes)
+
+    -- | Header metrics.
+    --
+    headerMetrics    :: SlotMetric p,
+
+    -- | Fetch metrics.
+    --
+    fetchedMetrics   :: SlotMetric (p, SizeInBytes),
+
+    -- | Registry recording when a peer joined the board of 'PeerMetrics'.  The
+    -- values are average header and fetched metrics.
+    --
+    peerRegistry     :: PeerRegistry p,
+
+    -- | A registry which indicates when the last time a peer was seen.
+    --
+    -- If a peer hasn't been seen since the oldest recorded slot number, it will
+    -- be removed.
+    --
+    lastSeenRegistry :: LastSeenRegistry p,
+
+    -- | Latest slot registered in the leader board.
+    --
+    lastSlotNo       :: SlotNo,
+
+    -- | Metrics configuration.  Its kept here just for convenience.
+    --
+    metricsConfig    :: PeerMetricsConfiguration
   }
+
+
+-- | Average results at a given slot.
+--
+data AverageMetrics = AverageMetrics {
+    averageUpstreamyness    :: !Int,
+    averageFetchynessBlocks :: !Int,
+    averageFetchynessBytes  :: !Int
+  }
+  deriving Show
 
 
 newPeerMetric
     :: MonadSTM m
-    => m (PeerMetrics m p)
+    => PeerMetricsConfiguration
+    -> m (PeerMetrics m p)
 newPeerMetric = newPeerMetric' IntPSQ.empty IntPSQ.empty
 
 
@@ -77,16 +131,39 @@ newPeerMetric'
     :: MonadSTM m
     => SlotMetric p
     -> SlotMetric (p, SizeInBytes)
+    -> PeerMetricsConfiguration
     -> m (PeerMetrics m p)
-newPeerMetric' headerMetrics fetchedMetrics =
+newPeerMetric' headerMetrics fetchedMetrics metricsConfig =
   PeerMetrics <$> newTVarIO PeerMetricsState {
                                 headerMetrics,
-                                fetchedMetrics
+                                fetchedMetrics,
+                                peerRegistry = OrdPSQ.empty,
+                                lastSeenRegistry = OrdPSQ.empty,
+                                lastSlotNo = SlotNo 0,
+                                metricsConfig
                               }
+
+updateLastSlot :: SlotNo -> PeerMetricsState p -> PeerMetricsState p
+updateLastSlot slotNo state@PeerMetricsState { lastSlotNo }
+  | slotNo > lastSlotNo = state { lastSlotNo = slotNo }
+  | otherwise           = state
+
+
+firstSlotNo :: PeerMetricsState p -> Maybe SlotNo
+firstSlotNo PeerMetricsState {headerMetrics, fetchedMetrics} =
+    (\a b -> min (f a) (f b))
+      <$> IntPSQ.minView headerMetrics
+      <*> IntPSQ.minView fetchedMetrics
+  where
+    f :: (a, SlotNo, b, c) -> SlotNo
+    f (_, slotNo, _, _) = slotNo
+
 
 reportMetric
     :: forall m p.
-       ( MonadSTM m )
+       ( MonadSTM m
+       , Ord p
+       )
      => PeerMetricsConfiguration
      -> PeerMetrics m p
      -> ReportPeerMetrics m (ConnectionId p)
@@ -101,20 +178,26 @@ nullMetric =
   ReportPeerMetrics nullTracer nullTracer
 
 
-slotMetricKey :: SlotNo -> Int
-slotMetricKey (SlotNo s) = fromIntegral s
+slotToInt :: SlotNo -> Int
+slotToInt = fromIntegral . unSlotNo
 
 
--- | Tracer which updates header metrics (upstreameness).
+-- | Tracer which updates header metrics (upstreameness) and inserts new peers
+-- into 'peerRegistry'.
 --
 headerMetricTracer
     :: forall m p.
-       ( MonadSTM m )
+       ( MonadSTM m
+       , Ord p
+       )
     => PeerMetricsConfiguration
     -> PeerMetrics m p
     -> Tracer (STM m) (TraceLabelPeer (ConnectionId p) (SlotNo, Time))
-headerMetricTracer config PeerMetrics{peerMetricsVar} =
-    (\(TraceLabelPeer con d) -> TraceLabelPeer (remoteAddress con) d)
+headerMetricTracer config peerMetrics@PeerMetrics{peerMetricsVar} =
+    (\(TraceLabelPeer con (slotNo, _)) -> TraceLabelPeer (remoteAddress con) slotNo)
+    `contramap`
+    peerRegistryTracer peerMetrics
+ <> (\(TraceLabelPeer con d) -> TraceLabelPeer (remoteAddress con) d)
     `contramap`
     metricsTracer
       (headerMetrics <$> readTVar peerMetricsVar)
@@ -123,11 +206,14 @@ headerMetricTracer config PeerMetrics{peerMetricsVar} =
       config
 
 
--- | Tracer which updates fetched metrics (fetchyness).
+-- | Tracer which updates fetched metrics (fetchyness) and inserts new peers
+-- into 'peerRegistry'.
 --
 fetchedMetricTracer
     :: forall m p.
-       ( MonadSTM m )
+       ( MonadSTM m
+       , Ord p
+       )
     => PeerMetricsConfiguration
     -> PeerMetrics m p
     -> Tracer (STM m) (TraceLabelPeer (ConnectionId p)
@@ -135,8 +221,11 @@ fetchedMetricTracer
                                       , SlotNo
                                       , Time
                                       ))
-fetchedMetricTracer config PeerMetrics{peerMetricsVar} =
-    (\(TraceLabelPeer con (bytes, slot, time)) ->
+fetchedMetricTracer config peerMetrics@PeerMetrics{peerMetricsVar} =
+    (\(TraceLabelPeer con (_, slot, _)) -> TraceLabelPeer (remoteAddress con) slot)
+    `contramap`
+    peerRegistryTracer peerMetrics
+ <> (\(TraceLabelPeer con (bytes, slot, time)) ->
        TraceLabelPeer (remoteAddress con, bytes) (slot, time))
     `contramap`
      metricsTracer
@@ -145,17 +234,132 @@ fetchedMetricTracer config PeerMetrics{peerMetricsVar} =
                                       (\metrics -> metrics { fetchedMetrics }))
        config
 
+
+--
+--  peer registry tracer which maintains 'peerRegistry' and 'lastSeenRegistry'
+--
+
+-- | Insert new peer into 'PeerMetricsState'.  If this peer hasn't been
+-- recorded before, we compute the current average score and record it in
+-- 'peerRegistry'.  Entries in `peerRegistry' are only kept if they are newer
+-- than the oldest slot in the 'headerMetrics' and 'fetchedMetrics'.
+--
+-- Implementation detail:
+-- We need first check 'lastSeenRegistry' which checks if a peer is part of the
+-- leader board.  If a peer has not contributed to 'PeerMetrics' in
+-- `maxEntriesToTrack` slots, we will consider it as a new peer.  Without using
+-- `lastSeenRegistry` we could consider a peer new while it exists in peer
+-- metrics for a very long time.  Just using `peerRegistry` does not guarantee
+-- that.
+--
+insertPeer :: forall p. Ord p
+           => p
+           -> SlotNo -- ^ current slot
+           -> PeerMetricsState p
+           -> PeerMetricsState p
+insertPeer p slotNo
+           peerMetricsState@PeerMetricsState { lastSeenRegistry, peerRegistry } =
+    if p `OrdPSQ.member` lastSeenRegistry
+    then peerMetricsState
+    else case OrdPSQ.alter f p peerRegistry of
+           (False,  peerRegistry') -> peerMetricsState { peerRegistry = peerRegistry' }
+           (True,  _peerRegistry') -> peerMetricsState
+  where
+    f :: Maybe (SlotNo, AverageMetrics) -> (Bool, Maybe (SlotNo, AverageMetrics))
+    f a@Just {} = (True,  a)
+    f Nothing   = (False, Just ( slotNo
+                               , AverageMetrics {
+                                     averageUpstreamyness    = avg upstreamenessResults,
+                                     averageFetchynessBytes  = avg fetchynessBytesResults,
+                                     averageFetchynessBlocks = avg fetchynessBlocksResults
+                                   }
+                               ))
+      where
+        upstreamenessResults    = upstreamynessImpl    peerMetricsState
+        fetchynessBytesResults  = fetchynessBytesImpl  peerMetricsState
+        fetchynessBlocksResults = fetchynessBlocksImpl peerMetricsState
+
+    avg :: Map p Int -> Int
+    avg m | Map.null m = 0
+    avg m =
+      -- division truncated towards the plus infinity, rather then the minus
+      -- infinity
+      case getSum (foldMap Sum m) `divMod` Map.size m of
+        (x, 0) -> x
+        (x, _) -> x + 1
+
+
+-- | A tracer which takes care about:
+--
+-- * inserting new peers to 'peerRegistry'
+-- * removing old entries of 'peerRegistry'
+--
+-- * inserting new peers to 'lastSeenRegistry'
+-- * removing old entries of 'lastSeenRegistry'
+--
+peerRegistryTracer :: forall p m.
+                      ( MonadSTM m
+                      , Ord p
+                      )
+                   => PeerMetrics m p
+                   -> Tracer (STM m) (TraceLabelPeer p SlotNo)
+peerRegistryTracer PeerMetrics { peerMetricsVar } =
+    Tracer $ \(TraceLabelPeer peer slotNo) -> do
+      -- order matters: 'insertPeer' must access the previous value of
+      -- lastSeenRegistry
+      modifyTVar peerMetricsVar $ updateLastSlot slotNo
+                                . witnessedPeer peer slotNo
+                                . insertPeer peer slotNo
+                                . afterSlot
+  where
+    snd_ (_, slotNo, _, _) = slotNo
+
+    -- remove all entries which are older than the oldest slot in the
+    -- 'PeerMetrics'
+    afterSlot :: PeerMetricsState p -> PeerMetricsState p
+    afterSlot peerMetrics@PeerMetricsState { headerMetrics,
+                                             fetchedMetrics,
+                                             peerRegistry,
+                                             lastSeenRegistry } =
+      let -- the oldest slot in the metrics leader board
+          slotNo :: SlotNo
+          slotNo = fromMaybe 0 $
+            (snd_ <$> IntPSQ.minView headerMetrics)
+            `min`
+            (snd_ <$> IntPSQ.minView fetchedMetrics)
+
+      in peerMetrics
+           { peerRegistry     = snd (OrdPSQ.atMostView slotNo peerRegistry),
+             lastSeenRegistry = snd (OrdPSQ.atMostView slotNo lastSeenRegistry)
+           }
+
+    witnessedPeer :: p -> SlotNo
+                  -> PeerMetricsState p -> PeerMetricsState p
+    witnessedPeer peer slotNo
+                  peerMetrics@PeerMetricsState { lastSeenRegistry } =
+                  peerMetrics { lastSeenRegistry =
+                                  OrdPSQ.insert peer slotNo () lastSeenRegistry
+                              }
+
+
+--
+-- Metrics tracer
+--
+
+-- | A metrics tracer which updates the metric.
+--
 metricsTracer
-    :: forall m p.  ( MonadSTM m )
+    :: forall m p.
+       MonadSTM m
     => STM m (SlotMetric p)       -- ^ read metrics
     -> (SlotMetric p -> STM m ()) -- ^ update metrics
     -> PeerMetricsConfiguration
     -> Tracer (STM m) (TraceLabelPeer p (SlotNo, Time))
 metricsTracer getMetrics writeMetrics PeerMetricsConfiguration { maxEntriesToTrack } = Tracer $ \(TraceLabelPeer !peer (!slot, !time)) -> do
     metrics <- getMetrics
-    case IntPSQ.lookup (slotMetricKey slot) metrics of
+    case IntPSQ.lookup (slotToInt slot) metrics of
          Nothing -> do
-             let metrics' = IntPSQ.insert (slotMetricKey slot) slot (peer, time) metrics
+             let metrics'  = IntPSQ.insert (slotToInt slot) slot (peer, time) metrics
              if IntPSQ.size metrics' > maxEntriesToTrack
                 then
                   case IntPSQ.minView metrics' of
@@ -168,7 +372,7 @@ metricsTracer getMetrics writeMetrics PeerMetricsConfiguration { maxEntriesToTra
          Just (_, (_, oldTime)) ->
              if oldTime <= time
                 then return ()
-                else writeMetrics (IntPSQ.insert (slotMetricKey slot) slot (peer, time) metrics)
+                else writeMetrics (IntPSQ.insert (slotToInt slot) slot (peer, time) metrics)
 
 
 --
@@ -197,8 +401,14 @@ upstreamynessImpl
        Ord p
     => PeerMetricsState p
     -> Map p Int
-upstreamynessImpl PeerMetricsState { headerMetrics } =
-    IntPSQ.fold' count Map.empty headerMetrics
+upstreamynessImpl state@PeerMetricsState { headerMetrics,
+                                           peerRegistry,
+                                           lastSlotNo,
+                                           metricsConfig
+                                         } =
+    Map.unionWith (+) (IntPSQ.fold' count Map.empty headerMetrics)
+                      (OrdPSQ.fold' (countCorrection (firstSlotNo state))
+                                    Map.empty peerRegistry)
   where
     count :: Int
           -> SlotNo
@@ -211,6 +421,21 @@ upstreamynessImpl PeerMetricsState { headerMetrics } =
         fn :: Maybe Int -> Maybe Int
         fn Nothing  = Just 1
         fn (Just c) = Just $! c + 1
+
+    countCorrection :: Maybe SlotNo
+                    -> p
+                    -> SlotNo
+                    -> AverageMetrics
+                    -> Map p Int
+                    -> Map p Int
+    countCorrection minSlotNo peer joinedAt AverageMetrics { averageUpstreamyness } m =
+        Map.insert peer
+                   (adjustAvg metricsConfig
+                              minSlotNo
+                              joinedAt
+                              lastSlotNo
+                              averageUpstreamyness)
+                   m
 
 
 -- | Returns a Map which counts the number of bytes downloaded for a given
@@ -230,8 +455,14 @@ fetchynessBytesImpl
        Ord p
     => PeerMetricsState p
     -> Map p Int
-fetchynessBytesImpl PeerMetricsState { fetchedMetrics } =
-    IntPSQ.fold' count Map.empty fetchedMetrics
+fetchynessBytesImpl state@PeerMetricsState { fetchedMetrics,
+                                             peerRegistry,
+                                             lastSlotNo,
+                                             metricsConfig
+                                           } =
+    Map.unionWith (+) (IntPSQ.fold' count Map.empty fetchedMetrics)
+                      (OrdPSQ.fold' (countCorrection (firstSlotNo state))
+                                     Map.empty peerRegistry)
   where
     count :: Int
           -> SlotNo
@@ -244,6 +475,21 @@ fetchynessBytesImpl PeerMetricsState { fetchedMetrics } =
         fn :: Maybe Int -> Maybe Int
         fn Nothing         = Just $ fromIntegral bytes
         fn (Just oldBytes) = Just $! oldBytes + fromIntegral bytes
+
+    countCorrection :: Maybe SlotNo
+                    -> p
+                    -> SlotNo
+                    -> AverageMetrics
+                    -> Map p Int
+                    -> Map p Int
+    countCorrection minSlotNo peer joinedAt AverageMetrics { averageFetchynessBytes } m =
+        Map.insert peer
+                   (adjustAvg metricsConfig
+                              minSlotNo
+                              joinedAt
+                              lastSlotNo
+                              averageFetchynessBytes)
+                   m
 
 
 -- | Returns a Map which counts the number of times a given peer was the first
@@ -263,8 +509,14 @@ fetchynessBlocksImpl
        Ord p
     => PeerMetricsState p
     -> Map p Int
-fetchynessBlocksImpl PeerMetricsState { fetchedMetrics } =
-    IntPSQ.fold' count Map.empty fetchedMetrics
+fetchynessBlocksImpl state@PeerMetricsState { fetchedMetrics,
+                                              peerRegistry,
+                                              lastSlotNo,
+                                              metricsConfig
+                                            } =
+    Map.unionWith (+) (IntPSQ.fold' count Map.empty fetchedMetrics)
+                      (OrdPSQ.fold' (countCorrection (firstSlotNo state))
+                                    Map.empty peerRegistry)
   where
     count :: Int
           -> SlotNo
@@ -278,4 +530,49 @@ fetchynessBlocksImpl PeerMetricsState { fetchedMetrics } =
         fn Nothing  = Just 1
         fn (Just c) = Just $! c + 1
 
+    countCorrection :: Maybe SlotNo
+                    -> p
+                    -> SlotNo
+                    -> AverageMetrics
+                    -> Map p Int
+                    -> Map p Int
+    countCorrection minSlotNo peer joinedAt AverageMetrics { averageFetchynessBlocks } m =
+        Map.insert peer
+                   (adjustAvg metricsConfig
+                              minSlotNo
+                              joinedAt
+                              lastSlotNo
+                              averageFetchynessBlocks)
+                   m
 
+
+--
+-- Utils
+--
+
+
+adjustAvg :: PeerMetricsConfiguration
+          -> Maybe SlotNo -- ^ smallest slot number
+          -> SlotNo       -- ^ slot when joined the leader board
+          -> SlotNo       -- ^ current slot
+          -> Int
+          -> Int
+adjustAvg PeerMetricsConfiguration { maxEntriesToTrack } minSlotNo joinedSlotNo lastSlotNo avg
+    -- when there are only a few results in the 'PeerMetricsState' we don't
+    -- take into account the average.  This allows the system to start, without
+    -- penalising the peers which we connected to early.
+    | lastSlot - minSlot + 1 < maxEntriesToTrack `div` 2
+    = 0
+
+    -- the peer is too old to take the correction into account.
+    | lastSlot - joinedSlot + 1 >= maxEntriesToTrack
+    = 0
+
+    | otherwise
+    = (maxEntriesToTrack + joinedSlot - lastSlot) * avg
+      `div` maxEntriesToTrack
+  where
+    minSlot, lastSlot, joinedSlot :: Int
+    minSlot    = maybe 1 slotToInt minSlotNo
+    lastSlot   = slotToInt lastSlotNo
+    joinedSlot = slotToInt joinedSlotNo

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
@@ -30,6 +30,7 @@ module Ouroboros.Network.PeerSelection.PeerMetric
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer (..), contramap, nullTracer)
+import           Data.Bifunctor (Bifunctor (..))
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as IntPSQ
 import           Data.Map.Strict (Map)
@@ -194,10 +195,10 @@ headerMetricTracer
     -> PeerMetrics m p
     -> Tracer (STM m) (TraceLabelPeer (ConnectionId p) (SlotNo, Time))
 headerMetricTracer config peerMetrics@PeerMetrics{peerMetricsVar} =
-    (\(TraceLabelPeer con (slotNo, _)) -> TraceLabelPeer (remoteAddress con) slotNo)
+    bimap remoteAddress fst
     `contramap`
     peerRegistryTracer peerMetrics
- <> (\(TraceLabelPeer con d) -> TraceLabelPeer (remoteAddress con) d)
+ <> first remoteAddress
     `contramap`
     metricsTracer
       (headerMetrics <$> readTVar peerMetricsVar)
@@ -222,7 +223,7 @@ fetchedMetricTracer
                                       , Time
                                       ))
 fetchedMetricTracer config peerMetrics@PeerMetrics{peerMetricsVar} =
-    (\(TraceLabelPeer con (_, slot, _)) -> TraceLabelPeer (remoteAddress con) slot)
+    bimap remoteAddress (\(_, slotNo, _) -> slotNo)
     `contramap`
     peerRegistryTracer peerMetrics
  <> (\(TraceLabelPeer con (bytes, slot, time)) ->

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -25,6 +25,7 @@ import qualified Test.Ouroboros.Network.PeerSelection (tests)
 import qualified Test.Ouroboros.Network.PeerSelection.Json (tests)
 import qualified Test.Ouroboros.Network.PeerSelection.LocalRootPeers
 import qualified Test.Ouroboros.Network.PeerSelection.MockEnvironment
+import qualified Test.Ouroboros.Network.PeerSelection.PeerMetric
 import qualified Test.Ouroboros.Network.PeerSelection.RootPeersDNS
 import qualified Test.Ouroboros.Network.Testnet (tests)
 import qualified Test.Ouroboros.Network.TxSubmission (tests)
@@ -66,6 +67,7 @@ tests =
   , Test.Ouroboros.Network.PeerSelection.Json.tests
   , Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
+  , Test.Ouroboros.Network.PeerSelection.PeerMetric.tests
   , Test.Ouroboros.Network.PeerSelection.RootPeersDNS.tests
   , Test.Ouroboros.Network.KeepAlive.tests
   , Test.Ouroboros.Network.TxSubmission.tests

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -62,7 +62,8 @@ import           Ouroboros.Network.PeerSelection.Governor
                      (PeerSelectionTargets (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers
                      (LedgerPeersConsensusInterface (..), UseLedgerAfter (..))
-import           Ouroboros.Network.PeerSelection.PeerMetric (newPeerMetric)
+import           Ouroboros.Network.PeerSelection.PeerMetric
+                     (PeerMetricsConfiguration (..), newPeerMetric)
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
                      (DomainAccessPoint (..), LookupReqs (..),
                      RelayAccessPoint (..))
@@ -163,7 +164,7 @@ run blockGeneratorArgs limits ni na tracersExtra =
       $ \ nodeKernel nodeKernelThread -> do
         dnsTimeoutScriptVar <- LazySTM.newTVarIO (aDNSTimeoutScript na)
         dnsLookupDelayScriptVar <- LazySTM.newTVarIO (aDNSLookupDelayScript na)
-        peerMetrics <- newPeerMetric
+        peerMetrics <- newPeerMetric PeerMetricsConfiguration { maxEntriesToTrack = 180 }
         let -- diffusion interfaces
             interfaces :: Diff.P2P.Interfaces (NtNFD m) NtNAddr NtNVersion NtNVersionData
                                               (NtCFD m) NtCAddr NtCVersion NtCVersionData

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -34,8 +34,7 @@ import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadST (MonadST)
 import qualified Control.Monad.Class.MonadSTM as LazySTM
 import           Control.Monad.Class.MonadSTM.Strict (MonadLabelledSTM,
-                     MonadSTM (STM, atomically), MonadTraceSTM, StrictTVar,
-                     newTVar)
+                     MonadSTM (STM), MonadTraceSTM, StrictTVar)
 import           Control.Monad.Class.MonadThrow (MonadEvaluate, MonadMask,
                      MonadThrow, SomeException)
 import           Control.Monad.Class.MonadTime (DiffTime, MonadTime)
@@ -44,7 +43,6 @@ import           Control.Monad.Fix (MonadFix)
 import           Control.Tracer (nullTracer)
 
 import           Data.IP (IP (..))
-import qualified Data.IntPSQ as IntPSQ
 import           Data.Map (Map)
 import           Data.Set (Set)
 import qualified Data.Text as Text
@@ -64,7 +62,7 @@ import           Ouroboros.Network.PeerSelection.Governor
                      (PeerSelectionTargets (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers
                      (LedgerPeersConsensusInterface (..), UseLedgerAfter (..))
-import           Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics (..))
+import           Ouroboros.Network.PeerSelection.PeerMetric (newPeerMetric)
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
                      (DomainAccessPoint (..), LookupReqs (..),
                      RelayAccessPoint (..))
@@ -165,9 +163,7 @@ run blockGeneratorArgs limits ni na tracersExtra =
       $ \ nodeKernel nodeKernelThread -> do
         dnsTimeoutScriptVar <- LazySTM.newTVarIO (aDNSTimeoutScript na)
         dnsLookupDelayScriptVar <- LazySTM.newTVarIO (aDNSLookupDelayScript na)
-        peerMetrics  <- atomically $ PeerMetrics
-          <$> newTVar IntPSQ.empty
-          <*> newTVar IntPSQ.empty
+        peerMetrics <- newPeerMetric
         let -- diffusion interfaces
             interfaces :: Diff.P2P.Interfaces (NtNFD m) NtNAddr NtNVersion NtNVersionData
                                               (NtCFD m) NtCAddr NtCVersion NtCVersionData

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -265,12 +265,14 @@ run blockGeneratorArgs limits ni na tracersExtra =
 
     argsExtra :: Diff.P2P.ArgumentsExtra m
     argsExtra = Diff.P2P.ArgumentsExtra
-      { Diff.P2P.daPeerSelectionTargets = aPeerSelectionTargets na
-      , Diff.P2P.daReadLocalRootPeers   = aReadLocalRootPeers na
-      , Diff.P2P.daReadPublicRootPeers  = aReadPublicRootPeers na
-      , Diff.P2P.daReadUseLedgerAfter   = aReadUseLedgerAfter na
-      , Diff.P2P.daProtocolIdleTimeout  = aProtocolIdleTimeout na
-      , Diff.P2P.daTimeWaitTimeout      = aTimeWaitTimeout na
+      { Diff.P2P.daPeerSelectionTargets  = aPeerSelectionTargets na
+      , Diff.P2P.daReadLocalRootPeers    = aReadLocalRootPeers na
+      , Diff.P2P.daReadPublicRootPeers   = aReadPublicRootPeers na
+      , Diff.P2P.daReadUseLedgerAfter    = aReadUseLedgerAfter na
+      , Diff.P2P.daProtocolIdleTimeout   = aProtocolIdleTimeout na
+      , Diff.P2P.daTimeWaitTimeout       = aTimeWaitTimeout na
+      , Diff.P2P.daDeadlineChurnInterval = 3300
+      , Diff.P2P.daBulkChurnInterval     = 300
       }
 
     appArgs :: Node.AppArgs m

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Policies.hs
@@ -153,16 +153,13 @@ prop_hotToWarmM ArbitraryPolicyArguments{..} seed = do
     let rng = mkStdGen seed
     rngVar <- newTVarIO rng
     cmVar <- newTVarIO apaChurnMode
-    hVar <- newTVarIO apaHeaderMetric
-    fVar <- newTVarIO apaFetchedMetric
-
+    metrics <- newPeerMetric' apaHeaderMetric apaFetchedMetric
 
     let policies = simplePeerSelectionPolicy
                         rngVar
                         (readTVar cmVar)
                         metrics
                         (ReconnectDelay 10)
-        metrics = PeerMetrics hVar fVar
     picked <- atomically $ policyPickHotPeersToDemote policies
                   (const PeerSourceLocalRoot)
                   peerConnectFailCount
@@ -209,7 +206,7 @@ prop_randomDemotion :: ArbitraryPolicyArguments
 prop_randomDemotion args seed = runSimOrThrow $ prop_randomDemotionM args seed
 
 
--- Verifies that Tepid (formely hot) or failing peers are more likely to get
+-- Verifies that Tepid (formerly hot) or failing peers are more likely to get
 -- demoted/forgotten.
 prop_randomDemotionM :: forall m.
                         ( MonadSTM m
@@ -222,16 +219,13 @@ prop_randomDemotionM ArbitraryPolicyArguments{..} seed = do
     let rng = mkStdGen seed
     rngVar <- newTVarIO rng
     cmVar <- newTVarIO apaChurnMode
-    hVar <- newTVarIO apaHeaderMetric
-    fVar <- newTVarIO apaFetchedMetric
-
+    metrics <- newPeerMetric' apaHeaderMetric apaFetchedMetric
 
     let policies = simplePeerSelectionPolicy
                         rngVar
                         (readTVar cmVar)
                         metrics
                         (ReconnectDelay 10)
-        metrics = PeerMetrics hVar fVar
     doDemotion numberOfTries policies Map.empty
 
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Policies.hs
@@ -154,6 +154,7 @@ prop_hotToWarmM ArbitraryPolicyArguments{..} seed = do
     rngVar <- newTVarIO rng
     cmVar <- newTVarIO apaChurnMode
     metrics <- newPeerMetric' apaHeaderMetric apaFetchedMetric
+                              PeerMetricsConfiguration { maxEntriesToTrack = 180 }
 
     let policies = simplePeerSelectionPolicy
                         rngVar
@@ -220,6 +221,7 @@ prop_randomDemotionM ArbitraryPolicyArguments{..} seed = do
     rngVar <- newTVarIO rng
     cmVar <- newTVarIO apaChurnMode
     metrics <- newPeerMetric' apaHeaderMetric apaFetchedMetric
+                              PeerMetricsConfiguration { maxEntriesToTrack = 180 }
 
     let policies = simplePeerSelectionPolicy
                         rngVar

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Policies.hs
@@ -182,11 +182,11 @@ prop_hotToWarmM ArbitraryPolicyArguments{..} seed = do
     noneWorse metrics pickedSet = do
         scores <- atomically $ case apaChurnMode of
                       ChurnModeNormal -> do
-                          hup <- upstreamyness <$> getHeaderMetrics metrics
-                          bup <- fetchynessBlocks <$> getFetchedMetrics metrics
+                          hup <- upstreamyness metrics
+                          bup <- fetchynessBlocks metrics
                           return $ Map.unionWith (+) hup bup
-                      ChurnModeBulkSync -> fetchynessBytes <$>
-                          getFetchedMetrics metrics
+                      ChurnModeBulkSync ->
+                          fetchynessBytes metrics
         let (picked, notPicked) = Map.partitionWithKey fn scores
             maxPicked = maximum $ Map.elems picked
             minNotPicked = minimum $ Map.elems notPicked

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -357,6 +357,7 @@ mockPeerSelectionActions' tracer
               let interpretScriptDelay NoDelay    = 1
                   interpretScriptDelay ShortDelay = 60
                   interpretScriptDelay LongDelay  = 600
+                  interpretScriptDelay (Delay a)  = a -- not used by the generator
               done <-
                 case demotion of
                   Noop   -> return True

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerMetric.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/PeerMetric.hs
@@ -1,0 +1,422 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Ouroboros.Network.PeerSelection.PeerMetric where
+
+
+import           Control.Monad (when)
+import           Control.Monad.Class.MonadAsync
+import qualified Control.Monad.Class.MonadSTM as LazySTM
+import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+import           Control.Tracer (Tracer (..), traceWith)
+
+import           Data.Foldable (Foldable (foldl'), foldr')
+import           Data.List (sortOn)
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.Merge.Strict as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+import           Network.Mux.Trace (TraceLabelPeer (..))
+
+import           Ouroboros.Network.ConnectionId
+import           Ouroboros.Network.DeltaQ (SizeInBytes)
+import           Ouroboros.Network.PeerSelection.PeerMetric
+
+import           Cardano.Slotting.Slot (SlotNo (..))
+
+import           Control.Monad.IOSim
+
+import           Ouroboros.Network.Testing.Data.Script
+import           TestLib.Utils (AllProperty (..))
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.PeerSelection.PeerMetric"
+  [ testProperty "insert peer invariant"       prop_insert_peer
+  , testProperty "metrics results are bounded" prop_metrics_are_bounded
+  , testProperty "size property"               prop_bounded_size
+  ]
+
+
+
+newtype TestAddress = TestAddress Int
+  deriving (Show, Eq, Ord)
+
+instance Arbitrary TestAddress where
+    arbitrary = do
+      size <- choose (0, 20)
+      TestAddress . getPositive <$> resize size arbitrary
+    shrink (TestAddress addr) =
+      TestAddress . getPositive <$> shrink (Positive addr)
+
+data Event =
+    FetchedHeader TestAddress SlotNo
+  | FetchedBlock  TestAddress SlotNo SizeInBytes
+  deriving Show
+
+eventPeer :: Event -> TestAddress
+eventPeer (FetchedHeader peer _)   = peer
+eventPeer (FetchedBlock  peer _ _) = peer
+
+eventSlot :: Event -> SlotNo
+eventSlot (FetchedHeader _ slotNo)   = slotNo
+eventSlot (FetchedBlock  _ slotNo _) = slotNo
+
+instance Arbitrary Event where
+    arbitrary = oneof [ FetchedHeader <$> arbitrary
+                                      <*> (SlotNo . getSmall . getPositive <$> arbitrary)
+                      , FetchedBlock  <$> arbitrary
+                                      <*> (SlotNo . getSmall . getPositive <$> arbitrary)
+                                      <*> (arbitrary `suchThat` \sizeInBytes -> 0 < sizeInBytes && sizeInBytes <= 2_000_000)
+                      ]
+    shrink  FetchedHeader {} = []
+    shrink (FetchedBlock peer slotNo size) =
+      [ FetchedBlock peer slotNo size'
+      | size' <- shrink size
+      , size' > 0
+      ]
+
+
+newtype FixedScript = FixedScript { getFixedScript :: Script Event }
+  deriving Show
+
+-- | Order events by 'SlotNo'
+--
+-- TODO: 'SizeInBytes' should be a function of 'SlotNo'
+--
+mkFixedScript :: Script Event -> FixedScript
+mkFixedScript (Script events) = FixedScript
+                              . Script
+                              $ NonEmpty.sortWith
+                                  eventSlot
+                                  events
+
+instance Arbitrary FixedScript where
+    -- Generated scripts must be long enough. We ignore first 100 results, to
+    -- avoid effects when the peer metrics has not enough data  and thus it is
+    -- ignoring averages: 'Ouroboros.Network.PeerSelection.PeerMetric.adjustAvg'.
+    arbitrary = mkFixedScript
+            <$> resize 360 arbitrary
+                `suchThat` \(Script as) -> NonEmpty.length as > 100
+    shrink (FixedScript script) = mkFixedScript `map` shrink script
+
+
+mkTimedScript :: FixedScript -> TimedScript Event
+mkTimedScript = go . fmap (\a -> (a, eventSlot a)) . getFixedScript
+  where
+    go :: Script (Event, SlotNo) -> TimedScript Event
+    go (Script script) = Script
+                       . NonEmpty.fromList
+                       . foldr' f []
+                       $ zip events ((Just . snd) `map` tail events ++ [Nothing])
+      where
+        events = NonEmpty.toList script
+
+    f :: ((Event, SlotNo), Maybe SlotNo)
+      -> [(Event, ScriptDelay)]
+      -> [(Event, ScriptDelay)]
+    f ((event, slotNo), nextSlotNo) as =
+      (event, Delay $ slotDiffTime slotNo nextSlotNo) : as
+
+    slotToTime :: SlotNo -> Time
+    slotToTime (SlotNo slotNo) = Time $ realToFrac slotNo -- each slot takes 1s
+
+    slotDiffTime :: SlotNo -> Maybe SlotNo -> DiffTime
+    slotDiffTime _slotNo Nothing           = 0
+    slotDiffTime  slotNo (Just nextSlotNo) = slotToTime nextSlotNo
+                                  `diffTime` slotToTime slotNo
+
+
+data PeerMetricsTrace = PeerMetricsTrace {
+      pmtPeer             :: TestAddress,
+      pmtSlot             :: SlotNo,
+      pmtUpstreamyness    :: Map TestAddress Int,
+      pmtFetchynessBytes  :: Map TestAddress Int,
+      pmtFetchynessBlocks :: Map TestAddress Int,
+      pmtJoinedAt         :: Map TestAddress SlotNo
+    }
+  deriving Show
+
+
+simulatePeerMetricScript
+  :: forall m.
+     ( MonadAsync m
+     , MonadTimer m
+     , MonadMonotonicTime m
+     )
+  => Tracer m PeerMetricsTrace
+  -> PeerMetricsConfiguration
+  -> FixedScript
+  -> m ()
+simulatePeerMetricScript tracer config script = do
+      peerMetrics <- newPeerMetric config
+      let reporter :: ReportPeerMetrics m (ConnectionId TestAddress)
+          reporter = reportMetric config peerMetrics
+      v <- atomically (initScript timedScript)
+      go v peerMetrics reporter
+    where
+      timedScript ::  TimedScript Event
+      timedScript = mkTimedScript script
+
+      go :: LazySTM.TVar m (TimedScript Event)
+         -> PeerMetrics m TestAddress
+         -> ReportPeerMetrics m (ConnectionId TestAddress)
+         -> m ()
+      go v peerMetrics reporter@ReportPeerMetrics { reportHeader, reportFetch } = do
+        (continue, (ev, delay)) <- (\case Left  a -> (False, a)
+                                          Right a -> (True,  a))
+                               <$> stepScriptOrFinish v
+        time <- getMonotonicTime
+        peer <- case ev of
+          FetchedHeader peer slotNo -> do
+            atomically $ traceWith reportHeader
+                       $ TraceLabelPeer ConnectionId {
+                                            localAddress  = TestAddress 0,
+                                            remoteAddress = peer
+                                          }
+                                        (slotNo, time)
+            return peer
+
+          FetchedBlock peer slotNo size -> do
+            atomically $ traceWith reportFetch
+                       $ TraceLabelPeer ConnectionId {
+                                            localAddress  = TestAddress 0,
+                                            remoteAddress = peer
+                                          }
+                                        (size, slotNo, time)
+            return peer
+
+        trace <- atomically $
+           PeerMetricsTrace
+                 <$> pure peer
+                 <*> pure (eventSlot ev)
+                 <*> upstreamyness      peerMetrics
+                 <*> fetchynessBytes    peerMetrics
+                 <*> fetchynessBlocks   peerMetrics
+                 <*> joinedPeerMetricAt peerMetrics
+        traceWith tracer trace
+
+        when continue $ do
+          threadDelay (interpretScriptDelay delay)
+          go v peerMetrics reporter
+
+      interpretScriptDelay NoDelay       = 0
+      interpretScriptDelay ShortDelay    = 1
+      interpretScriptDelay LongDelay     = 3600
+      interpretScriptDelay (Delay delay) = delay
+
+
+-- | Check that newly added peer is never in the 20% worst performing peers (if
+-- there are at least 5 results).
+--
+prop_insert_peer :: FixedScript -> Property
+prop_insert_peer script =
+    label ("length: "
+           ++ show (  len `div` band      * band
+                   , (len `div` band + 1) * band  - 1
+                   )) $
+    label (case trace of
+            [] -> "empty"
+            _  -> "non-empty") $
+    getAllProperty $ foldMap go
+                   $ zip (Nothing : Just `map` trace) trace
+  where
+    band = 50
+    len = case getFixedScript script of Script as -> NonEmpty.length as
+
+    config :: PeerMetricsConfiguration
+    config = PeerMetricsConfiguration { maxEntriesToTrack = 180 }
+
+    sim :: IOSim s ()
+    sim = simulatePeerMetricScript (Tracer traceM) config script
+
+    -- drop first 90 slots
+    trace :: [PeerMetricsTrace]
+    trace = dropWhile (\a -> pmtSlot a <= firstSlot + 90)
+          $ selectTraceEventsDynamic (runSimTrace sim)
+      where
+        firstSlot = case script of
+            FixedScript (Script (a :| _)) -> eventSlot a
+
+    go :: (Maybe PeerMetricsTrace, PeerMetricsTrace)
+       -> AllProperty
+    go (Nothing, _) = AllProperty (property True)
+    go (Just prev, res@PeerMetricsTrace { pmtPeer             = peer,
+                                          pmtUpstreamyness    = upstreamynessResults,
+                                          pmtFetchynessBytes  = fetchynessBytesResults,
+                                          pmtFetchynessBlocks = fetchynessBlocksResults,
+                                          pmtJoinedAt         = joinedAtResults
+                                        }) =
+      if peer `Map.member` pmtUpstreamyness prev
+      || peer `Map.member` pmtFetchynessBytes prev
+      || peer `Map.member` pmtFetchynessBlocks prev
+      then AllProperty $ property True
+      else AllProperty ( counterexample (show (res, prev))
+                       $ checkResult "upstreamyness"    peer joinedAtResults upstreamynessResults)
+        <> AllProperty ( counterexample (show (res ,prev))
+                       $ checkResult "fetchynessBytes"  peer joinedAtResults fetchynessBytesResults)
+        <> AllProperty ( counterexample (show (res, prev))
+                       $ checkResult "fetchynessBlocks" peer joinedAtResults fetchynessBlocksResults)
+
+    -- check that the peer is not in 20% worst peers, but only if there are more
+    -- than 5 results.
+    checkResult :: String
+                -> TestAddress
+                -> Map TestAddress SlotNo
+                -> Map TestAddress Int
+                -> Property
+    checkResult name peer joinedAt m =
+          (\peers -> counterexample (name ++ ": peer (" ++ show peer ++ ") member of "
+                                          ++ show (peers, m'))
+                                    (Set.notMember peer peers))
+        . Set.fromList
+        . map fst
+        . take (size `div` 5)
+        . sortOn (snd :: (a, (Int, Maybe SlotNo)) -> (Int, Maybe SlotNo))
+        . Map.toList
+        $ m'
+      where
+        m' = Map.merge (Map.mapMissing (\_ a -> (a, Nothing)))
+                        Map.dropMissing
+                       (Map.zipWithMatched (\_ a b -> (a, Just b)))
+                       m
+                       joinedAt
+        size = Map.size m
+
+
+-- | Check that the results are always positive.
+--
+prop_metrics_are_bounded :: FixedScript -> Property
+prop_metrics_are_bounded script =
+    getAllProperty $ foldMap go trace
+  where
+    config :: PeerMetricsConfiguration
+    config = PeerMetricsConfiguration { maxEntriesToTrack = 180 }
+
+    sim :: IOSim s ()
+    sim = simulatePeerMetricScript (Tracer traceM) config script
+
+    trace :: [PeerMetricsTrace]
+    trace = selectTraceEventsDynamic (runSimTrace sim)
+
+    safeMaximum :: Map a Int -> Int
+    safeMaximum m | Map.null m = 0
+    safeMaximum m = maximum m
+
+    -- We bound each result by twice the maximum value, that's very
+    -- conservative. Less conservative would be maximal value plus average of
+    -- last `maxEntriesToTrack` results or so.
+    bound :: Int
+    bound =
+        (2 *)
+      . safeMaximum
+      . Map.fromListWith (+)
+      . foldr (\a as -> case a of
+                  FetchedHeader peer _   -> (peer, 1) : as
+                  FetchedBlock  peer _ _ -> (peer, 1) : as)
+              []
+      $ case getFixedScript script of
+          Script as -> as
+
+    fetchyness_bytes_bound :: Int
+    fetchyness_bytes_bound =
+        (2 *)
+      . safeMaximum
+      . fmap fromIntegral
+      . Map.fromListWith (+)
+      . foldr (\a as -> case a of
+                  FetchedHeader {}          -> as
+                  FetchedBlock peer _ bytes -> (peer, bytes) : as)
+              []
+      $ case getFixedScript script of
+          Script as -> as
+
+
+    go :: PeerMetricsTrace
+       -> AllProperty
+    go PeerMetricsTrace { pmtUpstreamyness,
+                          pmtFetchynessBytes,
+                          pmtFetchynessBlocks
+                        } =
+         foldMap (\a -> AllProperty
+                      $ counterexample
+                          (show ("upstreameness", a, bound, pmtUpstreamyness))
+                          (a >= 0))
+                 pmtUpstreamyness
+      <> foldMap (\a -> AllProperty
+                      $ counterexample
+                          (show ("fetchynessBytes", a, fetchyness_bytes_bound, pmtFetchynessBytes))
+                          (a >= 0 && a <= fetchyness_bytes_bound))
+                 pmtFetchynessBytes
+      <> foldMap (\a -> AllProperty
+                      $ counterexample
+                          (show ("fetchynessBlocks", a, bound))
+                          (a >= 0))
+                 pmtFetchynessBlocks
+
+
+-- | Check that the result are bounded.
+--
+-- The bound is 'maxEntriesToTrack' times number of peers in the simulation.
+-- This could be lowered by computing number of peers in each
+-- 'maxEntriesToTrack' slots window.
+--
+prop_bounded_size :: Positive Int -> FixedScript -> Property
+prop_bounded_size (Positive maxEntriesToTrack) script =
+    getAllProperty $ foldMap go trace
+  where
+    config :: PeerMetricsConfiguration
+    config = PeerMetricsConfiguration { maxEntriesToTrack }
+
+    sim :: IOSim s ()
+    sim = simulatePeerMetricScript (Tracer traceM) config script
+
+    trace :: [PeerMetricsTrace]
+    trace = selectTraceEventsDynamic (runSimTrace sim)
+
+    number_of_peers :: Int
+    number_of_peers = Set.size
+                    . Set.fromList
+                    . foldl' (\as a -> eventPeer a : as) []
+                    $ case getFixedScript script of
+                        Script as -> as
+
+    bound :: Int
+    bound = maxEntriesToTrack * number_of_peers
+
+    go :: PeerMetricsTrace -> AllProperty
+    go PeerMetricsTrace {
+           pmtUpstreamyness,
+           pmtFetchynessBytes,
+           pmtFetchynessBlocks
+         } = AllProperty ( counterexample
+                             (    "upstreamyness: "
+                               ++ show (Map.size pmtUpstreamyness)
+                               ++ " ≰ "
+                               ++ show maxEntriesToTrack )
+                             ( Map.size pmtUpstreamyness <= bound )
+                         )
+          <> AllProperty ( counterexample
+                             (    "fetchynessBytes: "
+                               ++ show (Map.size pmtFetchynessBytes)
+                               ++ " ≰ "
+                               ++ show maxEntriesToTrack)
+                             ( Map.size pmtFetchynessBytes <= bound )
+                         )
+          <> AllProperty ( counterexample
+                             (    "fetchynessBlocks: "
+                               ++ show (Map.size pmtFetchynessBlocks)
+                               ++ " ≰ "
+                               ++ show maxEntriesToTrack)
+                             ( Map.size pmtFetchynessBlocks <= bound )
+                         )


### PR DESCRIPTION
# Description

This PR makes sure that newly added peers to `PeerMetrics` are never in 20% of worst performing peers.  Currently the churn interval and number of records kept by `PeerMetrics` are in sync, peers added just before the churn event can be removed as they might have too few results.  In the future the churn interval and the number of records kept by `PeerMetrics` might diverge, and thus it's more important to make sure that newly added peers are not immediately removed.

This PR solves this problem by keeping track of average results when a peer joined the leader board and is using linear regression to adjust peer results for the leader board period where the peer was absent from the leader board.

Fixes #3861

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
