### PR TITLE
db-synthesizer: enhance with append mode

### DIFF
--- a/ouroboros-consensus-cardano-tools/app/DBSynthesizer/Parsers.hs
+++ b/ouroboros-consensus-cardano-tools/app/DBSynthesizer/Parsers.hs
@@ -41,7 +41,7 @@ parseDBSynthesizerOptions :: Parser DBSynthesizerOptions
 parseDBSynthesizerOptions =
   DBSynthesizerOptions
     <$> parseForgeOptions
-    <*> parseForce
+    <*> parseOpenMode
 
 parseForgeOptions :: Parser ForgeLimit
 parseForgeOptions =
@@ -136,3 +136,16 @@ parseForce =
     (     short 'f'
       <>  help "Force overwrite an existing Chain DB"
     )
+
+parseAppend :: Parser Bool
+parseAppend =
+  switch
+    (     short 'a'
+      <>  help "Append to an existing Chain DB"
+    )
+
+parseOpenMode :: Parser DBSynthesizerOpenMode
+parseOpenMode =
+      (parseForce *> pure OpenCreateForce)
+  <|> (parseAppend *> pure OpenAppend)
+  <|> pure OpenCreate

--- a/ouroboros-consensus-cardano-tools/app/db-synthesizer.hs
+++ b/ouroboros-consensus-cardano-tools/app/db-synthesizer.hs
@@ -5,7 +5,7 @@
 --                       [--shelley-vrf-key FILE] [--shelley-kes-key FILE]
 --                       [--bulk-credentials-file FILE]
 --                       ((-s|--slots NUMBER) | (-b|--blocks NUMBER) |
---                         (-e|--epochs NUMBER)) [-f]
+--                         (-e|--epochs NUMBER)) [-f | -a]
 --
 -- Available options:
 --   --config FILE            Path to the node's config.json
@@ -20,6 +20,7 @@
 --   -b,--blocks NUMBER       Amount of blocks to forge
 --   -e,--epochs NUMBER       Amount of epochs to process
 --   -f                       Force overwrite an existing Chain DB
+--   -a                       Append to an existing Chain DB
 module Main (main) where
 
 import           System.Exit

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Types.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Types.hs
@@ -42,9 +42,15 @@ data ForgeLimit =
 newtype ForgeResult = ForgeResult {resultForged :: Int}
   deriving (Eq, Show)
 
+data DBSynthesizerOpenMode =
+      OpenCreate
+    | OpenCreateForce
+    | OpenAppend
+    deriving (Eq, Show)
+
 data DBSynthesizerOptions = DBSynthesizerOptions {
-    synthLimit          :: !ForgeLimit
-  , synthForceDBRemoval :: !Bool
+    synthLimit    :: !ForgeLimit
+  , synthOpenMode :: !DBSynthesizerOpenMode
   }
   deriving Show
 


### PR DESCRIPTION
This PR is an enhancement to  `db-synthesizer`.

- A mode of operation is added, where the tool appends to an existing ChainDB.
- The append mode is reached via the API type `DBSynthesizerOpenMode` or the command line flag `-a`.
- The existing multi-step test for the synthesizer tool is extended by an additional append step.
