### PR TITLE
Test that UTxO tables are updated correctly on era transitions

### DIFF
--- a/anti-diff/src/Data/Map/Diff/Strict.hs
+++ b/anti-diff/src/Data/Map/Diff/Strict.hs
@@ -36,6 +36,8 @@ module Data.Map.Diff.Strict (
   , singleton
   , singletonDelete
   , singletonInsert
+    -- * Predicates
+  , null
     -- * Class instances for @'DiffHistory'@
   , areInverses
     -- * Values and keys
@@ -60,7 +62,7 @@ module Data.Map.Diff.Strict (
   , unsafeFoldMapDiffEntry
   ) where
 
-import           Prelude hiding (last, length, splitAt)
+import           Prelude hiding (last, length, null, splitAt)
 
 import           Data.Bifunctor
 import           Data.Foldable (toList)
@@ -207,6 +209,14 @@ singletonDelete = singleton . Delete
 
 last :: NEDiffHistory v -> DiffEntry v
 last (unNEDiffHistory -> _ NESeq.:||> e) = e
+
+{------------------------------------------------------------------------------
+  Predicates
+------------------------------------------------------------------------------}
+
+null :: Diff k v -> Bool
+null (Diff m) = Map.null m
+
 
 {------------------------------------------------------------------------------
   Class instances for @'Diff'@

--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -49,6 +49,8 @@ library
 
                      , byron-spec-ledger
 
+                     , cardano-slotting
+
                      , ouroboros-network
                      , ouroboros-consensus
                      , ouroboros-consensus-test

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -1,14 +1,15 @@
-{-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Consensus.Byron.Generators (
     RegularBlock (..)
   , epochSlots
+  , genByronLedgerConfig
+  , genByronLedgerState
   , k
   , protocolMagicId
   ) where
@@ -19,7 +20,9 @@ import qualified Data.Map.Strict as Map
 
 import           Cardano.Binary (fromCBOR, toCBOR)
 import           Cardano.Chain.Block (ABlockOrBoundary (..),
-                     ABlockOrBoundaryHdr (..))
+                     ABlockOrBoundaryHdr (..), ChainValidationState (..),
+                     cvsPreviousHash)
+
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.Byron.API as API
 import           Cardano.Chain.Common (KeyHash)
@@ -27,6 +30,7 @@ import qualified Cardano.Chain.Delegation as CC.Del
 import qualified Cardano.Chain.Delegation.Validation.Activation as CC.Act
 import qualified Cardano.Chain.Delegation.Validation.Interface as CC.DI
 import qualified Cardano.Chain.Delegation.Validation.Scheduling as CC.Sched
+import           Cardano.Chain.Genesis as Byron
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import           Cardano.Chain.Slotting (EpochNumber, EpochSlots (..),
                      SlotNumber)
@@ -36,6 +40,7 @@ import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.Update.Validation.Registration as CC.Reg
 import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Crypto.Hashing (Hash)
+import           Cardano.Slotting.Slot (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
@@ -55,6 +60,7 @@ import           Test.QuickCheck.Hedgehog (hedgehog)
 import qualified Test.Cardano.Chain.Block.Gen as CC
 import qualified Test.Cardano.Chain.Common.Gen as CC
 import qualified Test.Cardano.Chain.Delegation.Gen as CC
+import qualified Test.Cardano.Chain.Genesis.Gen as CC
 import qualified Test.Cardano.Chain.MempoolPayload.Gen as CC
 import qualified Test.Cardano.Chain.Slotting.Gen as CC
 import qualified Test.Cardano.Chain.UTxO.Gen as CC
@@ -271,6 +277,28 @@ instance Arbitrary ByronTransition where
 
 instance Arbitrary (LedgerState ByronBlock EmptyMK) where
   arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
+
+-- | Generator for a Byron ledger state in which the tip of the ledger given by
+-- `byronLedgerTipBlockNo` matches that derived from the `ChainValidationState` in
+-- `byronLedgerState`.
+genByronLedgerState :: Gen (LedgerState ByronBlock EmptyMK)
+genByronLedgerState = do
+  chainValidationState <- arbitrary
+  ledgerTransition <- arbitrary
+  ledgerTipBlockNo <- genLedgerTipBlockNo chainValidationState
+  pure $ ByronLedgerState {
+      byronLedgerTipBlockNo = ledgerTipBlockNo
+    , byronLedgerState = chainValidationState
+    , byronLedgerTransition = ledgerTransition
+    }
+  where
+    genLedgerTipBlockNo ChainValidationState { cvsPreviousHash } =
+      case cvsPreviousHash of
+        Left _  -> pure Origin
+        Right _ -> At <$> arbitrary
+
+genByronLedgerConfig :: Gen Byron.Config
+genByronLedgerConfig = hedgehog $ CC.genConfig protocolMagicId
 
 instance Arbitrary (TipInfoIsEBB ByronBlock) where
   arbitrary = TipInfoIsEBB <$> arbitrary <*> elements [IsEBB, IsNotEBB]

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -30,7 +30,7 @@ import qualified Cardano.Chain.Delegation as CC.Del
 import qualified Cardano.Chain.Delegation.Validation.Activation as CC.Act
 import qualified Cardano.Chain.Delegation.Validation.Interface as CC.DI
 import qualified Cardano.Chain.Delegation.Validation.Scheduling as CC.Sched
-import           Cardano.Chain.Genesis as Byron
+import qualified Cardano.Chain.Genesis as Byron
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import           Cardano.Chain.Slotting (EpochNumber, EpochSlots (..),
                      SlotNumber)
@@ -288,7 +288,7 @@ genByronLedgerState = do
   ledgerTipBlockNo <- genLedgerTipBlockNo chainValidationState
   pure $ ByronLedgerState {
       byronLedgerTipBlockNo = ledgerTipBlockNo
-    , byronLedgerState = chainValidationState
+    , byronLedgerState      = chainValidationState
     , byronLedgerTransition = ledgerTransition
     }
   where

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -279,8 +279,8 @@ instance Arbitrary (LedgerState ByronBlock EmptyMK) where
   arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
 
 -- | Generator for a Byron ledger state in which the tip of the ledger given by
--- `byronLedgerTipBlockNo` matches that derived from the `ChainValidationState` in
--- `byronLedgerState`.
+-- `byronLedgerTipBlockNo` is consistent with the chain validation state, i.e., if there is no
+-- previous block, the ledger tip wil be `Origin`.
 genByronLedgerState :: Gen (LedgerState ByronBlock EmptyMK)
 genByronLedgerState = do
   chainValidationState <- arbitrary

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -87,6 +87,7 @@ test-suite test
                        Test.Consensus.Cardano.ByronCompatibility
                        Test.Consensus.Cardano.Golden
                        Test.Consensus.Cardano.Serialisation
+                       Test.Consensus.Cardano.Translation
                        Test.ThreadNet.AllegraMary
                        Test.ThreadNet.Cardano
                        Test.ThreadNet.MaryAlonzo
@@ -103,11 +104,18 @@ test-suite test
                      , sop-core
                      , tasty
                      , tasty-quickcheck
+                     , hedgehog-quickcheck
+                     , anti-diff
 
+                     , cardano-crypto-wrapper
+                     , cardano-data
                      , cardano-ledger-alonzo
+                     , cardano-ledger-alonzo-test
                      , cardano-ledger-byron
+                     , cardano-ledger-byron-test
                      , cardano-ledger-core
                      , cardano-ledger-shelley
+                     , cardano-ledger-shelley-test
                      , cardano-protocol-tpraos
 
                      , ouroboros-network

--- a/ouroboros-consensus-cardano-test/test/Main.hs
+++ b/ouroboros-consensus-cardano-test/test/Main.hs
@@ -11,6 +11,7 @@ import           Test.Util.Nightly
 import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
 import qualified Test.Consensus.Cardano.Golden (tests)
 import qualified Test.Consensus.Cardano.Serialisation (tests)
+import qualified Test.Consensus.Cardano.Translation (tests)
 -- import qualified Test.ThreadNet.AllegraMary (tests)
 -- import qualified Test.ThreadNet.Cardano (tests)
 -- import qualified Test.ThreadNet.MaryAlonzo (tests)
@@ -33,4 +34,5 @@ tests =
   -- , Test.ThreadNet.Cardano.tests
   -- , Test.ThreadNet.MaryAlonzo.tests
   -- , Test.ThreadNet.ShelleyAllegra.tests
+  , Test.Consensus.Cardano.Translation.tests
   ]

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
@@ -1,0 +1,320 @@
+{-# LANGUAGE BlockArguments        #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module Test.Consensus.Cardano.Translation (tests) where
+
+import           Data.Int (Int64)
+import qualified Data.ListMap as ListMap
+import           Data.Map.Diff.Strict (Diff (..))
+import qualified Data.Map.Diff.Strict as Diff
+import qualified Data.Map.Strict as Map
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Cardano.Slotting.EpochInfo (fixedEpochInfo)
+import           Cardano.Slotting.Slot (EpochNo (..))
+
+import qualified Cardano.Chain.Block as Byron
+import qualified Cardano.Chain.UTxO as Byron
+import           Cardano.Ledger.Alonzo ()
+import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
+import           Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (..),
+                     Prices (..))
+import           Cardano.Ledger.BaseTypes (Network (Testnet), TxIx (..))
+import           Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Era as Core
+import           Cardano.Ledger.Shelley.API
+                     (NewEpochState (stashedAVVMAddresses), ShelleyGenesis (..),
+                     ShelleyGenesisStaking (..), TxIn (..),
+                     translateCompactTxOutByronToShelley,
+                     translateTxIdByronToShelley)
+import           Cardano.Ledger.Shelley.PParams (emptyPParams)
+import           Cardano.Ledger.Shelley.UTxO
+
+import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
+                     (slotLengthFromSec)
+import           Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import           Ouroboros.Consensus.Cardano.CanHardFork ()
+import           Ouroboros.Consensus.HardFork.Combinator (InPairs (..),
+                     hardForkEraTranslation, translateLedgerState)
+import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+                     (TranslateLedgerState (translateLedgerStateWith))
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (AllPairs,
+                     RequiringBoth, provideBoth)
+import           Ouroboros.Consensus.Ledger.Basics (ApplyMapKind' (..), DiffMK,
+                     EmptyMK, LedgerConfig, LedgerState)
+import           Ouroboros.Consensus.Protocol.Praos
+import           Ouroboros.Consensus.Protocol.Praos.Common
+                     (MaxMajorProtVer (..))
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
+import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
+import           Ouroboros.Consensus.TypeFamilyWrappers
+import           Ouroboros.Consensus.Util (dimap)
+
+import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, byronLedgerState)
+
+import           Ouroboros.Consensus.Shelley.Eras
+import           Ouroboros.Consensus.Shelley.HFEras ()
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
+                     ShelleyLedgerConfig, mkShelleyLedgerConfig,
+                     shelleyLedgerState, shelleyLedgerTables, shelleyUTxOTable)
+import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+
+-- TODO: Not sure where to put these
+import           Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import           Test.Cardano.Ledger.Shelley.Utils (unsafeBoundRational)
+import           Test.Consensus.Byron.Generators (genByronLedgerConfig,
+                     genByronLedgerState)
+import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
+import           Test.Consensus.Shelley.Generators ()
+import           Test.Consensus.Shelley.MockCrypto
+
+import           Test.Util.Time (dawnOfTime)
+
+-- Definitions to make the signatures a bit less unwieldy
+type Crypto = MockCryptoCompatByron
+type Proto  = TPraos Crypto
+
+tests :: TestTree
+tests = testGroup "UpdateTablesOnEraTransition" $ toTestTrees predicates tls
+  where
+    tls = translateLedgerState hardForkEraTranslation
+    predicates :: InPairs TranslationPredicate (CardanoEras Crypto)
+    predicates =
+        PCons (TranslationPredicate "ByronToShelley" byronUtxosAreInsertsInShelleyUtxoDiff)
+      $ PCons (TranslationPredicate "ShelleyToAllegra" shelleyAvvmAddressesAreDeletesInUtxoDiff)
+      $ PCons (TranslationPredicate "AllegraToMary" utxoTablesAreEmpty)
+      $ PCons (TranslationPredicate "MaryToAlonzo" utxoTablesAreEmpty)
+      $ PCons (TranslationPredicate "AlonzoToBabbage" utxoTablesAreEmpty)
+        PNil
+
+{-------------------------------------------------------------------------------
+    Specific predicates
+-------------------------------------------------------------------------------}
+
+byronUtxosAreInsertsInShelleyUtxoDiff
+  :: LedgerState ByronBlock EmptyMK
+  -> LedgerState (ShelleyBlock Proto (ShelleyEra Crypto)) DiffMK
+  -> Bool
+byronUtxosAreInsertsInShelleyUtxoDiff srcLedgerState destLedgerState =
+    toNextUtxoDiff srcLedgerState == extractUtxoDiff destLedgerState
+  where
+    toNextUtxoDiff
+      :: LedgerState ByronBlock mk
+      -> Diff (TxIn Crypto) (Core.TxOut (ShelleyEra Crypto))
+    toNextUtxoDiff ledgerState =
+      let
+        Byron.UTxO utxo = Byron.cvsUtxo $ byronLedgerState ledgerState
+        keyFn = translateTxInByronToShelley . Byron.fromCompactTxIn
+        valFn = Diff.singletonInsert . translateCompactTxOutByronToShelley
+      in
+        Diff $ dimap keyFn valFn utxo
+
+    translateTxInByronToShelley :: Byron.TxIn -> TxIn Crypto
+    translateTxInByronToShelley byronTxIn =
+      let
+        Byron.TxInUtxo txId txIx = byronTxIn
+        shelleyTxId' = translateTxIdByronToShelley txId
+      in
+        TxIn shelleyTxId' (TxIx $ fromIntegral txIx)
+
+shelleyAvvmAddressesAreDeletesInUtxoDiff
+  :: LedgerState (ShelleyBlock Proto (ShelleyEra Crypto)) EmptyMK
+  -> LedgerState (ShelleyBlock Proto (AllegraEra Crypto)) DiffMK
+  -> Bool
+shelleyAvvmAddressesAreDeletesInUtxoDiff srcLedgerState destLedgerState =
+    toNextUtxoDiff srcLedgerState == extractUtxoDiff destLedgerState
+  where
+    toNextUtxoDiff
+      :: LedgerState (ShelleyBlock Proto (ShelleyEra Crypto)) EmptyMK
+      -> Diff (TxIn Crypto) (Core.TxOut (AllegraEra Crypto))
+    toNextUtxoDiff = avvmAddressesToUtxoDiff . stashedAVVMAddresses . shelleyLedgerState
+    avvmAddressesToUtxoDiff (UTxO m) =
+      let fn txOut = Diff.singletonDelete (Core.translateEra' () txOut)
+      in Diff $ dimap id fn m
+
+utxoTablesAreEmpty
+  :: LedgerState (ShelleyBlock srcProto srcEra) EmptyMK
+  -> LedgerState (ShelleyBlock destProto destEra) DiffMK
+  -> Bool
+utxoTablesAreEmpty _ destLedgerState = Diff.null $ extractUtxoDiff destLedgerState
+
+{-------------------------------------------------------------------------------
+    Generating tests for all translation predicates
+-------------------------------------------------------------------------------}
+
+-- | Predicate on pairs of ledger states of subsequent eras that are converted to property tests.
+data TranslationPredicate src dest = TranslationPredicate {
+    tpTestName :: TestName
+  , tpRun      :: LedgerState src EmptyMK -> LedgerState dest DiffMK -> Bool
+}
+
+-- Intermediate data type
+-- REVIEW: Can we get rid of this?
+data PreProperty x y = PreProperty {
+    ppTestName :: TestName
+  , ppRun      :: TestSetup x y -> Bool
+}
+
+toTestTrees
+  :: (AllPairs TestSetup Arbitrary xs, AllPairs TestSetup Show xs)
+  => InPairs TranslationPredicate xs
+  -> InPairs (RequiringBoth WrapLedgerConfig TranslateLedgerState) xs
+  -> [TestTree]
+toTestTrees predicates translations = mkTestTrees $ zipInPairs predicates translations
+  where
+    fn
+      :: TranslationPredicate x y
+      -> RequiringBoth WrapLedgerConfig TranslateLedgerState x y
+      -> PreProperty x y
+    fn TranslationPredicate {..} translateLedgerState = PreProperty {
+      ppTestName = tpTestName
+    , ppRun = \TestSetup {..} ->
+        let translation = provideBoth
+                translateLedgerState
+                (WrapLedgerConfig tsSrcLedgerConfig)
+                (WrapLedgerConfig tsDestLedgerConfig)
+            destState = translateLedgerStateWith translation tsEpochNo tsSrcLedgerState
+        in tpRun tsSrcLedgerState destState
+    }
+
+    zipInPairs
+      :: InPairs TranslationPredicate xs
+      -> InPairs (RequiringBoth WrapLedgerConfig TranslateLedgerState) xs
+      -> InPairs PreProperty xs
+    zipInPairs PNil PNil                 = PNil
+    zipInPairs (PCons b bs) (PCons z zs) = PCons (fn b z) (zipInPairs bs zs)
+
+    mkTestTrees
+      :: (AllPairs TestSetup Arbitrary xs, AllPairs TestSetup Show xs)
+      => InPairs PreProperty xs -> [TestTree]
+    mkTestTrees PNil                        = []
+    mkTestTrees (PCons PreProperty {..} cs) =
+      testProperty ppTestName ppRun : mkTestTrees cs
+
+{-------------------------------------------------------------------------------
+    Utilities
+-------------------------------------------------------------------------------}
+
+extractUtxoDiff
+  :: LedgerState (ShelleyBlock proto era) DiffMK
+  -> Diff (TxIn (EraCrypto era)) (Core.TxOut era)
+extractUtxoDiff shelleyLedgerState =
+  let ApplyDiffMK tables = shelleyUTxOTable $ shelleyLedgerTables shelleyLedgerState
+  in tables
+
+{-------------------------------------------------------------------------------
+    TestSetup
+-------------------------------------------------------------------------------}
+
+data TestSetup src dest = TestSetup {
+    tsSrcLedgerConfig  :: LedgerConfig src
+  , tsDestLedgerConfig :: LedgerConfig dest
+  , tsSrcLedgerState   :: LedgerState src EmptyMK
+  , tsEpochNo          :: EpochNo
+}
+
+deriving instance ( Show (LedgerConfig src)
+                  , Show (LedgerConfig dest)
+                  , Show (LedgerState src EmptyMK)) => Show (TestSetup src dest)
+
+-- todo: Useful to merge some of these instances?
+instance Arbitrary (TestSetup ByronBlock (ShelleyBlock Proto (ShelleyEra Crypto))) where
+  arbitrary =
+    let ledgerConfig = fixedShelleyLedgerConfig ()
+    in TestSetup <$> genByronLedgerConfig
+                 <*> pure ledgerConfig
+                 <*> genByronLedgerState
+                 <*> (EpochNo <$> arbitrary)
+
+instance Arbitrary (TestSetup (ShelleyBlock Proto (ShelleyEra Crypto))
+                              (ShelleyBlock Proto (AllegraEra Crypto))) where
+  arbitrary = TestSetup (fixedShelleyLedgerConfig ())
+                        (fixedShelleyLedgerConfig ())
+                        <$> genShelleyLedgerState
+                        <*> (EpochNo <$> arbitrary)
+
+instance Arbitrary (TestSetup (ShelleyBlock Proto (AllegraEra Crypto))
+                              (ShelleyBlock Proto (MaryEra Crypto))) where
+  arbitrary = TestSetup (fixedShelleyLedgerConfig ())
+                        (fixedShelleyLedgerConfig ())
+                        <$> genShelleyLedgerState
+                        <*> (EpochNo <$> arbitrary)
+
+instance Arbitrary (TestSetup (ShelleyBlock Proto (MaryEra Crypto))
+                              (ShelleyBlock Proto (AlonzoEra Crypto))) where
+  arbitrary = TestSetup (fixedShelleyLedgerConfig ())
+                        <$> (fixedShelleyLedgerConfig <$> genAlonzoGenesis)
+                        <*> genShelleyLedgerState
+                        <*> (EpochNo <$> arbitrary)
+
+instance Arbitrary (TestSetup (ShelleyBlock (TPraos Crypto) (AlonzoEra Crypto))
+                              (ShelleyBlock (Praos Crypto) (BabbageEra Crypto))) where
+  arbitrary = TestSetup <$> (fixedShelleyLedgerConfig <$> genAlonzoGenesis)
+                        <*> (fixedShelleyLedgerConfig <$> genAlonzoGenesis)
+                        <*> genShelleyLedgerState
+                        <*> (EpochNo <$> arbitrary)
+
+{-------------------------------------------------------------------------------
+    Generators
+-------------------------------------------------------------------------------}
+
+genShelleyLedgerState :: CanMock proto era => Gen (LedgerState (ShelleyBlock proto era) EmptyMK)
+genShelleyLedgerState = arbitrary
+
+-- A fixed ledger config should be sufficient as the updating of the ledger tables on era
+-- transitions does not depend on the configurations of any of the ledgers involved..
+-- TODO: Check this
+fixedShelleyLedgerConfig :: Core.TranslationContext era -> ShelleyLedgerConfig era
+fixedShelleyLedgerConfig translationContext = mkShelleyLedgerConfig
+      shelleyGenesis
+      translationContext
+      (fixedEpochInfo (sgEpochLength shelleyGenesis) (slotLengthFromSec 2))
+      (MaxMajorProtVer 1000)
+  where
+    shelleyGenesis = ShelleyGenesis {
+          sgSystemStart = dawnOfTime
+        , sgNetworkMagic = 0
+        , sgNetworkId = Testnet
+        , sgActiveSlotsCoeff = unsafeBoundRational 0.8
+        , sgSecurityParam = 10
+        , sgEpochLength = 10
+        , sgSlotsPerKESPeriod = 10
+        , sgMaxKESEvolutions = 10
+        , sgSlotLength = 10
+        , sgUpdateQuorum = 6
+        , sgMaxLovelaceSupply = 10
+        , sgProtocolParams = emptyPParams
+        , sgGenDelegs = Map.empty
+        , sgInitialFunds = ListMap.empty
+        , sgStaking = ShelleyGenesisStaking ListMap.empty ListMap.empty
+    }
+
+genAlonzoGenesis :: Gen AlonzoGenesis
+genAlonzoGenesis = do
+  prices <- Prices <$> arbitrary <*> arbitrary
+  maxTxUnits <- ExUnits <$> genFromIntegral <*> genFromIntegral
+  maxBlockExUnits <- ExUnits <$> genFromIntegral <*> genFromIntegral
+  pure $ AlonzoGenesis {
+      coinsPerUTxOWord = Coin 10
+    , costmdls = CostModels Map.empty
+    , prices = prices
+    , maxTxExUnits = maxTxUnits
+    , maxBlockExUnits = maxBlockExUnits
+    , maxValSize = 10
+    , collateralPercentage = 10
+    , maxCollateralInputs = 10
+    }
+  where
+    genFromIntegral = fromIntegral <$> choose (0, maxBound :: Int64)

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
@@ -40,7 +40,8 @@ import           Cardano.Ledger.Shelley.API
                      ShelleyGenesisStaking (..), TxIn (..),
                      translateCompactTxOutByronToShelley,
                      translateTxIdByronToShelley)
