### PR TITLE
CAD-4707 Pull out common ChainDbArgs from tests

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -36,6 +36,7 @@ library
 
                        Test.Util.Blob
                        Test.Util.BoolProps
+                       Test.Util.ChainDB
                        Test.Util.ChainUpdates
                        Test.Util.ChunkInfo
                        Test.Util.Classify

--- a/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module Test.Util.ChainDB (
+    MinimalChainDbArgs (..)
+  , NodeDBs (..)
+  , emptyNodeDBs
+  , fromMinimalChainDbArgs
+  , mkTestChunkInfo
+  ) where
+
+
+import           Control.Tracer (nullTracer)
+import           Data.Functor.Identity (Identity)
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Config
+                     (TopLevelConfig (topLevelConfigLedger),
+                     configSecurityParam)
+import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture (..))
+import qualified Ouroboros.Consensus.Fragment.Validated as VF
+import           Ouroboros.Consensus.HardFork.History.EraParams (EraParams,
+                     eraEpochSize)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
+import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Storage.ChainDB hiding
+                     (TraceFollowerEvent (..))
+import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (..))
+import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
+import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+                     (simpleChunkInfo)
+import qualified Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy as LedgerDB
+import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
+import           Ouroboros.Consensus.Util.IOLike hiding (invariant)
+import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
+
+import           Test.Util.FS.Sim.MockFS
+import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.STM (simHasFS)
+
+
+
+-- | A vector with an element for each database of a node
+--
+-- The @db@ type parameter is instantiated by this module at types for mock
+-- filesystems; either the 'MockFS' type or reference cells thereof.
+data NodeDBs db = NodeDBs {
+    nodeDBsImm :: db
+  , nodeDBsVol :: db
+  , nodeDBsLgr :: db
+  }
+  deriving (Functor, Foldable, Traversable)
+
+emptyNodeDBs :: MonadSTM m => m (NodeDBs (StrictTVar m MockFS))
+emptyNodeDBs = NodeDBs
+  <$> uncheckedNewTVarM Mock.empty
+  <*> uncheckedNewTVarM Mock.empty
+  <*> uncheckedNewTVarM Mock.empty
+
+-- | Minimal set of arguments for creating a ChainDB instance for testing purposes.
+data MinimalChainDbArgs m blk = MinimalChainDbArgs {
+    mcdbTopLevelConfig :: TopLevelConfig blk
+  , mcdbChunkInfo      :: ImmutableDB.ChunkInfo
+  -- ^ Specifies the layout of the ImmutableDB on disk.
+  , mcdbInitLedger     :: ExtLedgerState blk
+  -- ^ The initial ledger state.
+  , mcdbRegistry       :: ResourceRegistry m
+  -- ^ Keeps track of non-lexically scoped resources.
+  , mcdbNodeDBs        :: NodeDBs (StrictTVar m MockFS)
+  -- ^ File systems underlying the immutable, volatile and ledger databases.
+  -- Would be useful to default this to StrictTVar's containing empty MockFS's.
+  }
+
+-- | Utility function to get a default chunk info in case we have EraParams available.
+mkTestChunkInfo :: LedgerConfig blk ~ EraParams => TopLevelConfig blk -> ImmutableDB.ChunkInfo
+mkTestChunkInfo = simpleChunkInfo . eraEpochSize . topLevelConfigLedger
+
+-- | Creates a default set of of arguments for ChainDB tests.
+fromMinimalChainDbArgs ::
+     ( MonadThrow m
+     , MonadSTM m
+     , ConsensusProtocol (BlockProtocol blk)
+     )
+  => MinimalChainDbArgs m blk -> ChainDbArgs Identity m blk
+fromMinimalChainDbArgs MinimalChainDbArgs {..} = ChainDbArgs {
+    cdbHasFSImmutableDB       = SomeHasFS $ simHasFS (nodeDBsImm mcdbNodeDBs)
+  , cdbHasFSVolatileDB        = SomeHasFS $ simHasFS (nodeDBsVol mcdbNodeDBs)
+  , cdbHasFSLgrDB             = SomeHasFS $ simHasFS (nodeDBsLgr mcdbNodeDBs)
+  , cdbImmutableDbValidation  = ImmutableDB.ValidateAllChunks
+  , cdbVolatileDbValidation   = VolatileDB.ValidateAll
+  , cdbMaxBlocksPerFile       = VolatileDB.mkBlocksPerFile 4
+  , cdbDiskPolicy             = LedgerDB.defaultDiskPolicy (configSecurityParam mcdbTopLevelConfig)
+                                  LedgerDB.DefaultSnapshotInterval
+  -- ^ Keep 2 ledger snapshots, and take a new snapshot at least every 2 * k seconds, where k is the
+  -- security parameter.
+  , cdbTopLevelConfig         = mcdbTopLevelConfig
+  , cdbChunkInfo              = mcdbChunkInfo
+  , cdbCheckIntegrity         = const True
+  -- ^ Getting a verified block component does not do any integrity checking, both for the
+  -- ImmutableDB, as the VolatileDB. This is done in @extractBlockComponent@ in the iterator for the
+  -- ImmutableDB, and in @getBlockComponent@ for the VolatileDB.
+  , cdbGenesis                = return mcdbInitLedger
+  , cdbCheckInFuture          = CheckInFuture $ \vf -> pure (VF.validatedFragment vf, [])
+  -- ^ Blocks are never in the future.
+  , cdbImmutableDbCacheConfig = ImmutableDB.CacheConfig 2 60
+  -- ^ Cache at most 2 chunks and expire each chunk after 60 seconds of being unused.
+  , cdbTracer                 = nullTracer
+  , cdbTraceLedger            = nullTracer
+  , cdbRegistry               = mcdbRegistry
+  , cdbGcDelay                = 1
+  , cdbGcInterval             = 1
+  , cdbBlocksToAddSize        = 1
+  }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB.hs
@@ -3,5 +3,6 @@ module Ouroboros.Consensus.Storage.ChainDB (
   , module Ouroboros.Consensus.Storage.ChainDB.Impl
   ) where
 
