### PR TITLE
UTxO-HD: simplify mempool

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -223,7 +223,7 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params credss =
 instance NodeInitStorage DualByronBlock where
   -- Just like Byron, we need to start with an EBB
   nodeInitChainDB cfg InitChainDB { getCurrentLedger, addBlock } = do
-      tip <- ledgerTipPoint (Proxy @DualByronBlock) <$> getCurrentLedger
+      tip <- ledgerTipPoint <$> getCurrentLedger
       case tip of
         BlockPoint {} -> return ()
         GenesisPoint  -> addBlock genesisEBB

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -273,7 +273,7 @@ instance NodeInitStorage ByronBlock where
   -- If the current chain is empty, produce a genesis EBB and add it to the
   -- ChainDB. Only an EBB can have Genesis (= empty chain) as its predecessor.
   nodeInitChainDB cfg InitChainDB { getCurrentLedger, addBlock } = do
-      tip <- ledgerTipPoint (Proxy @ByronBlock) <$> getCurrentLedger
+      tip <- ledgerTipPoint <$> getCurrentLedger
       case tip of
         BlockPoint {} -> return ()
         GenesisPoint  -> addBlock genesisEBB

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -120,8 +120,8 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg = do
         unticked <- do
           mExtLedger <- lift $ atomically $ ChainDB.getPastLedger chainDB bcPrevPoint
           case mExtLedger of
