### PR TITLE
Allow chain selection for different blocks with same `SelectView`

### DIFF
--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -181,7 +181,7 @@ instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
           InPairs.RequireBoth $ \(WrapLedgerConfig cfg1) (WrapLedgerConfig cfg2) ->
             HFC.TranslateForecast $ forecastAcrossShelley cfg1 cfg2
 
-  hardForkChainSel = Tails.mk2 SelectSameProtocol
+  hardForkChainSel = Tails.mk2 CompareSameSelectView
 
   hardForkInjectTxs =
         InPairs.mk2

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -308,25 +308,16 @@ instance CardanoHardForkConstraints c => CanHardFork (CardanoEras c) where
               :* CompareBlockNo
               :* Nil)
         -- Shelley <-> Allegra, ...
-      $ TCons (SelectSameProtocol :* SelectSameProtocol :* SelectSameProtocol :* alonzoBabbageEraSelection :* Nil)
+      $ TCons (CompareSameSelectView :* CompareSameSelectView :* CompareSameSelectView :* CompareSameSelectView :* Nil)
         -- Allegra <-> Mary, ...
-      $ TCons (SelectSameProtocol :* SelectSameProtocol :* alonzoBabbageEraSelection :* Nil)
+      $ TCons (CompareSameSelectView :* CompareSameSelectView :* CompareSameSelectView :* Nil)
         -- Mary <-> Alonzo, ...
-      $ TCons (SelectSameProtocol :* alonzoBabbageEraSelection :* Nil)
+      $ TCons (CompareSameSelectView :* CompareSameSelectView :* Nil)
         -- Alonzo <-> Babbage, ...
-      $ TCons (alonzoBabbageEraSelection :* Nil)
+      $ TCons (CompareSameSelectView :* Nil)
         -- Babbage <-> ...
       $ TCons Nil
       $ TNil
