### PR TITLE
Comment on why we should keep getIsInvalidBlock separate

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -311,15 +311,28 @@ data ChainDB m blk = ChainDB {
       -- Blocks unknown to the ChainDB will result in 'False'.
       --
       -- If the hash corresponds to a block that is known to be invalid, but
-      -- is now older than @k@, this function may return 'False'.
+      -- is now older than 'k', this function may return 'False'.
       --
-      -- Whenever a new invalid block is added, the @Fingerprint@ will be
+      -- Whenever a new invalid block is added, the 'Fingerprint' will be
       -- changed. This is useful when \"watching\" this function in a
       -- transaction.
       --
       -- Note that when invalid blocks are garbage collected and thus no
       -- longer detected by this function, the 'Fingerprint' doesn't have to
       -- change, since the function will not detect new invalid blocks.
+      --
+      -- It might seem natural to have this function also return whether the
+      -- ChainDB knows that a block is valid, thereby subsuming the 'getIsValid'
+      -- function and simplifying the API. However, this adds the overhead of
+      -- checking whether the block is valid for blocks that are not known to be
+      -- invalid that does not give useful information to current clients
+      -- (ChainSync), since they are only interested in whether a block is known
+      -- to be invalid. The extra information of whether a block is valid is
+      -- only used for testing.
+      --
+      -- In particular, this affects the watcher in 'bracketChainSyncClient',
+      -- which rechecks the blocks in all candidate chains whenever a new
+      -- invalid block is detected. These blocks are likely to be valid.
     , getIsInvalidBlock :: STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
 
       -- | Close the ChainDB


### PR DESCRIPTION
Add comment why we shouldn't `getIsValid` into `getIsInvalidBlock` in the ChainDB API.

Closes #3974.

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job runs out of memory, e.g. in https://github.com/input-output-hk/ouroboros-network/runs/7231748864?check_suite_focus=true
 
 - The tests in WallClock.delay* can fail under load (quite rarely): https://hydra.iohk.io/build/16723452/nixlog/76

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
