### PR TITLE
log handshake error in state peer actions

### DIFF
--- a/docs/interface-CHANGELOG.md
+++ b/docs/interface-CHANGELOG.md
@@ -5,6 +5,10 @@ team.  See [consensus
 CHANGELOG](../ouroboros-consensus/docs/interface-CHANGELOG.md) file for how
 this changelog is supposed to be used.
 
+## Circa 2022-11-07
+
+- Improved `outbound-governor`'s `FailureType`: now includes handshake error.
+
 ## Circa 2022-10-11
 
 - `PeerSelectionCounters` includes local peers information.

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -137,7 +137,7 @@ data TracersExtra ntnAddr ntnVersion ntnVersionData
         :: Tracer m PeerSelectionCounters
 
     , dtPeerSelectionActionsTracer
-        :: Tracer m (PeerSelectionActionsTrace ntnAddr)
+        :: Tracer m (PeerSelectionActionsTrace ntnAddr ntnVersion)
 
     , dtConnectionManagerTracer
         :: Tracer m (ConnectionManagerTrace

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
@@ -165,7 +165,7 @@ data DiffusionTestTrace =
       DiffusionLocalRootPeerTrace (TraceLocalRootPeers NtNAddr SomeException)
     | DiffusionPublicRootPeerTrace TracePublicRootPeers
     | DiffusionPeerSelectionTrace (TracePeerSelection NtNAddr)
-    | DiffusionPeerSelectionActionsTrace (PeerSelectionActionsTrace NtNAddr)
+    | DiffusionPeerSelectionActionsTrace (PeerSelectionActionsTrace NtNAddr NtNVersion)
     | DiffusionDebugPeerSelectionTrace (DebugPeerSelection NtNAddr)
     | DiffusionConnectionManagerTrace
         (ConnectionManagerTrace NtNAddr
@@ -468,7 +468,7 @@ prop_peer_selection_action_trace_coverage defaultBearerInfo diffScript =
                                 tracerDiffusionSimWithTimeName
                                 nullTracer
 
-      events :: [PeerSelectionActionsTrace NtNAddr]
+      events :: [PeerSelectionActionsTrace NtNAddr NtNVersion]
       events = mapMaybe (\case DiffusionPeerSelectionActionsTrace st -> Just st
                                _                                     -> Nothing
                         )
@@ -483,7 +483,8 @@ prop_peer_selection_action_trace_coverage defaultBearerInfo diffScript =
              . traceEvents
              $ runSimTrace sim
 
-      peerSelectionActionsTraceMap :: PeerSelectionActionsTrace NtNAddr -> String
+      peerSelectionActionsTraceMap :: PeerSelectionActionsTrace NtNAddr NtNVersion
+                                   -> String
       peerSelectionActionsTraceMap (PeerStatusChanged _)             =
         "PeerStatusChanged"
       peerSelectionActionsTraceMap (PeerStatusChangeFailure _ ft) =


### PR DESCRIPTION
Although it's also logged by `ConnectionHandlerTrace`, it's better to be verbose about it.

The issue came out [here](https://forum.cardano.org/t/error-cardano-node/110039/4).