### PR TITLE
UTxO-HD: Disable LMDB tests in MINGW32

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
@@ -1,5 +1,7 @@
 module Test.Ouroboros.Storage.LedgerDB (tests) where
 
+import           System.Info (os)
+
 import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage.LedgerDB.DbChangelog as DbChangelog
@@ -9,10 +11,9 @@ import qualified Test.Ouroboros.Storage.LedgerDB.InMemory as InMemory
 import qualified Test.Ouroboros.Storage.LedgerDB.OnDisk as OnDisk
 
 tests :: TestTree
-tests = testGroup "LedgerDB" [
-      HD.tests
-    , InMemory.tests
-    , OnDisk.tests
-    , DiskPolicy.tests
-    , DbChangelog.tests
-    ]
+tests = testGroup "LedgerDB" ([ HD.tests | os /= "mingw32" ] <>  -- FIXME: Should re-enable at some point, see #4022
+                              [ InMemory.tests
+                              , OnDisk.tests
+                              , DiskPolicy.tests
+                              , DbChangelog.tests
+                              ])

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -57,6 +57,7 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import qualified System.Directory as Dir
 import qualified System.IO.Temp as Temp
+import           System.Info (os)
 import           System.Random (getStdRandom, randomR)
 
 import           Test.QuickCheck (Gen)
@@ -102,11 +103,14 @@ import           Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary ()
 
 tests :: TestTree
 tests = askOption $ \showTrace -> testGroup "OnDisk"
-  [ TTT.testPropertyTraceable' "LedgerSimple-InMem" $
-      prop_sequential 100000 (inMemDbEnv showTrace) uniform
-  , TTT.testPropertyTraceable' "LedgerSimple-LMDB" $
-      prop_sequential 2000 (lmdbDbEnv showTrace testLMDBLimits) lmdbCustom
-  ]
+  ([ TTT.testPropertyTraceable' "LedgerSimple-InMem" $
+     prop_sequential 100000 (inMemDbEnv showTrace) uniform
+   ] <>
+   [ TTT.testPropertyTraceable' "LedgerSimple-LMDB" $
+     prop_sequential 2000 (lmdbDbEnv showTrace testLMDBLimits) lmdbCustom
+   | os /= "mingw32"  -- FIXME: Should re-enable at some point, see #4022
+   ]
+  )
   where
     uniform = CmdDistribution
         { freqCurrent = 1


### PR DESCRIPTION
# Description

These tests deadlock on Windows, we don't have time to investigate it now and it is blocking the Hydra runners.