### PR TITLE
github-actions: use $GITHUB_OUTPUT variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,27 +125,14 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: "Configure cabal.project.local"
+      if: runner.os != 'Windows'
       run: |
-        # running cabal configure overrides every other configuration already
-        # present in the cabal.project.local file so it is quite disruptive. By
-        # manually adding the options we want, this is always consistent.
-        cat ./cabal.project.local.ci >> ./cabal.project.local
+        cp .github/workflows/cabal.project.local.Linux cabal.project.local
 
-        cat >> cabal.project.local <<EOF
-
-        -- Add strcittvar check
-        package io-classes
-          flags: +checktvarinvariant
-
-        package cardano-crypto-praos
-          flags: -external-libsodium-vrf
-
-        -- cabal configure --enable-tests
-        ignore-project: False
-        tests: True
-        EOF
-
-        cat ./cabal.project.local
+    - name: "Configure cabal.project.local Windows"
+      if: runner.os == 'Windows'
+      run: |
+        cp .github/workflows/cabal.project.local.Windows cabal.project.local
 
     - name: Record dependencies
       id: record-deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
 
         ghc --version
         cabal --version
-        echo "::set-output name=cabal-store::$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store"
+        echo "cabal-store=$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store" >> $GITHUB_OUTPUT
 
     - name: Update Hackage index
       run: cabal update
@@ -152,7 +152,7 @@ jobs:
       run: |
         cabal build all --dry-run
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
-        echo "::set-output name=weeknum::$(/bin/date -u "+%W")"
+        echo "weeknum=$(/bin/date -u "+%W")" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       name: "Cache `cabal store`"

--- a/.github/workflows/cabal.project.local.Linux
+++ b/.github/workflows/cabal.project.local.Linux
@@ -1,5 +1,7 @@
 max-backjumps: 5000
 reorder-goals: True
+ignore-project: False
+tests: True
 
 package Win32-network
   ghc-options: -Werror
@@ -9,13 +11,13 @@ package ntp-client
   ghc-options: -Werror
   flags: +demo
 
-package io-sim-classes
-  ghc-options: -Werror
-  flags: +asserts
-
 package io-sim
   ghc-options: -Werror
   flags: +asserts
+
+-- Add strcittvar check
+package io-classes
+  flags: +checktvarinvariant
 
 package monoidal-synchronisation
   ghc-options: -Werror
@@ -43,3 +45,6 @@ package ouroboros-network
 
 package cardano-client
   ghc-options: -Werror
+
+package cardano-crypto-praos
+  flags: -external-libsodium-vrf

--- a/.github/workflows/cabal.project.local.Windows
+++ b/.github/workflows/cabal.project.local.Windows
@@ -1,0 +1,71 @@
+max-backjumps: 5000
+reorder-goals: True
+ignore-project: False
+tests: True
+
+package Win32-network
+  ghc-options: -Werror
+  flags: +demo
+
+package ntp-client
+  ghc-options: -Werror
+  flags: +demo
+
+package io-sim
+  ghc-options: -Werror
+  flags: +asserts
+
+-- Add strcittvar check
+package io-classes
+  flags: +checktvarinvariant
+
+package monoidal-synchronisation
+  ghc-options: -Werror
+
+package typed-protocols
+  ghc-options: -Werror
+
+package typed-protocols-examples
+  ghc-options: -Werror
+  flags:
+
+package network-mux
+  ghc-options: -Werror
+  flags: +ipv6 +asserts
+
+package ouroboros-network-testing
+  ghc-options: -Werror
+
+package ouroboros-network-framework
+  ghc-options: -Werror
+
+package ouroboros-network
+  ghc-options: -Werror
+  flags: +ipv6 +cddl +asserts
+
+package cardano-client
+  ghc-options: -Werror
+
+package cardano-crypto-praos
+  flags: -external-libsodium-vrf
+
+package HsOpenSSL
+  extra-include-dirs: D:/a/_temp/msys64/mingw64/include
+  extra-lib-dirs: D:/a/_temp/msys64/mingw64/lib
+  flags: +use-pkg-config
+
+package secp256k1-haskell
+  extra-include-dirs: D:/a/_temp/msys64/mingw64/include
+  extra-lib-dirs: D:/a/_temp/msys64/mingw64/lib
+
+package basement
+  extra-include-dirs: D:/a/_temp/msys64/mingw64/include
+  extra-lib-dirs: D:/a/_temp/msys64/mingw64/lib
+
+package cardano-crypto-class
+  extra-include-dirs: D:/a/_temp/msys64/mingw64/include
+  extra-lib-dirs: D:/a/_temp/msys64/mingw64/lib
+
+package cardano-crypto-praos
+  extra-include-dirs: D:/a/_temp/msys64/mingw64/include
+  extra-lib-dirs: D:/a/_temp/msys64/mingw64/lib

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,8 @@ doc/protocols.pdf
 doc/protocols.toc
 
 .ghc.environment.*
-cabal.project.local*
-cabal.project.local~
-!cabal.project.local.ci
+/cabal.project.local*
+/cabal.project.local~
 !cabal.project.local.github-pages
 dist-newstyle/
 dist/


### PR DESCRIPTION
Removes a waning, see [GitHub's annoucment](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).