### PR TITLE
UTxO-HD: Rewrite mempool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,12 @@ jobs:
           mingw-w64-x86_64-toolchain
           mingw-w64-x86_64-libsodium
           mingw-w64-x86_64-lmdb
-          mingw-w64-x86_64-cmake
           mingw-w64-x86_64-jq
+
+    - name: "WIN: Setup pkg-config"
+      if: runner.os == 'Windows'
+      run: |
+        pacman --noconfirm -S mingw-w64-x86_64-pkg-config
 
     - name: "LINUX: Setup haskell"
       if: runner.os != 'Windows'

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,7 @@
 index-state: 2022-02-18T00:00:00Z
 -- ^ When updating the index state to a date after 2022-06-21, the @Isomorphism@
-class in @ouroboros-consensus-test.Test.Util.Orphans.Isomorphism@ should be
-replaced by the @IsomorphicTo@ class from the @isomorphism-class@ package.
+-- class in @ouroboros-consensus-test.Test.Util.Orphans.Isomorphism@ should be
+-- replaced by the @IsomorphicTo@ class from the @isomorphism-class@ package.
 
 packages: ./ouroboros-network-testing
           ./monoidal-synchronisation

--- a/ouroboros-consensus-byron-test/test/Main.hs
+++ b/ouroboros-consensus-byron-test/test/Main.hs
@@ -4,8 +4,8 @@ import           Test.Tasty
 
 import qualified Test.Consensus.Byron.Golden (tests)
 import qualified Test.Consensus.Byron.Serialisation (tests)
