### PR TITLE
Clarify current VRF tie breaking implementation

### DIFF
--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/Common.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/Common.hs
@@ -49,13 +49,14 @@ newtype MaxMajorProtVer = MaxMajorProtVer
 -- 1. By chain length, with longer chains always preferred.
 -- 2. If the tip of each chain was issued by the same agent, then we prefer
 --    the chain whose tip has the highest ocert issue number.
--- 3. By the leader value of the chain tip, with lower values preferred.
+-- 3. By a VRF value from the chain tip, with lower values preferred. See
+--    @pTieBreakVRFValue@ for which one is used.
 data PraosChainSelectView c = PraosChainSelectView
   { csvChainLength :: BlockNo,
     csvSlotNo      :: SlotNo,
     csvIssuer      :: SL.VKey 'SL.BlockIssuer c,
     csvIssueNo     :: Word64,
-    csvLeaderVRF   :: VRF.OutputVRF (VRF c)
+    csvTieBreakVRF :: VRF.OutputVRF (VRF c)
   }
   deriving (Show, Eq, Generic, NoThunks)
 
@@ -64,7 +65,7 @@ instance Crypto c => Ord (PraosChainSelectView c) where
     mconcat
       [ compare `on` csvChainLength,
         whenSame csvIssuer (compare `on` csvIssueNo),
-        compare `on` Down . csvLeaderVRF
+        compare `on` Down . csvTieBreakVRF
       ]
     where
       -- When the @a@s are equal, use the given comparison function,

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Protocol.hs
@@ -20,7 +20,7 @@ import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Config ()
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract
                      (ShelleyProtocolHeader, pHeaderIssueNo, pHeaderIssuer,
-                     pHeaderVRFValue, protocolHeaderView)
+                     pTieBreakVRFValue, protocolHeaderView)
 
 {-------------------------------------------------------------------------------
   Support for Transitional Praos consensus algorithm
@@ -36,7 +36,7 @@ instance ShelleyCompatible proto era => BlockSupportsProtocol (ShelleyBlock prot
       , csvSlotNo      = blockSlot hdr
       , csvIssuer      = hdrIssuer
       , csvIssueNo     = pHeaderIssueNo shdr
-      , csvLeaderVRF   = pHeaderVRFValue shdr
+      , csvTieBreakVRF = pTieBreakVRFValue shdr
       }
     where
       hdrIssuer ::  SL.VKey 'SL.BlockIssuer (EraCrypto era)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
@@ -178,9 +178,9 @@ class ProtocolHeaderSupportsProtocol proto where
     ShelleyProtocolHeader proto -> VKey 'BlockIssuer (ProtoCrypto proto)
   pHeaderIssueNo ::
     ShelleyProtocolHeader proto -> Word64
-  -- | VRF value in the header, used to choose between otherwise equally
+  -- | A VRF value in the header, used to choose between otherwise equally
   -- preferable chains.
-  pHeaderVRFValue ::
+  pTieBreakVRFValue ::
     ShelleyProtocolHeader proto -> OutputVRF (VRF (ProtoCrypto proto))
 
 -- | Indicates that the protocol header supports the Shelley ledger. We may need

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
@@ -138,7 +138,13 @@ instance PraosCrypto c => ProtocolHeaderSupportsProtocol (Praos c) where
       }
   pHeaderIssuer = hbVk . headerBody
   pHeaderIssueNo = SL.ocertN . hbOCert . headerBody
-  pHeaderVRFValue = certifiedOutput . hbVrfRes . headerBody
+
+  -- This is the "unified" VRF value, prior to range extension which yields e.g.
+  -- the leader VRF value used for slot election.
+  --
+  -- In the future, we might want to use a dedicated range-extended VRF value
+  -- here instead.
+  pTieBreakVRFValue = certifiedOutput . hbVrfRes . headerBody
 
 instance PraosCrypto c => ProtocolHeaderSupportsLedger (Praos c) where
   mkHeaderView hdr@Header {headerBody} =

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -108,7 +108,13 @@ instance PraosCrypto c => ProtocolHeaderSupportsProtocol (TPraos c) where
   protocolHeaderView = id
   pHeaderIssuer = SL.bheaderVk . SL.bhbody
   pHeaderIssueNo = SL.ocertN . SL.bheaderOCert . SL.bhbody
-  pHeaderVRFValue = certifiedOutput . SL.bheaderL . SL.bhbody
+
+  -- As this is the leader VRF value, which is used for slot election in the
+  -- first place, it gives an advantage to smaller pools in a multi-leader slot.
+  -- This was not an intentional decision, see
+  -- https://github.com/input-output-hk/ouroboros-network/issues/4051 for a more
+  -- detailed discussion.
+  pTieBreakVRFValue = certifiedOutput . SL.bheaderL . SL.bhbody
 
 instance PraosCrypto c => ProtocolHeaderSupportsLedger (TPraos c) where
   mkHeaderView = SL.makeHeaderView


### PR DESCRIPTION
# Description

Update/correct potentially misleading names of VRF-related functions (in particular `csvLeaderVRF`), and provide context for why a particular VRF value is used for tie breaking.   

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
