### PR TITLE
Update consensus/README

### DIFF
--- a/ouroboros-consensus/README.md
+++ b/ouroboros-consensus/README.md
@@ -12,14 +12,14 @@ This package contains:
 * `docs`: documentation, in particular, `docs/report` contains the technical
   report about the consensus and storage layer.
 
-Related packages:
+The following packages use `ouroboros-consensus` to integrate specific ledgers:
 
 * `../ouroboros-consensus-byron`: integration with the Byron ledger, including
   protocol tests simulating various node setups.
 
 * `../ouroboros-consensus-byronspec`: integration with the Byron spec ledger.
   This is used to run the Byron protocol tests in lockstep with the spec to
-  detect any discrepancies.
+  detect any discrepancies between the specification and the implementation.
 
 * `../ouroboros-consensus-shelley`: integration with the Shelley ledger,
   including protocol tests simulating various node setups.


### PR DESCRIPTION
Explain how the consensus/README packages are related to `ouroboros-consensus`.


<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job runs out of memory, e.g. in https://github.com/input-output-hk/ouroboros-network/runs/7231748864?check_suite_focus=true
 
 - The tests in WallClock.delay* can fail under load (quite rarely): https://hydra.iohk.io/build/16723452/nixlog/76

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->
# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
