### PR TITLE
UTxO-HD: reenable ThreadNet Cardano tests

### DIFF
--- a/ouroboros-consensus-cardano-test/test/Main.hs
+++ b/ouroboros-consensus-cardano-test/test/Main.hs
@@ -11,10 +11,10 @@ import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
 import qualified Test.Consensus.Cardano.Golden (tests)
 import qualified Test.Consensus.Cardano.Serialisation (tests)
 import qualified Test.Consensus.Cardano.Translation (tests)
--- import qualified Test.ThreadNet.AllegraMary (tests)
--- import qualified Test.ThreadNet.Cardano (tests)
--- import qualified Test.ThreadNet.MaryAlonzo (tests)
--- import qualified Test.ThreadNet.ShelleyAllegra (tests)
+import qualified Test.ThreadNet.AllegraMary (tests)
+import qualified Test.ThreadNet.Cardano (tests)
+import qualified Test.ThreadNet.MaryAlonzo (tests)
+import qualified Test.ThreadNet.ShelleyAllegra (tests)
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
 
@@ -31,9 +31,11 @@ tests =
   [ Test.Consensus.Cardano.ByronCompatibility.tests
   , Test.Consensus.Cardano.Golden.tests
   , Test.Consensus.Cardano.Serialisation.tests
-  -- , Test.ThreadNet.AllegraMary.tests
-  -- , Test.ThreadNet.Cardano.tests
-  -- , Test.ThreadNet.MaryAlonzo.tests
-  -- , Test.ThreadNet.ShelleyAllegra.tests
+  , testGroup "ThreadNet" [
+      Test.ThreadNet.AllegraMary.tests
+      , Test.ThreadNet.Cardano.tests
+      , Test.ThreadNet.MaryAlonzo.tests
+      , Test.ThreadNet.ShelleyAllegra.tests
+      ]
   , Test.Consensus.Cardano.Translation.tests
   ]


### PR DESCRIPTION
# Description

The tests now pass. Have to be merged after #4076 

