### PR TITLE
Make monitorPeerConnection non-blocking

### DIFF
--- a/docs/interface-CHANGELOG.md
+++ b/docs/interface-CHANGELOG.md
@@ -5,6 +5,12 @@ team.  See [consensus
 CHANGELOG](../ouroboros-consensus/docs/interface-CHANGELOG.md) file for how
 this changelog is supposed to be used.
 
+## Circa 2022-10-11
+
+- `PeerSelectionCounters` includes local peers information.
+- `ReconnectDelay` added `Fractional` instance, semigroup instance is based on
+  `Max` and monoid instance was removed.
+
 ## Circa 2022-09-20
 
 - 'InitializationTracer' type renamed as 'DiffusionTracer'.

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1148,7 +1148,7 @@ withConnectionManager ConnectionManagerArguments {
                     --
                     -- Key was overwritten in the dictionary (stateVar),
                     -- so we do not trace anything as it was already traced upon
-                    -- overwritting.
+                    -- overwriting.
                      else return [ ]
 
                 traverse_ (traceWith trTracer . TransitionTrace peerAddr) transitions
@@ -1243,8 +1243,9 @@ withConnectionManager ConnectionManagerArguments {
                       NotInResponderMode -> return ()
                     return $ Connected connId dataFlow handle
 
-    -- Needs 'mask' in order to guarantee that the traces are logged if the an
-    -- Async exception lands between the successful STM action and the logging action.
+    -- We need 'mask' in order to guarantee that the traces are logged if an
+    -- async exception lands between the successful STM action and the logging
+    -- action.
     unregisterInboundConnectionImpl
         :: StrictTMVar m (ConnectionManagerState peerAddr handle handleError version m)
         -> peerAddr

--- a/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
@@ -17,6 +17,7 @@ import           Data.Semigroup (Max (..))
 newtype ReconnectDelay = ReconnectDelay { reconnectDelay :: DiffTime }
   deriving Eq
   deriving newtype Num
+  deriving newtype Fractional
   deriving Semigroup via Max DiffTime
 
 type ReturnPolicy a = a -> ReconnectDelay

--- a/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
@@ -20,6 +20,10 @@ newtype ReconnectDelay = ReconnectDelay { reconnectDelay :: DiffTime }
   deriving newtype Fractional
   deriving Semigroup via Max DiffTime
 
+-- It ought to be derived via 'Quiet' but 'Difftime' lacks 'Generic' instance.
+instance Show ReconnectDelay where
+    show (ReconnectDelay d) = "ReconnectDelay " ++ show d
+
 type ReturnPolicy a = a -> ReconnectDelay
 
 -- | 'ReturnPolicy' allows to compute reconnection delay from value return by

--- a/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 
@@ -11,18 +12,12 @@ module Ouroboros.Network.ExitPolicy
   ) where
 
 import           Control.Monad.Class.MonadTime
+import           Data.Semigroup (Max (..))
 
 newtype ReconnectDelay = ReconnectDelay { reconnectDelay :: DiffTime }
   deriving Eq
   deriving newtype Num
-
--- | 'ReconnectDelay' is an additive monoid.
---
-instance Semigroup ReconnectDelay where
-    ReconnectDelay a <> ReconnectDelay b = ReconnectDelay (a + b)
-
-instance Monoid ReconnectDelay where
-    mempty = ReconnectDelay 0
+  deriving Semigroup via Max DiffTime
 
 type ReturnPolicy a = a -> ReconnectDelay
 
@@ -42,7 +37,7 @@ data ExitPolicy a =
 
 alwaysCleanReturnPolicy :: ReconnectDelay -- ^ reconnection delay on error
                         -> ExitPolicy a
-alwaysCleanReturnPolicy = ExitPolicy mempty
+alwaysCleanReturnPolicy = ExitPolicy $ \_ -> 0
 
 -- | 'ExitPolicy' with 10s error delay.
 --

--- a/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ExitPolicy.hs
@@ -15,7 +15,7 @@ import           Control.Monad.Class.MonadTime
 import           Data.Semigroup (Max (..))
 
 newtype ReconnectDelay = ReconnectDelay { reconnectDelay :: DiffTime }
-  deriving Eq
+  deriving (Eq, Ord)
   deriving newtype Num
   deriving newtype Fractional
   deriving Semigroup via Max DiffTime

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -538,7 +538,7 @@ peerSelectionGovernorLoop tracer
                      -> Guarded (STM m) (TimedDecision m peeraddr peerconn)
     guardedDecisions blockedAt st =
       -- All the alternative potentially-blocking decisions.
-         Monitor.connections          actions policy st
+         Monitor.connections          actions st
       <> Monitor.jobs                 jobPool st
       <> Monitor.targetPeers          actions st
       <> Monitor.localRoots           actions policy st

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -442,7 +442,9 @@ peerSelectionGovernor :: (MonadAsync m, MonadLabelledSTM m, MonadMask m,
                       -> PeerSelectionPolicy  peeraddr m
                       -> m Void
 peerSelectionGovernor tracer debugTracer countersTracer fuzzRng actions policy =
-    JobPool.withJobPool $ \jobPool ->
+    JobPool.withJobPool $ \jobPool -> do
+      localPeers <- map (\(target, _) -> (target, 0))
+                <$> atomically (readLocalRootPeers actions)
       peerSelectionGovernorLoop
         tracer
         debugTracer
@@ -450,7 +452,7 @@ peerSelectionGovernor tracer debugTracer countersTracer fuzzRng actions policy =
         actions
         policy
         jobPool
-        (emptyPeerSelectionState fuzzRng)
+        (emptyPeerSelectionState fuzzRng localPeers)
 
 -- | Our pattern here is a loop with two sets of guarded actions:
 --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -246,9 +246,10 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                      (fuzz, fuzzRng')  = randomR (-2, 2 :: Double) fuzzRng
                      delay             = realToFrac fuzz + policyErrorDelay
                      knownPeers'       = if peeraddr `KnownPeers.member` knownPeers
-                                            then KnownPeers.setConnectTime
-                                                   (Set.singleton peeraddr)
-                                                   (delay `addTime` now)
+                                            then KnownPeers.setConnectTimes
+                                                   (Map.singleton
+                                                     peeraddr
+                                                     (delay `addTime` now))
                                                  $ snd $ KnownPeers.incrementFailCount
                                                    peeraddr
                                                    knownPeers
@@ -501,10 +502,10 @@ jobDemoteActivePeer PeerSelectionActions{peerStateActions = PeerStateActions {de
             peerSet               = Set.singleton peeraddr
             activePeers'          = Set.delete peeraddr activePeers
             inProgressDemoteHot'  = Set.delete peeraddr inProgressDemoteHot
-            knownPeers'           = KnownPeers.setConnectTime
-                                      peerSet
-                                      ((realToFrac rFuzz + policyErrorDelay)
-                                       `addTime` now)
+            knownPeers'           = KnownPeers.setConnectTimes
+                                      (Map.singleton
+                                        peeraddr
+                                        ((realToFrac rFuzz + policyErrorDelay) `addTime` now))
                                   . Set.foldr'
                                       ((snd .) . KnownPeers.incrementFailCount)
                                       knownPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -266,9 +266,10 @@ jobPromoteColdPeer PeerSelectionActions {
                                                    (EstablishedPeers.size establishedPeers)
                                                    peeraddr delay e,
             decisionState = st {
-                              knownPeers            = KnownPeers.setConnectTime
-                                                        (Set.singleton peeraddr)
-                                                        (delay `addTime` now)
+                              knownPeers            = KnownPeers.setConnectTimes
+                                                        (Map.singleton
+                                                          peeraddr
+                                                          (delay `addTime` now))
                                                         knownPeers',
                               inProgressPromoteCold = Set.delete peeraddr
                                                         (inProgressPromoteCold st),
@@ -426,14 +427,15 @@ jobDemoteEstablishedPeer PeerSelectionActions{peerStateActions = PeerStateAction
         let (rFuzz, fuzzRng')     = randomR (-2, 2 :: Double) fuzzRng
             peerSet               = Set.singleton peeraddr
             inProgressDemoteWarm' = Set.delete peeraddr inProgressDemoteWarm
-            knownPeers'           = KnownPeers.setConnectTime
-                                     peerSet
-                                     ((realToFrac rFuzz + policyErrorDelay)
-                                      `addTime` now)
-                                   . Set.foldr'
-                                     ((snd .) . KnownPeers.incrementFailCount)
-                                     knownPeers
-                                   $ peerSet
+            knownPeers'           = KnownPeers.setConnectTimes
+                                      (Map.singleton
+                                        peeraddr
+                                        ((realToFrac rFuzz + policyErrorDelay)
+                                         `addTime` now))
+                                  . Set.foldr'
+                                      ((snd .) . KnownPeers.incrementFailCount)
+                                      knownPeers
+                                  $ peerSet
             establishedPeers'     = EstablishedPeers.deletePeers
                                      peerSet
                                      establishedPeers in

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -153,7 +153,7 @@ connections PeerSelectionActions{
         in assert (activePeers' `Set.isSubsetOf`
                      Map.keysSet (EstablishedPeers.toMap establishedPeers'))
             Decision {
-              decisionTrace = TraceDemoteAsynchronous (fst <$> demotions),
+              decisionTrace = TraceDemoteAsynchronous demotions,
               decisionJobs  = [],
               decisionState = st {
                                 activePeers       = activePeers',

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -33,7 +33,8 @@ import qualified Ouroboros.Network.ExitPolicy as ExitPolicy
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import           Ouroboros.Network.PeerSelection.Governor.ActivePeers
                      (jobDemoteActivePeer)
-import           Ouroboros.Network.PeerSelection.Governor.Types
+import           Ouroboros.Network.PeerSelection.Governor.Types hiding
+                     (PeerSelectionCounters (..))
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
 import           Ouroboros.Network.PeerSelection.Types

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -302,27 +302,35 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
 --     network disconnect to cause us to flush our full known peer set by
 --     considering them all to have bad connectivity.
 --     Should also take account of DNS failures for root peer set.
---     lastSucessfulNetworkEvent :: Time
+--     lastSuccessfulNetworkEvent :: Time
      }
   deriving (Show, Functor)
 
 data PeerSelectionCounters = PeerSelectionCounters {
-      coldPeers :: Int,
-      warmPeers :: Int,
-      hotPeers  :: Int
+      coldPeers  :: Int,
+      warmPeers  :: Int,
+      hotPeers   :: Int,
+      localRoots :: [(Int, Int)]
     } deriving (Eq, Show)
 
 peerStateToCounters :: Ord peeraddr => PeerSelectionState peeraddr peerconn -> PeerSelectionCounters
-peerStateToCounters st = PeerSelectionCounters { coldPeers, warmPeers, hotPeers }
+peerStateToCounters st = PeerSelectionCounters { coldPeers, warmPeers, hotPeers, localRoots }
   where
     knownPeersSet = KnownPeers.toSet (knownPeers st)
     establishedPeersSet = EstablishedPeers.toSet (establishedPeers st)
-    coldPeers = Set.size $ knownPeersSet Set.\\ establishedPeersSet
-    warmPeers = Set.size $ establishedPeersSet Set.\\ activePeers st
-    hotPeers  = Set.size $ activePeers st
+    coldPeers  = Set.size $ knownPeersSet Set.\\ establishedPeersSet
+    warmPeers  = Set.size $ establishedPeersSet Set.\\ activePeers st
+    hotPeers   = Set.size $ activePeers st
+    localRoots =
+      [ (target, active)
+      | (target, members) <- LocalRootPeers.toGroupSets (localRootPeers st)
+      , let active = Set.size (members `Set.intersection` activePeers st)
+      ]
 
-emptyPeerSelectionState :: StdGen -> PeerSelectionState peeraddr peerconn
-emptyPeerSelectionState rng =
+emptyPeerSelectionState :: StdGen
+                        -> [(Int, Int)]
+                        -> PeerSelectionState peeraddr peerconn
+emptyPeerSelectionState rng localRoots =
     PeerSelectionState {
       targets              = nullPeerSelectionTargets,
       localRootPeers       = LocalRootPeers.empty,
@@ -339,7 +347,7 @@ emptyPeerSelectionState rng =
       inProgressDemoteWarm     = Set.empty,
       inProgressDemoteHot      = Set.empty,
       fuzzRng                  = rng,
-      countersCache            = Cache (PeerSelectionCounters 0 0 0)
+      countersCache            = Cache (PeerSelectionCounters 0 0 0 localRoots)
     }
 
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -621,7 +621,7 @@ data TracePeerSelection peeraddr =
      | TraceDemoteHotFailed    Int Int peeraddr SomeException
      -- | target active, actual active, peer
      | TraceDemoteHotDone      Int Int peeraddr
-     | TraceDemoteAsynchronous (Map peeraddr PeerStatus)
+     | TraceDemoteAsynchronous (Map peeraddr (PeerStatus, Maybe ReconnectDelay))
      | TraceGovernorWakeup
      | TraceChurnWait          DiffTime
      | TraceChurnMode          ChurnMode

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -212,9 +212,9 @@ data PeerSelectionActions peeraddr peerconn m = PeerSelectionActions {
 -- | Callbacks which are performed to change peer state.
 --
 data PeerStateActions peeraddr peerconn m = PeerStateActions {
-    -- | Monitor peer state.
+    -- | Monitor peer state.  Must be non-blocking.
     --
-    monitorPeerConnection    :: peerconn -> STM m (PeerStatus, ReconnectDelay),
+    monitorPeerConnection    :: peerconn -> STM m (PeerStatus, Maybe ReconnectDelay),
 
     -- | Establish new connection: cold to warm.
     --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -771,7 +771,7 @@ withPeerStateActions PeerStateActionsArguments {
         h (Just (Returned a)) = Just $ epReturnDelay spsExitPolicy a
         -- Note: we do 'RethrowPolicy' in 'ConnectionHandler' (see
         -- 'makeConnectionHandler').
-        h (Just Errored {})   = Just $ ReconnectDelay 10
+        h (Just Errored {})   = Just $ epErrorDelay spsExitPolicy
         h (Just NotRunning)   = Nothing
         h Nothing             = Nothing
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -233,7 +233,7 @@ run blockGeneratorArgs limits ni na tracersExtra =
               , Diff.P2P.daPeerMetrics            = peerMetrics
                 -- fetch mode is not used (no block-fetch mini-protocol)
               , Diff.P2P.daBlockFetchMode         = pure FetchModeDeadline
-              , Diff.P2P.daReturnPolicy           = mempty
+              , Diff.P2P.daReturnPolicy           = \_ -> 0
               }
 
         apps <- Node.applications @_ @BlockHeader nodeKernel Node.cborCodecs limits appArgs

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -2155,7 +2155,7 @@ selectGovState :: Eq a
 selectGovState f =
     Signal.nub
   -- TODO: #3182 Rng seed should come from quickcheck.
-  . Signal.fromChangeEvents (f $ Governor.emptyPeerSelectionState $ mkStdGen 42)
+  . Signal.fromChangeEvents (f $ Governor.emptyPeerSelectionState (mkStdGen 42) [])
   . Signal.selectEvents
       (\case GovernorDebug (TraceGovernorState _ _ st) -> Just (f st)
              _                                         -> Nothing)

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -1643,7 +1643,7 @@ prop_governor_target_established_below env =
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerCold) status)
+                         failures = Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
                      TracePromoteWarmFailed _ _ peer _ ->
                        Just (Set.singleton peer)
                      _ -> Nothing
@@ -1730,7 +1730,7 @@ prop_governor_target_active_below env =
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerWarm) status)
+                         failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
                      _ -> Nothing
               )
           . selectGovEvents
@@ -1950,7 +1950,7 @@ prop_governor_target_established_local env =
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerCold) status)
+                         failures = Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
                      TracePromoteWarmFailed _ _ peer _ ->
                        Just (Set.singleton peer)
                      _ -> Nothing
@@ -2039,7 +2039,7 @@ prop_governor_target_active_local_below env =
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerWarm) status)
+                         failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
                      _ -> Nothing
               )
           . selectGovEvents

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -434,9 +434,9 @@ mockPeerSelectionActions' tracer
         let !conns' = Map.delete peeraddr conns
         writeTVar connsVar conns'
 
-    monitorPeerConnection :: PeerConn m -> STM m (PeerStatus, ReconnectDelay)
+    monitorPeerConnection :: PeerConn m -> STM m (PeerStatus, Maybe ReconnectDelay)
     monitorPeerConnection (PeerConn _peeraddr conn) = (,) <$> readTVar conn
-                                                          <*> pure mempty
+                                                          <*> pure Nothing
 
 
 snapshotPeersStatus :: MonadInspectSTM m

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
@@ -1233,7 +1233,7 @@ prop_diffusion_target_established_local defaultBearerInfo diffScript =
                          | otherwise         -> Just failures
                          where
                            failures =
-                             Map.keysSet (Map.filter (==PeerCold) status)
+                             Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
                        TracePromoteWarmFailed _ _ peer _ ->
                          Just (Set.singleton peer)
                        _ -> Nothing
@@ -1386,7 +1386,7 @@ prop_diffusion_target_active_below defaultBearerInfo diffScript =
                          | Set.null failures -> Nothing
                          | otherwise         -> Just failures
                          where
-                           failures = Map.keysSet (Map.filter (==PeerWarm) status)
+                           failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
                        _ -> Nothing
                 )
             . selectDiffusionPeerSelectionEvents

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
@@ -1995,7 +1995,7 @@ selectDiffusionPeerSelectionState :: Eq a
 selectDiffusionPeerSelectionState f =
     Signal.nub
   -- TODO: #3182 Rng seed should come from quickcheck.
-  . Signal.fromChangeEvents (f $ Governor.emptyPeerSelectionState $ mkStdGen 42)
+  . Signal.fromChangeEvents (f $ Governor.emptyPeerSelectionState (mkStdGen 42) [])
   . Signal.selectEvents
       (\case
         DiffusionDebugPeerSelectionTrace (TraceGovernorState _ _ st) -> Just (f st)


### PR DESCRIPTION
# Description

Fixes #4064

TODO:
* [ ] ~improve network simulation test so it catches the problem~ (it will be done in another PR)
* [x] update changelog

- connection-manager: reworded some comments
- peer-state-actions: make monitorPeerSelection non-blocking
- peer-state-actions: use updateUnlessCold
- peer-state-actions: use epErrorDelay
- exit-policy: derive semigroup via Max
- exit-policy: derive Fractional instance for ReconnectDelay
- peer-selection: trace reconnect delay with 'TraceDemoteAsynchronous'
- peer-selection: refactor monitoring connections
- peer-selection: added localRoots to PeerSelectionCounters

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
