### PR TITLE
Workaround for Hydra `cp` corruption

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,16 @@ let
   sources = import ./sources.nix { pkgs = import nixpkgs { }; }
     // sourcesOverride;
   iohkNixMain = import sources.iohk-nix { };
-  haskellNix = import sources."haskell.nix" { inherit system sourcesOverride; };
+  patchedHaskellNixSrc = let
+    pkgs = import (import sources."haskell.nix" {
+      inherit system;
+    }).sources.nixpkgs-unstable { };
+  in pkgs.applyPatches {
+    name = "haskell.nix-patched";
+    src = sources."haskell.nix";
+    patches = [ ./haskell.nix-cp-sync.patch ];
+  };
+  haskellNix = import patchedHaskellNixSrc { inherit system sourcesOverride; };
   haskellNixArgs = haskellNix.nixpkgsArgs;
   nixpkgs = if (sources ? nixpkgs) then
     (builtins.trace ''

--- a/nix/haskell.nix-cp-sync.patch
+++ b/nix/haskell.nix-cp-sync.patch
@@ -1,0 +1,12 @@
+diff --git a/builder/comp-builder.nix b/builder/comp-builder.nix
+index 7f7fe586..9408f191 100644
+--- a/builder/comp-builder.nix
++++ b/builder/comp-builder.nix
+@@ -511,6 +511,7 @@ let
+         mkdir -p $out/bin
+         if [ -f ${testExecutable} ]; then
+           mkdir -p $(dirname $out/bin/${exeName})
++          ${lib.optionalString stdenv.buildPlatform.isLinux "sync"}
+           ${if stdenv.hostPlatform.isGhcjs then ''
+             cat <(echo \#!${lib.getBin buildPackages.nodejs-12_x}/bin/node) ${testExecutable} >| $out/bin/${exeName}
+             chmod +x $out/bin/${exeName}


### PR DESCRIPTION
# Description

From time to time, the test suite executables get corrupted while getting copied, resulting in failures like
```
/nix/store/6dpldw6wq7dh8zgp7x4q20xpiqlsp6aj-stdenv-linux/setup: line 1391: /nix/store/kj98n1f8q2qrm9clv1vb7pf0x3scs6c4-ouroboros-consensus-cardano-tools-test-test-0.1.0.0/bin/test: cannot execute binary file: Exec format error
```
Due to caching, it is not possible to simply restart this test, as the executable is built in a separate derivation. Hence, it requires us to e.g. increment counters in source files to manually force a rebuild, which is very tedious. 

The cause for this behavior is an interaction between `cp` and a ZFS bug which is fixed upstream, but not yet deployed on the Hydra runners. This PR calls `sync` before copying the file, as advised by @cleverca22, hopefully making these failures disappear.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
