### PR TITLE
Fix `Arbitrary` instance for keys and values in `DiffSeq` benchmarks

### DIFF
--- a/ouroboros-consensus-test/bench-storage/Bench/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
+++ b/ouroboros-consensus-test/bench-storage/Bench/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
@@ -117,8 +117,9 @@ import           QuickCheck.GenT (Arbitrary (arbitrary), Gen, MonadGen (..),
 import           Test.Tasty.Bench (Benchmark, bcompare, bcompareWithin, bench,
                      bgroup, env, nf)
 import           Test.Tasty.QuickCheck (Positive (getPositive), Property,
-                     Small (getSmall), conjoin, counterexample, forAll,
-                     generate, once, testProperty, (.&&.), (===))
+                     Small (getSmall), arbitraryBoundedIntegral, conjoin,
+                     counterexample, forAll, generate, once, testProperty,
+                     (.&&.), (===))
 
 import           Ouroboros.Consensus.Block (SlotNo (..))
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD as HD
@@ -553,12 +554,12 @@ newtype Value = Value ShortByteString
 
 -- | UTxO keys are expected to be 32 byte cryptographic hashes.
 instance Arbitrary Key where
-  arbitrary = Key . B.pack <$> replicateM 32 arbitrary
+  arbitrary = Key . B.pack <$> replicateM 32 arbitraryBoundedIntegral
 
 -- | UTxO entries, i.e., key-value pairs, are expected to be around 100-128 bytes
 -- in size. (@32 + 64 ~= 100@)
 instance Arbitrary Value where
-  arbitrary = Value . B.pack <$> replicateM 64 arbitrary
+  arbitrary = Value . B.pack <$> replicateM 64 arbitraryBoundedIntegral
 
 {-------------------------------------------------------------------------------
   Command generator: Monad transformer stack


### PR DESCRIPTION
# Description

This is a fix related to benchmarks that were introduced in https://github.com/input-output-hk/ouroboros-network/pull/3997.

In the `DiffSeq` benchmarks, we set out to generate keys and values as uniformly random 32-byte and 64-byte `ShortByteStrings` respectively, which model 32-byte and 64-byte cryptographic hashes, by generating and packing 32 and 64 `Word8`s respectively:

```haskell
newtype Key = Key ShortByteString
newtype Value = Value ShortByteString

instance Arbitrary Key where
  arbitrary = Key . B.pack <$> replicateM 32 arbitrary

instance Arbitrary Value where
  arbitrary = Value . B.pack <$> replicateM 64 arbitrary
```

However, in Quickcheck (2.14.2), the `Arbitrary` instance for `Word8` is:

```haskell
instance Arbitrary Word8 where
  arbitrary = arbitrarySizedBoundedIntegral
  shrink    = shrinkIntegral
```

where `arbitrarySizedBoundedIntegral` is:

```haskell
-- | Generates an integral number from a bounded domain. The number is
-- chosen from the entire range of the type, but small numbers are
-- generated more often than big numbers. Inspired by demands from
-- Phil Wadler.
arbitrarySizedBoundedIntegral :: (Bounded a, Integral a) => Gen a
```

This means that we are currently not picking keys and values from a uniform distribution. Instead, we should use:

```haskell
-- | Generates an integral number. The number is chosen uniformly from
-- the entire range of the type. You may want to use
-- 'arbitrarySizedBoundedIntegral' instead.
arbitraryBoundedIntegral :: (Bounded a, Integral a) => Gen a
```

So, now we have:

```haskell
instance Arbitrary Key where
  arbitrary = Key . B.pack <$> replicateM 32 arbitraryBoundedIntegral

instance Arbitrary Value where
  arbitrary = Value . B.pack <$> replicateM 64 arbitraryBoundedIntegral
```

## Changes in benchmark results

Performance gains decrease with respect to previous results as listed in https://github.com/input-output-hk/cardano-updates/blob/consensus/update-2022-08-31/posts/2022-08-31-consensus.markdown. Still, speedups are in the range of `[3.33, 4.75]` across the different configurations.

|Configuration|Implementation|Mean CPU time|2*Stdev (CPU time)|
|-|-|-|-|
|Default|AntiDiff|2.974 s (0.26x)|273 ms|
|Default|LegacyDiff|11.416 s|11 ms|
|No switches|AntiDiff|2.553 s (0.24x)|156 ms|
|No switches|LegacyDiff|10.838 s|65 ms|
|Only small switches|AntiDiff|2.442 s (0.21x)|14 ms|
|Only small switches|LegacyDiff|11.760 s|331 ms|
|No switches, larger flushes (every 100 pushes)|AntiDiff|2.261 s (0.30x)|45 ms|
|No switches, larger flushes (every 100 pushes)|LegacyDiff|7.531 s|612 ms|

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
