### PR TITLE
Fix typo for Network docs CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ haddocks/
 /docs/**/*.fdb_latexmk
 /docs/**/*.fls
 /docs/**/*.log
+/docs/**/*.lot
 /docs/**/*.out
 /docs/**/*.pdf
 /docs/**/*.synctex.gz

--- a/docs/network-design/network-design.tex
+++ b/docs/network-design/network-design.tex
@@ -4257,7 +4257,7 @@ The $\Delta{}Q|_G$ value\footnote{The concept of $\Delta{}Q$ is
   explained in \cite{Comp20}. Here is a link to
   \href{https://www.slideshare.net/pnsol-slides/q-and-blockchain-83943683}{{slides
   on applicability to block chain}}.} here is for the round trip time,
-the $\Delta{}Q|_S$ is $8\times{}10^{-8}$ s/o^\footnote{s/o - seconds per octet}
+the $\Delta{}Q|_S$ is $8\times{}10^{-8}$ s/o\footnote{s/o - seconds per octet}
 (the typical value from tests), and the $\Delta{}Q$ per direction is taken to
 be $1/2$ the round trip (reasonable in an AWS environment, not so in an
 asymmetric networking case e.g. residential, SME)


### PR DESCRIPTION
# Description

A small typo was preventing the Hydra job to succeed.