---import qualified Test.ThreadNet.Byron (tests)
---import qualified Test.ThreadNet.DualByron (tests)
+import qualified Test.ThreadNet.Byron (tests)
+import qualified Test.ThreadNet.DualByron (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -15,6 +15,6 @@ tests =
   testGroup "byron"
   [ Test.Consensus.Byron.Golden.tests
   , Test.Consensus.Byron.Serialisation.tests
-  -- , Test.ThreadNet.Byron.tests
-  -- , Test.ThreadNet.DualByron.tests
+  , Test.ThreadNet.Byron.tests
+  , Test.ThreadNet.DualByron.tests
   ]

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -41,6 +41,11 @@ newtype instance Validated (GenTx ByronSpecBlock) = ValidatedByronSpecGenTx {
 
 type instance ApplyTxErr ByronSpecBlock = ByronSpecGenTxErr
 
+-- | This data family instance is not used anywhere but still required by the
+-- instance of @LedgerSupportsMempool ByronSpecBlock@
+newtype instance TxId (GenTx ByronSpecBlock) = TxId Int
+  deriving newtype NoThunks
+
 instance LedgerSupportsMempool ByronSpecBlock where
   applyTx cfg _wti _slot tx (TickedByronSpecLedgerState tip st) =
         fmap (\st' ->

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -316,7 +316,7 @@ withLedgerTablesHelper ::
   -> HardForkState fany (ShelleyBasedHardForkEras proto1 era1 proto2 era2)
   -> LedgerTables (LedgerState (ShelleyBasedHardForkBlock proto1 era1 proto2 era2)) mk
   -> HardForkState fmk (ShelleyBasedHardForkEras proto1 era1 proto2 era2)
-withLedgerTablesHelper with (HardForkState tele) (ShelleyBasedHardForkLedgerTables appliedMK) = undefined
+withLedgerTablesHelper with (HardForkState tele) (ShelleyBasedHardForkLedgerTables appliedMK) =
       HardForkState
     $ unconsolidateShelleyTele
     $ SOP.hap

--- a/ouroboros-consensus-cardano-test/test/Main.hs
+++ b/ouroboros-consensus-cardano-test/test/Main.hs
@@ -29,9 +29,8 @@ tests =
   [ Test.Consensus.Cardano.ByronCompatibility.tests
   , Test.Consensus.Cardano.Golden.tests
   , Test.Consensus.Cardano.Serialisation.tests
- -- FIXME: disabled tests. Must re-enable them
- -- , Test.ThreadNet.AllegraMary.tests
- -- , Test.ThreadNet.Cardano.tests
- -- , Test.ThreadNet.MaryAlonzo.tests
- -- , Test.ThreadNet.ShelleyAllegra.tests
+  -- , Test.ThreadNet.AllegraMary.tests
+  -- , Test.ThreadNet.Cardano.tests
+  -- , Test.ThreadNet.MaryAlonzo.tests
+  -- , Test.ThreadNet.ShelleyAllegra.tests
   ]

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -9,7 +9,7 @@ license-files:
 author:             IOHK Formal methods team
 maintainer:         operations@iohk.io
 
-source-repository-head
+source-repository head
     type: git
     location: https://github.com/input-output-hk/ouroboros-network
     subdir: ouroboros-consensus-protocol

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Test.Consensus.Mempool (tests) where
@@ -33,6 +34,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Cardano.Binary (Encoding, toCBOR)
 import           Cardano.Crypto.Hash
+import           Cardano.Slotting.Slot
 
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -42,17 +44,18 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
-import qualified Ouroboros.Consensus.HeaderValidation as TechDebt
 import           Ouroboros.Consensus.Ledger.Abstract
-import qualified Ouroboros.Consensus.Ledger.Extended as TechDebt
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Mock.Ledger hiding (TxId)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.Protocol.BFT
-import           Ouroboros.Consensus.Util (StaticEither (..), repeatedly,
-                     repeatedlyM, safeMaximumOn, (.:))
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore
+import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
+                     (LedgerBackingStore (LedgerBackingStore))
+import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM,
+                     safeMaximumOn, (.:))
 import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -782,21 +785,11 @@ withTestMempool setup@TestSetup {..} prop =
 
       -- Set up the LedgerInterface
       varCurrentLedgerState <- uncheckedNewTVarM testLedgerState
-      let fudge ls = TechDebt.ExtLedgerState {
-              headerState = TechDebt.HeaderState {
-                  headerStateTip      = Origin
-                , headerStateChainDep = ()
-                }
-            , ledgerState = ls
-            }
-          ledgerInterface = LedgerInterface
-            { getCurrentLedgerState = fudge <$> readTVar varCurrentLedgerState
-            , getLedgerStateForTxs  = \seP m -> case seP of
-                StaticLeft () -> do
-                  lst <- atomically $ readTVar varCurrentLedgerState
-                  (a, _) <- m $ fudge lst
-                  pure $ StaticLeft (a, polyEmptyLedgerTables)   -- TestBlock has no tables
-                StaticRight _p -> error "TODO Mempool test does not yet exercise this, does it?"
+      trivialLedgerBackingStore <- trivialBackingStore polyEmptyLedgerTables
+      let ledgerInterface = LedgerInterface
+            { getCurrentLedgerAndChangelog = (, MempoolChangelog Origin polyEmptyLedgerTables) <$> readTVar varCurrentLedgerState
+            , getBackingStore  = pure $ LedgerBackingStore trivialLedgerBackingStore
+            , withReadLock     = id
             }
 
       -- Set up the Tracer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -127,15 +127,7 @@ data instance Ticked1 (LedgerState (HardForkBlock xs)) mk =
 
 deriving anyclass instance
      CanHardFork xs
-  => NoThunks (Ticked1 (LedgerState (HardForkBlock xs)) EmptyMK)
-
-deriving anyclass instance
-     CanHardFork xs
-  => NoThunks (Ticked1 (LedgerState (HardForkBlock xs)) ValuesMK)
-
-deriving anyclass instance
-     CanHardFork xs
-  => NoThunks (Ticked1 (LedgerState (HardForkBlock xs)) SeqDiffMK)
+  => NoThunks (Ticked1 (LedgerState (HardForkBlock xs)) TrackingMK)
 
 instance ( CanHardFork xs
          , NoThunks (LedgerTables (LedgerState (HardForkBlock xs)) SeqDiffMK)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -96,12 +96,14 @@ module Ouroboros.Consensus.Ledger.Basics (
   , forgetLedgerTablesDiffs
   , forgetLedgerTablesDiffsTicked
   , forgetLedgerTablesValues
+  , forgetLedgerTablesValuesTicked
   , polyEmptyLedgerTables
   , prependLedgerTablesDiffs
   , prependLedgerTablesDiffsFromTicked
   , prependLedgerTablesDiffsRaw
   , prependLedgerTablesDiffsTicked
   , prependLedgerTablesTrackingDiffs
+  , rawReapplyTracking
   , reapplyTrackingTicked
     -- ** Special classes of ledger states
   , InMemory (..)
@@ -629,6 +631,10 @@ rawForgetValues (ApplyTrackingMK _vs d) = ApplyDiffMK d
 
 forgetLedgerTablesValues :: TableStuff l => l TrackingMK -> l DiffMK
 forgetLedgerTablesValues = mapOverLedgerTables rawForgetValues
+
+forgetLedgerTablesValuesTicked :: TickedTableStuff l => Ticked1 l TrackingMK -> Ticked1 l DiffMK
+forgetLedgerTablesValuesTicked = mapOverLedgerTablesTicked rawForgetValues
+
 
 -- Forget diffs
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -58,10 +58,9 @@ data WhetherToIntervene
 
 class ( UpdateLedger blk
       , NoThunks (GenTx blk)
+      , NoThunks (GenTxId blk)
       , NoThunks (Validated (GenTx blk))
-      , NoThunks (TickedLedgerState blk EmptyMK)
-      , NoThunks (TickedLedgerState blk ValuesMK)
-      , NoThunks (TickedLedgerState blk SeqDiffMK)
+      , NoThunks (TickedLedgerState blk TrackingMK)
       , Show (GenTx blk)
       , Show (Validated (GenTx blk))
       , Show (ApplyTxErr blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool.hs
@@ -3,4 +3,6 @@ module Ouroboros.Consensus.Mempool (module X) where
 
 import           Ouroboros.Consensus.Mempool.API as X
 import           Ouroboros.Consensus.Mempool.Impl as X
+import           Ouroboros.Consensus.Mempool.Impl.Types as X
+                     (MempoolChangelog (..))
 import           Ouroboros.Consensus.Mempool.TxSeq as X (TicketNo)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
@@ -1,13 +1,16 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE NamedFieldPuns       #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- | Types required for implementing the Mempool.
 
@@ -16,41 +19,123 @@ module Ouroboros.Consensus.Mempool.Impl.Types (
     InternalState (..)
   , initInternalState
   , isMempoolSize
+    -- * Snapshot
+  , MempoolSnapshot (..)
     -- * Validation result
   , ValidationResult (..)
   , extendVRNew
   , extendVRPrevApplied
   , revalidateTxsFor
-  , validateStateFor
+    --  , validateStateFor
     -- * Tick ledger state
+  , ForgeLedgerState (..)
   , tickLedgerState
     -- * Conversions
   , internalStateFromVR
   , validationResultFromIS
+    -- * Mempool Changelog
+  , MempoolChangelog (..)
+    -- * Mempool size
+  , MempoolCapacityBytes (..)
+  , MempoolCapacityBytesOverride (..)
+  , TxSeq.MempoolSize (..)
+  , computeMempoolCapacity
+    -- * Tx addition
+  , MempoolAddTxResult (..)
+  , isMempoolTxAdded
+  , isMempoolTxRejected
+  , mempoolTxAddedToMaybe
+    -- * Tracing
+  , TraceEventMempool (..)
   ) where
 
 import           Control.Exception (assert)
 import           Control.Monad.Except
+import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (isNothing)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Typeable
+import           Data.Word
 import           GHC.Generics (Generic)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
-import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxSeq (..),
                      TxTicket (..))
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (applyDiff)
 import           Ouroboros.Consensus.Util (repeatedly)
 import           Ouroboros.Consensus.Util.IOLike
+
+import           Ouroboros.Network.Protocol.TxSubmission2.Type (TxSizeInBytes)
+
+{-------------------------------------------------------------------------------
+  Ledger state considered for forging
+-------------------------------------------------------------------------------}
+
+-- | The ledger state wrt to which we should produce a block
+--
+-- The transactions in the mempool will be part of the body of a block, but a
+-- block consists of a header and a body, and the full validation of a block
+-- consists of first processing its header and only then processing the body.
+-- This is important, because processing the header may change the state of the
+-- ledger: the update system might be updated, scheduled delegations might be
+-- applied, etc., and such changes should take effect before we validate any
+-- transactions.
+data ForgeLedgerState blk =
+    -- | The slot number of the block is known
+    --
+    -- This will only be the case when we realized that we are the slot leader
+    -- and we are actually producing a block.
+    ForgeInKnownSlot SlotNo (TickedLedgerState blk DiffMK)
+
+    -- | The slot number of the block is not yet known
+    --
+    -- When we are validating transactions before we know in which block they
+    -- will end up, we have to make an assumption about which slot number to use
+    -- for 'applyChainTick' to prepare the ledger state; we will assume that
+    -- they will end up in the slot after the slot at the tip of the ledger.
+  | ForgeInUnknownSlot (LedgerState blk EmptyMK)
+
+-- | Tick the 'LedgerState' using the given 'BlockSlot' or the next slot after
+-- the ledger state on top of which we are going to apply the transactions.
+tickLedgerState
+  :: forall blk. (UpdateLedger blk, ValidateEnvelope blk)
+  => LedgerConfig     blk
+  -> ForgeLedgerState blk
+  -> (SlotNo, TickedLedgerState blk DiffMK)
+tickLedgerState _   (ForgeInKnownSlot s st) = (s, st)
+tickLedgerState cfg (ForgeInUnknownSlot st) =
+  let
+      slot =
+          -- Optimistically assume that the transactions will be included in a
+          -- block in the next available slot
+          --
+          -- TODO: We should use time here instead
+          -- <https://github.com/input-output-hk/ouroboros-network/issues/1298>
+          -- Once we do, the ValidateEnvelope constraint can go.
+          case ledgerTipSlot st of
+             Origin      -> minimumPossibleSlotNo (Proxy @blk)
+             NotOrigin s -> succ s
+  in
+    (slot, applyChainTick cfg slot st)
 
 {-------------------------------------------------------------------------------
   Internal State
 -------------------------------------------------------------------------------}
+
+-- | A minimal version of the @DbChangelog@ with just the data needed by the
+-- mempool
+data MempoolChangelog blk = MempoolChangelog {
+    mcAnchor      :: !(WithOrigin SlotNo)
+  , mcDifferences :: !(LedgerTables (LedgerState blk) SeqDiffMK)
+  } deriving (Generic)
+
+deriving instance ( NoThunks (LedgerTables (LedgerState blk) SeqDiffMK)
+                  ) => NoThunks (MempoolChangelog blk)
 
 -- | Internal state in the mempool
 data InternalState blk = IS {
@@ -81,9 +166,12 @@ data InternalState blk = IS {
       -- INVARIANT: 'isLedgerState' is the ledger resulting from applying the
       -- transactions in 'isTxs' against the ledger identified 'isTip' as tip
       -- after ticking it to 'isSlotNo'.
-      --
-      -- TODO: check this property.
-    , isLedgerState  :: !(TickedLedgerState blk TrackingMK)
+    , isLedgerState  :: !(TickedLedgerState blk DiffMK)
+
+      -- | The changelog as captured on the last sync with the ledger. While the
+      -- anchor of the backing store doesn't change, this changelog can be used
+      -- to forward values up to the 'isLedgerState'.
+    , isDbChangelog  :: !(MempoolChangelog blk)
 
       -- | The tip of the chain that 'isTxs' was validated against
     , isTip          :: !(ChainHash blk)
@@ -115,14 +203,17 @@ data InternalState blk = IS {
 
 deriving instance ( NoThunks (Validated (GenTx blk))
                   , NoThunks (GenTxId blk)
-                  , NoThunks (TickedLedgerState blk TrackingMK)
+                  , NoThunks (TickedLedgerState blk DiffMK)
+                  , NoThunks (LedgerTables (LedgerState blk) SeqDiffMK)
+                  , NoThunks (LedgerTables (LedgerState blk) KeysMK)
+                  , NoThunks (MempoolChangelog blk)
                   , StandardHash blk
                   , Typeable blk
                   ) => NoThunks (InternalState blk)
 
 -- | \( O(1) \). Return the number of transactions in the internal state of
 -- the Mempool paired with their total size in bytes.
-isMempoolSize :: InternalState blk -> MempoolSize
+isMempoolSize :: InternalState blk -> TxSeq.MempoolSize
 isMempoolSize = TxSeq.toMempoolSize . isTxs
 
 initInternalState
@@ -130,12 +221,14 @@ initInternalState
   => MempoolCapacityBytesOverride
   -> TicketNo  -- ^ Used for 'isLastTicketNo'
   -> SlotNo
-  -> TickedLedgerState blk TrackingMK
+  -> TickedLedgerState blk DiffMK
+  -> MempoolChangelog blk
   -> InternalState blk
-initInternalState capacityOverride lastTicketNo slot st = IS {
+initInternalState capacityOverride lastTicketNo slot st mc = IS {
       isTxs          = TxSeq.Empty
     , isTxIds        = Set.empty
     , isLedgerState  = st
+    , isDbChangelog  = mc
     , isTip          = castHash (getTipHash st)
     , isSlotNo       = slot
     , isLastTicketNo = lastTicketNo
@@ -177,7 +270,16 @@ data ValidationResult invalidTx blk = ValidationResult {
 
       -- | The state of the ledger after applying 'vrValid' against the ledger
       -- state identified by 'vrBeforeTip'.
+      --
+      -- INVARIANT: Must contain the diffs for all the applied transactions
+      -- during the validation process in which this ValidationResult is being
+      -- created, as well as the values for the new transactions remaining to be
+      -- validated.
     , vrAfter          :: TickedLedgerState blk TrackingMK
+
+      -- | The db changelog captured on the last sync with the ledger. Doesn't
+      -- change while validating transactions.
+    , vrDbChangelog    :: MempoolChangelog blk
 
       -- | The transactions that were invalid, along with their errors
       --
@@ -208,7 +310,7 @@ extendVRPrevApplied :: (LedgerSupportsMempool blk, HasTxId (GenTx blk))
                     -> ValidationResult (Validated (GenTx blk)) blk
 extendVRPrevApplied cfg txTicket vr =
     case runExcept (reapplyTx cfg vrSlotNo tx (forgetLedgerTablesDiffsTicked vrAfter)) of
-      Left err  -> vr { vrInvalid = (tx, err) : vrInvalid
+      Left err  -> vr { vrInvalid    = (tx, err) : vrInvalid
                       }
       Right st' -> vr { vrValid      = vrValid :> txTicket
                       , vrValidTxIds = Set.insert (txId (txForgetValidated tx)) vrValidTxIds
@@ -262,59 +364,6 @@ extendVRNew cfg txSize wti tx vr = assert (isNothing vrNewValid) $
 
     nextTicketNo = succ vrLastTicketNo
 
--- | Given a (previously valid) internal state, validate it against the given
--- ledger state and slot.
---
--- When these match the internal state's 'isTip' and 'isSlotNo', this is very
--- cheap, as the given internal state will already be valid against the given
--- inputs. However, it is important to note that the new state passed as
--- parameter ('blockLedgerState') potentially includes some values which were
--- not required by the set of transactions that were used on the last mempool
--- revalidation/sync, therefore not being in 'isLedgerState is'. Therefore the
--- way to get a state with those new values included is to apply the same
--- accumulated differences from 'isLedgerState is' to 'blockLedgerState'.
---
--- When these don't match, the transactions in the internal state will be
--- revalidated ('revalidateTxsFor') on top of the given ledger state.
---
--- The returned ticked ledger state will be used by the block forging logic to
--- determine how many transactions can be put on the new block, hence, the 'mk'
--- is irrelevant.
---
--- PRECONDITION: The differences in the internal state (which consist of
--- transaction differences and possibly ticking differences) must be applicable
--- to the ledger state provided in 'blockLedgerState', this means, that the keys
--- that were used to retrieve the values in 'blockLedgerState' must be a
--- superset of the keys that were used to retrieve the values in 'isLedgerState
--- is' (before ticking and applying the transactions).
-validateStateFor
-  :: (LedgerSupportsMempool blk, HasTxId (GenTx blk), ValidateEnvelope blk)
-  => InternalState    blk
-  -> LedgerConfig     blk
-  -> MempoolCapacityBytesOverride
-  -> ForgeLedgerState blk
-  -> (TickedLedgerState blk TrackingMK, ValidationResult (Validated (GenTx blk)) blk)
-validateStateFor is cfg capacityOverride blockLedgerState
-    | isTip    == castHash (getTipHash st')
-    , isSlotNo == slot
-    = ( -- 'isLedgerState is' is equivalent to st' except in the UTxO set.
-        -- Therefore it is safe to return this one, as we don't use the 'mk'.
-        isLedgerState is
-      , validationResultFromIS
-        is { isLedgerState = reapplyTrackingTicked (isLedgerState is) (forgeLedgerState blockLedgerState) })
-    | otherwise
-    = ( st'
-      , revalidateTxsFor
-        capacityOverride
-        cfg
-        slot
-        st'
-        isLastTicketNo
-        (TxSeq.toList isTxs))
-  where
-    IS { isTxs, isTip, isSlotNo, isLastTicketNo } = is
-    (slot, st') = tickLedgerState cfg blockLedgerState
-
 -- | Revalidate the given transactions (@['TxTicket' ('GenTx' blk)]@), against
 -- the given ticked ledger state.
 --
@@ -327,46 +376,20 @@ revalidateTxsFor
   => MempoolCapacityBytesOverride
   -> LedgerConfig blk
   -> SlotNo
-  -> TickedLedgerState blk TrackingMK
+  -> TickedLedgerState blk DiffMK
+  -> LedgerTables (LedgerState blk) ValuesMK
+  -> MempoolChangelog blk
   -> TicketNo -- ^ 'isLastTicketNo' & 'vrLastTicketNo'
   -> [TxTicket (Validated (GenTx blk))]
   -> ValidationResult (Validated (GenTx blk)) blk
-revalidateTxsFor capacityOverride cfg slot st lastTicketNo txTickets =
+revalidateTxsFor capacityOverride cfg slot st values mc lastTicketNo txTickets =
     repeatedly
       (extendVRPrevApplied cfg)
       txTickets
       vr
   where
-    vr = validationResultFromIS
-       $ initInternalState capacityOverride lastTicketNo slot st
-
-{-------------------------------------------------------------------------------
-  Ticking the ledger state
--------------------------------------------------------------------------------}
-
--- | Tick the 'LedgerState' using the given 'BlockSlot' or the next slot after
--- the ledger state on top of which we are going to apply the transactions.
-tickLedgerState
-  :: forall blk. (UpdateLedger blk, ValidateEnvelope blk)
-  => LedgerConfig     blk
-  -> ForgeLedgerState blk
-  -> (SlotNo, TickedLedgerState blk TrackingMK)
-tickLedgerState cfg fiks =
-  let st   = forgeLedgerState fiks
-      slot = case fiks of
-        ForgeInKnownSlot s _ -> s
-        ForgeInUnknownSlot{} ->
-          -- Optimistically assume that the transactions will be included in a block
-          -- in the next available slot
-          --
-          -- TODO: We should use time here instead
-          -- <https://github.com/input-output-hk/ouroboros-network/issues/1298>
-          -- Once we do, the ValidateEnvelope constraint can go.
-          case ledgerTipSlot st of
-             Origin      -> minimumPossibleSlotNo (Proxy @blk)
-             NotOrigin s -> succ s
-  in
-    (slot, attachAndApplyDiffsTicked (applyChainTick cfg slot (forgetLedgerTables st)) st)
+    vr = validationResultFromIS values
+       $ initInternalState capacityOverride lastTicketNo slot st mc
 
 {-------------------------------------------------------------------------------
   Conversions
@@ -375,11 +398,14 @@ tickLedgerState cfg fiks =
 -- | Construct internal state from 'ValidationResult'
 --
 -- Discards information about invalid and newly valid transactions
-internalStateFromVR :: ValidationResult invalidTx blk -> InternalState blk
+internalStateFromVR :: TickedTableStuff (LedgerState blk)
+                    => ValidationResult invalidTx blk
+                    -> InternalState blk
 internalStateFromVR vr = IS {
       isTxs          = vrValid
     , isTxIds        = vrValidTxIds
-    , isLedgerState  = vrAfter
+    , isLedgerState  = forgetLedgerTablesValuesTicked vrAfter
+    , isDbChangelog  = vrDbChangelog
     , isTip          = vrBeforeTip
     , isSlotNo       = vrSlotNo
     , isLastTicketNo = vrLastTicketNo
@@ -393,29 +419,198 @@ internalStateFromVR vr = IS {
       , vrValid
       , vrValidTxIds
       , vrAfter
+      , vrDbChangelog
       , vrLastTicketNo
       } = vr
 
 -- | Construct a 'ValidationResult' from internal state.
-validationResultFromIS :: InternalState blk -> ValidationResult invalidTx blk
-validationResultFromIS is = ValidationResult {
+validationResultFromIS :: TickedTableStuff (LedgerState blk)
+                       => LedgerTables (LedgerState blk) ValuesMK
+                       -> InternalState blk
+                       -> ValidationResult invalidTx blk
+validationResultFromIS values is = ValidationResult {
       vrBeforeTip      = isTip
     , vrSlotNo         = isSlotNo
     , vrBeforeCapacity = isCapacity
     , vrValid          = isTxs
     , vrValidTxIds     = isTxIds
     , vrNewValid       = Nothing
-    , vrAfter          = isLedgerState
+    , vrAfter          = zipOverLedgerTablesTicked f isLedgerState values
+    , vrDbChangelog    = isDbChangelog
     , vrInvalid        = []
     , vrLastTicketNo   = isLastTicketNo
     }
   where
+
+    f :: Ord k => DiffMK k v -> ValuesMK k v -> TrackingMK k v
+    f (ApplyDiffMK d) (ApplyValuesMK v) = ApplyTrackingMK (applyDiff v d) d
+
     IS {
         isTxs
       , isTxIds
       , isLedgerState
+      , isDbChangelog
       , isTip
       , isSlotNo
       , isLastTicketNo
       , isCapacity
       } = is
+
+{-------------------------------------------------------------------------------
+  Mempool capacity in bytes
+-------------------------------------------------------------------------------}
+
+-- | Represents the maximum number of bytes worth of transactions that a
+-- 'Mempool' can contain.
+newtype MempoolCapacityBytes = MempoolCapacityBytes {
+    getMempoolCapacityBytes :: Word32
+  }
+  deriving newtype (Eq, Show, NoThunks)
+
+-- | An override for the default 'MempoolCapacityBytes' which is 2x the
+-- maximum transaction capacity
+data MempoolCapacityBytesOverride
+  = NoMempoolCapacityBytesOverride
+    -- ^ Use 2x the maximum transaction capacity of a block. This will change
+    -- dynamically with the protocol parameters adopted in the current ledger.
+  | MempoolCapacityBytesOverride !MempoolCapacityBytes
+    -- ^ Use the following 'MempoolCapacityBytes'.
+  deriving (Eq, Show)
+
+-- | If no override is provided, calculate the default mempool capacity as 2x
+-- the current ledger's maximum transaction capacity of a block.
+computeMempoolCapacity
+  :: LedgerSupportsMempool blk
+  => TickedLedgerState blk mk
+  -> MempoolCapacityBytesOverride
+  -> MempoolCapacityBytes
+computeMempoolCapacity st = \case
+    NoMempoolCapacityBytesOverride        -> noOverride
+    MempoolCapacityBytesOverride override -> override
+  where
+    noOverride = MempoolCapacityBytes (txsMaxBytes st * 2)
+
+{-------------------------------------------------------------------------------
+  Result of adding a transaction to the mempool
+-------------------------------------------------------------------------------}
+
+-- | The result of attempting to add a transaction to the mempool.
+data MempoolAddTxResult blk
+  = MempoolTxAdded !(Validated (GenTx blk))
+    -- ^ The transaction was added to the mempool.
+  | MempoolTxRejected !(GenTx blk) !(ApplyTxErr blk)
+    -- ^ The transaction was rejected and could not be added to the mempool
+    -- for the specified reason.
+
+deriving instance (Eq (GenTx blk), Eq (Validated (GenTx blk)), Eq (ApplyTxErr blk)) => Eq (MempoolAddTxResult blk)
+deriving instance (Show (GenTx blk), Show (Validated (GenTx blk)), Show (ApplyTxErr blk)) => Show (MempoolAddTxResult blk)
+
+mempoolTxAddedToMaybe :: MempoolAddTxResult blk -> Maybe (Validated (GenTx blk))
+mempoolTxAddedToMaybe (MempoolTxAdded vtx) = Just vtx
+mempoolTxAddedToMaybe _                    = Nothing
+
+isMempoolTxAdded :: MempoolAddTxResult blk -> Bool
+isMempoolTxAdded MempoolTxAdded{} = True
+isMempoolTxAdded _                = False
+
+isMempoolTxRejected :: MempoolAddTxResult blk -> Bool
+isMempoolTxRejected MempoolTxRejected{} = True
+isMempoolTxRejected _                   = False
+
+{-------------------------------------------------------------------------------
+  Tracing support for the mempool operations
+-------------------------------------------------------------------------------}
+
+-- | Events traced by the Mempool.
+data TraceEventMempool blk
+  = TraceMempoolAddedTx
+      (Validated (GenTx blk))
+      -- ^ New, valid transaction that was added to the Mempool.
+      TxSeq.MempoolSize
+      -- ^ The size of the Mempool before adding the transaction.
+      TxSeq.MempoolSize
+      -- ^ The size of the Mempool after adding the transaction.
+  | TraceMempoolRejectedTx
+      (GenTx blk)
+      -- ^ New, invalid transaction thas was rejected and thus not added to
+      -- the Mempool.
+      (ApplyTxErr blk)
+      -- ^ The reason for rejecting the transaction.
+      TxSeq.MempoolSize
+      -- ^ The current size of the Mempool.
+  | TraceMempoolRemoveTxs
+      [Validated (GenTx blk)]
+      -- ^ Previously valid transactions that are no longer valid because of
+      -- changes in the ledger state. These transactions have been removed
+      -- from the Mempool.
+      TxSeq.MempoolSize
+      -- ^ The current size of the Mempool.
+  | TraceMempoolManuallyRemovedTxs
+      (NE.NonEmpty (GenTxId blk))
+      -- ^ Transactions that have been manually removed from the Mempool.
+      [Validated (GenTx blk)]
+      -- ^ Previously valid transactions that are no longer valid because they
+      -- dependend on transactions that were manually removed from the
+      -- Mempool. These transactions have also been removed from the Mempool.
+      --
+      -- This list shares not transactions with the list of manually removed
+      -- transactions.
+      TxSeq.MempoolSize
+      -- ^ The current size of the Mempool.
+
+deriving instance ( Eq (GenTx blk)
+                  , Eq (Validated (GenTx blk))
+                  , Eq (GenTxId blk)
+                  , Eq (ApplyTxErr blk)
+                  ) => Eq (TraceEventMempool blk)
+
+deriving instance ( Show (GenTx blk)
+                  , Show (Validated (GenTx blk))
+                  , Show (GenTxId blk)
+                  , Show (ApplyTxErr blk)
+                  ) => Show (TraceEventMempool blk)
+
+{-------------------------------------------------------------------------------
+  Snapshot of the mempool
+-------------------------------------------------------------------------------}
+
+-- | A pure snapshot of the contents of the mempool. It allows fetching
+-- information about transactions in the mempool, and fetching individual
+-- transactions.
+--
+-- This uses a transaction sequence number type for identifying transactions
+-- within the mempool sequence. The sequence number is local to this mempool,
+-- unlike the transaction hash. This allows us to ask for all transactions
+-- after a known sequence number, to get new transactions. It is also used to
+-- look up individual transactions.
+--
+-- Note that it is expected that 'getTx' will often return 'Nothing'
+-- even for tx sequence numbers returned in previous snapshots. This happens
+-- when the transaction has been removed from the mempool between snapshots.
+--
+data MempoolSnapshot blk idx = MempoolSnapshot {
+    -- | Get all transactions (oldest to newest) in the mempool snapshot along
+    -- with their ticket number.
+    snapshotTxs         :: [(Validated (GenTx blk), idx)]
+
+    -- | Get all transactions (oldest to newest) in the mempool snapshot,
+    -- along with their ticket number, which are associated with a ticket
+    -- number greater than the one provided.
+  , snapshotTxsAfter    :: idx -> [(Validated (GenTx blk), idx)]
+
+    -- | Get a specific transaction from the mempool snapshot by its ticket
+    -- number, if it exists.
+  , snapshotLookupTx    :: idx -> Maybe (Validated (GenTx blk))
+
+    -- | Determine whether a specific transaction exists within the mempool
+    -- snapshot.
+  , snapshotHasTx       :: GenTxId blk -> Bool
+
+    -- | Get the size of the mempool snapshot.
+  , snapshotMempoolSize :: TxSeq.MempoolSize
+
+    -- | The block number of the "virtual block" under construction
+  , snapshotSlotNo      :: SlotNo
+
+  , snapshotTipHash     :: ChainHash blk
+  }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -12,7 +12,8 @@
 -- > import           Ouroboros.Consensus.Mempool.TxSeq (TxSeq (..))
 -- > import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 module Ouroboros.Consensus.Mempool.TxSeq (
-    TicketNo (..)
+    MempoolSize (..)
+  , TicketNo (..)
   , TxSeq (Empty, (:>), (:<))
   , TxTicket (..)
   , fromList
@@ -30,13 +31,30 @@ module Ouroboros.Consensus.Mempool.TxSeq (
 import           Data.FingerTree.Strict (StrictFingerTree)
 import qualified Data.FingerTree.Strict as FingerTree
 import qualified Data.Foldable as Foldable
-import           Data.Word (Word64)
+import           Data.Word
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Network.Protocol.TxSubmission2.Type (TxSizeInBytes)
 
-import           Ouroboros.Consensus.Mempool.API (MempoolSize (..))
+{-------------------------------------------------------------------------------
+  Size of the mempool
+-------------------------------------------------------------------------------}
+
+-- | The size of a mempool.
+data MempoolSize = MempoolSize
+  { msNumTxs   :: !Word32
+    -- ^ The number of transactions in the mempool.
+  , msNumBytes :: !Word32
+    -- ^ The summed byte size of all the transactions in the mempool.
+  } deriving (Eq, Show)
+
+instance Semigroup MempoolSize where
+  MempoolSize xt xb <> MempoolSize yt yb = MempoolSize (xt + yt) (xb + yb)
+
+instance Monoid MempoolSize where
+  mempty = MempoolSize { msNumTxs = 0, msNumBytes = 0 }
+  mappend = (<>)
 
 {-------------------------------------------------------------------------------
   Mempool transaction sequence as a finger tree

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -99,10 +99,10 @@ defaultChainDbView ::
      (IOLike m, LedgerSupportsProtocol blk)
   => ChainDB m blk -> ChainDbView m blk
 defaultChainDbView chainDB = ChainDbView {
-      getCurrentChain       = ChainDB.getCurrentChain       chainDB
-    , getHeaderStateHistory = ChainDB.getHeaderStateHistory chainDB
-    , getPastLedger         = ChainDB.getPastLedger         chainDB
-    , getIsInvalidBlock     = ChainDB.getIsInvalidBlock     chainDB
+      getCurrentChain       =                   ChainDB.getCurrentChain       chainDB
+    , getHeaderStateHistory =                   ChainDB.getHeaderStateHistory chainDB
+    , getPastLedger         = fmap (fmap fst) . ChainDB.getPastLedger         chainDB
+    , getIsInvalidBlock     =                   ChainDB.getIsInvalidBlock     chainDB
     }
 
 -- newtype wrappers to avoid confusing our tip with their tip.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -77,6 +77,7 @@ import           Ouroboros.Consensus.HeaderStateHistory
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Mempool.Impl.Types (MempoolChangelog (..))
 import           Ouroboros.Consensus.Util (StaticEither (..), (..:))
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike
@@ -88,10 +89,12 @@ import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunis
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.FS.API.Types (FsError)
-import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
+import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
+                     (LedgerDB (ledgerDbChangelog))
 import qualified Ouroboros.Consensus.Storage.LedgerDB.InMemory as LedgerDB
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
-                     (LedgerBackingStoreValueHandle, LedgerDB')
+                     (LedgerBackingStore, LedgerBackingStoreValueHandle,
+                     LedgerDB')
 import           Ouroboros.Consensus.Storage.Serialisation
 
 -- Support for tests
@@ -321,28 +324,6 @@ data ChainDB m blk = ChainDB {
       -- change, since the function will not detect new invalid blocks.
     , getIsInvalidBlock :: STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
 
-      -- | Get a ledger state that contains the backing store values of the
-      -- given keys
-      --
-      -- The 'StaticLeft' case does not specify a point in the current chain, so
-      -- this function returns the ledger state at the tip of the 'ChainDB'.
-      --
-      -- In the 'StaticRight' case, 'Nothing' out means the requested point is
-      -- not on current chain, so that ledger state is unavailable.
-      --
-      -- TODO: we need to explain that 'a' parameter. What if we didn't have it?
-    , getLedgerStateForKeys ::
-        forall b a.
-             StaticEither b () (Point blk)
-          -> (   ExtLedgerState blk EmptyMK
-              -> m (a, LedgerTables (ExtLedgerState blk) KeysMK)
-             )
-          -> m (StaticEither
-                 b
-                        (a, LedgerTables (ExtLedgerState blk) ValuesMK)
-                 (Maybe (a, LedgerTables (ExtLedgerState blk) ValuesMK))
-               )
-
       -- | Get a 'LedgerDB' and a handle to a value of the backing store
       -- corresponding to the anchor of the 'LedgerDB'
       --
@@ -384,6 +365,14 @@ data ChainDB m blk = ChainDB {
       --
       -- 'False' when the database is closed.
     , isOpen             :: STM m Bool
+
+      -- | Return the backing store in the Ledger DB to be (for now at least)
+      -- used by the mempool.
+    , getBackingStore :: m (LedgerBackingStore m (ExtLedgerState blk))
+
+      -- | Perform a monadic operation holding the read lock on the DB
+      -- changelog.
+    , withLgrReadLock :: forall a. m a -> m a
     }
 
 getCurrentTip :: (Monad (STM m), HasHeader (Header blk))
@@ -406,15 +395,24 @@ getImmutableLedger ::
   => ChainDB m blk -> STM m (ExtLedgerState blk EmptyMK)
 getImmutableLedger = fmap LedgerDB.ledgerDbAnchor . getLedgerDB
 
--- | Get the ledger for the given point.
+-- | Get the ledger and changelog for the given point.
 --
 -- When the given point is not among the last @k@ blocks of the current
 -- chain (i.e., older than @k@ or not on the current chain), 'Nothing' is
 -- returned.
 getPastLedger ::
      (Monad (STM m), LedgerSupportsProtocol blk)
-  => ChainDB m blk -> Point blk -> STM m (Maybe (ExtLedgerState blk EmptyMK))
-getPastLedger db pt = LedgerDB.ledgerDbPast pt <$> getLedgerDB db
+  => ChainDB m blk
+  -> Point blk
+  -> STM m (Maybe ( ExtLedgerState blk EmptyMK, MempoolChangelog blk))
+getPastLedger db pt = do
+  mldb <- LedgerDB.ledgerDbPrefix pt <$> getLedgerDB db
+  pure $ fmap (\l -> ( LedgerDB.ledgerDbCurrent l
+                     , let c = ledgerDbChangelog l
+                       in MempoolChangelog
+                            (changelogDiffAnchor c)
+                            (unExtLedgerStateTables $ changelogDiffs c)))
+         mldb
 
 -- | Get a 'HeaderStateHistory' populated with the 'HeaderState's of the
 -- last @k@ blocks of the current chain.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -218,13 +218,14 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , stream                = Iterator.stream  h
             , newFollower           = Follower.newFollower h
             , getIsInvalidBlock     = getEnvSTM  h Query.getIsInvalidBlock
-            , getLedgerStateForKeys = \p m -> getEnv h $ \env' -> do
-                Query.getLedgerStateForKeys env' p m
             , closeDB               = closeDB h
             , isOpen                = isOpen  h
 
             , getLedgerBackingStoreValueHandle = \rreg p -> getEnv h $ \env' -> do
                 Query.getLedgerBackingStoreValueHandle env' rreg p
+
+            , getBackingStore       =       getEnv h (pure . LgrDB.lgrBackingStore . cdbLgrDB)
+            , withLgrReadLock       = \m -> getEnv h (flip LgrDB.withReadLock m    . cdbLgrDB)
             }
           testing = Internal
             { intCopyToImmutableDB       = getEnv  h Background.copyToImmutableDB


### PR DESCRIPTION
# Description

The previous design on the mempool exposed weird behaviors on the
workbench. This commit is a redesign of the mempool to not have to
revert back to the LedgerDB again on each operation. Now the Internal
State of the mempool holds a minimal version of the DbChangelog which is
used to rewind-read-forward values when validating transactions. In that
way, the mempool is much more independent and works similar to its
pre-UTxO-HD version.

Closes #4035 

# Checklist

- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
- Pull Request
    - [X] Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
    - [X] Reviewer requested