+
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import           Ouroboros.Consensus.Storage.ChainDB.Impl

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -158,7 +158,7 @@ data ChainDB m blk = ChainDB {
       --   (which does not correspond to an actual block)
       --
       -- * The volatile DB suffered some data loss
-      --   Typically (but not necessarily) the immutable DB will not be empty
+      --   Typically (but not necessarily) the volatile DB will not be empty
       --   and the anchor will be pointing to the tip of the immutable DB.
       --
       -- POSTCONDITION: The Chain DB will be able to switch to any fork starting

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -49,7 +49,11 @@ data ChainDbArgs f m blk = ChainDbArgs {
 
       -- Policy
     , cdbImmutableDbValidation  :: ImmutableDB.ValidationPolicy
+    -- ^ Which chunks of the ImmutableDB to validate on opening: all chunks, or
+    -- only the most recent chunk?
     , cdbVolatileDbValidation   :: VolatileDB.BlockValidationPolicy
+    -- ^ Should the parser for the VolatileDB fail when it encounters a
+    -- corrupt/invalid block?
     , cdbMaxBlocksPerFile       :: VolatileDB.BlocksPerFile
     , cdbDiskPolicy             :: LgrDB.DiskPolicy
 
@@ -57,6 +61,9 @@ data ChainDbArgs f m blk = ChainDbArgs {
     , cdbTopLevelConfig         :: HKD f (TopLevelConfig blk)
     , cdbChunkInfo              :: HKD f ChunkInfo
     , cdbCheckIntegrity         :: HKD f (blk -> Bool)
+    -- ^ Predicate to check for integrity of
+    -- 'Ouroboros.Consensus.Storage.Common.GetVerifiedBlock' components when
+    -- extracting them from both the VolatileDB and the ImmutableDB.
     , cdbGenesis                :: HKD f (m (ExtLedgerState blk))
     , cdbCheckInFuture          :: HKD f (CheckInFuture m blk)
     , cdbImmutableDbCacheConfig :: ImmutableDB.CacheConfig


### PR DESCRIPTION
# Pull out common ChainDbArgs from tests

Factor out common values for the ChainDbArgs used in various tests, to make it easier to set up new ChainDB tests in the future.

Closes CAD-4707.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
