### PR TITLE
Enable macos in GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ["8.10.7"]
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
 
     env:
       # current ref from: 27.02.2022
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+      # OpenSSL is installed in a non-standard location in MacOS. See
+      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
+      PKG_CONFIG_PATH: ${{ matrix.os == 'macos-latest' && '/usr/local/opt/openssl@1.1/lib/pkgconfig' || '' }}
 
     steps:
     - name: "WIN: Setup MSYS2 and libraries"
@@ -39,7 +42,7 @@ jobs:
           mingw-w64-x86_64-cmake
           mingw-w64-x86_64-jq
 
-    - name: "LINUX: Setup haskell"
+    - name: "LINUX | MAC: Setup haskell"
       if: runner.os != 'Windows'
       uses: haskell/actions/setup@v1
       id: setup-haskell
@@ -99,11 +102,20 @@ jobs:
         echo "CI_SECP_FLAGS=--prefix=/usr" >> $GITHUB_ENV
         echo "CI_SECP_INSTALL_CMD=sudo" >> $GITHUB_ENV
 
+    - name: "MAC: Install build environment (brew)"
+      if: runner.os == 'macOS'
+      run: |
+        brew install libsodium
+
+    - name: "MAC: Install build environment (for secp256k1)"
+      if: runner.os == 'macOS'
+      run: brew install autoconf automake libtool
+
     - name: "Install secp256k1"
       run: |
-        git clone https://github.com/bitcoin-core/secp256k1
+        git clone https://github.com/bitcoin-core/secp256k1.git
         ( cd secp256k1
-          git switch $SECP256K1_REF --detach
+          git reset --hard $SECP256K1_REF
           ./autogen.sh
           ./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
           make


### PR DESCRIPTION
# Description

Setup macOS based CI tests. 

Copied from [db-sync](https://github.com/input-output-hk/cardano-db-sync) and [node](https://github.com/input-output-hk/cardano-node) where we have similar test setups.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
