### PR TITLE
Use strict map

### DIFF
--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -10,7 +10,7 @@ module Test.ThreadNet.Infra.Byron.ProtocolInfo (
   ) where
 
 import           Data.Foldable (find)
-import           Data.Map (Map)
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           GHC.Stack (HasCallStack)

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -16,7 +16,7 @@ import           Control.Monad (guard)
 import           Data.ByteString (ByteString)
 import           Data.Coerce (coerce)
 import           Data.Functor.Identity
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -9,7 +9,7 @@ module Test.ThreadNet.DualByron (tests) where
 
 import           Control.Monad.Except
 import           Data.ByteString (ByteString)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Proxy
 import qualified Data.Set as Set
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/TwoEras.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/TwoEras.hs
@@ -34,7 +34,7 @@ module Test.ThreadNet.Infra.TwoEras (
 
 import           Control.Exception (assert)
 import           Data.Functor ((<&>))
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
 import           Data.Set (Set)
 import qualified Data.Set as Set

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -11,8 +11,8 @@ module Test.ThreadNet.TxGen.Cardano (CardanoTxGenExtra (..)) where
 
 import           Control.Exception (assert)
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
@@ -17,7 +17,7 @@
 module Test.ThreadNet.AllegraMary (tests) where
 
 import           Control.Monad (replicateM)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -9,7 +9,7 @@ module Test.ThreadNet.Cardano (tests) where
 
 import           Control.Exception (assert)
 import           Control.Monad (replicateM)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/MaryAlonzo.hs
@@ -15,7 +15,7 @@
 module Test.ThreadNet.MaryAlonzo (tests) where
 
 import           Control.Monad (replicateM)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -17,7 +17,7 @@
 module Test.ThreadNet.ShelleyAllegra (tests) where
 
 import           Control.Monad (replicateM)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -10,8 +10,8 @@ module Ouroboros.Consensus.Mock.Node.Praos (
   ) where
 
 import           Data.Bifunctor (second)
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Numeric.Natural (Natural)
 
 import           Cardano.Crypto.KES

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -4,8 +4,8 @@ module Ouroboros.Consensus.Mock.Node.PraosRule (
   , protocolInfoPraosRule
   ) where
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 
 import           Cardano.Crypto.KES
 import           Cardano.Crypto.VRF

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Alonzo.hs
@@ -1,6 +1,6 @@
 module Test.ThreadNet.Infra.Alonzo (degenerateAlonzoGenesis) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import           Cardano.Ledger.Alonzo.Scripts (CostModels (..), Prices (..))

--- a/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
@@ -35,7 +35,7 @@ module Test.ThreadNet.General (
 import           Control.Exception (assert)
 import           Control.Monad (guard)
 import           Control.Tracer (nullTracer)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word (Word64)

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Ref/PBFT.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Ref/PBFT.hs
@@ -28,8 +28,8 @@ import           Control.Applicative ((<|>))
 import           Control.Arrow ((&&&))
 import           Control.Monad (guard)
 import           Data.Foldable (foldl', toList)
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import           Data.Set (Set)

--- a/ouroboros-consensus-test/src/Test/Util/FileLock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FileLock.hs
@@ -2,8 +2,8 @@
 module Test.Util.FileLock (mockFileLock) where
 
 import           Control.Monad (join, void)
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.IOSim

--- a/ouroboros-consensus-test/src/Test/Util/InvertedMap.hs
+++ b/ouroboros-consensus-test/src/Test/Util/InvertedMap.hs
@@ -17,8 +17,8 @@ module Test.Util.InvertedMap (
 
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Type.Coercion
 
 -- | An inverted 'Map'

--- a/ouroboros-consensus-test/src/Test/Util/Schedule.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Schedule.hs
@@ -12,7 +12,7 @@ module Test.Util.Schedule (
   ) where
 
 import           Data.List (intercalate, unfoldr)
-import           Data.Map (Map)
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -21,7 +21,7 @@
 
 module Test.Consensus.HardFork.Combinator (tests) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.SOP.Strict hiding (shape)
 import           Data.Word
 import           GHC.Generics (Generic)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -44,8 +44,8 @@ import qualified Data.Binary as B
 import           Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Functor.Identity (Identity)
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Void

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
@@ -21,8 +21,8 @@ import           Control.Monad.Except
 import           Data.Either (isRight)
 import           Data.Foldable (toList)
 import           Data.List (intercalate)
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, listToMaybe)
 import           Data.SOP.Strict
 import           Data.Word

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -18,8 +18,8 @@ import           Control.Monad.State (State, evalState, get, modify)
 import           Data.Bifunctor (first)
 import           Data.Either (isRight)
 import           Data.List (foldl', isSuffixOf, nub, partition, sort)
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import           Data.Word

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -6,8 +6,8 @@
 module Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests) where
 
 import           Control.Tracer (nullTracer)
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 
 import           Control.Monad.IOSim (runSimOrThrow)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Paths.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Paths.hs
@@ -12,8 +12,8 @@ module Test.Ouroboros.Storage.ChainDB.Paths (tests) where
 
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -34,7 +34,7 @@ import           Data.Functor.Classes (Eq1, Show1)
 import           Data.Functor.Identity (Identity)
 import           Data.List (sortOn)
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Ord (Down (..))
 import           Data.Proxy

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -41,8 +41,8 @@ import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import           Data.Word (Word64)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -33,8 +33,8 @@ import           Data.Functor.Classes (Eq1, Show1)
 import           Data.Functor.Identity (Identity)
 import           Data.List (delete, partition, sortBy)
 import qualified Data.List.NonEmpty as NE
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (listToMaybe)
 import           Data.TreeDiff (Expr (App), defaultExprViaShow)
 import           Data.Typeable (Typeable)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -71,7 +71,7 @@ import           Data.Hashable
 import           Data.Int (Int64)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
 import           Data.Typeable (Typeable)
 import           Data.Word

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -36,8 +36,8 @@ module Test.Ouroboros.Storage.VolatileDB.Model (
 import qualified Codec.CBOR.Write as CBOR
 import           Control.Monad.Except (MonadError, throwError)
 import qualified Data.ByteString.Lazy as BL
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -25,7 +25,7 @@ import           Data.Functor.Classes
 import           Data.Functor.Identity (Identity)
 import           Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockCache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockCache.hs
@@ -16,8 +16,8 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache (
 
 import           Prelude hiding (lookup)
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 
 import           Ouroboros.Consensus.Block
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString as BS.Strict
 import qualified Data.ByteString.Lazy as BS.Lazy
 import           Data.Int
 import           Data.List (intercalate)
-import           Data.Map (Map)
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
 import           Data.Set (Set)


### PR DESCRIPTION
- Fixes thunk error in ConsensusConfig for TestBlock

# Description
The `ConsensusConfig` in `Test.Ouroboros.Storage.TestBlock` uses non-strict map. This causes a following thunk check failure while running `ouroboros-consensus-test:test:test-storage`. 

Also using Data.Map.Strict everwhere in the consensus code. All the changes are in test/mocks except `BlockCache.hs`. 

Note that this happens only in an non-optimized build. I am making this change to make it uniform across.

```
ChainDB q-s-m
FAIL
          *** Failed! (after 1 test):
          Exception:
            Invariant violation: ThunkInfo {thunkContext = ["Word64","Map","ConsensusConfig","TopLevelConfig","LgrDB","ChainDbEnv m TestBlock","ChainDbState"]}
            CallStack (from HasCallStack):
              error, called at src/Control/Concurrent/Class/MonadSTM/Strict/TVar.hs:194:31 in strict-stm-0.1.0.0-FMKB73e30op55aWYz7uFlL:Control.Concurrent.Class.MonadSTM.Strict.TVar
              checkInvariant, called at src/Control/Concurrent/Class/MonadSTM/Strict/TVar.hs:128:9 in strict-stm-0.1.0.0-FMKB73e30op55aWYz7uFlL:Control.Concurrent.Class.MonadSTM.Strict.TVar
              newTVarWithInvariantIO, called at src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs:44:13 in ouroboros-consensus-0.1.0.0-inplace:Ouroboros.Consensus.Util.MonadSTM.NormalForm
              newTVarIO, called at src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs:206:29 in ouroboros-consensus-0.1.0.0-inplace:Ouroboros.Consensus.Storage.ChainDB.Impl
```

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job runs out of memory, e.g. in https://github.com/input-output-hk/ouroboros-network/runs/7231748864?check_suite_focus=true
 
 - The tests in WallClock.delay* can fail under load (quite rarely): https://hydra.iohk.io/build/16723452/nixlog/76

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->



# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
