### PR TITLE
Update SendFetchRequest trace

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -186,7 +186,7 @@ blockFetchClient _version controlMessageSTM reportFetched
                 Right lower = AF.last fragment
                 Right upper = AF.head fragment
 
-        traceWith tracer (SendFetchRequest fragment)
+        traceWith tracer (SendFetchRequest fragment gsvs)
         return $
           SenderPipeline
             (ClientAgency TokIdle)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -383,6 +383,7 @@ data TraceFetchClientState header =
        -- over the wire.
      | SendFetchRequest
          (AnchoredFragment header)
+         PeerGSV
 
        -- | Mark the start of receiving a streaming batch of blocks. This will
        -- be followed by one or more 'CompletedBlockFetch' and a final


### PR DESCRIPTION


# Description
The incomming and outgoing G (RTT) can decide if we attempt to fetch a given block from a peer. Adding PeerGSV to SendFetchRequest lets us track G for not only the first node we downloaded a block from, but for all other download attempts we initiated for that block.

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
