### PR TITLE
Add Galois protocol tutorials

### DIFF
--- a/ouroboros-consensus-test/README.md
+++ b/ouroboros-consensus-test/README.md
@@ -10,3 +10,4 @@ This package contains:
 * `test-storage`: Tests of the storage layer.
 
 * `test-infra`: Tests of some of the infrastructure in `src`.
+

--- a/ouroboros-consensus/README.md
+++ b/ouroboros-consensus/README.md
@@ -12,6 +12,10 @@ This package contains:
 * `docs`: documentation, in particular, `docs/report` contains the technical
   report about the consensus and storage layer.
 
+* `src-docs`: a collection of tutorials that are helpful for understanding the
+  abstract structure of the consensus protocol. The structure of these is
+  explained in [docs/Tutorials.md](docs/Tutorials.md).
+
 The following packages use `ouroboros-consensus` to integrate specific ledgers:
 
 * `../ouroboros-consensus-byron`: integration with the Byron ledger, including

--- a/ouroboros-consensus/docs/AbstractProtocol.md
+++ b/ouroboros-consensus/docs/AbstractProtocol.md
@@ -1,0 +1,282 @@
+# Abstract Protocol
+
+## Tutorials
+
+### Overview
+
+- [Ouroboros.Consensus.Tutorial.Simple](tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs):
+  Simple round-robin instantiation of the abstract Ouroboros consensus protocol.
+- [Ouroboros.Consensus.Tutorial.WithEpoch](tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs):
+  Example in which the leader schedule depends on data from the chain.
+
+### Generating documents
+
+From the `ouroboros-consensus` directory, run for your choice of `<output
+file>`:
+
+    pandoc -s -f markdown+lhs src-docs/Ouroboros/Consensus/Tutorial/Simple.lhs -o <output file>
+
+## Key Type Families and Classes
+
+The following diagram depicts the relation between various constructs in the
+abstract specification of the protocol and the consensus-level view of th
+ledger.
+- Red boxes indicate concepts, or informal kinds (e.g., `ShelleyLedgerState`
+  would have the informal kind `Ledger`).
+- Blue boxes indicate data families.
+- Green boxes indicate type families.
+- Type or data families map the block attached to the incoming arrow to the
+  block attached to the outgoing arrow. When there is no outgoing arrow, the
+  family maps to any type (e.g., `BlockConfig blk`).
+
+```mermaid
+flowchart LR;
+
+  classDef df fill:#4285F4, border:10px;
+  classDef tf fill:#34A853;
+  classDef kind fill:#EA4335;
+
+  Block(Block)-->BlockProtocol[BlockProtocol blk]; class Block kind;
+  click Block "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs"
+  Block-->BlockConfig[BlockConfig blk]; class BlockConfig df
+  BlockProtocol[BlockProtocol blk]-.->Protocol(Protocol); class BlockProtocol tf;
+  click BlockProtocol "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs"
+  click BlockProtocol "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs"
+  click BlockConfig "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs"
+  Block-->StorageConfig; class StorageConfig df
+  click StorageConfig "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs"
+  Block-->CodecConfig[CodecConfig blk]; class CodecConfig df
+  click CodecConfig "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs"
+  Block-->Header[Header blk]; class Header df
+  click Header "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs"
+  Ledger(Ledger); class Ledger kind
+  click Ledger "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs"
+  Block-->LedgerState[LedgerState blk]; class LedgerState df;
+  click LedgerState "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs"
+
+  Block-->GenTx[GenTx blk]; class GenTx df
+  click GenTx "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMemPool.hs"
+  Block-->ApplyTxErr[ApplyTxErr blk]; class ApplyTxErr df
+  click ApplyTxErr "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMemPool.hs"
+  LedgerState-.->Ledger
+  Ledger-->AuxLedgerEvent[AuxLedgerEvent l]; class AuxLedgerEvent tf
+  click AuxLedgerEvent "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs"
+  Ledger-->LedgerErr[LedgerErr l]; class LedgerErr tf
+  click LedgerErr "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs"
+
+  Protocol(Protocol); class Protocol kind
+  Protocol-->ConsensusConfig[ConsensusConfig p]; class ConsensusConfig df
+  click ConsensusConfig "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+  subgraph ConsensusProtocol[class ConsensusProtocol]
+    ChainDepState[ChainDepState p]; class ChainDepState tf
+    click ChainDepState "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+    IsLeader[IsLeader p]; class IsLeader tf
+    click IsLeader "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+    CanBeLeader[CanBeLeader p]; class CanBeLeader tf
+    click CanBeLeader "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+    SelectView[SelectView p]; class SelectView tf
+    click SelectView "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+    LedgerView[LedgerView p]; class LedgerView tf
+    click LedgerView "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+    ValidationErr[ValidationErr p]; class ValidationErr tf
+    click ValidationErr "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+    ValidateView[ValidateView p]; class ValidateView tf
+    click ValidateView "https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs"
+  end
+  Protocol-->ChainDepState
+  Protocol-->IsLeader[IsLeader p]
+  Protocol-->CanBeLeader[CanBeLeader p]
+  Protocol-->SelectView[SelectView p]
+  Protocol-->LedgerView[LedgerView p]
+  Protocol-->ValidationErr[ValidationErr p]
+  Protocol-->ValidateView[ValidateView p]
+```
+## Birds Eye Overview of Consensus Types (Galois)
+
+See [Diagrammatic Conventions](#diagrammatic-conventions)
+
+### Type Families (standalone and associated types)
+
+From inspecting the directions of the arrows, it should be clear that `b :: B`
+fully determines---directly or indirectly---all the other types.
+
+``` haskell
+ P[rotocol]                       B[lock]                       L[edger]                     -- (the P,B,L "kinds")
+===                              ===                           ===
+                                                                                                  ┏━━━━━━━━━━━┓
+ p  ──(ConsensusConfig :: P→*)──────────────────────────────────────────────────────────────▶ cc  ┃{- static-}┃
+ p  ◀──(BlockProtocol :: B→P)──── b ──(BlockConfig :: B→*)──────────────────────────────────▶ bc  ┃{- config-}┃
+                                  b ──(LedgerState :: B→L)──▶ l ──(LedgerCfg :: L→*)────────▶ lc  ┃{- data  -}┃
+                                                                                                  ┗━━━━━━━━━━━┛
+
+                                  b ──(LedgerState :: B→L)──▶ l ──(AuxLedgerEvent :: L→*)──▶ lev   -- events emitted by ledger
+                                                              l ──(LedgerErr :: L→*)───────▶ lerr  -- errors when updating ledger
+
+
+                                  b ──(CodecConfig   :: B→*)──────▶ codecc -- for serialisation and deserialisation
+                                  b ──(StorageConfig :: B→*)──────▶ sc     -- for (re)initializing the Storage Layer
+                                  b ──(Header        :: B→*)──────▶ hdr    -- link block to its header
+
+                                              b,l ──(HeaderHash :: *→*)──────▶ hash   -- link block/ledger to a hash
+
+  p ──(ChainDepState :: P→*)──> cds     -- protocol specific state (part that depends on the chain), would rollback when chain does
+  p ──(IsLeader      :: P→*)──> isldr   -- evidence that a node /is/ the leader
+  p ──(CanBeLeader   :: P→*)──> cbldr   -- evidence that we /can/ be leader
+  p ──(SelectView    :: P→*)──> hdrVwCS -- projection of header used for chain selection (using 'Ord hdrVwCS'); often 'BlockNo'
+  p ──(ValidateView  :: P→*)──> hdrVwHV -- projection of header used for header validation (not full block validation)
+  p ──(LedgerView    :: P→*)──> ledvw   -- projection of the ledger state ('l') that is required by the protocol
+  p ──(ValidationErr :: P→*)──> valerr  -- the error result when failing to add new header to 'cds'
+
+                     s ───(Ticked :: *→*)───▶ s'   -- time related changes applied to some state ('l', 'ledvw', 'cds')
+
+                                  b ───(GenTx :: B→*)────────────────────────▶ tx      -- generalized transactions
+                                  b ───(ApplyTxErr :: B→*)───────────────────▶ txerr   -- errors
+
+                                  b,tx ───(Validated :: *→*)─────────────────▶ valb,valtx  -- add proof of validity to b,tx
+```
+
+### Type Constructors That are Type-Generic
+
+These type constructors effectively function as type families (as type families are used in their definitions):
+(This list is not exhaustive of all such types.)
+
+```haskell
+                                  b ────(Point :: B→*)───────────▶ point    -- newtype ... -- a point on the chain: hash & slotno
+
+                                  b ────(LedgerConfig :: B→*)───────────▶ lc    -- type LedgerConfig b = LedgerCfg (LedgerState b)
+                                  b ────(LedgerError  :: B→*)───────────▶ lerr  -- type LedgerError  b = LedgerErr (LedgerState b)
+                                  b ────(TickedLedgerState :: B→*)──────▶ tls   -- type TickedLedgerState b = Ticked (LedgerState b)
+
+                                  b,l ──(HeaderFields :: *→*)────────▶ data .. = .. SlotNo .. BlockNo .. HeaderHash b ..
+                                  b ────(ChainHash :: B→*)───────────▶ data ChainHash b = GenesisHash | BlockHash !(HeaderHash b)
+```
+
+### Key Type Classes
+
+The main `ConsensusProtocol` class:
+
+```haskell
+  class Ord (SelectView p) => ConsensusProtocol p where
+    type family {ChainDepState, IsLeader, CanBeLeader, SelectView, LedgerView, ValidationErr, ValidateView} :: P → *
+    checkIsLeader         :: cc → cbldr → SlotNo → Ticked cds → Maybe isldr          -- 'Just evidence' when we can lead this slot
+    tickChainDepState     :: cc → Ticked ledvw → SlotNo → cds → Ticked cds           -- update the 'cds' based on passage of time (SlotNo)
+    updateChainDepState   :: cc → hdrVwHV → SlotNo → Ticked cds → Except valerr cds  -- apply header to 'cds' (may error; leader check + etc.)
+    reupdateChainDepState :: cc → hdrVwHV → SlotNo → Ticked cds → cds                -- re-apply header to 'cds' (never errors)
+    protocolSecurityParam :: cc → SecurityParam                                      -- get security parameter 'k'
+```
+Classes connected to headers and blocks:
+```haskell
+ class (StandardHash b, Typeable b) => HasHeader b where -- abstract over block headers
+   getHeaderFields :: b → HeaderFields b    -- i.e., return three fields: slot, blockno, hash
+
+ class HasHeader (Header blk) => GetHeader blk where
+   getHeader          :: b → Header b             -- extract header from the block
+   blockMatchesHeader :: Header b → b → Bool      -- check if the header is the header of the block
+   headerIsEBB        :: Header b → Maybe EpochNo -- when the header of an Epoch Boundary Block (EBB), ...
+ 
+ class (HasHeader b, GetHeader b) => GetPrevHash b where   
+   headerPrevHash :: Header b → ChainHash b       -- get the hash of predecessor
+ 
+ -- construct the two views on block 'b' required by protocol 'p'
+ class (GetPrevHash b, ConsensusProtocol p) => BlockSupportsProtocol b where              
+   validateView :: bc → Header b → ValidateView p  -- project from hdr for hdr validation
+   selectView   :: bc → Header b → SelectView p    -- project from hdr for chain selection
+```
+Classes connected to ledgers:
+```haskell
+  class GetTip l where                         
+    getTip :: l → Point l               -- Point of the most recently applied block
+
+  class (GetTip l, GetTip (Ticked l)) => IsLedger l where
+    type family LedgerErr l      :: Type                   
+    type family AuxLedgerEvent l :: Type
+    applyChainTickLedgerResult   :: lc → SlotNo → l → LedgerResult l (Ticked l)  -- apply slot based state transformations (tip unchanged)
+        
+  class (IsLedger l, HeaderHash l ~ HeaderHash b, HasHeader b, HasHeader (Header b)) => ApplyBlock l b where
+    applyBlockLedgerResult   :: lc → b → Ticked l → Except (LedgerErr l) (LedgerResult l l)  
+    reapplyBlockLedgerResult :: lc → b → Ticked l →                       LedgerResult l l
+    
+  class ApplyBlock (LedgerState b) b => UpdateLedger b where
+    {}
+
+  -- | Link protocol to ledger
+  class (BlockSupportsProtocol b, UpdateLedger b, ValidateEnvelope b) => LedgerSupportsProtocol b where
+    protocolLedgerView   :: lc → Ticked l → Ticked ledvw   -- 'ledvw' ('LedgerView (BlockProtocol b)') extracted from the ledger
+    ledgerViewForecastAt :: lc → l → Forecast ledvw        -- get a forecast (of future 'ledvw's) from a given ledger state.
+      
+  class (UpdateLedger b) => LedgerSupportsMempool b where
+    txInvariant :: GenTx b → Bool                                                -- check if internal invariants of the transaction hold
+    applyTx   :: lc → WhetherToIntervene → SlotNo → tx → tls → Except txerr (tls, Validated tx)      -- apply an unvalidated transaction
+    reapplyTx :: lc →            SlotNo → Validated tx → tls → Except txerr tls          -- apply a previously validated transaction ...
+    txsMaxBytes :: tls → Word32                                   -- max number of bytes of transactions that can be put into a block
+    txInBlockSize :: tx → Word32                                  -- post-serialisation size in bytes of a 'GenTx b'
+    txForgetValidated :: Validated tx → tx                        -- discard the evidence that transaction has been previously validated
+```
+
+## Some Commonly Used Base Types (from pkgs ouroboros-consensus, cardano-base, and ouroboros-network)
+
+``` haskell
+data Forecast a = 
+  Forecast { forecastAt  :: WithOrigin SlotNo                                        -- Forecast a - Forecast the effect
+           , forecastFor :: SlotNo -> Except OutsideForecastRange (Ticked a)         --              of time ticking
+           }
+
+data LedgerResult l a = LedgerResult { lrEvents :: [AuxLedgerEvent l]        -- LedgerResult l a - The result of invoking 
+                                     , lrResult :: !a                        -- a ledger function that does validation
+                                     }
+
+data WithOrigin t = Origin | At !t
+
+newtype SlotNo = SlotNo {unSlotNo :: Word64}                    -- SlotNo - The 0-based index for the Ourboros time slot.
+
+data ChainHash b = GenesisHash | BlockHash !(HeaderHash b)
+
+data HeaderFields b = HeaderFields { headerFieldSlot    :: SlotNo                       -- HeaderFields - fields we expect
+                                   , headerFieldBlockNo :: BlockNo                      --                to be present in
+                                   , headerFieldHash    :: HeaderHash b                 --                a block.
+                                   }
+
+-- | A point on the chain is identified by its 'Slot' and 'HeaderHash'.
+newtype Point block = Point { getPoint :: WithOrigin (Point.Block SlotNo (HeaderHash block)) }
+
+-- Point is commonly "viewed" as the following:
+pattern GenesisPoint :: Point block
+pattern GenesisPoint = Point Origin
+pattern BlockPoint :: SlotNo -> HeaderHash block -> Point block
+pattern BlockPoint { atSlot, withHash } = Point (At (Point.Block atSlot withHash))
+{-# COMPLETE GenesisPoint, BlockPoint #-}
+
+```
+  
+## And Some Commonly Used Projections
+
+``` haskell
+blockHash :: HasHeader b => b -> HeaderHash b
+blockHash = headerFieldHash . getHeaderFields
+
+blockSlot :: HasHeader b => b -> SlotNo
+blockSlot = headerFieldSlot . getHeaderFields
+
+blockNo   :: HasHeader b => b -> BlockNo
+blockNo = headerFieldBlockNo . getHeaderFields
+```
+
+## Diagrammatic Conventions
+
+- Code should all be viewed fixed-font, at least 140 chars wide.
+
+- Regarding `P`, `B`, `L`
+   - these are not kinds in the code, but "morally equivalent",  created for the sake of documentation.
+   - `p`, `b`, and `l` are used as type names, respectively elements of the `P`,
+     `B`, and `L` kinds.
+  
+- Associated types are not being distinguished from standalone type families.
+  
+- NOTE: For the sake of line-width, or clarity, "type variables" are sometimes
+  used in place of "type-functions applied to variables".  This should not
+  result in ambiguity.  E.g.,
+   -  `p` in place of `BlockProtocol b`
+   -  `cds` in place of `ChainDepState p`
+  
+- To reduce the "noise", these type-class constraints are being ignored:
+  `NoThunks`, `Eq`, `Show`, `HasCallStack`; `Ord` is *not* being ignored.

--- a/ouroboros-consensus/docs/tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
+++ b/ouroboros-consensus/docs/tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
@@ -1,0 +1,708 @@
+% Example: Implementing a Simple Protocol Using `ouroborus-consensus`
+
+Generating Documentation From This File
+=======================================
+
+This file is written in a `markdown+lhs` style understood by `pandoc`.  To
+generate a document from this file - it is as simple as:
+
+```
+ pandoc -s -f markdown+lhs Tutorial.lhs -o <output file>
+```
+
+Which will work for many of the the output types supported by `pandoc`.
+
+
+Introduction and Motivation
+===========================
+
+This example is a compilable Literate Haskell (`.lhs`) file that instantiates
+the `ConsensusProtocol` typeclass to serve as an example of some of the
+high-level concepts in `ouroboros-consensus`
+
+This example uses several extensions:
+
+> {-# OPTIONS_GHC -Wno-unused-top-binds   #-}
+> {-# LANGUAGE TypeFamilies               #-}
+> {-# LANGUAGE DerivingVia                #-}
+> {-# LANGUAGE DataKinds                  #-}
+> {-# LANGUAGE DeriveGeneric              #-}
+> {-# LANGUAGE FlexibleInstances          #-}
+> {-# LANGUAGE DeriveAnyClass             #-}
+> {-# LANGUAGE MultiParamTypeClasses      #-}
+> {-# LANGUAGE StandaloneDeriving         #-}
+
+> module Ouroboros.Consensus.Tutorial.Simple () where
+
+First, some imports we'll need:
+
+> import Data.Void(Void)
+> import Data.Set(Set)
+> import qualified Data.Set as Set
+> import Data.Word(Word64, Word8)
+> import GHC.Generics (Generic)
+> import Codec.Serialise (Serialise)
+> import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
+> import Ouroboros.Consensus.Block.Abstract
+>   (blockNo, blockPoint, castHeaderFields, castPoint, BlockNo, SlotNo,
+>    BlockConfig, BlockProtocol, CodecConfig, GetHeader(..), GetPrevHash(..),
+>    Header, StorageConfig, ChainHash, HasHeader(..), HeaderFields(..),
+>    HeaderHash, Point, StandardHash)
+> import Ouroboros.Consensus.Protocol.Abstract
+>   (SecurityParam(..), ConsensusConfig, ConsensusProtocol(..) )
+> import Ouroboros.Consensus.Ticked ( Ticked(TickedTrivial) )
+> import Ouroboros.Consensus.Block
+>   (BlockSupportsProtocol (selectView, validateView))
+> import Ouroboros.Consensus.Ledger.Abstract
+>   (GetTip(..), IsLedger(..), LedgerCfg,
+>    LedgerResult(LedgerResult, lrEvents, lrResult),
+>    LedgerState, ApplyBlock(..), UpdateLedger)
+> import Ouroboros.Consensus.Ledger.SupportsProtocol
+>   (LedgerSupportsProtocol(..))
+> import Ouroboros.Consensus.Forecast (trivialForecast)
+> import Ouroboros.Consensus.HeaderValidation
+>   (ValidateEnvelope, BasicEnvelopeValidation, HasAnnTip)
+
+Conceptual Overview and Definitions of Key Terms
+================================================
+
+The object of interest to consensus is the **blockchain**.
+
+Within the context of this discussion a blockchain is linked-list-style chain of
+**blocks**, but its behavior is also subject to an integer-valued logical clock
+whose value is known as a **slot**.  The event that increments this clock is
+called a **tick**.
+
+Each block is associated with a single slot, though not every slot is associated
+with a block.  No two blocks have the same slot.  With that in mind, another way
+to consider the structure of a chain is to think of it as as a list of blocks
+each of which is separated by one or more ticks.
+
+We can then think of folding over this blockchain structure to compute some
+value that summarizes the entire history of the chain (blocks and ticks) in some
+way.  This same value might also be used to determine if a subsequent block is
+valid.  Computing this value is the responsibility of the **ledger** and the
+**ledger state** is the computed value.
+
+`ouroborus-consensus` combines features of much of this infrastructure taking
+(possibly simplified) views of blocks and the ledger and using them to decide
+between different proposed chains to implement eventual consistency across the
+nodes.
+
+The `Ticked` Family - Modeling the Passage of Time
+--------------------------------------------------
+
+Instances of the `Ticked` type family represents things that can evolve with
+respect to ticks - `Ticked a` is the type representing an `a` at some number of
+slots in the future.
+
+In this tutorial none of the implementations of `Ticked` will be especially
+interesting and will more or less be isomorphic to the `Identity` functor.
+Even if this is the case, `Ticked` helps us maintain some invariants - such as
+it being important that at least one tick happens between blocks.
+
+
+The `ConsensusProtocol` typeclass
+=================================
+
+The central abstraction of `ouroborus-consensus` is the `ConsensusProtocol`
+typeclass.  This class captures the relationship between consensus and the rest
+of the system (in particular the ledger) as a set of type families.
+
+To demonstrate these relationships, we will begin by defining a simple protocol
+creatively named `SP`.
+
+First, we define the type of the protocol itself.  This is a type-level "tag",
+this does not exist at the value level.
+
+> data SP
+
+The static configuration for `SP` is defined by defining an instance for the
+`ConsensusConfig` type family.  Some of the methods in `ConsensusProtocol` class
+such as `checkIsLeader` require an associated `ConsensusConfig p` so we define a
+simple one here:
+
+> data instance ConsensusConfig SP =
+>   SP_Config  { cfgsp_slotsLedByMe :: Set SlotNo
+>              }
+
+Next, we instantiate the `ConsensusProtocol` for `SP`:
+
+> instance ConsensusProtocol SP where
+>   type SelectView    SP = BlockNo
+>
+>   type LedgerView    SP = ()
+>
+>   type IsLeader      SP = SP_IsLeader
+>   type CanBeLeader   SP = SP_CanBeLeader
+>
+>   type ChainDepState SP = ()
+>   type ValidateView  SP = ()
+>   type ValidationErr SP = Void
+>
+>   checkIsLeader cfg SP_CanBeLeader slot _tcds =
+>       if slot `Set.member` cfgsp_slotsLedByMe cfg
+>       then Just SP_IsLeader
+>       else Nothing
+>
+>   protocolSecurityParam _cfg = k
+>
+>   tickChainDepState _ _ _ _ = TickedTrivial
+>
+>   updateChainDepState _ _ _ _ = return ()
+>
+>   reupdateChainDepState _ _ _ _ = ()
+
+Finally we define a few extra things used in this instantiation:
+
+> data SP_CanBeLeader = SP_CanBeLeader -- Evidence that we /can/ be a leader
+> data SP_IsLeader = SP_IsLeader       -- Evidence that we /are/ leader
+>
+> k :: SecurityParam
+> k = SecurityParam { maxRollbacks = 1 }
+
+Let's examine each of these in turn:
+
+Chain Selection: `SelectView`
+-----------------------------
+
+One of the major decisions when implementing a consensus protocol is encoding a
+policy for chain selection.  The `SelectView SP` type represents the information
+necessary from a block header to help make this decision.
+
+The other half of this - which explains how a `SelectView` is derived from a
+particular block - is expressed by the block's implementation of the
+`BlockSupportsProtocol` typeclass.
+
+The `preferCandidate` function in `Ouroboros.Consensus.Protocol.Abstract`
+demonstrates how this is used.
+
+Note that instantiations of `ConsensusProtocol` for some protocol `p`
+consequently requires `Ord (SelectView p)`.
+
+For `SP` we will use only `BlockNo` - to implement the simplest rule of
+preferring longer chains to shorter chains.
+
+
+Ledger Integration: `LedgerView`
+--------------------------------
+
+Some decisions that a consensus protocol needs to make will depend on the
+ledger's state, `LedgerState blk`.  The data required from the ledger is of
+type `LedgerView p` (i.e., the protocol determines what is needed).  Similar to
+`SelectView` the projection of `LedgerState blk` into `LedgerView p` exists in
+a typeclass, namely `LedgerSupportsProtocol`.
+
+For `SP` we do not require any information from the ledger to make decisions of
+any kind.  In the Praos protocol, the `LedgerView` contains information about
+the stake distribution among other things.
+
+Notably, this is used in the `tickChainDepState` function elsewhere in the
+`ConsensusProtocol`.
+
+
+Protocol State: `ChainDepState`, `ValidateView` and `ValidationErr`
+----------------------------------------------------------------
+
+`ChainDepState` describes the state of the protocol that evolves with the chain.
+Note, from [Cardano Consensus and Storage Layer]: ``we are referring to this as
+the “chain dependent state” to emphasize that this is state that evolves with
+the chain, and indeed is subject to rollback when we switch to alternatives
+forks. This distinguishes it from chain independent state such as evolving
+private keys, which are updated independently from blocks and are not subject to
+rollback.''
+
+`ValidateView` is a 'view' of a block (header) providing enough information to
+validate the block header.  It is called `ValidateView` because the functions
+used to compute new states from some combination of a prior `ChainDepState` and
+a `ValidateView` can _fail_ - producing a `ValidationErr`.
+
+There are some interesting constraints governing what can appropriately be used
+as a type fulfilling the requirements of `ValidateView` - in particular the fact
+that `ConsensusProtocol` instances are sometimes called upon to do _prediction_
+rather than just as a pure summary of history - and as such may not be able to
+witness a chain in its entirety.
+
+For more details, see the definition of `ConsensusProtocol`.
+
+
+Protocol State: `tickChainDepState`, `updateChainDepState` and `reupdateChainDepState`
+-----------------------------------------------------------------------------------
+
+These three functions model state transitions of values of type `ChainDepState`
+
+`tickChainDepState` computes a new `ChainDepState` from a prior state though a
+computation that models the (logical) passage of time.  In particular, it
+evolves the `chainDepState` some number of ticks given by the `SlotNo` argument.
+
+Unlike `updateChainDepState` this cannot fail under normal circumstances - if it
+could, that would mean there is some failure that is inevitable given the
+passage of time and if that is the case there would have been no reason not to
+throw such an error immediately.
+
+`updateChainDepState` (a better name would be "applyHeader") computes a new
+`ChainDepState` from a prior state and the needed view of the header,
+`ValidateView p`.  This could fail, producing a `ValidationErr p` instead of a
+`ChainDepState p`
+
+`reupdateChainDepState` is an optimization of `updateChainDepState` which is
+called when the header is known to be good (e.g., from a previous call to
+`updateChainDepState`) and the header check is unneeded.
+
+In the case of `SP` since the `chainDepState` is `()` these functions are not
+very interesting.  In the case of `tickChainDepState`, `TickedTrivial` is simply
+the `Ticked` instance for `()`.
+
+Leader Selection: `IsLeader`, `CanBeLeader`, `checkIsLeader`
+------------------------------------------------------------
+
+The type family `CanBeLeader` represents the ability for a particular node in
+the protocol to be a leader for a slot.  Put another way, a value of
+`CanBeLeader p` for a particular `p` witnesses the potential for a consensus
+participant to be a leader for a particular slot.
+
+In the same way, a value `IsLeader` witnesses the fact that a particular node is
+a leader for a slot.
+
+This notion of leadership is used to validate whether blocks are correct with
+respect to having been provably created by the leader of the slot the block
+appears in.  However, the details of what constitutes proof is specific to a
+particular blockchain, which is why it is dealt with abstractly in
+`ConsensusProtocol`.  Generally values of `CanBeLeader p` and `IsLeader p` are
+some sort of cryptographic evidence substantiating a claim to leadership.
+
+However, since we are less concerned about security in `SP`, we will use two
+simple singleton types - nothing cryptographic is happening at all.
+
+The `checkIsLeader` function uses these types in its determination of whether or
+not a node is a leader for a slot - returning `Nothing` if the node is not a
+slot leader or `Just (IsLeader p)` if it is.
+
+`SP` implements leadership by specifying, in the static `ProtocolConfig` for
+`SP`, a set of slots for which the particular node running the protocol is the
+leader.  `checkIsLeader` then looks up the slot number in this set and returns
+`Just SP_IsLeader` (aka `IsLeader SP`) if the node is configured to be a leader
+in this slot.
+
+
+The Security Parameter `k`: `protocolSecurityParam`
+---------------------------------------------------
+
+`ConsensusProtocol` requires that its static configuration -- which is to say
+the associated `ConsensusConfig p` for a particular `ConsensusProtocol p` --
+provide a security parameter (`SecurityParam`).  This requirement is embodied in
+the `protocolSecurityParam` method.
+
+For all known/current protocols, the security parameter is fixed for each
+blockchain (a protocol could be instantiated with different k's, but it should
+be configured the same for each node in that blockchain).
+
+The `maxRollbacks` field on the `SecurityParam` record (often referred to as
+`k`) describes how many blocks can be rolled back - any number of blocks greater
+than this should be considered permanently part of the chain with respect to the
+protocol.
+
+In the case of `SP` we allow 1 rollback.
+
+Further reading about Consensus
+-------------------------------
+
+The `ConsensusProtocol` class is also dealt with in some detail and with
+additional context in the [Cardano Consensus and Storage
+Layer](https://hydra.iohk.io/build/15874054/download/1/report.pdf) report.
+
+The `Ouroboros.Consensus.Protocol.Praos` module contains the instantiation of
+`ConsensusProtocol` for Praos.
+
+
+Blocks: The View From Consensus
+===============================
+
+In the discussion above, the reader may have noticed that we have only presented
+_views_ of some of the things consensus deals with.  This is to reduce coupling
+between `ConsensusProtocol p` and any particular block or ledger implementation.
+
+To enhance our example we'll implement a simple block and ledger that can be
+used with `SP` that logically keeps track of a single number.  Each block
+contains a list of transactions that either increment or decrement the number.
+At any point in time, the ledger's state can be thought of the net effect of all
+these transactions - in other words, the number of increment transactions minus
+the number of decrement transactions.
+
+Defining the Block
+------------------
+
+We'll start by defining the transaction type - this is what the block will
+contain:
+
+> data Tx = Inc | Dec
+>   deriving (Show, Eq, Generic, Serialise)
+
+Next, we'll define the block itself:
+
+> data BlockC =
+>   BlockC { bc_header :: Header BlockC
+>          , bc_body :: [Tx]
+>          }
+
+Which is to say, a block is just a header (`Header BlockC`) followed by a list
+of transactions (`[Tx]`) - we'll need to instantiate the `Header` family for
+`BlockC`.
+
+We'll deal with `Header BlockC` in the next section.
+
+Block Headers
+-------------
+
+The block header describes the _structure_ of the block chain - for example the
+hash of this block and that of the block before it.  As a side note, in the case
+of the genesis block, this "previous" hash will also be its own hash.  This
+corresponds to the `Header` data family (from
+`Ouroboros.Consensus.Block.Abstract`) which we'll instantiate as:
+
+> data instance Header BlockC =
+>   HdrBlockC { hbc_SlotNo :: SlotNo
+>             , hbc_BlockNo :: BlockNo
+>             , hbc_Hash :: HeaderHash BlockC
+>             , hbc_prev :: ChainHash BlockC
+>             }
+>   deriving stock (Show, Eq, Generic)
+>   deriving anyclass (Serialise)
+
+The `HeaderHash` type family describes the type used to represent hashes of
+headers - while the `ChainHash` type is either the `HeaderHash` of the prior
+block or `Genesis` if this is the genesis block.
+
+Accordingly, we'll instantiate `HeaderHash BlockC` as a list of bytes:
+
+> type instance HeaderHash BlockC = [Word8]
+
+We'll also instantiate the empty `StandardHash` class which does nothing that
+place additional constraints (already fulfilled by `[Word8]`) on `HeaderHash`.
+
+> instance StandardHash BlockC
+
+Because `Header` is a data family, functions using instantiations of this family
+will know nothing about the structure of the data - instead there are other
+typeclasses needed to build an interface to derive things that are needed from
+this value.  We'll implement those typeclasses next.
+
+
+
+Interface to the Block Header
+-----------------------------
+
+**`GetHeader`**
+
+The `GetHeader` class describes how to project a header - which is a value of
+type `Header BlockC` in our example - out of a block representation.  The
+implementation for `getHeader` is fairly straightforward - we can just use the
+record accessor `bc_header`:
+
+> instance GetHeader BlockC where
+>    getHeader = bc_header
+>    blockMatchesHeader = \_ _ -> True
+>    headerIsEBB = const Nothing
+
+
+**`GetPrevHash`**
+
+The `GetPrevHash` class contains a function that gets the hash of a previous
+block from the header - which is very simple for `Header BlockC`:
+
+> instance GetPrevHash BlockC where
+>  headerPrevHash = hbc_prev
+
+**`HasHeader`**
+
+The `HasHeader` typeclass has the `getHeaderFields` function which projects the
+information in the header to a `HeaderFields` record containing the slot, block
+number, and block hash.
+
+We implement this both for `Header Block`:
+
+> instance HasHeader (Header BlockC) where
+>   getHeaderFields hdr = HeaderFields
+>                          { headerFieldSlot = hbc_SlotNo hdr
+>                          , headerFieldBlockNo = hbc_BlockNo hdr
+>                          , headerFieldHash = hbc_Hash hdr
+>                          }
+
+As well as `BlockC` itself - which calls the `getHeaderFields` defined for
+`Header BlockC`:
+
+> instance HasHeader BlockC where
+>   getHeaderFields = castHeaderFields
+>                   . getHeaderFields
+>                   . bc_header
+
+**Validation**
+
+These classes require implementation but for this tutorial we don't really need
+to deal with them - so we'll leave them empty for now:
+
+> instance HasAnnTip BlockC where {}
+> instance ValidateEnvelope BlockC where {}
+> instance BasicEnvelopeValidation BlockC where {}
+
+Associating the Block and the Protocol - `BlockSupportsProtocol` and `BlockProtocol`
+------------------------------------------------------------------------------------
+
+So far, we've made no mention of `SP` in any of the definitions for `BlockC` -
+similarly, we've made no mention of `BlockC` in any of the definitions for `SP`
+we have to implement a few more typeclasses that define how the two are
+associated.
+
+More generally, a block has one and only one type of protocol - but the converse
+is not true - a protocol may have many types of block.  As such, the association
+between the two specifies the protocol for a particular type of block.  The type
+family establishing this relationship is the `BlockProtocol` family.
+
+Here, we define the protocol type for `BlockC` as `SP`:
+
+> type instance BlockProtocol BlockC = SP
+
+Also, the other half of `ValidateView SP` needs to be defined as well - which is
+how do we create a value of `ValidateView SP` given a block.  To do this, we
+instantiate the `BlockSupportsProtocol` typeclass.  Note that we do not need to
+say _which_ protocol is supported since there is only ever one protocol for a
+block, again established by our prior instantiation of `BlockProtocol`:
+
+> instance BlockSupportsProtocol BlockC where
+>   validateView _ _ = ()
+>   selectView _bcfg hdr = blockNo hdr
+
+Given that `ValidateView SP` is of type `()` there is only one possible
+implementation for this typeclass.  Later examples will require more interesting
+views of the block.
+
+Our example requires some additional configuration instances to be defined -
+we'll gloss over these for the time being but they allow for some additional
+static configuration of different things pertaining to blocks:
+
+> data instance BlockConfig BlockC = BCfgBlockC
+>   deriving (Generic, NoThunks)
+> data instance CodecConfig BlockC = CCfgBlockC
+>   deriving (Generic, NoThunks)
+> data instance StorageConfig BlockC = SCfgBlockC
+>   deriving (Generic, NoThunks)
+
+
+Consensus and The Ledger
+========================
+
+The _ledger_ specifies a state of the system represented by the blocks in a
+blockchain but also characterizes what transitions are valid for any particular
+state.
+
+Below we'll define a group of typeclasses that together implement a simple
+ledger that uses `BlockC` and that is suitable for our consensus protocol `SP`.
+
+
+`LedgerCfg` - Ledger Static Configuration
+-----------------------------------------
+
+Much like `ConsensusProtocol` and its `ConsensusConfig` configuration class, the
+ledger has an associated static configuration which is represented using the
+type family `LedgerCfg`.  For our example, we have nothing interesting to
+configure, thus:
+
+> type instance LedgerCfg (LedgerState BlockC) = ()
+
+`LedgerState` - The Value Computed by the Blockchain
+----------------------------------------------------
+
+`LedgerState` is a family which logically represents the value computed by the
+blockchain.  Put another way, it's a value derived from observing the the
+passage of time of the logical clock (aka slots) as well as any blocks
+inhabiting those slots - something like the result of a fold.
+
+Given that the `BlockC` transactions consist of incrementing and decrementing a
+number, we materialize that number in the `LedgerState`.  We'll also need to
+keep track of some information about the most recent block we have seen.
+
+> data instance LedgerState BlockC =
+>
+>   LedgerC
+>     -- the hash and slot number of the most recent block
+>     { lsbc_tip :: Point BlockC
+>     -- the computed result of applying all the transactions
+>     , lsbc_count :: Word64
+>     }
+>   deriving (Show, Eq, Generic, Serialise)
+
+The `Point` type (defined in `Ouroboros.Network.Block`) describes a particular
+place in the blockchain - a pair of a slot and a block hash.
+
+`Ticked (LedgerState BlockC)`
+---------------------------------------
+
+Again, the slot abstraction defines a logical clock - and instances of the
+`Ticked` family describe values that evolve with respect to this logical clock.
+As such, we will also need to define an instance of `Ticked` for our ledger
+state.  In our example, this is essentially an `Identity` functor:
+
+> newtype instance Ticked (LedgerState BlockC) =
+>   TickedLedgerStateC
+>     { unTickedLedgerStateC :: LedgerState BlockC }
+>   deriving (Show, Eq, Generic, Serialise)
+
+
+`IsLedger`
+----------
+
+The `IsLedger` class describes some of the basic functionality and associated
+types for a ledger.  Though we are here using
+
+> instance IsLedger (LedgerState BlockC) where
+>   type instance LedgerErr  (LedgerState BlockC) = Void
+>   type instance AuxLedgerEvent (LedgerState BlockC) = Void
+>
+>   applyChainTickLedgerResult _cfg _slot ldgrSt =
+>     LedgerResult { lrEvents = []
+>                  , lrResult = TickedLedgerStateC ldgrSt
+>                  }
+
+The `LedgerErr` type is the type of errors associated with this ledger that can
+be thrown while applying blocks or transactions.  In the case of `LedgerState
+BlockC` we are not expecting any errors, so we'll use `Void` here.
+
+The `AuxLedgerEvent` type describes events that can occur as output while
+applying blocks.  We will also not be using this for our example - as such we
+will also use `Void` here.
+
+The `applyChainTickLedgerResult` function 'ticks' the `LedgerState`, resulting
+in an updated `LedgerState` that has witnessed a change in slot (which, again,
+corresponds to a logical clock.)  Note that this function _does allow failure._
+If it did, that means the `LedgerState` is such that it is in a state that will
+eventually fail due to the passage of time and such errors should have been
+signalled earlier (for example, when applying blocks.)
+
+
+`ApplyBlock` - Applying Blocks to `LedgerState`
+-----------------------------------------------
+
+A block `b` is said to have been `applied` to a `LedgerState` if that
+`LedgerState` is the result of having witnessed `b` at some point.  We can
+express this as a function:
+
+> applyBlockTo :: BlockC -> Ticked (LedgerState BlockC) -> LedgerState BlockC
+> applyBlockTo block tickedLedgerState =
+>   ledgerState { lsbc_tip = blockPoint block
+>               , lsbc_count = lsbc_count'
+>               }
+>   where
+>     ledgerState = unTickedLedgerStateC tickedLedgerState
+>     lsbc_count' = foldl txDelta (lsbc_count ledgerState) (bc_body block)
+>     txDelta i tx =
+>       case tx of
+>         Inc -> i + 1
+>         Dec -> i - 1
+
+We use a `Ticked (LedgerState BlockC)` to enforce the invariant that we should
+not apply two blocks in a row - at least one tick (aka slot) must have elapsed
+between block applications.
+
+
+The interface used by the rest of the ledger infrastructure to access this is
+the `ApplyBlock` typeclass:
+
+> instance ApplyBlock (LedgerState BlockC) BlockC where
+>   applyBlockLedgerResult _ldgrCfg block tickedLdgrSt =
+>     pure $ LedgerResult { lrEvents = []
+>                         , lrResult = block `applyBlockTo` tickedLdgrSt
+>                         }
+>
+>   reapplyBlockLedgerResult _ldgrCfg block tickedLdgrSt =
+>     LedgerResult { lrEvents = []
+>                  , lrResult = block `applyBlockTo` tickedLdgrSt
+>                  }
+>
+>
+
+`applyBlockLedgerResult` tries to apply a block to the ledger and fails with a
+`LedgerErr` corresponding to the particular `LedgerState blk` if for whatever
+reason the block could not be applied.
+
+We previously defined `LedgerErr` as `()` This might seem troubling - for
+example, `BlockC` contains a slot number - what if we try to apply a block
+labelled with a slot that is already in the past?  However, this is something
+that should be checked by callers of this code.
+
+`reapplyBlockLedgerResult` similar but is meant to be called by code path that
+has previously established that the application of a block would not fail, so it
+admits no possibility for failure.
+
+Both of these return a `LedgerResult` record containing both the updated state
+as well as a list of `AuxLedgerEvent (LedgerState BlockC)` - the
+`AuxLedgerEvent` type family is intended to allow ledgers to emit extra "events"
+as part of applying blocks, but for our simple example we do not need to use
+this feature.
+
+Once we've defined `ApplyBlock` we can also instantiate the empty `UpdateLedger`
+class which captures the `ApplyBlock` relationship between a block type `block`
+and its ledger `LedgerState block` and indexes it by `block`.  We'll need this
+later for `LedgerSupportsProtocol`
+
+> instance UpdateLedger BlockC where {}
+
+`GetTip` - The Most Recently Applied Block
+------------------------------------------
+
+The `GetTip` typeclass describes how to get the `Point` of the tip - which is
+the most recently applied block.  We need to implement this both for
+`LedgerState BlockC` as well as its ticked version:
+
+> instance GetTip (Ticked (LedgerState BlockC)) where
+>    getTip = castPoint . lsbc_tip . unTickedLedgerStateC
+
+> instance GetTip (LedgerState BlockC) where
+>    getTip = castPoint . lsbc_tip
+
+Associating Ledgers to Protocols
+--------------------------------
+
+Similar to blocks, a typeclass is used to associate a ledger to a protocol.
+Note that since a block is associated with one and only one protocol, we can use
+the block to index both the ledger and the protocol.
+
+> instance LedgerSupportsProtocol BlockC where
+>   protocolLedgerView _lcfg  _tl = TickedTrivial
+>   ledgerViewForecastAt _lccf = trivialForecast
+
+The `protocolLedgerView` function describes how to project the
+consensus-specific `LedgerView` out of `LedgerState` and `LedgerCfg` together -
+however `SP` does not use any information from the ledger to make any decisions
+and since `LedgerView SP` is simply `()` - we use `TickedTrivial` here for the
+implementation of protocolLedgerView which constructs a `Ticked ()` value.
+
+`ledgerViewForecastAt` returns a `Forecast` (defined in
+`Ouroboros.Consensus.Forecast`) of a `LedgerView` - where a `Forecast` is a
+starting point `forecastAt` together with a function `forecastFor` which takes a
+slot number and either produces a forecasted value for that slot - in this case
+a possible future `LedgerView` at that slot.
+
+This `Forecast` is closely related to and is required to be consistent with
+`tickChainDepState` in `ConsensusProtocol` - the documentation for
+`LedgerSupportsProtocol` explains the relationship in more detail.
+
+Appendix: NoThunks Instances
+============================
+
+`NoThunks` is a class that comes from the `nothunks` package
+(https://hackage.haskell.org/package/nothunks) and helps diagnose various kinds
+of memory leaks having to do with thunks.  Many of the above classes require
+that `NoThunks` be instantiated as a prerequisite.
+
+To focus on the salient ideas of this document, we've put all the derivations of
+`NoThunks` here instead:
+
+> deriving via OnlyCheckWhnfNamed "SP_Config" (ConsensusConfig SP)
+>   instance NoThunks (ConsensusConfig SP)
+> deriving via OnlyCheckWhnfNamed "BlockC" BlockC
+>   instance NoThunks BlockC
+> deriving via OnlyCheckWhnfNamed "HdrBlockC" (Header BlockC)
+>   instance NoThunks (Header BlockC)
+> deriving via OnlyCheckWhnfNamed "LedgerC" (LedgerState BlockC)
+>   instance NoThunks (LedgerState BlockC)
+> deriving instance NoThunks (Ticked (LedgerState BlockC))

--- a/ouroboros-consensus/docs/tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/docs/tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -1,0 +1,675 @@
+% Example: A More Complex Example Protocol Involving Epochs
+
+Introduction
+============
+
+This tutorial builds on the example in `Tutorial.lhs` by specifying a block,
+ledger, and protocol for a blockchain that has a notion of epoch built into it -
+serving as an example of a case where the state of the ledger is used as part of
+the machinery of consensus.  It is highly recommended that the reader have read
+`Tutorial.lhs` before this if they are not already familiar with concepts such
+as `ConsensusProtocol` and `LedgerState`.
+
+Much like the previous example of `BlockC` this blockchain (with block type
+`BlockD`) models a single number resulting from a series of _increment_ and
+_decrement_ transactions in the block bodies.  However, the slots are now
+divided into **epochs** each of which has a fixed number of slots.
+
+Further, the chain is set up such that there are 20 _nodes_ labelled with a
+`NodeId` from 0 to 19 participating in the computation.
+
+At the beginning of an epoch, the current value of the ledger - that is, the sum
+of the _increment_ transactions minus the sum of the _decrement_ transactions is
+snapshotted as part of the ledger.
+
+During the epoch, the snapshot *from two epochs ago* determines which subset of
+a set of 20 nodes is allowed to lead slots.  If the snapshot is even, then slots
+contained in that epoch follow a round-robin leadership schedule among nodes 0
+through 9 inclusive.  Similarly, if the snapshot is odd then the slots of that
+epoch will be follow a round-robin leadership schedule from the set of nodes
+from 10 to 19.
+
+Though it is difficult to imagine a real system doing this, it is a simple
+example of a case where the value computed by the blockchain (the `LedgerState`)
+is relevant - through the leader schedule - to the behavior of consensus.  One
+can perhaps view it as a very simplified analog to stake distribution.
+
+Setup
+-----
+
+As before, we require a few language extensions:
+
+> {-# OPTIONS_GHC -Wno-unused-top-binds   #-}
+> {-# LANGUAGE TypeFamilies               #-}
+> {-# LANGUAGE DerivingVia                #-}
+> {-# LANGUAGE DataKinds                  #-}
+> {-# LANGUAGE DeriveGeneric              #-}
+> {-# LANGUAGE FlexibleInstances          #-}
+> {-# LANGUAGE MultiParamTypeClasses      #-}
+> {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+> {-# LANGUAGE DeriveAnyClass #-}
+> {-# LANGUAGE StandaloneDeriving         #-}
+
+> module Ouroboros.Consensus.Tutorial.WithEpoch () where
+
+And imports, of course:
+
+> import Control.Monad ()
+> import Control.Monad.Except (MonadError (throwError))
+> import Data.Word (Word64)
+> import GHC.Generics (Generic)
+> import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
+> import Data.Hashable (Hashable (hash))
+> import Codec.Serialise (Serialise)
+> import Ouroboros.Network.Point ()
+> import Ouroboros.Network.Block ()
+> import Ouroboros.Consensus.Block.Abstract
+>  (Header, SlotNo (..), HeaderHash, ChainHash, GetHeader (..),
+>   GetPrevHash (..), HasHeader (..), HeaderFields (..), StandardHash,
+>   BlockProtocol, castHeaderFields, blockNo, BlockConfig, CodecConfig,
+>   StorageConfig, Point, castPoint, WithOrigin (..), EpochNo (EpochNo),
+>   pointSlot, blockPoint, BlockNo (..))
+> import Ouroboros.Consensus.Block.SupportsProtocol
+>   (BlockSupportsProtocol (..))
+> import Ouroboros.Consensus.Protocol.Abstract
+>   (ConsensusConfig, SecurityParam, ConsensusProtocol (..))
+>
+> import Ouroboros.Consensus.Ticked (Ticked)
+> import Ouroboros.Consensus.Ledger.Abstract
+>   (LedgerState, LedgerCfg, GetTip, LedgerResult (..), ApplyBlock (..),
+>    UpdateLedger, IsLedger (..))
+>
+> import Ouroboros.Consensus.Ledger.SupportsMempool ()
+> import Ouroboros.Consensus.Ledger.SupportsProtocol
+>   (LedgerSupportsProtocol (..))
+>
+> import Ouroboros.Consensus.HeaderValidation
+>   (ValidateEnvelope, BasicEnvelopeValidation, HasAnnTip)
+> import Ouroboros.Consensus.Forecast
+>   (Forecast (..), OutsideForecastRange (..))
+> import Ouroboros.Consensus.Ledger.Basics (GetTip(..))
+
+
+Epochs
+------
+
+Epochs occur at a fixed interval:
+
+> slotsInEpoch :: Word64
+> slotsInEpoch = 50
+
+We also write a function from `WithOrigin SlotNo` to the corresponding epoch
+number to express this behavior.  The `WithOrigin` type allows us to describe
+the behavior of this in the presence of the first (origin) block on the chain.
+We will consider `Origin` to be a special epoch before the epochs of the slots
+proper:
+
+> epochOf :: WithOrigin SlotNo -> WithOrigin EpochNo
+> epochOf Origin = Origin
+> epochOf (NotOrigin s) = NotOrigin $ EpochNo $ unSlotNo s `div` slotsInEpoch
+
+From a particular `WithOrigin Slot` we can also determine when the next epoch
+will begin:
+
+> nextEpochStartSlot :: WithOrigin SlotNo -> SlotNo
+> nextEpochStartSlot wo =
+>   SlotNo $ case wo of
+>              Origin -> slotsInEpoch
+>              NotOrigin slot -> slotsInEpoch + slot' - (slot' `mod` slotsInEpoch)
+>                                where
+>                                 slot' = unSlotNo slot
+
+Hashing
+-------
+
+In this tutorial, we'll use a more real (but still very contrived) hashing
+infrastructure built on top of the `Hashable` class from the `hashable` package.
+
+Our infastructure is quite simple - a `newtype` for hashes:
+
+> newtype Hash = Hash Int
+>   deriving stock (Eq, Ord, Show, Generic)
+>   deriving newtype (NoThunks, Hashable, Serialise)
+
+And a function to turn `Hashable` things into values of type `Hash`.
+
+> mkHash :: Hashable a => a -> Hash
+> mkHash = Hash . hash
+
+We'll instantiate `Hashable` things as we need them throughout this example.
+
+
+Node Identifiers
+----------------
+
+We'll also need a notion of node identity since this will be used to specify
+some things with respect to leadership.  We'll assume all nodes that can lead
+have identifiers in the range of 0..19.
+
+> type NodeId = Word64
+
+Block
+=====
+
+Block Type
+----------
+
+Our block and transaction type is structurally the same as `BlockC` - a header
+followed by a list of transactions `Tx`:
+
+> data BlockD = BlockD { bd_header :: Header BlockD
+>                      , bd_body :: [Tx]
+>                      }
+>   deriving NoThunks via OnlyCheckWhnfNamed "BlockD" BlockD
+
+> data Tx = Inc | Dec
+>   deriving (Show, Eq, Generic, Serialise, NoThunks, Hashable)
+
+
+Block Header
+------------
+
+However, the header is somewhat different as it includes the node identifier
+that created the block.  Naturally in a more realistic system this would instead
+be some value that provides stronger (probably cryptographic) evidence for this
+block's provenance but since this is a simple example, we will simply use a
+`NodeId`:
+
+> data instance Header BlockD =
+>   HdrBlockD
+>     { hbd_SlotNo :: SlotNo
+>     , hbd_BlockNo :: BlockNo
+>     -- hash of whole block (excepting this field)
+>     , hbd_Hash :: HeaderHash BlockD
+>     , hbd_prev :: ChainHash BlockD
+>     , hbd_nodeId :: NodeId
+>     }
+>   deriving stock (Show, Eq, Generic)
+>   deriving anyclass (Serialise)
+>   deriving NoThunks via OnlyCheckWhnfNamed "HdrBlockD" (Header BlockD)
+
+
+Block Hashing
+-------------
+
+Since we're using a more complicated hashing scheme for `BlockD` than we used
+for `BlockC` we'll also need to specify how we compute hashes for `BlockD`.
+First, we specify the type of `HeaderHash BlockD` to be the `Hash` type we
+defined earlier:
+
+> type instance HeaderHash BlockD = Hash
+
+> instance StandardHash BlockD
+
+Then we define a function `computeBlockHash` which computes a `Hash` for a
+`BlockD` - basically aggregating all the data in the block besides the hash
+itself:
+
+> computeBlockHash :: BlockD -> Hash
+> computeBlockHash (BlockD hdr body) =
+>   mkHash ( unSlotNo (hbd_SlotNo hdr)
+>          , unBlockNo (hbd_BlockNo hdr)
+>          , hbd_prev hdr
+>          , body
+>          )
+
+Finally, a convenience function `addBlockHash` allows us to properly set the
+hash of a `BlockD` to its computed value:
+
+> addBlockHash :: BlockD -> BlockD
+> addBlockHash b = b { bd_header = header' }
+>   where
+>     header' = (bd_header b) { hbd_Hash = computeBlockHash b }
+
+The preceding definitions require that `ChainHash BlockD` be `Hashable` so we
+derive a suitable instance here:
+
+> deriving instance Hashable (ChainHash BlockD)
+
+
+Block Header
+------------
+
+As before, we to implement a few type families to fully specify the header -
+`GetHeader`, `GetPrevHash`, and `HasHeader`:
+
+> instance GetHeader BlockD where
+>   getHeader          = bd_header
+>
+>   blockMatchesHeader hdr blk =
+>     hbd_Hash hdr == computeBlockHash blk
+>
+>   headerIsEBB      _ = Nothing
+
+> instance GetPrevHash BlockD where
+>   headerPrevHash = hbd_prev
+
+> instance HasHeader (Header BlockD) where
+>   getHeaderFields hdr = HeaderFields
+>                           { headerFieldSlot = hbd_SlotNo hdr
+>                           , headerFieldBlockNo = hbd_BlockNo hdr
+>                           , headerFieldHash = hbd_Hash hdr
+>                           }
+
+> instance HasHeader BlockD where
+>   getHeaderFields = castHeaderFields
+>                   . getHeaderFields
+>                   . bd_header
+
+As part of our implementation of hashing, note that `blockMatchesHeader` in
+`GetHeader` now checks that the hash is correct.
+
+Block Configuration
+-------------------
+
+In this example, there is no interesting static configuration for blocks - so
+the following are trivial instances:
+
+> data instance CodecConfig BlockD = CCfgBlockD
+>   deriving (Generic, NoThunks)
+
+> data instance StorageConfig BlockD = SCfgBlockD
+>   deriving (Generic, NoThunks)
+
+> data instance BlockConfig BlockD = BCfgBlockD
+>   deriving (Generic, NoThunks)
+
+
+Validation
+----------
+
+Similarly, this example does not have any interesting validation logic, but a
+few more trivial implementations are needed:
+
+> instance HasAnnTip BlockD where {}
+> instance ValidateEnvelope BlockD where {}
+> instance BasicEnvelopeValidation BlockD where {}
+
+
+Ledger
+======
+
+While this is similar to the `LedgerState` for `BlockC` the `Ledger` instance
+corresponding to `BlockD` needs to hold snapshots of the count at the last two
+epoch boundaries - this is the `lsbd_snapshot1` and `lsbd_snapshot2` fields
+below:
+
+> data instance LedgerState BlockD =
+>   LedgerD
+>     { lsbd_tip :: Point BlockD    -- ^ Point of the last applied block.
+>                                   --   (Point is header hash and slot no.)
+>     , lsbd_count :: Word64        -- ^ results of the up/down Txs
+>     , lsbd_snapshot1 :: Word64    -- ^ snapshot of lsbd_count at
+>                                   --   end of previous epoch (1 epoch ago)
+>     , lsbd_snapshot2 :: Word64    -- ^ snapshot of lsbd_count at end
+>                                   --   of epoch (2 epochs ago)
+>                                   --   This will be the LedgerView that
+>                                   --   influences the leader schedule.
+>     }
+>   deriving (Show, Eq, Generic, Serialise, NoThunks)
+
+There is no interesting static configuration for this ledger:
+
+> type instance LedgerCfg (LedgerState BlockD) = ()
+
+Our `GetTip` implementation retrieves the tip from the `lsbd_tip` field:
+
+> instance GetTip (Ticked (LedgerState BlockD)) where
+>  getTip = castPoint . lsbd_tip . unTickedLedgerStateD
+
+> instance GetTip (LedgerState BlockD) where
+>   getTip = castPoint . lsbd_tip
+
+Ticking
+-------
+
+`LedgerState BlockD` also needs a corresponding `Ticked` instance which is still
+very simple:
+
+> newtype instance Ticked (LedgerState BlockD) =
+>   TickedLedgerStateD {
+>     unTickedLedgerStateD :: LedgerState BlockD
+>   }
+>   deriving stock (Show, Eq, Generic)
+>   deriving newtype (NoThunks, Serialise)
+
+Because the ledger now needs to track the snapshots in `lsbd_snapshot1` and
+`lsbd_snapshot2` we can express this in terms of ticking a `LedgerState BlockD`.
+We'll write a function (that we'll use later) to express this relationship
+computing the `Ticked (LedgerState BlockD)` resulting from a starting
+`LedgerState BlockD` being ticked to some slot in the future - assuming no
+intervening blocks are applied:
+
+> tickLedgerStateD ::
+>   SlotNo -> LedgerState BlockD -> Ticked (LedgerState BlockD)
+> tickLedgerStateD newSlot ldgrSt =
+>   TickedLedgerStateD $
+>     if isNewEpoch then
+>       ldgrSt{ lsbd_snapshot2 = lsbd_snapshot1 ldgrSt
+>                  -- save previous epoch snapshot (assumes we do not
+>                  -- go a full epoch without ticking)
+>             , lsbd_snapshot1 = lsbd_count ldgrSt
+>                  -- snapshot the count (at end of previous epoch)
+>             }
+>     else
+>       ldgrSt
+>
+>   where
+>   isNewEpoch =
+>     case compare
+>            (epochOf (pointSlot $ lsbd_tip ldgrSt)) -- epoch of last block added
+>            (epochOf (NotOrigin newSlot))           -- epoch of newSlot
+>     of
+>       LT -> True
+>       EQ -> False
+>       GT -> error "cannot tick slots backwards"
+
+Note that this implementation merely projects the current `lsbd_count` into the
+snapshot indefinitely far in the future - consistent with the assumption that no
+blocks are applied during the span of time represented by the slot argument.
+
+We can now use `tickLedgerStateD` to instantiate `IsLedger`:
+
+> instance IsLedger (LedgerState BlockD) where
+>   type instance LedgerErr (LedgerState BlockD) = String
+>   type instance AuxLedgerEvent (LedgerState BlockD) = ()
+>
+>   applyChainTickLedgerResult _cfg slot ldgrSt =
+>     LedgerResult { lrEvents = []
+>                  , lrResult = tickLedgerStateD slot ldgrSt
+>                  }
+
+`UpdateLedger` is necessary but its implementation is always empty:
+
+> instance UpdateLedger BlockD where {}
+
+Applying Blocks
+---------------
+
+Applying a `BlockD` to a `Ticked (LedgerState BlockD)` is (again) the result of
+applying each individual transaction - exactly as it was in for `BlockC`:
+
+> applyBlockTo :: BlockD -> Ticked (LedgerState BlockD) -> LedgerState BlockD
+> applyBlockTo block tickedLedgerState =
+>   ledgerState { lsbd_tip = blockPoint block
+>               , lsbd_count = lsbc_count'
+>               }
+>   where
+>     ledgerState = unTickedLedgerStateD tickedLedgerState
+>     lsbc_count' = foldl txDelta (lsbd_count ledgerState) (bd_body block)
+>     txDelta i tx =
+>       case tx of
+>         Inc -> i + 1
+>         Dec -> i - 1
+
+> instance ApplyBlock (LedgerState BlockD) BlockD where
+>   applyBlockLedgerResult _ldgrCfg b tickedLdgrSt =
+>     pure LedgerResult { lrResult = b `applyBlockTo` tickedLdgrSt
+>                       , lrEvents = []
+>                       }
+>
+>   reapplyBlockLedgerResult _ldgrCfg b tickedLdgrSt =
+>     LedgerResult { lrResult = b `applyBlockTo` tickedLdgrSt
+>                  , lrEvents = []
+>                  }
+
+Note that prior to `applyBlockLedgerResult` being invoked, the calling code will
+have already established that the header is valid and that the header matches
+the block.  As a result, we do not need to check that the leader is correct
+here.  Also, for this tutorial's notion of blocks applying blocks cannot fail
+because applying transactions cannot fail - even in cases where there is
+overflow `Data.Word` will wrap around.
+
+Protocol
+========
+
+Following the practice earlier established, we define an empty marker type for
+the protocol - `PrtclD`:
+
+> data PrtclD
+
+However, due to the fact that ability to be a slot leader now depends on the
+ledger we'll have a (slightly) more interesting set of evidence that a
+particular `NodeId` can be a leader.  This just consists of the `NodeId` itself
+- which is obviously insecure in that the proof we can be a leader should not be
+easy to falsify - it is fine for our example:
+
+> data PrtclD_CanBeLeader = PrtclD_CanBeLeader NodeId
+>   deriving (Eq, Show, Generic, NoThunks)
+
+The proof that we are a slot leader should be evident from the context - the
+combination of the slot number and the ledger's snapshot parity is sufficient
+evidence that a particular node is the leader for that slot - this makes our
+evidence that a particular node is the leader uninteresting given that security
+is not being considered in this example:
+
+> data PrtclD_IsLeader    = PrtclD_IsLeader
+
+With some notions of the types involved in leadership defined, we can now
+instantiate the `ConsensusConfig` with our security parameter as well as the
+particular `NodeId` - expressed as a `PrtclD_CanBeLeader` - that a particular
+instance of the `ConsensusProtocol` should be running as:
+
+> data instance ConsensusConfig PrtclD =
+>   PrtclD_Config
+>     { ccpd_securityParam :: SecurityParam  -- ^ i.e., 'k'
+>     , ccpd_mbCanBeLeader :: Maybe PrtclD_CanBeLeader
+>
+>       -- ^ To lead, a node must have a 'ccpd_mbCanBeLeader' equal to
+>       -- `Just (PrtclD_CanBeLeader nodeid)`.
+>       -- We expect this value would be extracted from a config file.
+>       --
+>       -- Invariant: nodeid's are unique.
+>     }
+>   deriving (Eq, Show)
+>   deriving NoThunks via OnlyCheckWhnfNamed "PrtclD_Config"
+>                         (ConsensusConfig PrtclD)
+
+We will also need to have a view of the ledger that contains enough information
+for the protocol to validate the leadership claim.  Since the leader for a slot
+is determined by the parity of the epoch snapshot along with the slot number,
+our `LedgerView` for `PrtclD` will simply be the snapshot (though we could have
+just as easily used a `Bool` representing the parity):
+
+> newtype LedgerViewD = LVD Word64
+>   deriving stock (Show, Eq, Generic)
+>   deriving newtype (Serialise, NoThunks)
+
+We also define a trivial `Ticked LedgerViewD` instance:
+
+> newtype instance Ticked LedgerViewD = TickedLedgerViewD LedgerViewD
+>   deriving stock (Show, Eq, Generic)
+>   deriving newtype (Serialise, NoThunks)
+
+The parity of the epoch snapshot and the slot are together _sufficient_ to
+determine the leadership schedule.  As such, we do not need any notion of state
+specific to `PrtclD`:
+
+> data ChainDepStateD = ChainDepStateD
+>   deriving (Eq,Show,Generic,NoThunks)
+
+However, the `Ticked` representation contains the `LedgerViewD` containing the
+epoch snapshot.  This is due to functions for `ConsensusProtocol` only taking
+the `LedgerView` as an argument in some cases:
+
+> data instance Ticked ChainDepStateD =
+>   TickedChainDepStateD { tickedChainDepLV :: LedgerViewD }
+>   deriving (Eq, Show, Generic, NoThunks)
+
+`ConsensusProtocol` is set up this way mostly because this is what
+implementations thus far have required, but the organization of the functions
+interacting with `ChainDepState` is currently under review.
+
+We can determine if a particular node is the leader of a slot given the slot
+number along with the epoch snapshot.  We can express this determination via a
+function modeling the leadership schedule.  For ease of use in our instantiation
+of `ConsensusProtocol PrtclD` we will represent the epoch snapshot using the
+`LedgerView` we just defined:
+
+> isLeader :: NodeId -> SlotNo -> LedgerView PrtclD -> Bool
+> isLeader nodeId (SlotNo slot) (LVD cntr) =
+>   case cntr `mod` 2 of
+>     -- nodes [0..9]   do round-robin (if even cntr)
+>     0 -> slot `mod` 10      == nodeId
+>     -- nodes [10..19] do round-robin (if odd cntr)
+>     1 -> (slot `mod` 10)+10 == nodeId
+>     _ -> error "panic: the impossible ..."
+
+Now we can instantiate `ConsensusProtocol PrtclD` proper with the types and
+functions defined above:
+
+> instance ConsensusProtocol PrtclD where
+>
+>   type ChainDepState PrtclD = ChainDepStateD
+>   type IsLeader PrtclD = PrtclD_IsLeader
+>   type CanBeLeader PrtclD = PrtclD_CanBeLeader
+>
+>   -- | View on a block header required for chain selection.  Here, BlockNo is
+>   --   sufficient. (BlockNo is also the default type for this type family.)
+>   type SelectView PrtclD = BlockNo
+>
+>   -- | View on the ledger required by the protocol
+>   type LedgerView PrtclD = LedgerViewD
+>
+>   -- | View on a block header required for header validation
+>   type ValidateView  PrtclD = NodeId  -- need this for the leader check
+>                                       -- currently not doing other checks
+>
+>   type ValidationErr PrtclD = String
+>
+>   -- | checkIsLeader - Am I the leader this slot?
+>   checkIsLeader cfg _cbl slot tcds =
+>     case ccpd_mbCanBeLeader cfg of
+>       Just (PrtclD_CanBeLeader nodeId)
+>         -- not providing any cryptographic proof
+>         | isLeader nodeId slot (tickedChainDepLV tcds) -> Just PrtclD_IsLeader
+>       _                             -> Nothing
+>
+>   protocolSecurityParam = ccpd_securityParam
+>
+>   tickChainDepState _cfg tlv _slot _cds = TickedChainDepStateD lv
+>     where
+>       TickedLedgerViewD lv = tlv
+>
+>   -- | apply the header (hdrView) and do a header check.
+>   --
+>   -- Here we check the block's claim to lead the slot (though in Protocol D,
+>   -- this doesn't give us too much confidence, as there is nothing that
+>   -- precludes a node from masquerading as any other node).
+>
+>   updateChainDepState _cfg hdrVw slot tcds =
+>     if isLeader hdrVw slot (tickedChainDepLV tcds) then
+>       return ChainDepStateD
+>     else
+>       throwError $ "leader check failed: " ++ show (hdrVw,slot)
+>
+>   reupdateChainDepState _ _ _ _ = ChainDepStateD
+
+Integration
+===========
+
+Block/Protocol Integration
+--------------------------
+
+Our implementation of `BlockSupportsProtocol BlockD` supports our definition of
+`ConsensusProtocol PrtclD` closely, with `validateView` extracting the `NodeId`
+from the block header, and `selectView` projecting out the block number:
+
+> instance BlockSupportsProtocol BlockD where
+>   validateView _bcfg hdr = hbd_nodeId hdr
+>
+>   selectView _bcfg hdr = blockNo hdr
+
+All that remains is to establish `PrtclD` as the protocol for
+`BlockD`:
+
+> type instance BlockProtocol BlockD = PrtclD
+
+Ledger/Protocol Integration
+---------------------------
+
+Implementing `LedgerSupportsProtocol` requires us to put a little more thought
+into forecasting.  Our range of forecasting now ends at the last slot in the
+following epoch.  There are two cases for which we can forecast the ticked
+ledger view: (1) the slot (`for` in the code below) is in the current epoch and
+(2) the slot is in the following epoch.
+
+> instance LedgerSupportsProtocol BlockD where
+>   protocolLedgerView _ldgrCfg (TickedLedgerStateD ldgrSt) =
+>     TickedLedgerViewD (LVD $ lsbd_snapshot2 ldgrSt)
+>       -- note that we use the snapshot from 2 epochs ago.
+>
+>   -- | Borrowing somewhat from Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+>   ledgerViewForecastAt _lccf ldgrSt =
+>     Forecast { forecastAt = at
+>              , forecastFor = \for->
+>                  if NotOrigin for < at then
+>                    error "this precondition violated: 'NotOrigin for < at'"
+>                  else if for >= maxFor then
+>                    throwError
+>                      OutsideForecastRange
+>                         { outsideForecastAt     = at
+>                         , outsideForecastMaxFor = maxFor
+>                         , outsideForecastFor    = for
+>                         }
+>                  else
+>                    return
+>                      $ TickedLedgerViewD $ LVD
+>                      $ if for < nextEpochStartSlot at then
+>                          lsbd_snapshot2 ldgrSt
+>                            -- for the rest of the current epoch,
+>                            -- it's the same as 'protocolLedgerView',
+>                            -- using snapshot from 2 epochs ago.
+>                        else
+>                          lsbd_snapshot1 ldgrSt
+>                            -- we can forecast into the following epoch because
+>                            -- we have the snapshot from 1 epoch ago.
+>              }
+>
+>     where
+>     -- | the current slot that the ledger reflects
+>     at :: WithOrigin SlotNo
+>     at = pointSlot $ lsbd_tip ldgrSt
+>
+>     -- | 'maxFor' is the "exclusive upper bound on the range of the forecast"
+>     -- (the name "max" does seem wrong, but we are following suit with the names
+>     -- and terminology in the 'Ouroboros.Consensus.Forecast' module)
+>     --
+>     -- In our case we can forecast for the current epoch and the following
+>     -- epoch.  The forecast becomes unknown at the start of the epoch
+>     -- after the following epoch:
+>     maxFor :: SlotNo
+>     maxFor = nextEpochStartSlot at + SlotNo slotsInEpoch
+
+Summary and Review
+==================
+
+Above, we defined a block, ledger, and consensus protocol as well as wrote the
+class/family instances necessary to connect them together.  The behavior of the
+blockchain modeled by these is very simple and does not deal with security
+considerations in any depth but does implement behavior - the leadership
+schedule - such that the valid future states of the chain depend on the value
+(aka `LedgerState`) computed by the chain in previous epochs.
+
+To review, we made a few changes from our even more trivial prior example
+involving `BlockC`:
+
+- We implemented a slightly more realistic version of hashing
+- Nodes participating in the protocols were given identifiers allowing a less
+  trivial version of leadership to be implemented
+- A node identifier was added to our block type
+- The `LedgerState` for our block type required the relevant data to be
+  snapshotted so that it could be tracked
+- The logic for applying blocks to the ledger in `ApplyBlock` needed to be aware
+  of the epoch changes such that it could update the snapshots accordingly when
+  blocks are applied
+- The `checkIsLeader` in the protocol changed to reflect the leadership schedule
+- The protocol's `LedgerView` also needed access to the relevant snapshot for
+  the epoch
+- Forecasting, as implemented in `LedgerSupportsProtocol`, needed to know when
+  to stop being able to forecast - namely when the supply of snapshot data is
+  exhausted
+
+While this is a large ecosystem of interrelated typeclasses and families, the
+overall organization of things is such that Haskell's type checking can help
+guide the implementation.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -340,3 +340,29 @@ library
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
     cpp-options:       -DENABLE_ASSERTIONS
+
+
+library tutorials
+  hs-source-dirs:      docs/tutorials
+  other-modules:       Ouroboros.Consensus.Tutorial.Simple
+                     , Ouroboros.Consensus.Tutorial.WithEpoch
+
+  build-depends:       base
+                     , containers
+                     , hashable
+                     , mtl
+                     , nothunks
+                     , serialise
+                     , ouroboros-consensus
+                     , ouroboros-network-api
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+                       -fno-ignore-asserts


### PR DESCRIPTION
# Description

Adds the example protocol instantiations provided by Galois to the repo. Reading these should help with understanding the abstract protocol typeclasses. Closes #4193.

This is a slightly modified copy of the original PR by Galois, from a Galois-owned repo. That one is here: https://github.com/input-output-hk/ouroboros-network/pull/3988.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