-import           Cardano.Ledger.Shelley.LedgerState hiding (LedgerState)
+import           Cardano.Ledger.Shelley.LedgerState (_utxo, esLState,
+                     lsUTxOState, nesEs)
 import           Cardano.Ledger.Shelley.PParams (emptyPParams)
 import           Cardano.Ledger.Shelley.UTxO (UTxO (..))
 
@@ -73,7 +74,6 @@ import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
                      shelleyLedgerState, shelleyLedgerTables, shelleyUTxOTable)
 import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 
--- TODO: Not sure where to put these
 import           Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import           Test.Cardano.Ledger.Shelley.Utils (unsafeBoundRational)
 import           Test.Consensus.Byron.Generators (genByronLedgerConfig,
@@ -298,9 +298,9 @@ instance Arbitrary (TestSetup (ShelleyBlock (TPraos Crypto) (AlonzoEra Crypto))
 genShelleyLedgerState :: CanMock proto era => Gen (LedgerState (ShelleyBlock proto era) EmptyMK)
 genShelleyLedgerState = arbitrary
 
--- A fixed ledger config should be sufficient as the updating of the ledger tables on era
--- transitions does not depend on the configurations of any of the ledgers involved..
--- TODO: Check this
+-- | A fixed ledger config should be sufficient as the updating of the ledger
+-- tables on era transitions does not depend on the configurations of any of
+-- the ledgers involved.
 fixedShelleyLedgerConfig :: Core.TranslationContext era -> ShelleyLedgerConfig era
 fixedShelleyLedgerConfig translationContext = mkShelleyLedgerConfig
       shelleyGenesis
@@ -309,21 +309,21 @@ fixedShelleyLedgerConfig translationContext = mkShelleyLedgerConfig
       (MaxMajorProtVer 1000)
   where
     shelleyGenesis = ShelleyGenesis {
-          sgSystemStart = dawnOfTime
-        , sgNetworkMagic = 0
-        , sgNetworkId = Testnet
-        , sgActiveSlotsCoeff = unsafeBoundRational 0.8
-        , sgSecurityParam = 10
-        , sgEpochLength = 10
+          sgSystemStart       = dawnOfTime
+        , sgNetworkMagic      = 0
+        , sgNetworkId         = Testnet
+        , sgActiveSlotsCoeff  = unsafeBoundRational 0.8
+        , sgSecurityParam     = 10
+        , sgEpochLength       = 10
         , sgSlotsPerKESPeriod = 10
-        , sgMaxKESEvolutions = 10
-        , sgSlotLength = 10
-        , sgUpdateQuorum = 6
+        , sgMaxKESEvolutions  = 10
+        , sgSlotLength        = 10
+        , sgUpdateQuorum      = 6
         , sgMaxLovelaceSupply = 10
-        , sgProtocolParams = emptyPParams
-        , sgGenDelegs = Map.empty
-        , sgInitialFunds = ListMap.empty
-        , sgStaking = ShelleyGenesisStaking ListMap.empty ListMap.empty
+        , sgProtocolParams    = emptyPParams
+        , sgGenDelegs         = Map.empty
+        , sgInitialFunds      = ListMap.empty
+        , sgStaking           = ShelleyGenesisStaking ListMap.empty ListMap.empty
     }
 
 genAlonzoGenesis :: Gen AlonzoGenesis

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
@@ -148,8 +148,8 @@ shelleyAvvmAddressesAreDeletesInUtxoDiff srcLedgerState destLedgerState =
       -> Diff (TxIn Crypto) (Core.TxOut (AllegraEra Crypto))
     toNextUtxoDiff = avvmAddressesToUtxoDiff . stashedAVVMAddresses . shelleyLedgerState
     avvmAddressesToUtxoDiff (UTxO m) =
-      let fn txOut = Diff.singletonDelete (Core.translateEra' () txOut)
-      in Diff $ dimap id fn m
+      let func txOut = Diff.singletonDelete (Core.translateEra' () txOut)
+      in Diff $ dimap id func m
 
 utxoTablesAreEmpty
   :: LedgerState (ShelleyBlock srcProto srcEra) EmptyMK

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -134,6 +134,8 @@ data ShelleyLedgerConfig era = ShelleyLedgerConfig {
     }
   deriving (Generic, NoThunks)
 
+deriving instance Show (Core.TranslationContext era) => Show (ShelleyLedgerConfig era)
+
 shelleyLedgerGenesis :: ShelleyLedgerConfig era -> SL.ShelleyGenesis era
 shelleyLedgerGenesis = getCompactGenesis . shelleyLedgerCompactGenesis
 

--- a/ouroboros-consensus/docs/AddingAnEra.md
+++ b/ouroboros-consensus/docs/AddingAnEra.md
@@ -125,3 +125,8 @@ be adding is the Alonzo era, which comes after the Mary era.
 
 * Extend `Test.ThreadNet.Cardano` with the new era. At the time of writing this
   hasn't been done yet for Allegra or Mary, though.
+
+* In `Test.Consensus.Cardano.Translation` add a `TranslationPredicate` that
+  specifies how the ledger tables should be updated on era transition, e.g., in
+  the case of Byron to Shelley all Byron UTxOs should be added as inserts to the
+  Shelley ledger tables.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
@@ -1,13 +1,14 @@
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE PolyKinds           #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
 
 -- | Intended for qualified import
 --
@@ -128,10 +129,7 @@ requiringBoth = flip go
   Constraints
 -------------------------------------------------------------------------------}
 
-type family AllPairs
-  (f :: k -> k -> Type)
-  (c :: Type -> Constraint)
-  (ts :: [Type]) :: Constraint where
-
+type AllPairs :: (k -> k -> Type) -> (Type -> Constraint) -> [k] -> Constraint
+type family AllPairs f c t where
   AllPairs f c '[t] = ()
   AllPairs f c (t ': s ': ts) = (c (f t s) , AllPairs f c (s ': ts))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
 -- | Intended for qualified import
@@ -31,6 +32,8 @@ module Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (
   , ignoringBoth
   , requiring
   , requiringBoth
+    -- * Constraints
+  , AllPairs
   ) where
 
 import           Data.Kind (Type)
@@ -120,3 +123,15 @@ requiringBoth = flip go
     go :: InPairs (RequiringBoth h f) xs -> NP h xs -> InPairs f xs
     go PNil         _              = PNil
     go (PCons f fs) (x :* y :* zs) = PCons (provideBoth f x y) (go fs (y :* zs))
+
+{-------------------------------------------------------------------------------
+  Constraints
+-------------------------------------------------------------------------------}
+
+type family AllPairs
+  (f :: k -> k -> Type)
+  (c :: Type -> Constraint)
+  (ts :: [Type]) :: Constraint where
+
+  AllPairs f c '[t] = ()
+  AllPairs f c (t ': s ': ts) = (c (f t s) , AllPairs f c (s ': ts))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -54,6 +54,8 @@ module Ouroboros.Consensus.Util (
   , checkThat
     -- * Sets
   , allDisjoint
+    -- * Maps
+  , dimap
     -- * Composition
   , (......:)
   , (.....:)
@@ -81,6 +83,8 @@ import           Data.Functor.Identity
 import           Data.Functor.Product
 import           Data.Kind (Constraint, Type)
 import           Data.List (foldl', maximumBy)
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -346,6 +350,10 @@ allDisjoint = go Set.empty
     go _   []       = True
     go acc (xs:xss) = Set.disjoint acc xs && go (Set.union acc xs) xss
 
+-- | Map over keys and values
+dimap :: Ord k2 => (k1 -> k2) -> (v1 -> v2) -> Map k1 v1 -> Map k2 v2
+dimap keyFn valFn = Map.foldlWithKey update Map.empty
+  where update m k1 v1 =  Map.insert (keyFn k1) (valFn v1) m
 {-------------------------------------------------------------------------------
   Composition
 -------------------------------------------------------------------------------}


### PR DESCRIPTION
# Description

Test that UTxO tables are computed correctly on era transitions, for all era transitions.

Closes #4043.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
