### PR TITLE
Monomorphise return type of toPureEpochInfo

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
@@ -12,6 +12,7 @@ module Ouroboros.Consensus.HardFork.History.EpochInfo (
 
 import           Control.Exception (throw)
 import           Control.Monad.Except (Except, runExcept, throwError)
+import           Data.Functor.Identity
 import           GHC.Stack
 
 import           Cardano.Slotting.EpochInfo.API
@@ -60,8 +61,5 @@ dummyEpochInfo = EpochInfo {
 --
 -- As per usual, this should only be used when the pure exception would
 -- indicate a bug.
-toPureEpochInfo ::
-     Applicative f
-  => EpochInfo (Except PastHorizonException)
-  -> EpochInfo f
+toPureEpochInfo :: EpochInfo (Except PastHorizonException) -> EpochInfo Identity
 toPureEpochInfo = hoistEpochInfo (either throw pure . runExcept)


### PR DESCRIPTION
# Description

Make return type of toPureEpochInfo monomorphic.

Closes CAD-4433.
Closes #3871.

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
