### PR TITLE
GHA: fix caching and others

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,7 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
     steps:
-    - name: "LINUX: Setup haskell"
-      if: runner.os != 'Windows'
-      uses: haskell/actions/setup@v2
-      id: setup-haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.6.2.0
-
-    - name: "WIN: Setup Haskell"
+    - name: "WIN: Install System Dependencies via pacman (msys2)"
       if: runner.os == 'Windows'
       run: |
         # ghcup should be installed on current GHA Windows runners. Let's use ghcup to run
@@ -44,13 +36,21 @@ jobs:
            libtool `
            make
 
-        # ... and also the ghc and cabal combination we want.
+    # this seems to break something. It _must_ come after the pacman setup
+    # above. It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and
+    # as such we'd need pacman.exe instead.
+    - name: Setup Haskell
+      run: |        
+        # Use GHCUP to manage ghc/cabal
         ghcup install ghc --set ${{ matrix.ghc }}
         ghcup install cabal --set 3.6.2.0
 
         ghc --version
         cabal --version
 
+    - name: "WIN: fixup cabal config"
+      if: runner.os == 'Windows'
+      run: |
         # make sure cabal knows about msys64, and mingw64 tools. Not clear why C:/cabal/config is empty
         # and C:/cabal doesn't even exist.  The ghcup bootstrap file should have create it in the image:
         # See https://github.com/haskell/ghcup-hs/blob/787edc17af4907dbc51c85e25c490edd8d68b80b/scripts/bootstrap/bootstrap-haskell#L591
@@ -70,14 +70,26 @@ jobs:
                           -a ("extra-lib-dirs: {0}, C:/msys64/mingw64/lib" -f $ghcMingwDir) `
                           -f init
 
-    - name: "OUTPUT Record cabal-store"
+    - name: "OUTPUT Record cabal-store (Linux)"
+      id: lin-setup-haskell
+      shell: bash
+      if: runner.os != 'Windows'
+      run: |
+        echo "cabal-store=/home/runner/.cabal/store" >> $GITHUB_OUTPUT
+        
+    - name: "OUTPUT Record cabal-store (Windows)"
       id: win-setup-haskell
       shell: bash
       if: runner.os == 'Windows'
-      run: echo "cabal-store=$(dirname $(cabal --help | tail -1 | tr -d ' '))\\store" >> $GITHUB_OUTPUT     
+      run: |
+        echo "cabal-store=C:\\cabal\\store" >> $GITHUB_OUTPUT     
 
-    - name: Set cache version
-      run: echo "CACHE_VERSION=20220919" >> $GITHUB_ENV
+    - name: "[OUTPUT] cache keys: version, weeknum"
+      id: cache-keys
+      shell: bash
+      run: |
+        echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
+        echo "CACHE_VERSION=20220919" >> $GITHUB_OUTPUT
 
     - name: "LINUX: Install build environment (apt-get)"
       if: runner.os == 'Linux'
@@ -133,16 +145,13 @@ jobs:
         cabal build all --dry-run
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
 
-    - name: "OUTPUT Record weeknum"
-      shell: bash
-      run: echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       name: "Cache `cabal store`"
       with:
-        path: ${{ runner.os == 'Windows' && steps.win-setup-haskell.outputs.cabal-store || steps.setup-haskell.outputs.cabal-store }}
-        key: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-        restore-keys: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+        path: ${{ runner.os == 'Windows' && steps.win-setup-haskell.outputs.cabal-store || steps.lin-setup-haskell.outputs.cabal-store }}
+        key: cache-dependencies-${{ steps.cache-keys.outputs.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+        restore-keys: cache-dependencies-${{ steps.cache-keys.outputs.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
     - uses: actions/cache@v3
       name: "Cache `dist-newstyle`"
@@ -150,8 +159,8 @@ jobs:
         path: |
           dist-newstyle
           !dist-newstyle/**/.git
-        key: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ steps.record-deps.outputs.weeknum }}
-        restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+        key: cache-dist-${{ steps.cache-keys.outputs.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ steps.cache-keys.outputs.weeknum }}
+        restore-keys: cache-dist-${{ steps.cache-keys.outputs.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
     - name: Build dependencies
       run: cabal build --only-dependencies all -j


### PR DESCRIPTION
This tries to simplify the GHA further.
- fix the Caching logic, by using output instead of a mixture of output and env.
- investigate if we can use ghcup for consistency on linux _and_ windows, instead of haskell actions + ghcup on windows.