### PR TITLE
Add function `getAskBlockValidity` to ChainDB API to replace `getIsValid` and `getIsInvalidBlock`.

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -227,7 +227,27 @@ data ChainDB m blk = ChainDB {
     -- TODO: Redundant, subsumed by getAskBlockValidity
     , getIsValid         :: STM m (RealPoint blk -> Maybe Bool)
 
-
+    -- | Return a fingerprinted function that tells whether a block is known to
+    -- be valid or invalid. If invalid, it also returns the reason.  The
+    -- function will return:
+    --
+    -- * @Just Valid@: for blocks in the volatile DB that have been validated
+    --   and were found to be valid. All blocks in the current chain
+    --   fragment (i.e., 'getCurrentChain') are valid.
+    --
+    -- * @Just (Invalid reason)@: for blocks in the volatile DB that have been
+    --   validated and were found to be invalid.
+    --
+    -- * @Nothing@: for blocks not or no longer in the volatile DB, whether
+    --   they are valid or not, including blocks in the immutable DB. Also
+    --   for blocks in the volatile DB that haven't been validated (yet),
+    --   e.g., because they are disconnected from the current chain or they
+    --   are part of a shorter fork.
+    --
+    -- Note that the fingerprint changes iff the function returned detects new
+    -- invalid blocks. In particular, the function's fingerprint does not change
+    -- when it detects more valid blocks or less invalid blocks (e.g., when
+    -- invalid blocks are garbage collected).
     , getAskBlockValidity :: STM m (WithFingerprint (RealPoint blk -> Maybe (BlockValidity blk)))
 
       -- | Get the highest slot number stored in the ChainDB.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -342,6 +342,7 @@ data ChainDB m blk = ChainDB {
       -- 'False' when the database is closed.
     , isOpen             :: STM m Bool
     }
+{-# DEPRECATED getIsValid, getIsInvalidBlock "Use getAskBlockValidity instead" #-}
 
 getCurrentTip :: (Monad (STM m), HasHeader (Header blk))
               => ChainDB m blk -> STM m (Network.Tip blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -18,7 +18,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Storage.ChainDB.API (
     -- * Main ChainDB API
-    ChainDB (..)
+    BlockValidity (..)
+  , ChainDB (..)
   , getCurrentLedger
   , getCurrentTip
   , getHeaderStateHistory
@@ -222,7 +223,12 @@ data ChainDB m blk = ChainDB {
       --   for blocks in the volatile DB that haven't been validated (yet),
       --   e.g., because they are disconnected from the current chain or they
       --   are part of a shorter fork.
+
+    -- TODO: Redundant, subsumed by getAskBlockValidity
     , getIsValid         :: STM m (RealPoint blk -> Maybe Bool)
+
+
+    , getAskBlockValidity :: STM m (WithFingerprint (RealPoint blk -> Maybe (BlockValidity blk)))
 
       -- | Get the highest slot number stored in the ChainDB.
       --
@@ -320,6 +326,8 @@ data ChainDB m blk = ChainDB {
       -- Note that when invalid blocks are garbage collected and thus no
       -- longer detected by this function, the 'Fingerprint' doesn't have to
       -- change, since the function will not detect new invalid blocks.
+
+    -- TODO: Redundant, subsumed by getAskBlockValidity
     , getIsInvalidBlock :: STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
 
       -- | Close the ChainDB
@@ -601,6 +609,8 @@ streamFrom from db registry blockComponent = do
 {-------------------------------------------------------------------------------
   Invalid block reason
 -------------------------------------------------------------------------------}
+
+data BlockValidity blk = Valid | Invalid (InvalidBlockReason blk)
 
 -- | The reason why a block is invalid.
 data InvalidBlockReason blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -218,6 +218,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , stream                = Iterator.stream  h
             , newFollower           = Follower.newFollower h
             , getIsInvalidBlock     = getEnvSTM  h Query.getIsInvalidBlock
+            , getAskBlockValidity   = getEnvSTM h Query.getAskBlockValidity
             , closeDB               = closeDB h
             , isOpen                = isOpen  h
             }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -38,7 +38,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry
   Misc
 -------------------------------------------------------------------------------}
 
--- | Wait until the TVar changed
+-- | Wait until a function of the TVar changed
 blockUntilChanged :: forall m a b. (MonadSTM m, Eq b)
                   => (a -> b) -> b -> STM m a -> STM m (a, b)
 blockUntilChanged f b getA = do


### PR DESCRIPTION
# Description

Extend ChainDB API with a function to replace both `getIsInvalidBlock` and `getIsValid`.

Closes #3974.

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job runs out of memory, e.g. in https://github.com/input-output-hk/ouroboros-network/runs/7231748864?check_suite_focus=true
 
 - The tests in WallClock.delay* can fail under load (quite rarely): https://hydra.iohk.io/build/16723452/nixlog/76

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
