### PR TITLE
Disable auto-run of tvar-invariant-check

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -68,7 +68,7 @@ let
         haskellPackages.ouroboros-consensus-shelley-test.components.tests.test;
     };
 
-    tvar-invariant-checks = recurseIntoAttrs {
+    nightly-checks.tvar-invariant-checks = recurseIntoAttrs {
       inherit haskellPackagesWithTVarCheck;
       tests = collectChecks' haskellPackagesWithTVarCheck;
     };


### PR DESCRIPTION
# Description

tvar-invariant checks are expected to run only in weekly builds. Currently, the tvar-invariant checks are always run as hydra collects the top level attributes and runs them. This comments makes tvar-invariant-checks part of nightly-checks.

To run the tvar-invariant-checks,

```bash
nix-build -A nightly-checks.tvar-invariant-checks.tests
```

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job runs out of memory, e.g. in https://github.com/input-output-hk/ouroboros-network/runs/7231748864?check_suite_focus=true
 
 - The tests in WallClock.delay* can fail under load (quite rarely): https://hydra.iohk.io/build/16723452/nixlog/76

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
