### PR TITLE
Remove `FromCBOR` and `ToCBOR` instances from `LedgerDB.HD` module.

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -32,6 +32,8 @@ module Test.Ouroboros.Storage.LedgerDB.OnDisk (
 
 import           Prelude hiding (elem)
 
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (Serialise)
 import qualified Codec.Serialise as S
 import           Control.Monad.Except (Except, runExcept)
@@ -313,8 +315,9 @@ instance SufficientSerializationForAnyBackingStore (LedgerState TestBlock) where
   codecLedgerTables = TokenToTValue $ CodecMK toCBOR toCBOR fromCBOR fromCBOR
 
 instance Serialise (LedgerTables (LedgerState TestBlock) EmptyMK) where
-  encode TokenToTValue {testUtxtokTable} = toCBOR testUtxtokTable
-  decode = fmap TokenToTValue fromCBOR
+  encode (TokenToTValue (_ :: EmptyMK Token TValue))
+         = CBOR.encodeNull
+  decode = TokenToTValue ApplyEmptyMK <$ CBOR.decodeNull
 
 instance ToCBOR Token where
   toCBOR (Token pt) = S.encode pt


### PR DESCRIPTION
# Description

Resolves #3945.

We remove `FromCBOR` and `ToCBOR` instances from `LedgerDB.HD` module. As a result, we can remove `FromCBOR` and `ToCBOR` instances for the `ApplyMapKind'` datatype as well. This warranted a small change to serialisation in the `OnDisk` tests.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
