### PR TITLE
Fix windows GHA

### DIFF
--- a/.github/workflows/build-secp256k1.bash
+++ b/.github/workflows/build-secp256k1.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+git clone https://github.com/bitcoin-core/secp256k1
+cd secp256k1
+git switch $SECP256K1_REF --detach
+./autogen.sh
+./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
+make
+make check
+$CI_SECP_INSTALL_CMD make install
+cd ..

--- a/.github/workflows/build-secp256k1.bash
+++ b/.github/workflows/build-secp256k1.bash
@@ -1,4 +1,7 @@
 #!/bin/bash
+# I don't understand why this just vanishes.
+export PATH=/usr/bin:$PATH
+
 echo ========
 echo $PATH
 echo ========

--- a/.github/workflows/build-secp256k1.bash
+++ b/.github/workflows/build-secp256k1.bash
@@ -1,4 +1,7 @@
 #!/bin/bash
+echo ========
+echo $PATH
+echo ========
 git clone https://github.com/bitcoin-core/secp256k1
 cd secp256k1
 git switch $SECP256K1_REF --detach

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,8 @@ jobs:
     - name: "WIN: Setup Haskell"
       if: runner.os == 'Windows'
       run: |
-        # ghcup should be installed on current GHA Windows runners.
-
-        # do we really need pkg-config? 
+        # ghcup should be installed on current GHA Windows runners. Let's use ghcup to run
+        # pacman, to install the necessary dependencies, ...
         ghcup run -- pacman --noconfirm -S `
            mingw-w64-x86_64-pkg-config `
            mingw-w64-x86_64-libsodium `
@@ -45,6 +44,7 @@ jobs:
            libtool `
            make
 
+        # ... and also the ghc and cabal combination we want.
         ghcup install ghc ${{ matrix.ghc }}
         ghcup set ghc ${{ matrix.ghc }}
         ghcup install cabal 3.6.2.0
@@ -53,7 +53,10 @@ jobs:
         ghc --version
         cabal --version
 
-        # make sure cabal knows about msys64, and mingw64 tools.
+        # make sure cabal knows about msys64, and mingw64 tools. Not clear why C:/cabal/config is empty
+        # and C:/cabal doesn't even exist.  The ghcup bootstrap file should have create it in the image:
+        # See https://github.com/haskell/ghcup-hs/blob/787edc17af4907dbc51c85e25c490edd8d68b80b/scripts/bootstrap/bootstrap-haskell#L591
+        # So we'll do it by hand here for now.
         cabal user-config -a "extra-prog-path: C:/msys64/mingw64/bin, C:/msys64/usr/bin" `
                           -a "extra-include-dirs: C:/msys64/mingw64/include" `
                           -a "extra-lib-dirs: C:/msys64/mingw64/lib" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,17 +76,16 @@ jobs:
 
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
-      shell: "C:\\msys64\\msys2.exe {0}"
       run: |  
         git clone https://github.com/bitcoin-core/secp256k1
-        ( cd secp256k1
-          git switch $SECP256K1_REF --detach
-          ./autogen.sh
-          ./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
-          make
-          make check
-          $CI_SECP_INSTALL_CMD make install
-        )
+        cd secp256k1
+        git switch $SECP256K1_REF --detach
+        ./autogen.sh
+        ./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
+        make
+        make check
+        $CI_SECP_INSTALL_CMD make install
+        cd ..
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
-      shell: C:\msys64\usr\bin\msys2 {0}
+      shell: C:\\msys64\\msys2.exe {0}
       run: |
         pacman --noconfirm -S mingw-w64-x86_64-pkg-config \
            mingw-w64-x86_64-libsodium \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,10 @@ jobs:
         restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
     - name: Build dependencies
-      run: cabal build --only-dependencies all
+      run: cabal build --only-dependencies all -j
 
     - name: Build projects [build]
-      run: cabal build all
+      run: cabal build all -j
 
     # Test network packages
 
