### PR TITLE
Update stylish-haskell to 0.14.3.0

### DIFF
--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -37,8 +37,8 @@ import           Text.Printf
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -16,10 +16,17 @@ with pkgs; {
   cabal =
     haskell-nix.tool localConfig.ghcVersion "cabal" { version = "latest"; };
 
-  stylish-haskell = haskell-nix.tool localConfig.ghcVersion "stylish-haskell" {
-    version = "0.13.0.0";
+  # can be changed back to haskell-nix.tool when we bump our index-state
+  stylish-haskell = (haskell-nix.cabalProject {
+    src = pkgs.fetchFromGitHub {
+      owner = "haskell";
+      repo = "stylish-haskell";
+      rev = "v0.14.3.0";
+      sha256 = "sha256-TF8VxrkE142D6dhWMbuAWTfVTafm8I2kpSnyW4eA8d0=";
+    };
+    compiler-nix-name = localConfig.ghcVersion;
     inherit (ouroborosNetworkHaskellPackages) index-state;
-  };
+  }).stylish-haskell.components.exes.stylish-haskell;
 
   trace = builtins.trace;
 }

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -16,8 +16,8 @@ import           Data.Maybe (fromMaybe)
 
 import qualified Byron.Spec.Ledger.Core as Spec
 import qualified Byron.Spec.Ledger.Delegation as Spec
-import qualified Byron.Spec.Ledger.UTxO as Spec
 import qualified Byron.Spec.Ledger.Update as Spec
+import qualified Byron.Spec.Ledger.UTxO as Spec
 
 import qualified Test.Cardano.Chain.Elaboration.Block as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Delegation as Spec.Test
@@ -27,9 +27,9 @@ import qualified Test.Cardano.Chain.UTxO.Model as Spec.Test
 
 import qualified Cardano.Chain.Block as Impl
 import qualified Cardano.Chain.Genesis as Impl
-import qualified Cardano.Chain.UTxO as Impl
 import qualified Cardano.Chain.Update as Impl
 import qualified Cardano.Chain.Update.Validation.Interface as Impl
+import qualified Cardano.Chain.UTxO as Impl
 
 import           Ouroboros.Consensus.HeaderValidation
 

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -27,8 +27,8 @@ import qualified Data.Map.Strict as Map
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Common as CC
-import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
+import qualified Cardano.Chain.UTxO as CC
 
 import           Ouroboros.Network.Block (Serialised (..))
 
@@ -48,14 +48,14 @@ import           Ouroboros.Consensus.Byron.Crypto.DSIGN (SignKeyDSIGN (..))
 import           Ouroboros.Consensus.Byron.Ledger
 import           Ouroboros.Consensus.Byron.Node (ByronLeaderCredentials (..))
 
-import           Test.Util.Serialisation.Golden (Labelled, labelled, unlabelled)
 import qualified Test.Util.Serialisation.Golden as Golden
+import           Test.Util.Serialisation.Golden (Labelled, labelled, unlabelled)
 import           Test.Util.Serialisation.Roundtrip (SomeResult (..))
 
 import qualified Test.Cardano.Chain.Common.Example as CC
 import qualified Test.Cardano.Chain.Genesis.Dummy as CC
-import qualified Test.Cardano.Chain.UTxO.Example as CC
 import qualified Test.Cardano.Chain.Update.Example as CC
+import qualified Test.Cardano.Chain.UTxO.Example as CC
 
 import           Test.ThreadNet.Infra.Byron.ProtocolInfo (mkLeaderCredentials)
 

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -29,10 +29,10 @@ import qualified Cardano.Chain.Delegation.Validation.Scheduling as CC.Sched
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import           Cardano.Chain.Slotting (EpochNumber, EpochSlots (..),
                      SlotNumber)
-import qualified Cardano.Chain.UTxO as CC.UTxO
 import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.Update.Validation.Registration as CC.Reg
