### PR TITLE
Fix GH Actions Windows CI: switch from pkgconf to pkg-config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,12 @@ jobs:
           git
           mingw-w64-x86_64-toolchain
           mingw-w64-x86_64-libsodium
-          mingw-w64-x86_64-cmake
           mingw-w64-x86_64-jq
+
+    - name: "WIN: Setup pkg-config"
+      if: runner.os == 'Windows'
+      run: |
+        pacman --noconfirm -S mingw-w64-x86_64-pkg-config
 
     - name: "LINUX: Setup haskell"
       if: runner.os != 'Windows'


### PR DESCRIPTION
# Description

This fixes [this CI error][CI error] that has appeared recently. 

MSYS2 recently updated (msys2/MINGW-packages#13257) its version of pkgconf, which is an alternative implementation of the "classic" pkg-config, with both providing the `pkg-config` binary. It seems that this does no longer work correctly (concretely, `pkg-config --modversion pkg1 pkg2 pkg3 ...` is supposed to output the version numbers for all arguments, but `pkgconf` returns at most two versions).

To fix this, I removed cmake (as it requires pkgconf), and we now install pkg-config manually, as putting it in the `install` block above causes it to be silently elided, as the mingw-w64-x86_64-toolchain group contains `pkgconf`.

[CI error]: https://github.com/input-output-hk/ouroboros-network/actions/runs/3182919997/jobs/5189490801

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