@@ -170,7 +170,7 @@ jobs:
 
     # issue: #1818
     - name: ourobors-network-framework [test]
-      run: cabal run ouroboros-network-framework:test -- -p '$0 != "typed-protocols.Socket.socket send receive IPv4"'
+      run: cabal run ouroboros-network-framework:test '--' -p '$0 != "typed-protocols.Socket.socket send receive IPv4"'
 
     - name: ouroboros-network [test]
       run: cabal run ouroboros-network:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,9 @@ jobs:
                           -a "extra-lib-dirs: C:/msys64/mingw64/lib" `
                           -f init
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Find pkg-config
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,16 @@ jobs:
 
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
-      shell: 'C:\msys64\usr\bin\msys2 {0}'
+      shell: C:\msys64\usr\bin\msys2 {0}
       run: |
+        pacman --noconfirm -S mingw-w64-x86_64-pkg-config \
+           mingw-w64-x86_64-libsodium \
+           base-devel \
+           autoconf-wrapper \
+           autoconf \
+           automake \
+           libtool \
+           make      
         git clone https://github.com/bitcoin-core/secp256k1
         ( cd secp256k1
           git switch $SECP256K1_REF --detach

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
       run: |
         # ghcup should be installed on current GHA Windows runners.
 
+        cabal --help
+
         # do we really need pkg-config? 
         ghcup run -- pacman --noconfirm -S `
            mingw-w64-x86_64-pkg-config `
@@ -53,7 +55,7 @@ jobs:
         ghc --version
         cabal --version
         
-        cabal user-config
+        cabal --help
 
     - name: Find pkg-config
       if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,8 @@ jobs:
            make
 
         # ... and also the ghc and cabal combination we want.
-        ghcup install ghc ${{ matrix.ghc }}
-        ghcup set ghc ${{ matrix.ghc }}
-        ghcup install cabal 3.6.2.0
-        ghcup set cabal 3.6.2.0
+        ghcup install ghc --set ${{ matrix.ghc }}
+        ghcup install cabal --set 3.6.2.0
 
         ghc --version
         ghc --print-libdir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
         echo "CI_SECP_INSTALL_CMD=sudo" >> $GITHUB_ENV
 
     - name: "Install secp256k1"
+      shell: bash
       run: |
         git clone https://github.com/bitcoin-core/secp256k1
         ( cd secp256k1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,17 +73,16 @@ jobs:
         echo "CI_SECP_FLAGS=--prefix=/usr" >> $GITHUB_ENV
         echo "CI_SECP_INSTALL_CMD=sudo" >> $GITHUB_ENV
 
+    - uses: actions/checkout@v3
 
     # TODO: this really should come from a pre-built location
     - name: "WIN: Install secp256k1"
       if: runner.os == 'Windows'
-      run: ghcup run -- bash ./build-secp256k1.bash 
+      run: ghcup run -- bash .github/workflows/build-secp256k1.bash 
 
     - name: "LINUX: Install secp256k1"
       if: runner.os != 'Windows'
-      run: bash ./build-secp256k1.bash 
-
-    - uses: actions/checkout@v3
+      run: bash .github/workflows/build-secp256k1.bash 
 
     - name: "Configure cabal.project.local"
       if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,6 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
     steps:
-    - name: "[DEBUG] Setup tmate session"
-      uses: mxschmitt/action-tmate@v3
-
-    - name: "WIN: Setup pkg-config"
-      if: runner.os == 'Windows'
-      run: |
-        pacman --noconfirm -S mingw-w64-x86_64-pkg-config
-
     - name: "LINUX: Setup haskell"
       if: runner.os != 'Windows'
       uses: haskell/actions/setup@v2
@@ -45,6 +37,9 @@ jobs:
         ghcup upgrade
         ghcup install ghc ${{ matrix.ghc }}
         ghcup install cabal 3.8.1.0
+
+        # do we really need this?
+        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
 
         ghc --version
         cabal --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,17 +75,13 @@ jobs:
 
 
     # TODO: this really should come from a pre-built location
-    - name: "Install secp256k1"
-      run: |  
-        git clone https://github.com/bitcoin-core/secp256k1
-        cd secp256k1
-        git switch $SECP256K1_REF --detach
-        ./autogen.sh
-        ./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
-        make
-        make check
-        make install
-        cd ..
+    - name: "WIN: Install secp256k1"
+      if: runner.os == 'Windows'
+      run: ghcup run -- bash ./build-secp256k1.bash 
+
+    - name: "LINUX: Install secp256k1"
+      if: runner.os != 'Windows'
+      run: bash ./build-secp256k1.bash 
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
         ghcup set cabal 3.6.2.0
 
         ghc --version
+        ghc --print-libdir
         cabal --version
 
         # make sure cabal knows about msys64, and mingw64 tools. Not clear why C:/cabal/config is empty
@@ -62,10 +63,10 @@ jobs:
         # https://github.com/msys2/MINGW-packages/issues/10837#issuecomment-1047105402
         # https://gitlab.haskell.org/ghc/ghc/-/issues/21111
         # if we _do_ want them, this would be the lines to add below
-        #                  -a "extra-include-dirs: C:/msys64/mingw64/include" `
-        #                  -a "extra-lib-dirs: C:/msys64/mingw64/lib" `
         
         cabal user-config -a "extra-prog-path: C:/msys64/mingw64/bin, C:/msys64/usr/bin" `
+                          -a "extra-include-dirs: C:/msys64/mingw64/include" `
+                          -a "extra-lib-dirs: C:/msys64/mingw64/lib" `
                           -f init
 
     - name: Find pkg-config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,8 @@ jobs:
       id: win-setup-haskell
       if: runner.os == 'Windows'
       env:
-        MSYS2_PATH_TYPE: inherit
-        CHERE_INVOKING: 1
         MSYSTEM: MINGW64
-      shell: C:\\msys64\\usr\\bin\\bash.exe {0}
+      shell: msys2 {0}
       run: |
         # ghcup should be installed on current GHA Windows runners.
         ghcup upgrade

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
-      shell: C:\msys64\usr\bin\bash.exe {0}
+      shell: msys2 {0}
       run: |
         git clone https://github.com/bitcoin-core/secp256k1
         ( cd secp256k1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,10 @@ jobs:
         ghc --version
         cabal --version
 
-        echo "cabal-store=$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store" >> $GITHUB_OUTPUT
+    - name: "OUTPUT Record cabal-store"
+      shell: bash
+      if: runner.os == 'Windows'
+      run: echo "cabal-store=$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store" >> $GITHUB_OUTPUT     
 
     - name: Set cache version
       run: echo "CACHE_VERSION=20220919" >> $GITHUB_ENV
@@ -109,7 +112,10 @@ jobs:
       run: |
         cabal build all --dry-run
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
-        echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
+
+    - name: "OUTPUT Record weeknum"
+      shell: bash
+      run: echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       name: "Cache `cabal store`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,9 @@ jobs:
 
     - name: Find pkg-config
       if: runner.os == 'Windows'
-      run: where.exe pkg-config
+      run: |
+        where.exe pkg-config
+        ghcup run -- where.exe pkg-config
 
     - name: "OUTPUT Record cabal-store"
       id: win-setup-haskell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
       run: |
         cabal build all --dry-run
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
-        echo "weeknum=$(/bin/date -u "+%W")" >> $GITHUB_OUTPUT
+        echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       name: "Cache `cabal store`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,9 @@ jobs:
            make
 
         ghcup install ghc ${{ matrix.ghc }}
+        ghcup set ghc ${{ matrix.ghc }}
         ghcup install cabal 3.6.2.0
+        ghcup set cabal 3.6.2.0
 
         ghc --version
         cabal --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         ./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
         make
         make check
-        $CI_SECP_INSTALL_CMD make install
+        make install
         cd ..
 
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
       run: |
         # ghcup should be installed on current GHA Windows runners.
 
-        cabal --help
-
         # do we really need pkg-config? 
         ghcup run -- pacman --noconfirm -S `
            mingw-w64-x86_64-pkg-config `
@@ -54,8 +52,12 @@ jobs:
 
         ghc --version
         cabal --version
-        
-        cabal --help
+
+        # make sure cabal knows about msys64, and mingw64 tools.
+        cabal user-config -a "extra-prog-path: C:/msys64/mingw64/bin, C:/msys64/usr/bin" `
+                          -a "extra-include-dirs: C:/msys64/mingw64/include" `
+                          -a "extra-lib-dirs: C:/msys64/mingw64/lib" `
+                          -f init
 
     - name: Find pkg-config
       if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,8 +73,9 @@ jobs:
         echo "CI_SECP_FLAGS=--prefix=/usr" >> $GITHUB_ENV
         echo "CI_SECP_INSTALL_CMD=sudo" >> $GITHUB_ENV
 
