### PR TITLE
Improve model ChainSel to fix ChainDB QSM test flakiness

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -433,8 +433,7 @@ addBlock cfg blk m = Model {
       immutableChainHashes `isPrefixOf`
       map blockHash (Chain.toOldestFirst fork)
 
-    consideredCandidates = filter (extendsImmutableChain . fst)
-      $ candidates
+    consideredCandidates = filter (extendsImmutableChain . fst) candidates
 
     newChain  :: Chain blk
     newLedger :: ExtLedgerState blk
@@ -450,7 +449,8 @@ addBlock cfg blk m = Model {
     valid' = foldl
                (Chain.foldChain (\s b -> Set.insert (blockHash b) s))
                (valid m)
-               (takeWhile (not . Chain.isPrefixOf newChain) (map fst consideredCandidates) ++ [newChain])
+               (takeWhile (not . Chain.isPrefixOf newChain)
+                (map fst consideredCandidates) ++ [newChain])
 
 -- = Getting the valid blocks
 --
@@ -876,8 +876,12 @@ validChains cfg m bs =
     -- first, which results in the valid chain A->B', which is then chosen
     -- over the equally preferable A->B as it will be the first in the list
     -- after a stable sort.
-    sortChains $ chains bs
+    sortChains $ pruneKnownInvalid <$> chains bs
   where
+    pruneKnownInvalid chain =
+      -- We don't want known invalid blocks to influence the sorting of candidate chains.
+      Chain.takeWhile (\b -> blockHash b `Map.notMember` (invalid m)) chain
+
     sortChains :: [Chain blk] -> [Chain blk]
     sortChains =
       sortBy $ flip (

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -521,13 +521,7 @@ instance Eq IsValidResult where
         (Just x1, Just x2) -> x1 == x2
         (Nothing, Nothing) -> True
         (Nothing, Just _)  -> True
-        (Just _,  Nothing) ->
-          -- TODO Right now, the model implementation sometimes
-          -- incorrectly returns Nothing while the real one returns
-          -- Just. To reduce test flakiness for now, we deviate from
-          -- the comments above, but we should try to change this back
-          -- to False in the future, cf. #3689.
-          True
+        (Just _,  Nothing) -> False
 
 {-------------------------------------------------------------------------------
   Max clock skew


### PR DESCRIPTION
# Description

Fix ChainDB QSM test by incorporating already detected invalid blocks into the model's logic that orders the candidate chains according to the way the actual implementation would try them.

Suppose that we have the candidate chains [GABCd, GAEf] in which lower case letters indicate invalid blocks, and in which the ChainDB already knows that d is invalid, and f is the last block that has been added.

The model implementation would:
1. order the candidates [GABCd, GAEf] (attempting to mimic the way the actual implementation tries chains),
2. truncate the chains to their valid prefixes [GABC, GAE]
3. select GABC as the current chain.  
It would not detect valid blocks in GAEf, in particular E.

The actual implementation already knows that d is invalid and would start from [GABC, GAEf], and the order in which it would try chains is [GAEf, GABC]. In the process it would detect that E is valid.

The solution proposed here changes 1. to already take into account known invalid blocks (we are keeping track of those in the model anyway).

Closes #3689.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