+import qualified Cardano.Chain.UTxO as CC.UTxO
 import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Crypto.Hashing (Hash)
 
@@ -54,8 +54,8 @@ import qualified Test.Cardano.Chain.Common.Gen as CC
 import qualified Test.Cardano.Chain.Delegation.Gen as CC
 import qualified Test.Cardano.Chain.MempoolPayload.Gen as CC
 import qualified Test.Cardano.Chain.Slotting.Gen as CC
-import qualified Test.Cardano.Chain.UTxO.Gen as CC
 import qualified Test.Cardano.Chain.Update.Gen as UG
+import qualified Test.Cardano.Chain.UTxO.Gen as CC
 import qualified Test.Cardano.Crypto.Gen as CC
 
 import           Test.Util.Orphans.Arbitrary ()

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -28,8 +28,8 @@ import qualified Cardano.Chain.Delegation as CC.Delegation
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Slotting as CC.Slot
 import qualified Cardano.Chain.Ssc as CC.Ssc
-import qualified Cardano.Chain.UTxO as CC.UTxO
 import qualified Cardano.Chain.Update as CC.Update
+import qualified Cardano.Chain.UTxO as CC.UTxO
 import qualified Cardano.Crypto as Crypto
 import           Cardano.Crypto.DSIGN
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -59,10 +59,10 @@ import           Cardano.Binary (encodeListLen, enforceSize, fromCBOR, toCBOR)
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Genesis as Gen
-import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Endorsement as UPE
 import qualified Cardano.Chain.Update.Validation.Interface as UPI
+import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.ValidationMode as CC
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -62,8 +62,8 @@ import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.MempoolPayload as CC
-import qualified Cardano.Chain.UTxO as Utxo
 import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Chain.UTxO as Utxo
 import qualified Cardano.Chain.ValidationMode as CC
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
@@ -23,8 +23,8 @@ import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
 import qualified Cardano.Chain.Delegation as CC
 import qualified Cardano.Chain.MempoolPayload as CC
-import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.Update as CC
+import qualified Cardano.Chain.UTxO as CC
 
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
@@ -8,10 +8,10 @@ module Ouroboros.Consensus.ByronSpec.Ledger (module X) where
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Block as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Forge as X
-import           Ouroboros.Consensus.ByronSpec.Ledger.GenTx as X
-                     (ByronSpecGenTx (..), ByronSpecGenTxErr (..))
 import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis as X
                      (ByronSpecGenesis (..))
+import           Ouroboros.Consensus.ByronSpec.Ledger.GenTx as X
+                     (ByronSpecGenTx (..), ByronSpecGenTxErr (..))
 import           Ouroboros.Consensus.ByronSpec.Ledger.Ledger as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Mempool as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans as X ()

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
@@ -21,8 +21,8 @@ import           GHC.Generics (Generic)
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
 import qualified Byron.Spec.Ledger.Delegation as Spec
-import qualified Byron.Spec.Ledger.UTxO as Spec
 import qualified Byron.Spec.Ledger.Update as Spec
+import qualified Byron.Spec.Ledger.UTxO as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
@@ -27,8 +27,8 @@ import           Numeric.Natural (Natural)
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
 import qualified Byron.Spec.Ledger.Core as Spec
-import qualified Byron.Spec.Ledger.UTxO as Spec
 import qualified Byron.Spec.Ledger.Update as Spec
+import qualified Byron.Spec.Ledger.UTxO as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans ()

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
@@ -31,8 +31,8 @@ import qualified Byron.Spec.Ledger.Delegation as Spec
 import qualified Byron.Spec.Ledger.STS.UTXO as Spec
 import qualified Byron.Spec.Ledger.STS.UTXOW as Spec
 import qualified Byron.Spec.Ledger.STS.UTXOWS as Spec
-import qualified Byron.Spec.Ledger.UTxO as Spec
 import qualified Byron.Spec.Ledger.Update as Spec