-            Just (l, _) -> return l
-            Nothing     -> exitEarly' "no ledger state"
+            Just l  -> return l
+            Nothing -> exitEarly' "no ledger state"
 
         ledgerView <-
           case runExcept $ forecastFor

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -737,7 +737,7 @@ translateLedgerStateByronToShelleyWrapper =
               $ ShelleyLedgerState {
                     shelleyLedgerTip =
                       translatePointByronToShelley
-                      (ledgerTipPoint (Proxy @ByronBlock) ledgerByron)
+                      (ledgerTipPoint ledgerByron)
                       (byronLedgerTipBlockNo ledgerByron)
                   , shelleyLedgerState =
                       SL.translateToShelleyLedgerState

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -546,7 +546,7 @@ instance SmallQuery (BlockQuery (SimpleBlock c ext)) where
 instance MockProtocolSpecific c ext => QueryLedger (SimpleBlock c ext) where
   answerBlockQuery _cfg QueryLedgerTip =
         castPoint
-      . ledgerTipPoint (Proxy @(SimpleBlock c ext))
+      . ledgerTipPoint
       . ledgerState
 
 instance EqQuery (BlockQuery (SimpleBlock c ext)) where

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -111,15 +111,12 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
-import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index as Index
-import qualified Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy as LgrDB
 import           Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore
                      (RangeQuery (RangeQuery))
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
                      (BackingStoreSelector (..), LedgerBackingStoreValueHandle,
                      LedgerDB', mkDiskLedgerView)
-import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
 import           Ouroboros.Consensus.Util.Enclose (pattern FallingEdge)
 
 import           Test.ThreadNet.TxGen
@@ -601,7 +598,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       -> (SlotNo -> STM m ())
       -> LedgerConfig blk
       -> STM m (LedgerState blk EmptyMK)
-      -> Mempool m blk TicketNo
+      -> Mempool m blk
       -> [GenTx blk]
          -- ^ valid transactions the node should immediately propagate
       -> m ()
@@ -636,8 +633,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
 
                 -- a new ledger state might render a crucial transaction valid
                 ldgrChanged = do
-                  let prj = ledgerTipPoint (Proxy @blk)
-                  (ledger', _) <- atomically $ blockUntilChanged prj (prj ledger) getLdgr
+                  (ledger', _) <- atomically $ blockUntilChanged ledgerTipPoint (ledgerTipPoint ledger) getLdgr
                   pure (slot, ledger', mempFp)
 
               -- wake up when any of those change
@@ -665,7 +661,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                    -> Seed
                    -> DiskLedgerView m (ExtLedgerState blk)
                       -- ^ How to get the current ledger state
-                   -> Mempool m blk TicketNo
+                   -> Mempool m blk
                    -> m ()
     forkTxProducer coreNodeId registry clock cfg nodeSeed dlv mempool =
         void $ OracularClock.forkEachSlot registry clock "txProducer" $ \curSlotNo -> do

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/NFData.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/NFData.hs
@@ -15,7 +15,6 @@ import           Data.Foldable
 import           Data.Sequence (Seq)
 import           Data.Sequence.NonEmpty (NESeq)
 
-import           Data.FingerTree.RootMeasured.Strict as RMFT
 import qualified Data.FingerTree.Strict as FT
 import           Data.Map.Diff.Strict (Diff (..), DiffEntry (..),
                      DiffHistory (..), Keys (..), NEDiffHistory (..),
@@ -24,9 +23,9 @@ import           Ouroboros.Consensus.Storage.LedgerDB.HD (SeqUtxoDiff (..),
                      SudElement (..), SudMeasure (..), UtxoDiff (..),
                      UtxoEntryDiff (..), UtxoEntryDiffState (..), UtxoKeys (..),
                      UtxoValues (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (DiffSeq (..),
-                     Element (..), InternalMeasure (..), Length (..),
-                     RootMeasure (..), SlotNoLB (..), SlotNoUB (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (Element (..),
+                     InternalMeasure (..), Length (..), RootMeasure (..),
+                     SlotNoLB (..), SlotNoUB (..))
 
 {------------------------------------------------------------------------------
   StrictFingerTree

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -36,7 +36,6 @@ module Ouroboros.Consensus.Ledger.Abstract (
 
 import           Control.Monad.Except
 import           Data.Kind (Type)
-import           Data.Proxy
 import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Consensus.Block.Abstract
@@ -269,20 +268,17 @@ refoldLedger cfg = repeatedly (\blk state -> applyLedgerTablesDiffs state $ tick
   Short-hand
 -------------------------------------------------------------------------------}
 
--- | Wrapper around 'ledgerTipPoint' that uses a proxy to fix @blk@
---
--- This is occassionally useful to guide type inference
 ledgerTipPoint ::
      UpdateLedger blk
-  => Proxy blk -> LedgerState blk mk -> Point blk
-ledgerTipPoint _ = castPoint . getTip
+  => LedgerState blk mk -> Point blk
+ledgerTipPoint = castPoint . getTip
 
 ledgerTipHash ::
      forall blk mk. UpdateLedger blk
   => LedgerState blk mk -> ChainHash blk
-ledgerTipHash = pointHash . (ledgerTipPoint (Proxy @blk))
+ledgerTipHash = pointHash . ledgerTipPoint
 
 ledgerTipSlot ::
      forall blk mk. UpdateLedger blk
   => LedgerState blk mk -> WithOrigin SlotNo
-ledgerTipSlot = pointSlot . (ledgerTipPoint (Proxy @blk))
+ledgerTipSlot = pointSlot . ledgerTipPoint

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool.hs
@@ -3,6 +3,4 @@ module Ouroboros.Consensus.Mempool (module X) where
 
 import           Ouroboros.Consensus.Mempool.API as X
 import           Ouroboros.Consensus.Mempool.Impl as X
-import           Ouroboros.Consensus.Mempool.Impl.Types as X
-                     (MempoolChangelog (..))
 import           Ouroboros.Consensus.Mempool.TxSeq as X (TicketNo)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -1,66 +1,49 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -- | Pure side of the Mempool implementation.
---
--- Operations are performed in a pure style returning data types that model
--- the control flow through the operation and can then be interpreted to perform
--- the actual STM/IO operations.
-
 module Ouroboros.Consensus.Mempool.Impl.Pure (
     -- * Mempool
-    RemoveTxs (..)
-  , SyncWithLedger (..)
-  , TryAddTxs (..)
+    TransactionResult (..)
   , pureGetSnapshotFor
   , pureRemoveTxs
   , pureSyncWithLedger
-  , pureTryAddTxs
-    -- * MempoolSnapshot
-  , implSnapshotFromIS
+  , pureTryAddTx
   ) where
 
 import           Control.Exception (assert)
 import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (isJust, isNothing)
-import qualified Data.Set as Set
 
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Mempool.API (TxSizeInBytes)
 import           Ouroboros.Consensus.Mempool.Impl.Types
-import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxTicket (..),
-                     zeroTicketNo)
+import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxTicket (..))
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
-
-import           Ouroboros.Network.Protocol.TxSubmission2.Type (TxSizeInBytes)
+import           Ouroboros.Consensus.Util (repeatedly)
 
 {-------------------------------------------------------------------------------
   Mempool Implementation
 -------------------------------------------------------------------------------}
 
--- | Result of trying to add a transaction to the mempool.
-data TryAddTxs blk =
-    -- | No space is left in the mempool and no more transactions could be
-    -- added.
+-- | Result of processing a transaction to be added to the mempool.
+data TransactionResult blk =
     NoSpaceLeft
-    -- | A transaction was processed.
-  | TryAddTxs
-      (Maybe (InternalState blk))
-      -- ^ If the transaction was accepted, the new state that can be written to
-      -- the TVar.
-      (MempoolAddTxResult blk)
-      -- ^ The result of trying to add the transaction to the mempool.
-      (TraceEventMempool blk)
-      -- ^ The event emitted by the operation.
+  | TransactionProcessed
+    (Maybe (InternalState blk))
+    -- ^ If the transaction was accepted, the new state that can be written to
+    -- the TVar.
+    (MempoolAddTxResult blk)
+    -- ^ The result of trying to add the transaction to the mempool.
+    (TraceEventMempool blk)
+    -- ^ The event emitted by the operation.
 
--- | Craft a 'TryAddTxs' value containing the resulting state if applicable, the
--- tracing event and the result of adding this transaction. See the
--- documentation of 'implTryAddTxs' for some more context.
-pureTryAddTxs
+-- | Craft a 'TransactionResult' value containing the resulting state if
+-- applicable, the tracing event and the result of adding this transaction. See
+-- the documentation of 'implTryAddTxs' for some more context.
+pureTryAddTx
   :: ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      )
@@ -75,8 +58,8 @@ pureTryAddTxs
      -- ^ The current internal state of the mempool.
   -> LedgerTables (LedgerState blk) ValuesMK
      -- ^ Values for this transaction
-  -> TryAddTxs blk
-pureTryAddTxs cfg txSize wti tx is values
+  -> TransactionResult blk
+pureTryAddTx cfg txSize wti tx is values
   | let size    = txSize tx
         curSize = msNumBytes  $ isMempoolSize is
   , curSize + size > getMempoolCapacityBytes (isCapacity is)
@@ -87,7 +70,7 @@ pureTryAddTxs cfg txSize wti tx is values
       -- ('tx'). So if it's not in 'vrInvalid', it must be in 'vrNewValid'.
       Right vtx ->
         assert (isJust (vrNewValid vr)) $
-          TryAddTxs
+          TransactionProcessed
             (Just is')
             (MempoolTxAdded vtx)
             (TraceMempoolAddedTx
@@ -98,7 +81,7 @@ pureTryAddTxs cfg txSize wti tx is values
       Left err ->
         assert (isNothing (vrNewValid vr))  $
           assert (length (vrInvalid vr) == 1) $
-            TryAddTxs
+            TransactionProcessed
               Nothing
               (MempoolTxRejected tx err)
               (TraceMempoolRejectedTx
@@ -106,157 +89,124 @@ pureTryAddTxs cfg txSize wti tx is values
                err
                (isMempoolSize is)
               )
-    where
-      (eVtx, vr) = extendVRNew cfg txSize wti tx $ validationResultFromIS values is
-      is'        = internalStateFromVR vr
+  where
+    (eVtx, vr) = extendVRNew cfg txSize wti tx $ validationResultFromIS values is
+    is'        = internalStateFromVR vr
 
--- | A datatype containing the state resulting after removing the requested
--- transactions from the mempool and maybe a message to be traced while removing
--- them.
-data RemoveTxs blk =
-    WriteRemoveTxs (InternalState blk) (TraceEventMempool blk)
-
--- | Craft a 'RemoveTxs' that manually removes the given transactions from the
--- mempool, returning inside it an updated InternalState.
+-- | Revalidate the other transactions in the mempool and provide an updated
+-- InternalState
 pureRemoveTxs
   :: ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      )
-  => LedgerConfig blk
-  -> MempoolCapacityBytesOverride
-  -> [TxTicket (Validated (GenTx blk))] -- ^ Txs to keep
-  -> NE.NonEmpty (GenTxId blk)
-  -> InternalState blk
+  => MempoolCapacityBytesOverride
+  -> LedgerConfig blk
   -> SlotNo
   -> TickedLedgerState blk DiffMK
   -> LedgerTables (LedgerState blk) ValuesMK
-  -> RemoveTxs blk
-pureRemoveTxs lcfg capacityOverride txs txIds IS { isLastTicketNo, isDbChangelog } slot lstate values =
-    let vr          = revalidateTxsFor
-                        capacityOverride
-                        lcfg
-                        slot
-                        lstate
-                        values
-                        isDbChangelog
-                        isLastTicketNo
-                        txs
-        is'         = internalStateFromVR vr
-        needsTrace  = TraceMempoolManuallyRemovedTxs
-                        txIds
-                        (map fst (vrInvalid vr))
-                        (isMempoolSize is')
-    in WriteRemoveTxs is' needsTrace
-
--- | A datatype containing the new state produced by syncing with the Ledger, a
--- snapshot of that mempool state and, if needed, a tracing message.
-data SyncWithLedger blk =
-    NewSyncedState (InternalState blk)
-                   (MempoolSnapshot blk TicketNo)
-                   (Maybe (TraceEventMempool blk))
+  -> TicketNo
+  -> [TxTicket (Validated (GenTx blk))] -- ^ Txs to keep
+  -> NE.NonEmpty (GenTxId blk) -- ^ IDs to remove
+  -> (InternalState blk, TraceEventMempool blk)
+pureRemoveTxs capacityOverride lcfg slot lstate values tkt txs txIds =
+    let (is', removed) = revalidateTxsFor
+                           capacityOverride
+                           lcfg
+                           slot
+                           lstate
+                           values
+                           tkt
+                           txs
+        trace = TraceMempoolManuallyRemovedTxs
+                  txIds
+                  removed
+                  (isMempoolSize is')
+    in (is', trace)
 
 -- | Create a 'SyncWithLedger' value representing the values that will need to
 -- be stored for committing this synchronization with the Ledger.
---
--- See the documentation of 'runSyncWithLedger' for more context.
 pureSyncWithLedger
   :: (LedgerSupportsMempool blk, HasTxId (GenTx blk))
-  => InternalState blk
+  => MempoolCapacityBytesOverride
+  -> LedgerConfig blk
   -> SlotNo
   -> TickedLedgerState blk DiffMK
   -> LedgerTables (LedgerState blk) ValuesMK
-  -> LedgerConfig blk
-  -> MempoolCapacityBytesOverride
-  -> SyncWithLedger blk
-pureSyncWithLedger istate slot lstate values lcfg capacityOverride =
-    let vr          = revalidateTxsFor
-                       capacityOverride
-                       lcfg
-                       slot
-                       lstate
-                       values
-                       (isDbChangelog istate)
-                       (isLastTicketNo istate)
-                       (TxSeq.toList $ isTxs istate)
-        removed     = map fst (vrInvalid vr)
-        istate'     = internalStateFromVR vr
-        mTrace      = if null removed
-                      then
-                        Nothing
-                      else
-                        Just $ TraceMempoolRemoveTxs removed (isMempoolSize istate')
-        snapshot    = implSnapshotFromIS istate'
-    in
-      NewSyncedState istate' snapshot mTrace
+  -> InternalState blk
+  -> ( InternalState blk
+     , Maybe (TraceEventMempool blk)
+     )
+pureSyncWithLedger capacityOverride lcfg slot lstate values istate =
+  let (is', removed) = revalidateTxsFor
+                         capacityOverride
+                         lcfg
+                         slot
+                         lstate
+                         values
+                         (isLastTicketNo istate)
+                         (TxSeq.toList $ isTxs istate)
+      mTrace = if null removed
+               then
+                 Nothing
+               else
+                 Just $ TraceMempoolRemoveTxs removed (isMempoolSize is')
+  in (is', mTrace)
 
 -- | Get a snapshot of the mempool state that is valid with respect to
 -- the given ledger state, together with the ticked ledger state.
 pureGetSnapshotFor
-  :: forall blk.
-     ( LedgerSupportsMempool blk
+  :: ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      )
-  => LedgerConfig blk
-  -> MempoolCapacityBytesOverride
+  => MempoolCapacityBytesOverride
+  -> LedgerConfig blk
+  -> LedgerTables (LedgerState blk) ValuesMK
   -> InternalState blk
   -> ForgeLedgerState blk
-  -> LedgerTables (LedgerState blk) ValuesMK
-  -> MempoolSnapshot blk TicketNo
-pureGetSnapshotFor _ _ _ ForgeInUnknownSlot{} _ = error "Tried to get a snapshot for unknown slot"
-pureGetSnapshotFor cfg capacityOverride is (ForgeInKnownSlot slot st) values = implSnapshotFromIS $
-  if (isTip is == castHash (getTipHash st) && isSlotNo is == slot)
-  then is
-  else internalStateFromVR
-     $ revalidateTxsFor
-         capacityOverride
-         cfg
-         slot
-         st
-         values
-         (isDbChangelog is)
-         (isLastTicketNo is)
-         (TxSeq.toList $ isTxs is)
+  -> MempoolSnapshot blk
+pureGetSnapshotFor _ _ _ _ ForgeInUnknownSlot{} =
+  error "Tried to get a snapshot for unknown slot"
+pureGetSnapshotFor capacityOverride cfg values is (ForgeInKnownSlot slot st) =
+  implSnapshotFromIS $
+    if (pointHash (isTip is) == castHash (getTipHash st) && isSlotNo is == slot)
+    then is
+    else fst $ revalidateTxsFor
+                 capacityOverride
+                 cfg
+                 slot
+                 st
+                 values
+                 (isLastTicketNo is)
+                 (TxSeq.toList $ isTxs is)
 
 {-------------------------------------------------------------------------------
-  MempoolSnapshot Implementation
+  Revalidate transactions
 -------------------------------------------------------------------------------}
 
--- | Create a 'MempoolSnapshot' from a given 'InternalState' of the mempool.
-implSnapshotFromIS
-  :: HasTxId (GenTx blk)
-  => InternalState blk
-  -> MempoolSnapshot blk TicketNo
-implSnapshotFromIS is = MempoolSnapshot {
-      snapshotTxs         = implSnapshotGetTxs         is
-    , snapshotTxsAfter    = implSnapshotGetTxsAfter    is
-    , snapshotLookupTx    = implSnapshotGetTx          is
-    , snapshotHasTx       = implSnapshotHasTx          is
-    , snapshotMempoolSize = implSnapshotGetMempoolSize is
-    , snapshotSlotNo      = isSlotNo                   is
-    , snapshotTipHash     = isTip                      is
-    }
- where
-  implSnapshotGetTxs :: InternalState blk
-                     -> [(Validated (GenTx blk), TicketNo)]
-  implSnapshotGetTxs = flip implSnapshotGetTxsAfter zeroTicketNo
-
-  implSnapshotGetTxsAfter :: InternalState blk
-                          -> TicketNo
-                          -> [(Validated (GenTx blk), TicketNo)]
-  implSnapshotGetTxsAfter IS{isTxs} =
-    TxSeq.toTuples . snd . TxSeq.splitAfterTicketNo isTxs
-
-  implSnapshotGetTx :: InternalState blk
-                    -> TicketNo
-                    -> Maybe (Validated (GenTx blk))
-  implSnapshotGetTx IS{isTxs} = (isTxs `TxSeq.lookupByTicketNo`)
-
-  implSnapshotHasTx :: Ord (GenTxId blk)
-                    => InternalState blk
-                    -> GenTxId blk
-                    -> Bool
-  implSnapshotHasTx IS{isTxIds} = flip Set.member isTxIds
-
-  implSnapshotGetMempoolSize :: InternalState blk
-                             -> MempoolSize
-  implSnapshotGetMempoolSize = TxSeq.toMempoolSize . isTxs
+-- | Revalidate the given transactions against the given ticked ledger state.
+--
+-- Note that this function will perform revalidation so it is expected that the
+-- transactions given to it were previously applied, for example if we are
+-- revalidating the whole set of transactions onto a new state, or if we remove
+-- some transactions and revalidate the remaining ones.
+revalidateTxsFor
+  :: (LedgerSupportsMempool blk, HasTxId (GenTx blk))
+  => MempoolCapacityBytesOverride
+  -> LedgerConfig blk
+  -> SlotNo
+  -> TickedLedgerState blk DiffMK
+     -- ^ The ticked ledger state againt which txs will be revalidated
+  -> LedgerTables (LedgerState blk) ValuesMK
+     -- ^ The tables with all the inputs for the transactions
+  -> TicketNo -- ^ 'isLastTicketNo' & 'vrLastTicketNo'
+  -> [TxTicket (Validated (GenTx blk))]
+  -> ( InternalState blk
+     , [Validated (GenTx blk)]
+     )
+revalidateTxsFor capacityOverride cfg slot st values lastTicketNo txTickets =
+    let vr = repeatedly
+             (extendVRPrevApplied cfg)
+             txTickets
+             $ validationResultFromIS values
+             $ initInternalState capacityOverride lastTicketNo slot st
+    in (internalStateFromVR vr, map fst (vrInvalid vr))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -101,10 +101,10 @@ defaultChainDbView ::
      (IOLike m, LedgerSupportsProtocol blk)
   => ChainDB m blk -> ChainDbView m blk
 defaultChainDbView chainDB = ChainDbView {
-      getCurrentChain       =                   ChainDB.getCurrentChain       chainDB
-    , getHeaderStateHistory =                   ChainDB.getHeaderStateHistory chainDB
-    , getPastLedger         = fmap (fmap fst) . ChainDB.getPastLedger         chainDB
-    , getIsInvalidBlock     =                   ChainDB.getIsInvalidBlock     chainDB
+      getCurrentChain       = ChainDB.getCurrentChain       chainDB
+    , getHeaderStateHistory = ChainDB.getHeaderStateHistory chainDB
+    , getPastLedger         = ChainDB.getPastLedger         chainDB
+    , getIsInvalidBlock     = ChainDB.getIsInvalidBlock     chainDB
     }
 
 -- newtype wrappers to avoid confusing our tip with their tip.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalTxMonitor/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalTxMonitor/Server.hs
@@ -10,18 +10,18 @@ import           Ouroboros.Network.Protocol.LocalTxMonitor.Type
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Mempool (TicketNo)
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Util.IOLike
 
 -- | Local transaction monitoring server, for inspecting the mempool.
 --
 localTxMonitorServer ::
-     forall blk idx m.
+     forall blk m.
      ( MonadSTM m
      , LedgerSupportsMempool blk
-     , Eq idx
      )
-  => Mempool m blk idx
+  => Mempool m blk
   -> LocalTxMonitorServer (GenTxId blk) (GenTx blk) SlotNo m ()
 localTxMonitorServer mempool =
     LocalTxMonitorServer (pure serverStIdle)
@@ -38,14 +38,14 @@ localTxMonitorServer mempool =
       }
 
     serverStAcquiring
-      :: (MempoolCapacityBytes, MempoolSnapshot blk idx)
+      :: (MempoolCapacityBytes, MempoolSnapshot blk)
       -> ServerStAcquiring (GenTxId blk) (GenTx blk) SlotNo m ()
     serverStAcquiring s@(_, snapshot) =
       SendMsgAcquired (snapshotSlotNo snapshot) (serverStAcquired s (snapshotTxs snapshot))
 
     serverStAcquired
-      :: (MempoolCapacityBytes, MempoolSnapshot blk idx)
-      -> [(Validated (GenTx blk), idx)]
+      :: (MempoolCapacityBytes, MempoolSnapshot blk)
+      -> [(Validated (GenTx blk), TicketNo)]
       -> ServerStAcquired (GenTxId blk) (GenTx blk) SlotNo m ()
     serverStAcquired s@(capacity, snapshot) txs =
       ServerStAcquired
@@ -76,8 +76,8 @@ localTxMonitorServer mempool =
 
     -- Are two snapshots equal? (from the perspective of this protocol)
     isSameSnapshot
-      :: MempoolSnapshot blk idx
-      -> MempoolSnapshot blk idx
+      :: MempoolSnapshot blk
+      -> MempoolSnapshot blk
       -> Bool
     isSameSnapshot a b =
       (snd <$> snapshotTxs a) == (snd <$> snapshotTxs b)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
@@ -24,7 +24,7 @@ import           Ouroboros.Consensus.Util.IOLike
 localTxSubmissionServer
   :: MonadSTM m
   => Tracer m (TraceLocalTxSubmissionServerEvent blk)
-  -> Mempool m blk idx
+  -> Mempool m blk
   -> LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()
 localTxSubmissionServer tracer mempool =
     server

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -24,8 +24,6 @@ module Ouroboros.Consensus.NodeKernel (
   , initNodeKernel
   ) where
 
-
-
 import           Control.DeepSeq (force)
 import           Control.Monad
 import           Control.Monad.Except
@@ -92,7 +90,7 @@ data NodeKernel m remotePeer localPeer blk = NodeKernel {
       getChainDB             :: ChainDB m blk
 
       -- | The node's mempool
-    , getMempool             :: Mempool m blk TicketNo
+    , getMempool             :: Mempool m blk
 
       -- | The node's top-level static configuration
     , getTopLevelConfig      :: TopLevelConfig blk
@@ -184,7 +182,7 @@ data InternalState m remotePeer localPeer blk = IS {
     , blockFetchInterface :: BlockFetchConsensusInterface remotePeer (Header blk) blk m
     , fetchClientRegistry :: FetchClientRegistry remotePeer (Header blk) blk m
     , varCandidates       :: StrictTVar m (Map remotePeer (StrictTVar m (AnchoredFragment (Header blk))))
-    , mempool             :: Mempool m blk TicketNo
+    , mempool             :: Mempool m blk
     }
 
 initInternalState
@@ -304,7 +302,7 @@ forkBlockForging IS{..} blockForging =
           -- produce a block that fits onto the ledger we got above; if the
           -- ledger in the meantime changes, the block we produce here may or
           -- may not be adopted, but it won't be invalid.
-          (unticked, dbch) <- do
+          unticked <- do
             mExtLedger <- lift $ atomically $ ChainDB.getPastLedger chainDB bcPrevPoint
             case mExtLedger of
               Just val -> return val
@@ -397,11 +395,14 @@ forkBlockForging IS{..} blockForging =
 
           mempoolSnapshot <- lift $ getSnapshotFor
                              mempool
+                             (castPoint $ getTip unticked)
                              currentSlot
                              tickedLedgerState
-                             dbch
 
-          pure ( mempoolSnapshot
+          let e = error "Mempool snapshot failed in forging loop. RAWLock violation"
+
+          pure ( -- OK because we are holding the read lock
+                 maybe e id mempoolSnapshot
                , bcPrevPoint
                , mempoolHash
                , mempoolSlotNo
@@ -438,7 +439,7 @@ forkBlockForging IS{..} blockForging =
 
             trace $ TraceForgedBlock
                       currentSlot
-                      (ledgerTipPoint (Proxy @blk) (ledgerState unticked))
+                      (ledgerTipPoint (ledgerState unticked))
                       newBlock
                       (snapshotMempoolSize mempoolSnapshot)
 
@@ -587,7 +588,7 @@ getMempoolReader
      , IOLike m
      , HasTxId (GenTx blk)
      )
-  => Mempool m blk TicketNo
+  => Mempool m blk
   -> TxSubmissionMempoolReader (GenTxId blk) (Validated (GenTx blk)) TicketNo m
 getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
     { mempoolZeroIdx     = zeroTicketNo
@@ -595,7 +596,7 @@ getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
     }
   where
     convertSnapshot
-      :: MempoolSnapshot               blk                                   TicketNo
+      :: MempoolSnapshot               blk
       -> MempoolReader.MempoolSnapshot (GenTxId blk) (Validated (GenTx blk)) TicketNo
     convertSnapshot MempoolSnapshot { snapshotTxsAfter, snapshotLookupTx,
                                       snapshotHasTx } =
@@ -613,7 +614,7 @@ getMempoolWriter
      , IOLike m
      , HasTxId (GenTx blk)
      )
-  => Mempool m blk TicketNo
+  => Mempool m blk
   -> TxSubmissionMempoolWriter (GenTxId blk) (GenTx blk) TicketNo m
 getMempoolWriter mempool = Inbound.TxSubmissionMempoolWriter
     { Inbound.txId          = txId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -16,6 +16,7 @@
 module Ouroboros.Consensus.Storage.ChainDB.API (
     -- * Main ChainDB API
     ChainDB (..)
+  , PointNotFound (..)
   , getCurrentLedger
   , getCurrentTip
   , getHeaderStateHistory
@@ -77,7 +78,6 @@ import           Ouroboros.Consensus.HeaderStateHistory
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
-import           Ouroboros.Consensus.Mempool.Impl.Types (MempoolChangelog (..))
 import           Ouroboros.Consensus.Util (StaticEither (..), (..:))
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike
@@ -89,12 +89,10 @@ import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunis
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.FS.API.Types (FsError)
-import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
-                     (LedgerDB (ledgerDbChangelog))
+import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.InMemory as LedgerDB
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
-                     (LedgerBackingStore, LedgerBackingStoreValueHandle,
-                     LedgerDB')
+                     (LedgerBackingStoreValueHandle, LedgerDB')
 import           Ouroboros.Consensus.Storage.Serialisation
 
 -- Support for tests
@@ -367,6 +365,15 @@ data ChainDB m blk = ChainDB {
                  )
                )
 
+      -- | Read and forward the values up to the given point on the chain. Returns
+      -- Nothing if the anchor moved or if the state is not found on the ledger db.
+    , getLedgerTablesAtFor ::
+           Point blk
+        -> LedgerTables (ExtLedgerState blk) KeysMK
+        -> m (Either
+                (PointNotFound blk)
+                (LedgerTables (ExtLedgerState blk) ValuesMK))
+
       -- | Close the ChainDB
       --
       -- Idempotent.
@@ -378,10 +385,6 @@ data ChainDB m blk = ChainDB {
       --
       -- 'False' when the database is closed.
     , isOpen             :: STM m Bool
-
-      -- | Return the backing store in the Ledger DB to be (for now at least)
-      -- used by the mempool.
-    , getBackingStore :: m (LedgerBackingStore m (ExtLedgerState blk))
 
       -- | Perform a monadic operation holding the read lock on the DB
       -- changelog.
@@ -417,15 +420,9 @@ getPastLedger ::
      (Monad (STM m), LedgerSupportsProtocol blk)
   => ChainDB m blk
   -> Point blk
-  -> STM m (Maybe ( ExtLedgerState blk EmptyMK, MempoolChangelog blk))
-getPastLedger db pt = do
-  mldb <- LedgerDB.ledgerDbPrefix pt <$> getLedgerDB db
-  pure $ fmap (\l -> ( LedgerDB.ledgerDbCurrent l
-                     , let c = ledgerDbChangelog l
-                       in MempoolChangelog
-                            (changelogDiffAnchor c)
-                            (unExtLedgerStateTables $ changelogDiffs c)))
-         mldb
+  -> STM m (Maybe (ExtLedgerState blk EmptyMK))
+getPastLedger db pt =
+  fmap LedgerDB.ledgerDbCurrent <$> LedgerDB.ledgerDbPrefix pt <$> getLedgerDB db
 
 -- | Get a 'HeaderStateHistory' populated with the 'HeaderState's of the
 -- last @k@ blocks of the current chain.
@@ -444,6 +441,9 @@ getHeaderStateHistory = fmap toHeaderStateHistory . getLedgerDB
     toHeaderStateHistory =
           HeaderStateHistory
         . LedgerDB.volatileStatesBimap headerState headerState
+
+-- | The requested point is not found on the ledger db
+data PointNotFound blk = PointNotFound !(Point blk)
 
 {-------------------------------------------------------------------------------
   Adding a block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -224,8 +224,8 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , getLedgerBackingStoreValueHandle = \rreg p -> getEnv h $ \env' -> do
                 Query.getLedgerBackingStoreValueHandle env' rreg p
 
-            , getBackingStore       =       getEnv h (pure . LgrDB.lgrBackingStore . cdbLgrDB)
-            , withLgrReadLock       = \m -> getEnv h (flip LgrDB.withReadLock m    . cdbLgrDB)
+            , getLedgerTablesAtFor  = \pt keys -> getEnv h (LgrDB.getLedgerTablesAtFor pt keys . cdbLgrDB)
+            , withLgrReadLock       = \m       -> getEnv h (flip LgrDB.withReadLock m    . cdbLgrDB)
             }
           testing = Internal
             { intCopyToImmutableDB       = getEnv  h Background.copyToImmutableDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -703,7 +703,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish =
 
         (tipPoint, (tipEpoch, tipSlotInEpoch)) =
           case pointToWithOriginRealPoint
-                 (ledgerTipPoint (Proxy @blk) ledger) of
+                 (ledgerTipPoint ledger) of
             Origin        -> error "cannot have switched to an empty chain"
             NotOrigin tip ->
               let query = History.slotToEpoch' (realPointSlot tip)


### PR DESCRIPTION
# Description

Arising from the discussion on the mempool tests, it followed that the mempool could probably become less aware of the LedgerDB, the Changelog and the BackingStore, and indeed the mempool can just ask the LedgerDB for UTxO values. This PR implements that and some side changes. In particular this is a comprehensive list of the changes:

- Some general cleanup on comments 
- Remove the `Proxy` from `ledgerTipPoint`
- Remove the `idx` type parameter from the `Mempool` and `MempoolSnapshot`
- Superflous indirection datatypes in `Mempool.Impl.Pure` are gone (`SyncWithLedger`, `RemoveTxs`,...)
- Pure functions that revalidate got the revalidation factored out into `revalidateTxsFor` and the arguments re-sorted
- Mempool now asks the ledgerdb to forward values. In particular
    - `LedgerInterface.getCurrentLedgerAndChangelog` is renamed to `LedgerInterface.getCurrentLedger`
    - `MempoolChangelog` is gone
    - new function `LedgerInterface.getLedgerTablesAtFor` which calls `LgrDB.getLedgerTablesAtFor`
    - `LedgerInterface.getBackingStore` is gone
    - Depending on the value returned from `getLedgerTablesAtFor` (of type `TablesForKeys`), new actions are performed. In particular if the anchor moved we read again, and if the ledger state is not found we recurse the whole action
    - The read lock is gone on the mempool side.
- `Mempool.API.getSnapshotFor` now might fail. Acquiring the lock prevents it from failing.
- `isTip` is now a `Point` which still contains the `ChainHash` it held before, but now it can be used to query for a point on the ledger database when forwarding

Closes #4161 
