### PR TITLE
Package constraints

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -1,3 +1,4 @@
+cabal-version:         3.0
 name:                  ouroboros-consensus-cardano
 version:               0.1.0.0
 synopsis:              The instantation of the Ouroboros consensus layer used by Cardano
@@ -10,7 +11,6 @@ author:                IOHK Engineering Team
 maintainer:            operations@iohk.io
 category:              Network
 build-type:            Simple
-cabal-version:         >=1.10
 
 source-repository head
   type:     git
@@ -53,7 +53,7 @@ library
                      , cardano-protocol-tpraos
                      , cardano-slotting
 
-                     , ouroboros-network
+                     , ouroboros-network ^>= 0.2
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-protocol

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -65,7 +65,7 @@ library
                        contra-tracer,
 
                        io-classes       ^>=0.3,
-                       network-mux       >=0.1 && <1.0,
+                       network-mux      ^>=0.2,
                        strict-stm       ^>=0.2,
                        typed-protocols  ^>=0.1,
 

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -90,18 +90,19 @@ library
                      , cardano-prelude
                      , contra-tracer
 
-                     , io-classes     ^>=0.3
+                     , io-classes
                      , monoidal-synchronisation
                                        >=0.1   && < 0.2
                      , network         >=3.1.2.2 && < 3.2
                      , network-mux    ^>=0.2
                      , ouroboros-network-api
+                                      ^>=0.1
                      , ouroboros-network-testing
                      , strict-stm     ^>=0.2
-                     , typed-protocols >=0.1   && < 0.2
+                     , typed-protocols
                      , typed-protocols-cborg
-                                       >=0.1   && < 0.2
-                     , Win32-network   >=0.1   && < 0.2
+                                      ^>=0.1
+                     , Win32-network  ^>=0.1
 
   if os(windows)
     build-depends:     Win32           >= 2.5.4.1 && <3.0

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -95,9 +95,10 @@ library
                        bytestring        >=0.10 && <0.12,
                        cborg             >=0.2.1 && <0.3,
 
-                       io-classes       ^>=0.3,
-                       ouroboros-network-api,
-                       typed-protocols   >=0.1 && <1.0,
+                       io-classes,
+                       ouroboros-network-api
+                                        ^>=0.1,
+                       typed-protocols,
                        typed-protocols-cborg
                                          >=0.1 && <1.0
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -119,15 +119,13 @@ library
                        contra-tracer,
                        monoidal-synchronisation,
 
-                       io-classes       ^>=0.3,
-                       network-mux       >=0.1 && <1.0,
+                       io-classes,
+                       network-mux,
                        ouroboros-network-api,
-                       ouroboros-network-framework
-                                         >=0.1 && <1.0,
-                       ouroboros-network-protocols
-                                        ^>=0.2,
-                       strict-stm       ^>=0.2,
-                       typed-protocols   >=0.1 && <1.0,
+                       ouroboros-network-framework ^>=0.2,
+                       ouroboros-network-protocols ^>=0.2,
+                       strict-stm,
+                       typed-protocols,
   if !os(windows)
     build-depends:     directory,
                        unix


### PR DESCRIPTION
# Description

- ouroboros-consensus-cardano: added upper bound on ouroboros-network

    Adding this constraint will save us in the future from building
    `cardano-node` with a wrong combination of `ouroboros-network`
    & `ouroboros-consensus` (at least as major versions are concerned).

- Simplified network package constraints

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
