### PR TITLE
Removed forecasting in forge logic

### DIFF
--- a/ouroboros-consensus/docs/interface-CHANGELOG.md
+++ b/ouroboros-consensus/docs/interface-CHANGELOG.md
@@ -56,6 +56,14 @@ may appear out of chronological order.
 The internals of each entry are organized similar to
 https://keepachangelog.com/en/1.1.0/, adapted to our plan explained above.
 
+## Circa 2022-10-25
+
+### Changed
+
+- The ordering of the events emited by the forging logic has changed. In particular:
+  - `TraceForgeTickedLedgerState` happens just before `TraceLedgerView`.
+  - `TraceNoLedgerView` will never be emitted.
+
 ## Circa 2022-09-30
 
 ### Fixed


### PR DESCRIPTION
# Description

As described in the comment, ticking and forecasting would produce the same result under the circumstances that take place on the forging loop, also as described by Section 5.2.3 of the Consensus Report.

Doing both calls is wasting performance, and doing just the ticking should be enough.

There is however the question about whether this violation of the Chain Growth invariant is acceptable or not. In case it is not, it seems that we can know if something is `OutsideForecastRange` without calling `TICKF` so maybe it is worth performing that check in the forging logic and at least we would be in the same situation as before this change and with one less expensive call.

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