+    # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
-      shell: bash
+      shell: C:\msys64\usr\bin\bash.exe {0}
       run: |
         git clone https://github.com/bitcoin-core/secp256k1
         ( cd secp256k1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,17 +32,15 @@ jobs:
     - name: "WIN: Setup Haskell"
       id: win-setup-haskell
       if: runner.os == 'Windows'
-      env:
-        MSYSTEM: MINGW64
-      shell: msys2 {0}
       run: |
         # ghcup should be installed on current GHA Windows runners.
+        # do we really need this?
+        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libsodium
+
         ghcup upgrade
         ghcup install ghc ${{ matrix.ghc }}
         ghcup install cabal 3.8.1.0
 
-        # do we really need this?
-        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libsodium
 
         ghc --version
         cabal --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
     steps:
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+
     - name: "LINUX: Setup haskell"
       if: runner.os != 'Windows'
       uses: haskell/actions/setup@v2
@@ -72,6 +76,7 @@ jobs:
         sudo apt-get -y install autoconf automake libtool
         echo "CI_SECP_FLAGS=--prefix=/usr" >> $GITHUB_ENV
         echo "CI_SECP_INSTALL_CMD=sudo" >> $GITHUB_ENV
+
 
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,6 @@ jobs:
       run: |
         # ghcup should be installed on current GHA Windows runners.
 
-        ghcup install ghc ${{ matrix.ghc }}
-        ghcup install cabal 3.8.1.0
-
         # do we really need pkg-config? 
         ghcup run -- pacman --noconfirm -S `
            mingw-w64-x86_64-pkg-config `
@@ -48,6 +45,9 @@ jobs:
            automake `
            libtool `
            make
+
+        ghcup install ghc ${{ matrix.ghc }}
+        ghcup install cabal 3.8.1.0
 
         ghc --version
         cabal --version
@@ -76,7 +76,7 @@ jobs:
 
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
-      shell: C:\\msys64\\msys2.exe {0}
+      shell: "C:\\msys64\\msys2.exe {0}"
       run: |  
         git clone https://github.com/bitcoin-core/secp256k1
         ( cd secp256k1
@@ -152,7 +152,7 @@ jobs:
       run: cabal run ouroboros-network:test
 
     # Consensus tests take too long on GitHub's Azure machines
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
+#     - name: Setup tmate session
+#       if: ${{ failure() }}
+#       uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,15 @@ jobs:
         # and C:/cabal doesn't even exist.  The ghcup bootstrap file should have create it in the image:
         # See https://github.com/haskell/ghcup-hs/blob/787edc17af4907dbc51c85e25c490edd8d68b80b/scripts/bootstrap/bootstrap-haskell#L591
         # So we'll do it by hand here for now.
+        #
+        # We'll _not_ add extra-include-dirs, or extra-lib-dirs, and rely on what's shipped with GHC.
+        # https://github.com/msys2/MINGW-packages/issues/10837#issuecomment-1047105402
+        # https://gitlab.haskell.org/ghc/ghc/-/issues/21111
+        # if we _do_ want them, this would be the lines to add below
+        #                  -a "extra-include-dirs: C:/msys64/mingw64/include" `
+        #                  -a "extra-lib-dirs: C:/msys64/mingw64/lib" `
+        
         cabal user-config -a "extra-prog-path: C:/msys64/mingw64/bin, C:/msys64/usr/bin" `
-                          -a "extra-include-dirs: C:/msys64/mingw64/include" `
-                          -a "extra-lib-dirs: C:/msys64/mingw64/lib" `
                           -f init
 
     - name: Find pkg-config
@@ -168,9 +174,8 @@ jobs:
     - name: ourobors-network-testing [test]
       run: cabal run ouroboros-network-testing:test
 
-    # issue: #1818
     - name: ourobors-network-framework [test]
-      run: cabal run ouroboros-network-framework:test '--' -p '$0 != "typed-protocols.Socket.socket send receive IPv4"'
+      run: cabal run ouroboros-network-framework:test
 
     - name: ouroboros-network [test]
       run: cabal run ouroboros-network:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,7 @@ jobs:
         ghcup install cabal 3.8.1.0
 
         # do we really need this?
-        ghcup run -- pacman --noconfirm -S \
-          mingw-w64-x86_64-pkg-config \
-          mingw-w64-x86_64-libsodium
+        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libsodium
 
         ghc --version
         cabal --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
            make
 
         ghcup install ghc ${{ matrix.ghc }}
-        ghcup install cabal 3.8.1.0
+        ghcup install cabal 3.6.2.0
 
         ghc --version
         cabal --version
@@ -83,9 +83,7 @@ jobs:
         MSYS2_PATH_TYPE: inherit
         MSYSTEM: MINGW64
         CHERE_INVOKING: 1
-      run: |
-         ghcup run -- env
-         ghcup run -- C:\\msys64\\usr\\bin\\bash.exe .github/workflows/build-secp256k1.bash
+      run: C:\\msys64\\usr\\bin\\bash.exe .github/workflows/build-secp256k1.bash
 
     - name: "LINUX: Install secp256k1"
       if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,9 @@ jobs:
         ghcup install cabal 3.8.1.0
 
         # do we really need this?
-        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
+        ghcup run -- pacman --noconfirm -S \
+          mingw-w64-x86_64-pkg-config \
+          mingw-w64-x86_64-libsodium
 
         ghc --version
         cabal --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,14 @@ jobs:
         # https://gitlab.haskell.org/ghc/ghc/-/issues/21111
         # if we _do_ want them, this would be the lines to add below
         
+        $ghcMingwDir = Join-Path -Path $(ghc --print-libdir) `
+                                 -ChildPath ../mingw/x86_64-*-mingw32/lib/ `
+                                 -Resolve
+        
         cabal user-config -a "extra-prog-path: C:/msys64/mingw64/bin, C:/msys64/usr/bin" `
                           -a "extra-include-dirs: C:/msys64/mingw64/include" `
-                          -a "extra-lib-dirs: C:/msys64/mingw64/lib" `
+                          -a ("extra-lib-dirs: {0}, C:/msys64/mingw64/lib" -f $ghcMingwDir) `
                           -f init
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
 
     - name: Find pkg-config
       if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,15 +77,7 @@ jobs:
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
       shell: C:\\msys64\\msys2.exe {0}
-      run: |
-        pacman --noconfirm -S mingw-w64-x86_64-pkg-config \
-           mingw-w64-x86_64-libsodium \
-           base-devel \
-           autoconf-wrapper \
-           autoconf \
-           automake \
-           libtool \
-           make      
+      run: |  
         git clone https://github.com/bitcoin-core/secp256k1
         ( cd secp256k1
           git switch $SECP256K1_REF --detach

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
 
-    defaults:
-      run:
-        shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -25,23 +21,6 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
     steps:
-    - name: "WIN: Setup MSYS2 and libraries"
-      if: runner.os == 'Windows'
-      uses: msys2/setup-msys2@v2
-      with:
-        update: true
-        install: >-
-          base-devel
-          autoconf-wrapper
-          autoconf
-          automake
-          libtool
-          make
-          git
-          mingw-w64-x86_64-toolchain
-          mingw-w64-x86_64-libsodium
-          mingw-w64-x86_64-jq
-
     - name: "WIN: Setup pkg-config"
       if: runner.os == 'Windows'
       run: |
@@ -59,33 +38,14 @@ jobs:
       id: win-setup-haskell
       if: runner.os == 'Windows'
       run: |
-        # see https://gitlab.haskell.org/haskell/ghcup-hs/-/blob/master/scripts/bootstrap/bootstrap-haskell
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | \
-          BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
-          BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=1 \
-          BOOTSTRAP_HASKELL_ADJUST_BASHRC=1 \
-          BOOTSTRAP_HASKELL_GHC_VERSION="${{ matrix.ghc }}" \
-          BOOTSTRAP_HASKELL_CABAL_VERSION="3.6.2.0" \
-          sh
-
-        # MSYS2 doesn't inherit $GITHUB_PATH so this is needed
-        cat <(echo "source /c/ghcup/env") ~/.bashrc > ~/.bashrc.new
-        mv ~/.bashrc.new ~/.bashrc
-
-        source ~/.bashrc
-
-        # There is an issue with crt libraries, fixed by prepending the ghc
-        # mingw32 libraries directory to every other library directory.
-        echo "# Original cabal config extra-lib-dirs"
-        grep extra-lib-dirs /c/cabal/config
-
-        sed -i 's/C:\\msys64\\mingw64\\lib/C:\\ghcup\\ghc\\8.10.7\\mingw\\x86_64-w64-mingw32\\lib, C:\\msys64\\mingw64\\lib/g' /c/cabal/config
-
-        echo "# Modified cabal config extra-lib-dirs"
-        grep extra-lib-dirs /c/cabal/config
+        # ghcup should be installed on current GHA Windows runners.
+        ghcup upgrade
+        ghcup install ghc ${{ matrix.ghc }}
+        ghcup install cabal 3.8.1.0
 
         ghc --version
         cabal --version
+
         echo "cabal-store=$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store" >> $GITHUB_OUTPUT
 
     - name: Set cache version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,12 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         # ghcup should be installed on current GHA Windows runners.
-        # do we really need this?
-        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libsodium
 
-        ghcup upgrade
         ghcup install ghc ${{ matrix.ghc }}
         ghcup install cabal 3.8.1.0
 
+        # do we really need pkg-config? 
+        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libsodium
 
         ghc --version
         cabal --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
         ghc --version
         cabal --version
 
+    - name: Find pkg-config
+      if: runner.os == 'Windows'
+      run: where.exe pkg-config
+
     - name: "OUTPUT Record cabal-store"
       id: win-setup-haskell
       shell: bash
@@ -135,7 +139,6 @@ jobs:
           !dist-newstyle/**/.git
         key: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ steps.record-deps.outputs.weeknum }}
         restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
-
 
     - name: Build dependencies
       run: cabal build --only-dependencies all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
       run: cabal run ouroboros-network:test
 
     # Consensus tests take too long on GitHub's Azure machines
-#     - name: Setup tmate session
-#       if: ${{ failure() }}
-#       uses: mxschmitt/action-tmate@v3
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
     - name: "WIN: Setup Haskell"
       id: win-setup-haskell
       if: runner.os == 'Windows'
+      shell: bash
       run: |
         # ghcup should be installed on current GHA Windows runners.
         ghcup upgrade

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
     steps:
+    - name: "[DEBUG] Setup tmate session"
+      uses: mxschmitt/action-tmate@v3
+
     - name: "WIN: Setup pkg-config"
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
         cabal-version: 3.6.2.0
 
     - name: "WIN: Setup Haskell"
-      id: win-setup-haskell
       if: runner.os == 'Windows'
       run: |
         # ghcup should be installed on current GHA Windows runners.
@@ -55,6 +54,7 @@ jobs:
         cabal --version
 
     - name: "OUTPUT Record cabal-store"
+      id: win-setup-haskell
       shell: bash
       if: runner.os == 'Windows'
       run: echo "cabal-store=$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store" >> $GITHUB_OUTPUT     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
         ghcup install cabal --set 3.6.2.0
 
         ghc --version
-        ghc --print-libdir
         cabal --version
 
         # make sure cabal knows about msys64, and mingw64 tools. Not clear why C:/cabal/config is empty
@@ -70,12 +69,6 @@ jobs:
                           -a "extra-include-dirs: C:/msys64/mingw64/include" `
                           -a ("extra-lib-dirs: {0}, C:/msys64/mingw64/lib" -f $ghcMingwDir) `
                           -f init
-
-    - name: Find pkg-config
-      if: runner.os == 'Windows'
-      run: |
-        where.exe pkg-config
-        ghcup run -- where.exe pkg-config
 
     - name: "OUTPUT Record cabal-store"
       id: win-setup-haskell
@@ -184,7 +177,13 @@ jobs:
       run: cabal run ouroboros-network:test
 
     # Consensus tests take too long on GitHub's Azure machines
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
+
+    # comment this back in for debugging. Remember to launch a
+    # `pwsh` from the tmux session to debug `pwsh` issues. And
+    # be reminded that the /msys2 and /msys2/mingw64 paths are
+    # not in PATH by default for the workflow, but tmate will
+    # put them in.
+#    - name: Setup tmate session
+#      if: ${{ failure() }}
+#      uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,11 @@ jobs:
     # TODO: this really should come from a pre-built location
     - name: "WIN: Install secp256k1"
       if: runner.os == 'Windows'
+      # Same env as tmate action
+      env:
+        MSYS2_PATH_TYPE: inherit
+        MSYSTEM: MINGW64
+        CHERE_INVOKING: 1
       run: |
          ghcup run -- env
          ghcup run -- C:\\msys64\\usr\\bin\\bash.exe .github/workflows/build-secp256k1.bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,10 +73,7 @@ jobs:
 
     - name: "LINUX: Install build environment (for secp256k1)"
       if: runner.os == 'Linux'
-      run: |
-        sudo apt-get -y install autoconf automake libtool
-        echo "CI_SECP_FLAGS=--prefix=/usr" >> $GITHUB_ENV
-        echo "CI_SECP_INSTALL_CMD=sudo" >> $GITHUB_ENV
+      run: sudo apt-get -y install autoconf automake libtool
 
     - uses: actions/checkout@v3
 
@@ -88,10 +85,16 @@ jobs:
         MSYS2_PATH_TYPE: inherit
         MSYSTEM: MINGW64
         CHERE_INVOKING: 1
+        # install secp into /mingw64 prefix, which is where pkg-config will look
+        # by default.
+        CI_SECP_FLAGS: "--prefix=/mingw64"
       run: C:\\msys64\\usr\\bin\\bash.exe .github/workflows/build-secp256k1.bash
 
     - name: "LINUX: Install secp256k1"
       if: runner.os != 'Windows'
+      env:
+        CI_SECP_FLAGS: "--prefix=/usr"
+        CI_SECP_INSTALL_CMD: sudo
       run: bash .github/workflows/build-secp256k1.bash 
 
     - name: "Configure cabal.project.local"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,8 @@ jobs:
 
         ghc --version
         cabal --version
+        
+        cabal user-config
 
     - name: Find pkg-config
       if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,11 @@ jobs:
     - name: "WIN: Setup Haskell"
       id: win-setup-haskell
       if: runner.os == 'Windows'
-      shell: bash
+      env:
+        MSYS2_PATH_TYPE: inherit
+        CHERE_INVOKING: 1
+        MSYSTEM: MINGW64
+      shell: C:\\msys64\\usr\\bin\\bash.exe {0}
       run: |
         # ghcup should be installed on current GHA Windows runners.
         ghcup upgrade

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     # TODO: this really should come from a pre-built location
     - name: "WIN: Install secp256k1"
       if: runner.os == 'Windows'
-      run: ghcup run -- bash .github/workflows/build-secp256k1.bash 
+      run: ghcup run -- C:\\msys64\\usr\\bin\\bash.exe .github/workflows/build-secp256k1.bash
 
     - name: "LINUX: Install secp256k1"
       if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,14 +39,14 @@ jobs:
         ghcup install cabal 3.8.1.0
 
         # do we really need pkg-config? 
-        ghcup run -- pacman --noconfirm -S \
-           mingw-w64-x86_64-pkg-config \
-           mingw-w64-x86_64-libsodium \
-           base-devel \
-           autoconf-wrapper \
-           autoconf \
-           automake \
-           libtool \
+        ghcup run -- pacman --noconfirm -S `
+           mingw-w64-x86_64-pkg-config `
+           mingw-w64-x86_64-libsodium `
+           base-devel `
+           autoconf-wrapper `
+           autoconf `
+           automake `
+           libtool `
            make
 
         ghc --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,9 @@ jobs:
     # TODO: this really should come from a pre-built location
     - name: "WIN: Install secp256k1"
       if: runner.os == 'Windows'
-      run: ghcup run -- C:\\msys64\\usr\\bin\\bash.exe .github/workflows/build-secp256k1.bash
+      run: |
+         ghcup run -- env
+         ghcup run -- C:\\msys64\\usr\\bin\\bash.exe .github/workflows/build-secp256k1.bash
 
     - name: "LINUX: Install secp256k1"
       if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,15 @@ jobs:
         ghcup install cabal 3.8.1.0
 
         # do we really need pkg-config? 
-        ghcup run -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libsodium
+        ghcup run -- pacman --noconfirm -S \
+           mingw-w64-x86_64-pkg-config \
+           mingw-w64-x86_64-libsodium \
+           base-devel \
+           autoconf-wrapper \
+           autoconf \
+           automake \
+           libtool \
+           make
 
         ghc --version
         cabal --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,6 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
     steps:
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
-
     - name: "LINUX: Setup haskell"
       if: runner.os != 'Windows'
       uses: haskell/actions/setup@v2
@@ -80,7 +76,7 @@ jobs:
 
     # TODO: this really should come from a pre-built location
     - name: "Install secp256k1"
-      shell: msys2 {0}
+      shell: 'C:\msys64\usr\bin\msys2 {0}'
       run: |
         git clone https://github.com/bitcoin-core/secp256k1
         ( cd secp256k1
@@ -156,3 +152,7 @@ jobs:
       run: cabal run ouroboros-network:test
 
     # Consensus tests take too long on GitHub's Azure machines
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+


### PR DESCRIPTION
This Pullrequest tries to fix our GitHub actions by making them a bit more resilient.

- Use PowerShell by default (the windows default).
- Use msys2, ghcup, ... that already come with the base windows image.
- Do not rely on msys2 as much as we can.
- Try not to cross the toolchains much (stock windows / msys2-mingw64), by isolating it's use, or trusting ghcup to run stuff for us.
- Externalise building libsecp256k1. (We should ultimately cache _just_ that thing, or even better pull a static pre-built version of this. It costs 4min for each commit!).
- Drop the typed-protocols test pattern. That seems to fail because there is no test that could match. (The test seems to have been moved?)
- Add tmate.io for debugging on failure