### PR TITLE
Disable ChainDB q-s-m test on Windows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,6 @@ Sadly, some CI checks are currently flaky. Right now, this includes:
 
  - GH Actions Windows job runs out of memory, e.g. in https://github.com/input-output-hk/ouroboros-network/runs/7231748864?check_suite_focus=true
  
- - The Hydra check for test-storage on Windows (mingwW64) fails with inscrutable malloc-related error messages: https://hydra.iohk.io/build/16260881/nixlog/1
-
  - The tests in WallClock.delay* can fail under load (quite rarely): https://hydra.iohk.io/build/16723452/nixlog/76
 
 If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB.hs
@@ -1,5 +1,7 @@
 module Test.Ouroboros.Storage.ChainDB (tests) where
 
+import           System.Info (os)
+
 import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage.ChainDB.GcSchedule as GcSchedule
@@ -9,10 +11,12 @@ import qualified Test.Ouroboros.Storage.ChainDB.Paths as Paths
 import qualified Test.Ouroboros.Storage.ChainDB.StateMachine as StateMachine
 
 tests :: TestTree
-tests = testGroup "ChainDB" [
+tests = testGroup "ChainDB" $ [
       Iterator.tests
     , GcSchedule.tests
     , Model.tests
     , Paths.tests
-    , StateMachine.tests
-    ]
+    ] <>
+    -- The ChainDB q-s-m test is flaky on Windows, see
+    -- https://github.com/input-output-hk/ouroboros-network/issues/3874
+    [ StateMachine.tests | os /= "mingw32" ]


### PR DESCRIPTION
# Description

Random Hydra failures caused by this test continue to be annoying, in particular for external contributors. As this test does not exercise any platform-specfic behavior and is still executed in Linux and macOS, disabling it should not reduce our coverage meaningfully.

Reenabling this test is tracked in #3874.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