+import qualified Byron.Spec.Ledger.UTxO as Spec
 import qualified Control.State.Transition as Spec
 
 import           Test.Cardano.Chain.Elaboration.Block as Spec.Test

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -50,8 +50,8 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.CanHardFork ()
 
-import           Test.Util.Serialisation.Golden (Examples, Labelled, labelled)
 import qualified Test.Util.Serialisation.Golden as Golden
+import           Test.Util.Serialisation.Golden (Examples, Labelled, labelled)
 import           Test.Util.Serialisation.Roundtrip (SomeResult (..))
 
 import qualified Test.Consensus.Byron.Examples as Byron

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -14,9 +14,9 @@ import           Control.Exception (assert)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
-import           Data.SOP.Strict
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Block (SlotNo (..))
 import           Ouroboros.Consensus.Config

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
@@ -20,9 +20,9 @@ import           Control.Monad (replicateM)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
-import           Data.SOP.Strict (NP (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
@@ -18,9 +18,9 @@ import           Control.Monad (replicateM)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
-import           Data.SOP.Strict (NP (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -20,9 +20,9 @@ import           Control.Monad (replicateM)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
-import           Data.SOP.Strict (NP (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Node/Protocol/Byron.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Node/Protocol/Byron.hs
@@ -25,8 +25,8 @@ import           Data.Text as Text (unpack)
 import           Cardano.Prelude
 
 import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.UTxO as UTxO
 import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Chain.UTxO as UTxO
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Byron.Crypto
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic)

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Byron.hs
@@ -21,8 +21,8 @@ import qualified Cardano.Crypto as Crypto
 
 import qualified Cardano.Chain.Block as Chain
 import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.UTxO as Chain
 import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Chain.UTxO as Chain
 
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -81,9 +81,9 @@ import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
 import           Ouroboros.Consensus.Protocol.Praos.Common
 import           Ouroboros.Consensus.Protocol.Praos.Header (HeaderBody)
+import qualified Ouroboros.Consensus.Protocol.Praos.Views as Views
 import           Ouroboros.Consensus.Protocol.Praos.VRF (InputVRF, mkInputVRF,
                      vrfLeaderValue, vrfNonceValue)
-import qualified Ouroboros.Consensus.Protocol.Praos.Views as Views
 import           Ouroboros.Consensus.Protocol.TPraos
                      (ConsensusConfig (TPraosConfig, tpraosEpochInfo, tpraosParams))
 import           Ouroboros.Consensus.Ticked (Ticked)

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -59,8 +59,8 @@ import           Test.Cardano.Ledger.Shelley.Examples.Consensus
                      ledgerExamplesShelley, testShelleyGenesis)
 import           Test.Cardano.Ledger.Shelley.Orphans ()
 import           Test.Util.Orphans.Arbitrary ()
-import           Test.Util.Serialisation.Golden (labelled, unlabelled)
 import qualified Test.Util.Serialisation.Golden as Golden
+import           Test.Util.Serialisation.Golden (labelled, unlabelled)
 import           Test.Util.Serialisation.Roundtrip (SomeResult (..))
 
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -80,8 +80,8 @@ import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
                      encodeWithOrigin)
 import           Ouroboros.Consensus.Util.Versioned
 
-import qualified Cardano.Ledger.BHeaderView as SL (BHeaderView)
 import qualified Cardano.Ledger.BaseTypes as SL (epochInfoPure)
+import qualified Cardano.Ledger.BHeaderView as SL (BHeaderView)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Control.State.Transition.Extended as STS

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
@@ -28,8 +28,8 @@ module Ouroboros.Consensus.Shelley.Protocol.Abstract (
 
 import           Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR))
 import           Cardano.Crypto.VRF (OutputVRF)
-import           Cardano.Ledger.BHeaderView (BHeaderView)
 import           Cardano.Ledger.BaseTypes (ProtVer)
+import           Cardano.Ledger.BHeaderView (BHeaderView)
 import           Cardano.Ledger.Crypto (Crypto, VRF)
 import           Cardano.Ledger.Hashes (EraIndependentBlockBody,
                      EraIndependentBlockHeader)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
@@ -11,8 +11,8 @@ module Ouroboros.Consensus.Shelley.Protocol.Praos (PraosEnvelopeError (..)) wher
 
 import qualified Cardano.Crypto.KES as KES
 import           Cardano.Crypto.VRF (certifiedOutput)
-import           Cardano.Ledger.BHeaderView
 import           Cardano.Ledger.BaseTypes (ProtVer (ProtVer))
+import           Cardano.Ledger.BHeaderView
 import           Cardano.Ledger.Keys (hashKey)
 import           Cardano.Ledger.Slot (SlotNo (unSlotNo))
 import           Cardano.Protocol.TPraos.OCert

--- a/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
@@ -74,8 +74,8 @@ import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
 import           Test.ThreadNet.Util.Seed
 
-import           Test.Util.FS.Sim.MockFS (MockFS)
 import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS (MockFS)
 import           Test.Util.HardFork.Future (Future)
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.IOLike ()

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -119,12 +119,12 @@ import           Test.ThreadNet.Util.NodeTopology
 import           Test.ThreadNet.Util.Seed
 
 import           Test.Util.ChainDB
-import           Test.Util.FS.Sim.MockFS (MockFS)
 import qualified Test.Util.FS.Sim.MockFS as Mock
-import           Test.Util.HardFork.Future (Future)
+import           Test.Util.FS.Sim.MockFS (MockFS)
 import qualified Test.Util.HardFork.Future as HFF
-import           Test.Util.HardFork.OracularClock (OracularClock (..))
+import           Test.Util.HardFork.Future (Future)
 import qualified Test.Util.HardFork.OracularClock as OracularClock
+import           Test.Util.HardFork.OracularClock (OracularClock (..))
 import           Test.Util.Slots (NumSlots (..))
 import           Test.Util.Time
 import           Test.Util.Tracer

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Ref/PBFT.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Ref/PBFT.hs
@@ -47,8 +47,8 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 import           Test.ThreadNet.Util.NodeJoinPlan
 
-import           Test.Util.InvertedMap (InvertedMap)
 import qualified Test.Util.InvertedMap as InvertedMap
+import           Test.Util.InvertedMap (InvertedMap)
 import           Test.Util.Slots (NumSlots (..))
 
 oneK :: Num a => PBftParams -> a

--- a/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
@@ -37,8 +37,8 @@ import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
 import           Ouroboros.Consensus.Util.IOLike hiding (invariant)
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
-import           Test.Util.FS.Sim.MockFS
 import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS
 import           Test.Util.FS.Sim.STM (simHasFS)
 
 

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/Error.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/Error.hs
@@ -47,8 +47,8 @@ import           Data.List (dropWhileEnd, intercalate)
 import           Data.Maybe (catMaybes, isNothing)
 import           Data.Word (Word64)
 
-import           Test.QuickCheck (Arbitrary (..), Gen)
 import qualified Test.QuickCheck as QC
+import           Test.QuickCheck (Arbitrary (..), Gen)
 
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.CallStack

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/MockFS.hs
@@ -76,8 +76,8 @@ import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Storage.FS.API.Types
 import           Ouroboros.Consensus.Util.CallStack
 
-import           Test.Util.FS.Sim.FsTree (FsTree (..), FsTreeError (..))
 import qualified Test.Util.FS.Sim.FsTree as FS
+import           Test.Util.FS.Sim.FsTree (FsTree (..), FsTreeError (..))
 
 {-------------------------------------------------------------------------------
   Mock FS types

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/Pure.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/Pure.hs
@@ -13,8 +13,8 @@ import           Control.Monad.State
 import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
 
-import           Test.Util.FS.Sim.MockFS (MockFS)
 import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS (MockFS)
 
 -- | Monad useful for running 'HasFS' in pure code
 newtype PureSimFS a = PureSimFS (StateT MockFS (Except FsError) a)

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/STM.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/STM.hs
@@ -13,8 +13,8 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
 
-import           Test.Util.FS.Sim.MockFS (HandleMock, MockFS)
 import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS (HandleMock, MockFS)
 import           Test.Util.FS.Sim.Pure (PureSimFS, runPureSimFS)
 
 {------------------------------------------------------------------------------

--- a/ouroboros-consensus-test/src/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus-test/src/Test/Util/QuickCheck.hs
@@ -40,8 +40,8 @@ import           Ouroboros.Consensus.Util (repeatedly)
 import           Ouroboros.Consensus.Util.Condense (Condense, condense)
 import           Ouroboros.Consensus.Util.SOP
 
-import           Test.QuickCheck hiding (elements)
 import qualified Test.QuickCheck as QC
+import           Test.QuickCheck hiding (elements)
 
 {-------------------------------------------------------------------------------
   Generic QuickCheck utilities

--- a/ouroboros-consensus-test/src/Test/Util/Slots.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Slots.hs
@@ -8,8 +8,8 @@ import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import           Quiet (Quiet (..))
-import           Test.QuickCheck (Arbitrary (..))
 import qualified Test.QuickCheck as QC
+import           Test.QuickCheck (Arbitrary (..))
 
 -- | Number of slots
 newtype NumSlots = NumSlots {unNumSlots :: Word64}

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -76,8 +76,8 @@ import           Ouroboros.Consensus.Util.STM (blockUntilJust,
                      forkLinkedWatcher)
 
 import           Test.Util.ChainUpdates
-import           Test.Util.LogicalClock (Tick (..))
 import qualified Test.Util.LogicalClock as LogicalClock
+import           Test.Util.LogicalClock (Tick (..))
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Schedule
 import           Test.Util.TestBlock

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -69,14 +69,14 @@ import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
 
 import           Test.Util.ChainUpdates (ChainUpdate (..), UpdateBehavior (..),
                      genChainUpdates, toChainUpdates)
-import           Test.Util.LogicalClock (NumTicks (..), Tick (..))
 import qualified Test.Util.LogicalClock as LogicalClock
+import           Test.Util.LogicalClock (NumTicks (..), Tick (..))
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Schedule (Schedule (..), genSchedule, joinSchedule,
                      lastTick, shrinkSchedule)
-import           Test.Util.TestBlock
 import qualified Test.Util.TestBlock as TestBlock
+import           Test.Util.TestBlock
 import           Test.Util.Tracer (recordingTracerTVar)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
@@ -29,11 +29,11 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
-import           Test.Util.FS.Sim.FsTree (FsTree (..))
-import           Test.Util.FS.Sim.MockFS (Files)
-import qualified Test.Util.FS.Sim.MockFS as Mock
-import           Test.Util.FS.Sim.STM (runSimFS)
 import           Test.Util.FileLock
+import           Test.Util.FS.Sim.FsTree (FsTree (..))
+import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS (Files)
+import           Test.Util.FS.Sim.STM (runSimFS)
 import           Test.Util.QuickCheck (ge)
 
 tests :: TestTree

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -28,13 +28,13 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.TreeDiff (defaultExprViaShow)
 import           Data.Typeable
-import           GHC.Generics (Generic, Generic1)
 import qualified Generics.SOP as SOP
+import           GHC.Generics (Generic, Generic1)
 
 import           Control.Monad.Class.MonadTimer
 
-import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
+import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck.Monadic as QC
 import           Test.StateMachine
 import qualified Test.StateMachine.Types as QSM

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -25,8 +25,8 @@ import           Ouroboros.Consensus.Storage.ChainDB.API (StreamFrom (..),
 
 import           Test.Util.TestBlock
 
-import           Test.Ouroboros.Storage.ChainDB.Model (ModelSupportsBlock)
 import qualified Test.Ouroboros.Storage.ChainDB.Model as M
+import           Test.Ouroboros.Storage.ChainDB.Model (ModelSupportsBlock)
 
 tests :: TestTree
 tests = testGroup "Model" [

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -95,20 +95,20 @@ import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
 
+import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 import           Test.Ouroboros.Storage.ChainDB.Model (FollowerId, IteratorId,
                      ModelSupportsBlock,
                      ShouldGarbageCollect (DoNotGarbageCollect, GarbageCollect))
-import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 import           Test.Ouroboros.Storage.Orphans ()
 import           Test.Ouroboros.Storage.TestBlock
 
 import           Test.Util.ChunkInfo
 import qualified Test.Util.Classify as C
-import           Test.Util.FS.Sim.MockFS (MockFS)
 import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS (MockFS)
 import           Test.Util.Orphans.ToExpr ()
-import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
+import           Test.Util.RefEnv (RefEnv)
 import           Test.Util.SOP
 import           Test.Util.Tracer (recordingTracerIORef)
 import           Test.Util.WithEq

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -41,9 +41,9 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Data.TreeDiff (ToExpr (..), defaultExprViaShow)
 import           Data.Word (Word64)
+import qualified Generics.SOP as SOP
 import           GHC.Generics
 import           GHC.Stack
-import qualified Generics.SOP as SOP
 import           System.IO.Temp (withTempDirectory)
 import           System.Random (getStdRandom, randomR)
 import           Text.Read (readMaybe)
@@ -52,8 +52,8 @@ import           Text.Show.Pretty (ppShow)
 import           Test.QuickCheck
 import qualified Test.QuickCheck.Monadic as QC
 import           Test.QuickCheck.Random (mkQCGen)
-import           Test.StateMachine (Concrete, Symbolic)
 import qualified Test.StateMachine as QSM
+import           Test.StateMachine (Concrete, Symbolic)
 import qualified Test.StateMachine.Sequential as QSM
 import qualified Test.StateMachine.Types as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
@@ -69,12 +69,12 @@ import           Ouroboros.Consensus.Util.Condense
 
 import qualified Test.Util.Classify as C
 import           Test.Util.FS.Sim.FsTree (FsTree (..))
-import           Test.Util.FS.Sim.MockFS (HandleMock, MockFS)
 import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS (HandleMock, MockFS)
 import           Test.Util.FS.Sim.Pure
 import           Test.Util.QuickCheck (collects)
-import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
+import           Test.Util.RefEnv (RefEnv)
 import           Test.Util.SOP
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
@@ -31,8 +31,8 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types (BlockOrEBB)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
                      (ShouldBeFinalised (..), reconstructPrimaryIndex)
 
-import           Test.Util.FS.Sim.MockFS (HandleMock)
 import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.MockFS (HandleMock)
 import qualified Test.Util.FS.Sim.STM as Sim
 import           Test.Util.Orphans.Arbitrary ()
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -39,9 +39,9 @@ import           Data.Maybe (listToMaybe)
 import           Data.TreeDiff (Expr (App), defaultExprViaShow)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word16, Word32, Word64)
+import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
 import           GHC.Stack (HasCallStack)
-import qualified Generics.SOP as SOP
 import           NoThunks.Class (AllowThunk (..))
 import           System.Random (getStdRandom, randomR)
 import           Text.Show.Pretty (ppShow)
@@ -80,8 +80,8 @@ import qualified Test.Util.FS.Sim.MockFS as Mock
 import           Test.Util.Orphans.Slotting.Arbitrary ()
 import           Test.Util.Orphans.ToExpr ()
 import           Test.Util.QuickCheck (collects)
-import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
+import           Test.Util.RefEnv (RefEnv)
 import           Test.Util.SOP
 import           Test.Util.Tracer (recordingTracerIORef)
 import           Test.Util.WithEq

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -49,8 +49,8 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import           System.Random (getStdRandom, randomR)
 
-import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
+import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck.Monadic as QC
 import qualified Test.QuickCheck.Random as QC
 import           Test.StateMachine hiding (showLabelledExamples)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -30,9 +30,9 @@ import           Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
+import qualified Generics.SOP as SOP
 import           GHC.Generics
 import           GHC.Stack
-import qualified Generics.SOP as SOP
 import           System.Random (getStdRandom, randomR)
 import           Text.Show.Pretty (ppShow)
 

--- a/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
+++ b/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
@@ -21,8 +21,8 @@ import qualified Data.ByteString.Internal as Internal
 import           Data.Int (Int64)
 import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Ptr)
-import           System.Posix (Fd)
 import qualified System.Posix as Posix
+import           System.Posix (Fd)
 
 -- Package 'unix' exports the same module.
 import           "unix-bytestring" System.Posix.IO.ByteString (fdPreadBuf)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Parser.hs
@@ -18,8 +18,8 @@ import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Functor ((<&>))
 import           Data.Word (Word64)
-import           Streaming (Of, Stream)
 import qualified Streaming as S
+import           Streaming (Of, Stream)
 import qualified Streaming.Prelude as S
 
 import           Ouroboros.Consensus.Block hiding (headerHash)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Parser.hs
@@ -15,8 +15,8 @@ module Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser (
 import           Data.Bifunctor (bimap)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Word (Word64)
-import           Streaming.Prelude (Of (..), Stream)
 import qualified Streaming.Prelude as S
+import           Streaming.Prelude (Of (..), Stream)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr (..),

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -50,8 +50,8 @@ import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 
 import qualified Streaming as S
-import           Streaming.Prelude (Of (..), Stream)
 import qualified Streaming.Prelude as S
+import           Streaming.Prelude (Of (..), Stream)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -24,8 +24,8 @@ import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Exception (IOException)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime (MonadTime (..))
 import           Control.Monad.Class.MonadTimer
@@ -44,8 +44,8 @@ import           Network.TypedProtocol.Core
 
 import           Options.Applicative
 
-import           System.Random (RandomGen)
 import qualified System.Random as Random
+import           System.Random (RandomGen)
 
 import           Network.TypedProtocol.ReqResp.Client
 import           Network.TypedProtocol.ReqResp.Codec.CBOR
@@ -58,8 +58,8 @@ import           Ouroboros.Network.ConnectionHandler
 import           Ouroboros.Network.ConnectionId
 import           Ouroboros.Network.ConnectionManager.Core
 import           Ouroboros.Network.ConnectionManager.Types
-import           Ouroboros.Network.IOManager
 import qualified Ouroboros.Network.InboundGovernor.ControlChannel as Server
+import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.MuxMode
 import           Ouroboros.Network.Protocol.Handshake

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor/State.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor/State.hs
@@ -33,8 +33,8 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Cache (Cache)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           System.Random (StdGen)
 import qualified System.Random as Rnd
+import           System.Random (StdGen)
 
 import qualified Network.Mux as Mux
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -25,8 +25,8 @@ import           Control.Exception (AssertionFailed, SomeAsyncException (..))
 import           Control.Monad (replicateM, when, (>=>))
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadTest
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
@@ -82,12 +82,12 @@ import           Ouroboros.Network.ConnectionManager.Core
 import           Ouroboros.Network.ConnectionManager.Types
 import qualified Ouroboros.Network.ConnectionManager.Types as CM
 import           Ouroboros.Network.Driver.Limits
-import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..))
 import qualified Ouroboros.Network.InboundGovernor as IG
 import qualified Ouroboros.Network.InboundGovernor.ControlChannel as Server
 import           Ouroboros.Network.InboundGovernor.State
                      (InboundGovernorCounters (..))
+import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.MuxMode
 import           Ouroboros.Network.Protocol.Handshake

--- a/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
@@ -21,8 +21,8 @@ module Test.Simulation.Network.Snocket
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -19,8 +19,8 @@ import           Data.Word
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer (nullTracer)
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -79,9 +79,9 @@ import           Ouroboros.Network.Diffusion.Common hiding (nullTracers)
 import qualified Ouroboros.Network.Diffusion.Policies as Diffusion.Policies
 import           Ouroboros.Network.Diffusion.Utils
 import           Ouroboros.Network.ExitPolicy
-import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..),
                      RemoteTransitionTrace)
+import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.Mux hiding (MiniProtocol (..))
 import           Ouroboros.Network.MuxMode
 import           Ouroboros.Network.NodeToClient (NodeToClientVersion (..),

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -14,8 +14,8 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Word (Word32)
-import           System.Random
 import qualified System.Random as Rnd
+import           System.Random
 
 import           Ouroboros.Network.ConnectionManager.Types (ConnectionType (..),
                      Provenance (..), PrunePolicy)

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -14,8 +14,8 @@ import           Codec.Serialise (Serialise (..))
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -99,10 +99,10 @@ import           Ouroboros.Network.Testing.Data.Script (Script (..))
 import           Simulation.Network.Snocket (AddressType (..), FD)
 
 import qualified Test.Ouroboros.Network.Diffusion.Node.MiniProtocols as Node
+import qualified Test.Ouroboros.Network.Diffusion.Node.NodeKernel as Node
 import           Test.Ouroboros.Network.Diffusion.Node.NodeKernel
                      (NodeKernel (..), NtCAddr, NtCVersion, NtCVersionData,
                      NtNAddr, NtNVersion, NtNVersionData (..))
-import qualified Test.Ouroboros.Network.Diffusion.Node.NodeKernel as Node
 import           Test.Ouroboros.Network.PeerSelection.RootPeersDNS
                      (DNSLookupDelay, DNSTimeout, mockDNSActions)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/KeepAlive.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/KeepAlive.hs
@@ -11,8 +11,8 @@ import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad (void)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -45,8 +45,8 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Time.Clock (secondsToDiffTime)
 import           Data.Void (Void)
-import           System.Random (StdGen, mkStdGen)
 import qualified System.Random as Random
+import           System.Random (StdGen, mkStdGen)
 
 import           Network.DNS (Domain, TTL)
 
@@ -87,10 +87,10 @@ import           Test.Ouroboros.Network.Diffusion.Node.NodeKernel
                      (BlockGeneratorArgs, NtCAddr, NtCVersion, NtCVersionData,
                      NtNAddr, NtNAddr_ (IPAddr), NtNVersion, NtNVersionData,
                      randomBlockGenerationArgs)
-import           Test.Ouroboros.Network.PeerSelection.RootPeersDNS
-                     (DNSLookupDelay (..), DNSTimeout (..))
 import qualified Test.Ouroboros.Network.PeerSelection.RootPeersDNS as PeerSelection hiding
                      (tests)
+import           Test.Ouroboros.Network.PeerSelection.RootPeersDNS
+                     (DNSLookupDelay (..), DNSTimeout (..))
 
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, choose,
                      chooseInt, counterexample, frequency, oneof, property,

--- a/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
@@ -16,8 +16,8 @@ import           Control.Concurrent.Class.MonadSTM
 import           Control.Exception (SomeException (..))
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer


### PR DESCRIPTION
# Description

Update stylish-haskell to 0.14.3.0 (see the [CHANGELOG][s-h-cl]), motivated by a bug in stylish-haskell 0.13 w.r.t. marking a module as deprecated. There are some benign import sorting changes.

[s-h-cl]: https://github.com/haskell/stylish-haskell/blob/main/CHANGELOG

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
