### PR TITLE
peer-selection: added TraceDemoteLocalAsynchronous trace

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -32,6 +32,7 @@ module Ouroboros.Network.PeerSelection.Governor
   ) where
 
 import           Data.Cache
+import           Data.Foldable (traverse_)
 import           Data.Semigroup (Min (..))
 import           Data.Void (Void)
 
@@ -505,7 +506,7 @@ peerSelectionGovernorLoop tracer
       let Decision { decisionTrace, decisionJobs, decisionState } =
             timedDecision now
           newCounters = peerStateToCounters decisionState
-      traceWith tracer decisionTrace
+      traverse_ (traceWith tracer) decisionTrace
       traceWithCache countersTracer
                      (countersCache decisionState)
                      newCounters
@@ -569,7 +570,7 @@ wakeupDecision :: PeerSelectionState peeraddr peerconn
                -> TimedDecision m peeraddr peerconn
 wakeupDecision st _now =
   Decision {
-    decisionTrace = TraceGovernorWakeup,
+    decisionTrace = [TraceGovernorWakeup],
     decisionState = st,
     decisionJobs  = []
   }

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -99,10 +99,10 @@ belowTargetLocal actions
           selectedToPromote' = EstablishedPeers.toMap establishedPeers
                                  `Map.restrictKeys` selectedToPromote
       return $ \_now -> Decision {
-        decisionTrace = TracePromoteWarmLocalPeers
-                          [ (target, Set.size membersActive)
-                          | (target, _, membersActive) <- groupsBelowTarget ]
-                          selectedToPromote,
+        decisionTrace = [TracePromoteWarmLocalPeers
+                           [ (target, Set.size membersActive)
+                           | (target, _, membersActive) <- groupsBelowTarget ]
+                           selectedToPromote],
         decisionState = st {
                           inProgressPromoteWarm = inProgressPromoteWarm
                                                <> selectedToPromote
@@ -177,10 +177,10 @@ belowTargetOther actions
           selectedToPromote' = EstablishedPeers.toMap establishedPeers
                                  `Map.restrictKeys` selectedToPromote
       return $ \_now -> Decision {
-        decisionTrace = TracePromoteWarmPeers
-                          targetNumberOfActivePeers
-                          numActivePeers
-                          selectedToPromote,
+        decisionTrace = [TracePromoteWarmPeers
+                           targetNumberOfActivePeers
+                           numActivePeers
+                           selectedToPromote],
         decisionState = st {
                           inProgressPromoteWarm = inProgressPromoteWarm
                                                <> selectedToPromote
@@ -260,9 +260,9 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                                               -- the failure.
                                               knownPeers in
                  Decision {
-                   decisionTrace = TracePromoteWarmFailed targetNumberOfActivePeers
-                                                          (Set.size activePeers)
-                                                          peeraddr e,
+                   decisionTrace = [TracePromoteWarmFailed targetNumberOfActivePeers
+                                                           (Set.size activePeers)
+                                                           peeraddr e],
                    decisionState = st {
                                      inProgressPromoteWarm = Set.delete peeraddr
                                                                (inProgressPromoteWarm st),
@@ -273,9 +273,9 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
                    decisionJobs  = []
                  }
             else Decision {
-                   decisionTrace = TracePromoteWarmAborted targetNumberOfActivePeers
-                                                           (Set.size activePeers)
-                                                           peeraddr,
+                   decisionTrace = [TracePromoteWarmAborted targetNumberOfActivePeers
+                                                            (Set.size activePeers)
+                                                            peeraddr],
                    decisionState = st,
                    decisionJobs  = []
                  }
@@ -296,9 +296,9 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
           then
             let activePeers' = Set.insert peeraddr activePeers in
             Decision {
-              decisionTrace = TracePromoteWarmDone targetNumberOfActivePeers
-                                                   (Set.size activePeers')
-                                                   peeraddr,
+              decisionTrace = [TracePromoteWarmDone targetNumberOfActivePeers
+                                                    (Set.size activePeers')
+                                                    peeraddr],
               decisionState = st {
                                 activePeers           = activePeers',
                                 inProgressPromoteWarm = Set.delete peeraddr
@@ -308,9 +308,9 @@ jobPromoteWarmPeer PeerSelectionActions{peerStateActions = PeerStateActions {act
             }
           else
             Decision {
-              decisionTrace = TracePromoteWarmAborted targetNumberOfActivePeers
-                                                      (Set.size activePeers)
-                                                      peeraddr,
+              decisionTrace = [TracePromoteWarmAborted targetNumberOfActivePeers
+                                                       (Set.size activePeers)
+                                                       peeraddr],
               decisionState = st,
               decisionJobs  = []
             }
@@ -391,10 +391,10 @@ aboveTargetLocal actions
                                 `Map.restrictKeys` selectedToDemote
 
       return $ \_now -> Decision {
-        decisionTrace = TraceDemoteLocalHotPeers
-                          [ (target, Set.size membersActive)
-                          | (target, _, membersActive) <- groupsAboveTarget ]
-                          selectedToDemote,
+        decisionTrace = [TraceDemoteLocalHotPeers
+                           [ (target, Set.size membersActive)
+                           | (target, _, membersActive) <- groupsAboveTarget ]
+                           selectedToDemote],
         decisionState = st {
                           inProgressDemoteHot = inProgressDemoteHot
                                              <> selectedToDemote
@@ -452,10 +452,10 @@ aboveTargetOther actions
                                 `Map.restrictKeys` selectedToDemote
 
       return $ \_now -> Decision {
-        decisionTrace = TraceDemoteHotPeers
-                          targetNumberOfActivePeers
-                          numActivePeers
-                          selectedToDemote,
+        decisionTrace = [TraceDemoteHotPeers
+                           targetNumberOfActivePeers
+                           numActivePeers
+                           selectedToDemote],
         decisionState = st {
                           inProgressDemoteHot = inProgressDemoteHot
                                              <> selectedToDemote
@@ -514,8 +514,8 @@ jobDemoteActivePeer PeerSelectionActions{peerStateActions = PeerStateActions {de
                                      peerSet
                                      establishedPeers in
         Decision {
-        decisionTrace = TraceDemoteHotFailed targetNumberOfActivePeers
-                                             (Set.size activePeers) peeraddr e,
+        decisionTrace = [TraceDemoteHotFailed targetNumberOfActivePeers
+                                              (Set.size activePeers) peeraddr e],
         decisionState = st {
                           inProgressDemoteHot = inProgressDemoteHot',
                           fuzzRng = fuzzRng',
@@ -541,9 +541,9 @@ jobDemoteActivePeer PeerSelectionActions{peerStateActions = PeerStateActions {de
         let activePeers' = Set.delete peeraddr activePeers
             knownPeers'  = setTepidFlag peeraddr knownPeers in
         Decision {
-          decisionTrace = TraceDemoteHotDone targetNumberOfActivePeers
-                                             (Set.size activePeers')
-                                             peeraddr,
+          decisionTrace = [TraceDemoteHotDone targetNumberOfActivePeers
+                                              (Set.size activePeers')
+                                              peeraddr],
           decisionState = st {
                             activePeers         = activePeers',
                             knownPeers          = knownPeers',

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -109,10 +109,10 @@ belowTargetLocal actions
                              availableToPromote
                              numPeersToPromote
       return $ \_now -> Decision {
-        decisionTrace = TracePromoteColdLocalPeers
-                          targetNumberOfLocalPeers
-                          numLocalEstablishedPeers
-                          selectedToPromote,
+        decisionTrace = [TracePromoteColdLocalPeers
+                           targetNumberOfLocalPeers
+                           numLocalEstablishedPeers
+                           selectedToPromote],
         decisionState = st {
                           inProgressPromoteCold = inProgressPromoteCold
                                                <> selectedToPromote
@@ -192,10 +192,10 @@ belowTargetOther actions
                              availableToPromote
                              numPeersToPromote
       return $ \_now -> Decision {
-        decisionTrace = TracePromoteColdPeers
-                          targetNumberOfEstablishedPeers
-                          numEstablishedPeers
-                          selectedToPromote,
+        decisionTrace = [TracePromoteColdPeers
+                           targetNumberOfEstablishedPeers
+                           numEstablishedPeers
+                           selectedToPromote],
         decisionState = st {
                           inProgressPromoteCold = inProgressPromoteCold
                                                <> selectedToPromote
@@ -262,9 +262,9 @@ jobPromoteColdPeer PeerSelectionActions {
                       )
         in
           Decision {
-            decisionTrace = TracePromoteColdFailed targetNumberOfEstablishedPeers
-                                                   (EstablishedPeers.size establishedPeers)
-                                                   peeraddr delay e,
+            decisionTrace = [TracePromoteColdFailed targetNumberOfEstablishedPeers
+                                                    (EstablishedPeers.size establishedPeers)
+                                                    peeraddr delay e],
             decisionState = st {
                               knownPeers            = KnownPeers.setConnectTimes
                                                         (Map.singleton
@@ -299,9 +299,9 @@ jobPromoteColdPeer PeerSelectionActions {
                                         knownPeers
 
         in Decision {
-             decisionTrace = TracePromoteColdDone targetNumberOfEstablishedPeers
-                                                  (EstablishedPeers.size establishedPeers')
-                                                  peeraddr,
+             decisionTrace = [TracePromoteColdDone targetNumberOfEstablishedPeers
+                                                   (EstablishedPeers.size establishedPeers')
+                                                   peeraddr],
              decisionState = st {
                                establishedPeers      = establishedPeers',
                                inProgressPromoteCold = Set.delete peeraddr
@@ -382,10 +382,10 @@ aboveTarget actions
                                 `Map.restrictKeys` selectedToDemote
 
       return $ \_now -> Decision {
-        decisionTrace = TraceDemoteWarmPeers
-                          targetNumberOfEstablishedPeers
-                          numEstablishedPeers
-                          selectedToDemote,
+        decisionTrace = [TraceDemoteWarmPeers
+                           targetNumberOfEstablishedPeers
+                           numEstablishedPeers
+                           selectedToDemote],
         decisionState = st {
                           inProgressDemoteWarm = inProgressDemoteWarm
                                               <> selectedToDemote
@@ -440,9 +440,9 @@ jobDemoteEstablishedPeer PeerSelectionActions{peerStateActions = PeerStateAction
                                      peerSet
                                      establishedPeers in
         Decision {
-        decisionTrace = TraceDemoteWarmFailed targetNumberOfEstablishedPeers
-                                              (EstablishedPeers.size establishedPeers)
-                                              peeraddr e,
+        decisionTrace = [TraceDemoteWarmFailed targetNumberOfEstablishedPeers
+                                               (EstablishedPeers.size establishedPeers)
+                                               peeraddr e],
         decisionState = st {
                           inProgressDemoteWarm = inProgressDemoteWarm',
                           fuzzRng = fuzzRng',
@@ -465,9 +465,9 @@ jobDemoteEstablishedPeer PeerSelectionActions{peerStateActions = PeerStateAction
         let establishedPeers' = EstablishedPeers.delete peeraddr
                                                         establishedPeers
         in Decision {
-             decisionTrace = TraceDemoteWarmDone targetNumberOfEstablishedPeers
-                                                 (EstablishedPeers.size establishedPeers')
-                                                 peeraddr,
+             decisionTrace = [TraceDemoteWarmDone targetNumberOfEstablishedPeers
+                                                  (EstablishedPeers.size establishedPeers')
+                                                  peeraddr],
              decisionState = st {
                                establishedPeers     = establishedPeers',
                                inProgressDemoteWarm = Set.delete peeraddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -64,11 +64,11 @@ belowTarget actions
                              numGossipReqsPossible
       let numGossipReqs = Set.size selectedForGossip
       return $ \now -> Decision {
-        decisionTrace = TraceGossipRequests
-                          targetNumberOfKnownPeers
-                          numKnownPeers
-                          availableForGossip
-                          selectedForGossip,
+        decisionTrace = [TraceGossipRequests
+                           targetNumberOfKnownPeers
+                           numKnownPeers
+                           availableForGossip
+                           selectedForGossip],
         decisionState = st {
                           inProgressGossipReqs = inProgressGossipReqs
                                                + numGossipReqs,
@@ -111,7 +111,7 @@ jobGossip PeerSelectionActions{requestPeerGossip}
     handler peers e = return $
       Completion $ \st _ ->
       Decision {
-        decisionTrace = TraceGossipResults [ (p, Left e) | p <- peers ],
+        decisionTrace = [TraceGossipResults [ (p, Left e) | p <- peers ]],
         decisionState = st {
                           inProgressGossipReqs = inProgressGossipReqs st
                                                - length peers
@@ -136,7 +136,7 @@ jobGossip PeerSelectionActions{requestPeerGossip}
           let peerResults = zip peers totalResults
               newPeers    = [ p | Right ps <- totalResults, p <- ps ]
           return $ Completion $ \st _ -> Decision {
-            decisionTrace = TraceGossipResults peerResults,
+            decisionTrace = [TraceGossipResults peerResults],
             decisionState = st {
                               --TODO: also update with the failures
                               knownPeers = KnownPeers.insert
@@ -165,7 +165,7 @@ jobGossip PeerSelectionActions{requestPeerGossip}
                                  | (a, Nothing) <- zip gossips partialResults ]
 
           return $ Completion $ \st _ -> Decision {
-            decisionTrace = TraceGossipResults peerResults,
+            decisionTrace = [TraceGossipResults peerResults],
             decisionState = st {
                               --TODO: also update with the failures
                               knownPeers = KnownPeers.insert
@@ -210,7 +210,7 @@ jobGossip PeerSelectionActions{requestPeerGossip}
       mapM_ cancel gossipsIncomplete
 
       return $ Completion $ \st _ -> Decision {
-        decisionTrace = TraceGossipResults peerResults,
+        decisionTrace = [TraceGossipResults peerResults],
         decisionState = st {
                           --TODO: also update with the failures
                           knownPeers = KnownPeers.insert
@@ -303,10 +303,10 @@ aboveTarget PeerSelectionPolicy {
                     (KnownPeers.toSet knownPeers'))
 
               Decision {
-                decisionTrace = TraceForgetColdPeers
-                                  targetNumberOfKnownPeers
-                                  numKnownPeers
-                                  selectedToForget,
+                decisionTrace = [TraceForgetColdPeers
+                                   targetNumberOfKnownPeers
+                                   numKnownPeers
+                                   selectedToForget],
                 decisionState = st { knownPeers      = knownPeers',
                                      publicRootPeers = publicRootPeers' },
                 decisionJobs  = []

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/RootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/RootPeers.hs
@@ -46,9 +46,9 @@ belowTarget actions
   , blockedAt >= publicRootRetryTime
   = Guarded Nothing $
       return $ \_now -> Decision {
-        decisionTrace = TracePublicRootsRequest
-                          targetNumberOfRootPeers
-                          numRootPeers,
+        decisionTrace = [TracePublicRootsRequest
+                           targetNumberOfRootPeers
+                           numRootPeers],
         decisionState = st { inProgressPublicRootsReq = True },
         decisionJobs  = [jobReqPublicRootPeers actions maxExtraRootPeers]
       }
@@ -92,10 +92,10 @@ jobReqPublicRootPeers PeerSelectionActions{requestPublicRootPeers}
           publicRootRetryTime'     :: Time
           publicRootRetryTime'     = addTime publicRootRetryDiffTime' now
        in Decision {
-            decisionTrace = TracePublicRootsFailure
-                              e
-                              publicRootBackoffs'
-                              publicRootRetryDiffTime',
+            decisionTrace = [TracePublicRootsFailure
+                               e
+                               publicRootBackoffs'
+                               publicRootRetryDiffTime'],
             decisionState = st {
                               inProgressPublicRootsReq = False,
                               publicRootBackoffs  = publicRootBackoffs',
@@ -140,10 +140,10 @@ jobReqPublicRootPeers PeerSelectionActions{requestPublicRootPeers}
                      (KnownPeers.toSet knownPeers'))
 
              Decision {
-                decisionTrace = TracePublicRootsResults
-                                  newPeers
-                                  publicRootBackoffs'
-                                  publicRootRetryDiffTime,
+                decisionTrace = [TracePublicRootsResults
+                                   newPeers
+                                   publicRootBackoffs'
+                                   publicRootRetryDiffTime],
                 decisionState = st {
                                   publicRootPeers     = publicRootPeers',
                                   knownPeers          = knownPeers',

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -547,7 +547,7 @@ instance Alternative m => Semigroup (Guarded m a) where
 
 data Decision m peeraddr peerconn = Decision {
          -- | A trace event to classify the decision and action
-       decisionTrace :: TracePeerSelection peeraddr,
+       decisionTrace :: [TracePeerSelection peeraddr],
 
          -- | An updated state to use immediately
        decisionState :: PeerSelectionState peeraddr peerconn,
@@ -618,7 +618,7 @@ data TracePeerSelection peeraddr =
      -- | target established, actual established, selected peers
      | TraceDemoteWarmPeers    Int Int (Set peeraddr)
      -- | target established, actual established, peer, reason
-     | TraceDemoteWarmFailed   Int Int  peeraddr SomeException
+     | TraceDemoteWarmFailed   Int Int peeraddr SomeException
      -- | target established, actual established, peer
      | TraceDemoteWarmDone     Int Int peeraddr
      -- | target active, actual active, selected peers
@@ -629,7 +629,8 @@ data TracePeerSelection peeraddr =
      | TraceDemoteHotFailed    Int Int peeraddr SomeException
      -- | target active, actual active, peer
      | TraceDemoteHotDone      Int Int peeraddr
-     | TraceDemoteAsynchronous (Map peeraddr (PeerStatus, Maybe ReconnectDelay))
+     | TraceDemoteAsynchronous      (Map peeraddr (PeerStatus, Maybe ReconnectDelay))
+     | TraceDemoteLocalAsynchronous (Map peeraddr (PeerStatus, Maybe ReconnectDelay))
      | TraceGovernorWakeup
      | TraceChurnWait          DiffTime
      | TraceChurnMode          ChurnMode

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -556,34 +556,35 @@ collectTraces trace =
     Set.fromList [ traceNum e | (_, GovernorEvent e) <- trace ]
 
 traceNum :: TracePeerSelection peeraddr -> Int
-traceNum TraceLocalRootPeersChanged{} = 00
-traceNum TraceTargetsChanged{}        = 01
-traceNum TracePublicRootsRequest{}    = 02
-traceNum TracePublicRootsResults{}    = 03
-traceNum TracePublicRootsFailure{}    = 04
-traceNum TraceGossipRequests{}        = 05
-traceNum TraceGossipResults{}         = 06
-traceNum TraceForgetColdPeers{}       = 07
-traceNum TracePromoteColdPeers{}      = 08
-traceNum TracePromoteColdLocalPeers{} = 09
-traceNum TracePromoteColdFailed{}     = 10
-traceNum TracePromoteColdDone{}       = 11
-traceNum TracePromoteWarmPeers{}      = 12
-traceNum TracePromoteWarmLocalPeers{} = 13
-traceNum TracePromoteWarmFailed{}     = 14
-traceNum TracePromoteWarmDone{}       = 15
-traceNum TraceDemoteWarmPeers{}       = 16
-traceNum TraceDemoteWarmFailed{}      = 17
-traceNum TraceDemoteWarmDone{}        = 18
-traceNum TraceDemoteHotPeers{}        = 19
-traceNum TraceDemoteLocalHotPeers{}   = 20
-traceNum TraceDemoteHotFailed{}       = 21
-traceNum TraceDemoteHotDone{}         = 22
-traceNum TraceDemoteAsynchronous{}    = 23
-traceNum TraceGovernorWakeup{}        = 24
-traceNum TraceChurnWait{}             = 25
-traceNum TraceChurnMode{}             = 26
-traceNum TracePromoteWarmAborted{}    = 27
+traceNum TraceLocalRootPeersChanged{}   = 00
+traceNum TraceTargetsChanged{}          = 01
+traceNum TracePublicRootsRequest{}      = 02
+traceNum TracePublicRootsResults{}      = 03
+traceNum TracePublicRootsFailure{}      = 04
+traceNum TraceGossipRequests{}          = 05
+traceNum TraceGossipResults{}           = 06
+traceNum TraceForgetColdPeers{}         = 07
+traceNum TracePromoteColdPeers{}        = 08
+traceNum TracePromoteColdLocalPeers{}   = 09
+traceNum TracePromoteColdFailed{}       = 10
+traceNum TracePromoteColdDone{}         = 11
+traceNum TracePromoteWarmPeers{}        = 12
+traceNum TracePromoteWarmLocalPeers{}   = 13
+traceNum TracePromoteWarmFailed{}       = 14
+traceNum TracePromoteWarmDone{}         = 15
+traceNum TraceDemoteWarmPeers{}         = 16
+traceNum TraceDemoteWarmFailed{}        = 17
+traceNum TraceDemoteWarmDone{}          = 18
+traceNum TraceDemoteHotPeers{}          = 19
+traceNum TraceDemoteLocalHotPeers{}     = 20
+traceNum TraceDemoteHotFailed{}         = 21
+traceNum TraceDemoteHotDone{}           = 22
+traceNum TraceDemoteAsynchronous{}      = 23
+traceNum TraceGovernorWakeup{}          = 24
+traceNum TraceChurnWait{}               = 25
+traceNum TraceChurnMode{}               = 26
+traceNum TracePromoteWarmAborted{}      = 27
+traceNum TraceDemoteLocalAsynchronous{} = 28
 
 allTraceNames :: Map Int String
 allTraceNames =
@@ -614,7 +615,9 @@ allTraceNames =
    , (23, "TraceDemoteAsynchronous")
    , (24, "TraceGovernorWakeup")
    , (25, "TraceChurnWait")
-   , (26, "TracePromoteWarmAborted")
+   , (26, "TraceChurnMode")
+   , (27, "TracePromoteWarmAborted")
+   , (28, "TraceDemoteAsynchronous")
    ]
 
 
@@ -1644,6 +1647,11 @@ prop_governor_target_established_below env =
                        | otherwise         -> Just failures
                        where
                          failures = Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
+                     TraceDemoteLocalAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
                      TracePromoteWarmFailed _ _ peer _ ->
                        Just (Set.singleton peer)
                      _ -> Nothing
@@ -1727,6 +1735,11 @@ prop_governor_target_active_below env =
                        Just (Set.singleton peer)
                      --TODO
                      TraceDemoteAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
+                     TraceDemoteLocalAsynchronous status
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
@@ -1951,6 +1964,11 @@ prop_governor_target_established_local env =
                        | otherwise         -> Just failures
                        where
                          failures = Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
+                     TraceDemoteLocalAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
                      TracePromoteWarmFailed _ _ peer _ ->
                        Just (Set.singleton peer)
                      _ -> Nothing
@@ -2036,6 +2054,11 @@ prop_governor_target_active_local_below env =
                        Just (Set.singleton peer)
                      --TODO
                      TraceDemoteAsynchronous status
+                       | Set.null failures -> Nothing
+                       | otherwise         -> Just failures
+                       where
+                         failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
+                     TraceDemoteLocalAsynchronous status
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
@@ -548,7 +548,7 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
         "TracePromoteColdPeers"
       peerSelectionTraceMap (TracePromoteColdLocalPeers _ _ _)  =
         "TracePromoteColdLocalPeers"
-      peerSelectionTraceMap (TracePromoteColdFailed _ _ _ _ _) =
+      peerSelectionTraceMap (TracePromoteColdFailed _ _ _ _ _)  =
         "TracePromoteColdFailed"
       peerSelectionTraceMap (TracePromoteColdDone _ _ _)        =
         "TracePromoteColdDone"
@@ -556,7 +556,7 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
         "TracePromoteWarmPeers"
       peerSelectionTraceMap (TracePromoteWarmLocalPeers _ _)    =
         "TracePromoteWarmLocalPeers"
-      peerSelectionTraceMap (TracePromoteWarmFailed _ _ _ _)   =
+      peerSelectionTraceMap (TracePromoteWarmFailed _ _ _ _)    =
         "TracePromoteWarmFailed"
       peerSelectionTraceMap (TracePromoteWarmDone _ _ _)        =
         "TracePromoteWarmDone"
@@ -564,7 +564,7 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
         "TracePromoteWarmAborted"
       peerSelectionTraceMap (TraceDemoteWarmPeers _ _ _)        =
         "TraceDemoteWarmPeers"
-      peerSelectionTraceMap (TraceDemoteWarmFailed _ _ _ _)    =
+      peerSelectionTraceMap (TraceDemoteWarmFailed _ _ _ _)     =
         "TraceDemoteWarmFailed"
       peerSelectionTraceMap (TraceDemoteWarmDone _ _ _)         =
         "TraceDemoteWarmDone"
@@ -572,12 +572,14 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
         "TraceDemoteHotPeers"
       peerSelectionTraceMap (TraceDemoteLocalHotPeers _ _)      =
         "TraceDemoteLocalHotPeers"
-      peerSelectionTraceMap (TraceDemoteHotFailed _ _ _ _)     =
+      peerSelectionTraceMap (TraceDemoteHotFailed _ _ _ _)      =
         "TraceDemoteHotFailed"
       peerSelectionTraceMap (TraceDemoteHotDone _ _ _)          =
         "TraceDemoteHotDone"
       peerSelectionTraceMap (TraceDemoteAsynchronous _)         =
         "TraceDemoteAsynchronous"
+      peerSelectionTraceMap (TraceDemoteLocalAsynchronous _)    =
+        "TraceDemoteLocalAsynchronous"
       peerSelectionTraceMap TraceGovernorWakeup                 =
         "TraceGovernorWakeup"
       peerSelectionTraceMap (TraceChurnWait _)                  =
@@ -1253,6 +1255,12 @@ prop_diffusion_target_established_local defaultBearerInfo diffScript =
                          where
                            failures =
                              Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
+                       TraceDemoteLocalAsynchronous status
+                         | Set.null failures -> Nothing
+                         | otherwise         -> Just failures
+                         where
+                           failures =
+                             Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
                        TracePromoteWarmFailed _ _ peer _ ->
                          Just (Set.singleton peer)
                        _ -> Nothing
@@ -1407,6 +1415,11 @@ prop_diffusion_target_active_below defaultBearerInfo diffScript =
                          | otherwise         -> Just failures
                          where
                            failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
+                       TraceDemoteLocalAsynchronous status
+                         | Set.null failures -> Nothing
+                         | otherwise         -> Just failures
+                         where
+                           failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
                        _ -> Nothing
                 )
             . selectDiffusionPeerSelectionEvents
@@ -1548,6 +1561,13 @@ prop_diffusion_target_active_local_below defaultBearerInfo diffScript =
                          --TODO: the simulation does not yet cause this to happen
                          Just (Set.singleton peer)
                        TraceDemoteAsynchronous status
+                         | Set.null failures -> Nothing
+                         | otherwise         -> Just failures
+                         where
+                           -- unlike in the governor case we take into account
+                           -- all asynchronous demotions
+                           failures = Map.keysSet status
+                       TraceDemoteLocalAsynchronous status
                          | Set.null failures -> Nothing
                          | otherwise         -> Just failures
                          where
@@ -1720,6 +1740,10 @@ prop_diffusion_async_demotions defaultBearerInfo diffScript =
                          where
                            demotions = Set.singleton (remoteAddress connId)
                        DiffusionPeerSelectionTrace (TraceDemoteAsynchronous status) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Map.keysSet (Map.filter ((==PeerCold) . fst) status)
+                       DiffusionPeerSelectionTrace (TraceDemoteLocalAsynchronous status) ->
                            Just $ Left (Just failures)
                          where
                            failures = Map.keysSet (Map.filter ((==PeerCold) . fst) status)


### PR DESCRIPTION
For SPOs it's quite important to track these demotions.  This trace must
have at least `Warning` severity.
