### PR TITLE
Updated versions of github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ["8.10.7"]
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     env:
       # current ref from: 27.02.2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: "LINUX: Setup haskell"
       if: runner.os != 'Windows'
-      uses: haskell/actions/setup@v1
+      uses: haskell/actions/setup@v2
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -111,7 +111,7 @@ jobs:
           $CI_SECP_INSTALL_CMD make install
         )
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Update Hackage index
       run: cabal update
@@ -146,14 +146,14 @@ jobs:
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
         echo "::set-output name=weeknum::$(/bin/date -u "+%W")"
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: "Cache `cabal store`"
       with:
         path: ${{ runner.os == 'Windows' && steps.win-setup-haskell.outputs.cabal-store || steps.setup-haskell.outputs.cabal-store }}
         key: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
         restore-keys: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: "Cache `dist-newstyle`"
       with:
         path: |

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "ci/hydra:Cardano:ouroboros-network:required",
-  "build (8.10.7, ubuntu-20.04)",
+  "build (8.10.7, ubuntu-latest)",
   "build (8.10.7, windows-latest)",
 ]
 timeout_sec = 7200


### PR DESCRIPTION
- `actions/checkout@v3`
- `actions/cache@v3`
- using `ubuntu-latest` instead of the `ubuntu-20.04`
- introduced dependabot for GitHub Actions.
