### PR TITLE
Fix invalid Haddock markup

### DIFF
--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -185,7 +185,7 @@ data BlockContext blk = BlockContext
   , bcPrevPoint :: !(Point blk)
   }
 
-  -- | Create the 'BlockContext' from the header of the previous block
+-- | Create the 'BlockContext' from the header of the previous block
 blockContextFromPrevHeader ::
      HasHeader (Header blk)
   => Header blk

--- a/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
@@ -94,19 +94,19 @@ fromMinimalChainDbArgs MinimalChainDbArgs {..} = ChainDbArgs {
   , cdbMaxBlocksPerFile       = VolatileDB.mkBlocksPerFile 4
   , cdbDiskPolicy             = LedgerDB.defaultDiskPolicy (configSecurityParam mcdbTopLevelConfig)
                                   LedgerDB.DefaultSnapshotInterval
-  -- ^ Keep 2 ledger snapshots, and take a new snapshot at least every 2 * k seconds, where k is the
+  -- Keep 2 ledger snapshots, and take a new snapshot at least every 2 * k seconds, where k is the
   -- security parameter.
   , cdbTopLevelConfig         = mcdbTopLevelConfig
   , cdbChunkInfo              = mcdbChunkInfo
   , cdbCheckIntegrity         = const True
-  -- ^ Getting a verified block component does not do any integrity checking, both for the
+  -- Getting a verified block component does not do any integrity checking, both for the
   -- ImmutableDB, as the VolatileDB. This is done in @extractBlockComponent@ in the iterator for the
   -- ImmutableDB, and in @getBlockComponent@ for the VolatileDB.
   , cdbGenesis                = return mcdbInitLedger
   , cdbCheckInFuture          = CheckInFuture $ \vf -> pure (VF.validatedFragment vf, [])
-  -- ^ Blocks are never in the future.
+  -- Blocks are never in the future.
   , cdbImmutableDbCacheConfig = ImmutableDB.CacheConfig 2 60
-  -- ^ Cache at most 2 chunks and expire each chunk after 60 seconds of being unused.
+  -- Cache at most 2 chunks and expire each chunk after 60 seconds of being unused.
   , cdbTracer                 = nullTracer
   , cdbTraceLedger            = nullTracer
   , cdbRegistry               = mcdbRegistry


### PR DESCRIPTION
# Description

Fixes invalid Haddock markup introduced in #3817 and #3936.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
