### PR TITLE
consensus: make TickHardForkLedgerView fields strict

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
@@ -46,8 +46,8 @@ type HardForkLedgerView = HardForkLedgerView_ WrapLedgerView
 -------------------------------------------------------------------------------}
 
 data instance Ticked (HardForkLedgerView_ f xs) = TickedHardForkLedgerView {
-      tickedHardForkLedgerViewTransition :: TransitionInfo
-    , tickedHardForkLedgerViewPerEra     :: HardForkState (Ticked :.: f) xs
+      tickedHardForkLedgerViewTransition :: !TransitionInfo
+    , tickedHardForkLedgerViewPerEra     :: !(HardForkState (Ticked :.: f) xs)
     }
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
While preparing PR #4014, I noticed the `forecast` function for `CardanoBlock` was lazy. This small patch makes it strict.

This is a Draft PR because I'm not totally sure we want it to be strict.