-    where
-      -- Across alonzo and Babbage, the protocol changes, but the select view
-      -- remains the same.
-      alonzoBabbageEraSelection :: AcrossEraSelection
-        (ShelleyBlock (TPraos c) e1)
-        (ShelleyBlock (Praos c) e2)
-      alonzoBabbageEraSelection = CustomChainSel (
-          \l r -> compare l (coerce r)
-        )
   hardForkInjectTxs =
         PCons (ignoringBoth $ Pair2 cannotInjectTx cannotInjectValidatedTx)
       $ PCons (   ignoringBoth

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -30,7 +30,7 @@ import           Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (listToMaybe, mapMaybe)
 import           Data.Proxy
-import           Data.SOP.Strict (NP (..), unComp, (:.:) (..))
+import           Data.SOP.Strict (hpure, unComp, (:.:) (..))
 import           Data.Word
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
@@ -57,10 +57,12 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
                      (RequiringBoth (..), ignoringBoth)
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Tails (Tails (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 
 import           Ouroboros.Consensus.Byron.Ledger
 import qualified Ouroboros.Consensus.Byron.Ledger.Inspect as Byron.Inspect
 import           Ouroboros.Consensus.Byron.Node ()
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT (PBft, PBftCrypto)
 import           Ouroboros.Consensus.Protocol.PBFT.State (PBftState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as PBftState
@@ -301,23 +303,9 @@ instance CardanoHardForkConstraints c => CanHardFork (CardanoEras c) where
     }
   hardForkChainSel =
         -- Byron <-> Shelley, ...
-        TCons (  CompareBlockNo
-              :* CompareBlockNo
-              :* CompareBlockNo
-              :* CompareBlockNo
-              :* CompareBlockNo
-              :* Nil)
-        -- Shelley <-> Allegra, ...
-      $ TCons (CompareSameSelectView :* CompareSameSelectView :* CompareSameSelectView :* CompareSameSelectView :* Nil)
-        -- Allegra <-> Mary, ...
-      $ TCons (CompareSameSelectView :* CompareSameSelectView :* CompareSameSelectView :* Nil)
-        -- Mary <-> Alonzo, ...
-      $ TCons (CompareSameSelectView :* CompareSameSelectView :* Nil)
-        -- Alonzo <-> Babbage, ...
-      $ TCons (CompareSameSelectView :* Nil)
-        -- Babbage <-> ...
-      $ TCons Nil
-      $ TNil
+        TCons (hpure CompareBlockNo)
+        -- Inter-Shelley-based
+      $ Tails.hcpure (Proxy @(HasPraosSelectView c)) CompareSameSelectView
   hardForkInjectTxs =
         PCons (ignoringBoth $ Pair2 cannotInjectTx cannotInjectValidatedTx)
       $ PCons (   ignoringBoth
@@ -345,6 +333,9 @@ instance CardanoHardForkConstraints c => CanHardFork (CardanoEras c) where
                   (translateValidatedTxAlonzoToBabbageWrapper ctxt)
               )
       $ PNil
+
+class    (SelectView (BlockProtocol blk) ~ PraosChainSelectView c) => HasPraosSelectView c blk
+instance (SelectView (BlockProtocol blk) ~ PraosChainSelectView c) => HasPraosSelectView c blk
 
 {-------------------------------------------------------------------------------
   Translation from Byron to Shelley

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -46,17 +46,6 @@ data AcrossEraSelection :: Type -> Type -> Type where
        SelectView (BlockProtocol x) ~ SelectView (BlockProtocol y)
     => AcrossEraSelection x y
 
-  -- | Custom chain selection
-  --
-  -- This is the most general form, and allows to override chain selection for
-  -- the specific combination of two eras with a custom comparison function.
-  CustomChainSel ::
-       (    SelectView (BlockProtocol x)
-         -> SelectView (BlockProtocol y)
-         -> Ordering
-       )
-    -> AcrossEraSelection x y
-
 {-------------------------------------------------------------------------------
   Compare two eras
 -------------------------------------------------------------------------------}
@@ -70,7 +59,6 @@ acrossEras ::
 acrossEras (WithBlockNo bnoL (WrapSelectView l))
            (WithBlockNo bnoR (WrapSelectView r)) = \case
     CompareBlockNo        -> compare bnoL bnoR
-    CustomChainSel f      -> f l r
     CompareSameSelectView -> compare l r
 
 acrossEraSelection ::

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -39,18 +39,11 @@ data AcrossEraSelection :: Type -> Type -> Type where
   -- protocols, and we just want to choose the longer chain.
   CompareBlockNo :: AcrossEraSelection x y
 
-  -- | Two eras running the same protocol
-  --
-  -- In this case, we can just call @compareChains@ even across eras.
-  -- (The 'ChainSelConfig' must also be the same in both eras: we assert this
-  -- at the value level.)
-  --
-  -- NOTE: We require that the eras have the same /protocol/, not merely the
-  -- same 'SelectView', because if we have two eras with different protocols
-  -- that happen to use the same 'SelectView' but a different way to compare
-  -- chains, it's not clear how to do cross-era selection.
-  SelectSameProtocol ::
-       BlockProtocol x ~ BlockProtocol y
+  -- | Two eras using the same 'SelectView'. In this case, we can just compare
+  -- chains even across eras, as the chain ordering is fully captured by
+  -- 'SelectView' and its 'Ord' instance.
+  CompareSameSelectView ::
+       SelectView (BlockProtocol x) ~ SelectView (BlockProtocol y)
     => AcrossEraSelection x y
 
   -- | Custom chain selection
@@ -76,9 +69,9 @@ acrossEras ::
   -> Ordering
 acrossEras (WithBlockNo bnoL (WrapSelectView l))
            (WithBlockNo bnoR (WrapSelectView r)) = \case
-    CompareBlockNo     -> compare bnoL bnoR
-    CustomChainSel f   -> f l r
-    SelectSameProtocol -> compare l r
+    CompareBlockNo        -> compare bnoL bnoR
+    CustomChainSel f      -> f l r
+    CompareSameSelectView -> compare l r
 
 acrossEraSelection ::
      All SingleEraBlock              xs


### PR DESCRIPTION
# Description

Clarify under which circumstances we can compare different blocks (see the first commit message), which enables boilerplate reduction in `hardForkChainSel` for the Cardano eras.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
