### PR TITLE
Enable NoThunk tests by adding checkTVarInvariant option for building 'strict-stm'

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,9 @@ let
 
   coveredProject = ouroborosNetworkHaskellPackages.appendModule { coverage = true; };
 
+  haskellPackagesWithTVarCheck = recRecurseIntoAttrs
+    (selectProjectPackages ouroborosNetworkHaskellPackagesWithTVarCheck);
+
   validate-mainnet = import ./nix/validate-mainnet.nix {
     inherit pkgs;
     byron-db-converter =
@@ -63,6 +66,11 @@ let
         haskellPackages.ouroboros-consensus-cardano-test.components.tests.test;
       Shelley =
         haskellPackages.ouroboros-consensus-shelley-test.components.tests.test;
+    };
+
+    tvar-invariant-checks = recurseIntoAttrs {
+      inherit haskellPackagesWithTVarCheck;
+      tests = collectChecks' haskellPackagesWithTVarCheck;
     };
 
     shell = import ./shell.nix {

--- a/nix/ouroboros-network.nix
+++ b/nix/ouroboros-network.nix
@@ -4,7 +4,9 @@
 { lib, stdenv, pkgs, haskell-nix, buildPackages, config ? { }
   # Enable profiling
 , profiling ? config.haskellNix.profiling or false
-, libsodium-vrf ? pkgs.libsodium-vrf }:
+, libsodium-vrf ? pkgs.libsodium-vrf 
+  # Enable strict TVar invariant check flag in strict-stm
+, checkTVarInvariant ? false }:
 let
   compiler-nix-name = pkgs.localConfig.ghcVersion;
   src = haskell-nix.haskellLib.cleanGit {
@@ -42,6 +44,10 @@ let
           # and test suites.
           doCoverage = config.coverage;
         });
+      }
+      {   
+        packages.strict-stm.components.library.configureFlags =
+          lib.mkForce (if checkTVarInvariant then ["-f checktvarinvariant"] else []);
       }
       {
         # Apply profiling arg to all library components in the build:

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -5,6 +5,11 @@ with pkgs; {
     inherit config pkgs lib stdenv haskell-nix buildPackages;
   };
 
+  ouroborosNetworkHaskellPackagesWithTVarCheck = import ./ouroboros-network.nix {
+    inherit config pkgs lib stdenv haskell-nix buildPackages;
+    checkTVarInvariant = true;
+  };
+
   network-docs = callPackage ./network-docs.nix { };
   consensus-docs = callPackage ./consensus-docs.nix { };
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,18 @@
 # This file is used by nix-shell.
 # It just takes the shell attribute from default.nix.
 { config ? { }, sourcesOverride ? { }, withHoogle ? false
-, pkgs ? import ./nix { inherit config sourcesOverride; } }:
+, pkgs ? import ./nix { inherit config sourcesOverride; }
+, checkTVarInvariant ? false }:
 with pkgs;
 let
+  hsPkgs =
+    if checkTVarInvariant
+    then ouroborosNetworkHaskellPackagesWithTVarCheck
+    else ouroborosNetworkHaskellPackages;
+
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
-  shell = ouroborosNetworkHaskellPackages.shellFor {
+  shell = hsPkgs.shellFor {
     name = "cabal-dev-shell";
 
     packages = ps:


### PR DESCRIPTION
# Description

- Add a flag checkTVarInvariant to ./nix/ouroboros-network.nix
- haskellPackagesWithTVarCheck points to strict-stm package with "checktvarinvariant" flag enabled.
- nix-build -A tvar-invariant-checks.tests runs the tests with "checktvarinvariant" flag turned on

This PR allows adding an ability to run strict tvar invariant check in strict-stm. This enables `nothunk` tests, and also simplifies running it. The github actions will be added once existing nothunk failures (#4006 ) are fixed.

E.g. to run a single test

``` bash
nix-build -A tvar-invariant-checks.tests.ouroboros-consensus-test.test-storage
```
To enter nix-shell with `checkTVarInvariant` enabled

```bash
nix-shell --arg checkTVarInvariant true
```
And then in the nix shell, it is possible to use `cabal` to run the tests for checking no thunks.

E.g.
```bash
cabal run test-storage
```

fixes #3001 

# Checklist
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
