### PR TITLE
Add note to diff sequence benchmarks that explains the use of `arbitraryBoundedintegral`.

### DIFF
--- a/ouroboros-consensus-test/bench-storage/Bench/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
+++ b/ouroboros-consensus-test/bench-storage/Bench/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
@@ -553,6 +553,20 @@ newtype Value = Value ShortByteString
   deriving newtype NFData
 
 -- | UTxO keys are expected to be 32 byte cryptographic hashes.
+--
+-- == Note [Use of arbitraryBoundedIntegral]
+--
+-- We try to simulate a consensus workload as best as possible. In this case, we
+-- are simulating operations on a sequence of UTxO (i.e., key-value pairs)
+-- differences. UTxO keys are 32-byte cryptographic hashes, where each hash is
+-- equally likely to occur, and so if we generate random UTxO-like keys, we
+-- should ensure that we pick the keys uniformly random from the whole range of
+-- possible 32-byte keys. Previously, we were using
+-- @'arbitrarySizedBoundedIntegral'@ to generate the keys: though this picks
+-- from the full range of 32-byte keys, it does not pick from a uniform
+-- distribution because smaller keys are more likely to be picked.
+-- @'arbitraryBoundedIntegral'@ does pick from a uniform distribution, so we use
+-- that here.
 instance Arbitrary Key where
   arbitrary = Key . B.pack <$> replicateM 32 arbitraryBoundedIntegral
 


### PR DESCRIPTION
# Description

Follow-up to #4143, addressing this comment: https://github.com/input-output-hk/ouroboros-network/pull/4143#issuecomment-1321826474.

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
