### PR TITLE
Allow hashable >=^ 1.4

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -211,7 +211,7 @@ library
   exposed-modules:     Ouroboros.Network.MockChain.Chain
                        Ouroboros.Network.MockChain.ProducerState
                        Ouroboros.Network.Testing.ConcreteBlock
-  build-depends:       hashable          >=1.2 && <1.4,
+  build-depends:       hashable          >=1.2 && <1.5,
                        text              >=1.2 && <1.3,
                        time              >=1.9.1 && <1.11
 


### PR DESCRIPTION
# Description

This PR relaxes the upper bound for the `hashable` library to include versions >=^ 1.4

https://hackage.haskell.org/package/hashable-1.4.1.0/changelog

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
