### PR TITLE
Add ReleaseProcess.md

### DIFF
--- a/ouroboros-consensus/docs/ReleaseProcess.md
+++ b/ouroboros-consensus/docs/ReleaseProcess.md
@@ -121,7 +121,7 @@ This scheme allows for multiple commits to declare their package has the same ve
 This means the mapping from commit hash <-> released version number is unfortunately not one-to-one.
 There is obviously some possibility for confusion there.
 However, we think the probability is low: if users only retrieve our code from the package repositories that we insert our release into, then the mapping will be one-to-one (as enforced by those repositories).
-Despite it being relatively easy to preclude this risk (add an extra `.0` dimension to the just-released versions immediately after announcing them, remove it when preparing the next release, but immediately add it back, etc -- thus between-release commits are always versions MAJOR.MINOR.PATCH.0), we're choosing not to.
+Despite it being relatively easy to preclude this risk (add an extra .0 dimension to the just-released versions immediately after announcing them, remove it when preparing the next release, but immediately add it back, etc -- thus between-release commits are always versions MAJOR.MINOR.PATCH.0), we're choosing not to.
 The mitigation is quite simple, but that extra version dimension is unfamiliar to the broader community and so is likely to cause confusion of its own.
 We are, though, ready to try this mitigation if the lack of one-to-one mapping does end up causing enough confusion.
 
@@ -155,34 +155,34 @@ Consider just one package, FOO.
 Suppose we have released the following versions: 1.0.0 and 2.0.0.
 The commit history might look like the following linear chain, with the tags and branch pointers annotated.
 
-`
+```
 D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.0.x, branch: main)
 C - replace that confusing feature with much nicer one
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
 A - ...
-`
+```
 
 If we subsequently merge a PR that fixes a minor bug present in 2.0.0, it'd then look like this.
 
-`
+```
 E - fix that off-by-one error (branch: main)
 D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.0.x)
 C - replace that confusing feature with much nicer one
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
 A - ...
-`
+```
 
-We could have also advanced `release-FOO-2.0.x`, but the relevent RULES above do not _require_ doing so until we release version 2.0.1.
+We could have also advanced release-FOO-2.0.x, but the relevent RULES above do not _require_ doing so until we release version 2.0.1.
 Once we do that, we'd have the following.
 
-`
+```
 F - the release of FOO-2.0.1 (tag: release-FOO-2.0.1, branch: release-FOO-2.0.x, branch: main)
 E - fix that off-by-one error
 D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0)
 C - replace that confusing feature with much nicer one
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
 A - ...
-`
+```
 
 We must advance release-FOO-2.0.x to the F commit, because we released F as a version 2.0.X and so the RULE above requires that the F commit is included in the first-parent history of release-FOO-2.0.x.
 
@@ -191,39 +191,39 @@ We might want to fix it because our users aren't yet ready to integrate the new 
 Thus, we'd merge a bugfix PR directly into the release-1.0.x branch.
 Note that we should merge bugfixes into main branch and then backport them onto a release branch when we can, but in this example the buggy feature no longer exists on the main branch.
 
-`
+```
 G - fix confusion in the old logic (branch: release-FOO-1.0.x)
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
-`
+```
 
 Once that patch passes validation, we could then release 1.0.1.
 
-`
+```
 H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1, branch: release-FOO-1.0.x)
 G - fix confusion in the old logic
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
-`
+```
 
 Now suppose we could have easily backported E onto 1.0.x as well.
 If we're making another release of the 1.0 version, our users would likely appreciate us including as many bugfixes as we can.
 
-`
+```
 I - cherry-pick of E (branch: release-FOO-1.0.x)
 H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1)
 G - fix confusion in the old logic
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
-`
+```
 
 And shortly the following.
 
-`
+```
 J - the release of FOO-1.0.2 (tag: release-FOO-1.0.2, branch: release-FOO-1.0.x)
 I - cherry-pick of E
 H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1)
 G - fix confusion in the old logic
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
-`
+```

--- a/ouroboros-consensus/docs/ReleaseProcess.md
+++ b/ouroboros-consensus/docs/ReleaseProcess.md
@@ -22,7 +22,7 @@ If you search for "RULE:" in this document, you'll find the key statements.
 ## Rules for Branches
 
 The Consensus team will sometimes be maintaining multiple MAJOR.MINOR versions of the same package simultaneously.
-EG We might release FOO-2.4.1 on Monday, release FOO-2.3.7 on Wednesday, and release FOO-2.4.2 on Friday, etc.
+EG If we were currently maintaining a 2.3 version and a 2.4 version simultaneously, then we might release FOO-2.4.1 on Monday, release FOO-2.3.7 on Wednesday, and release FOO-2.4.2 on Friday, etc.
 
 - Whenever we're maintaining only the one greatest-ever MAJOR.MINOR version of a package, then all work on that package will happen on the main branch.
 - Whenever we're also maintaining some lesser MAJOR.MINOR versions of a package, then some work for that package will also be happening on the respective _release branches_.
@@ -32,6 +32,7 @@ A _release branch_ is a branch dedicated to the maintenance of some older releas
 RULE: If we have released a package FOO-X.Y.Z, then the release-FOO-X.Y.x branch MUST exist and its first-parent history MUST include the commit released as FOO-X.Y.Z.
 For example, when releasing version 2.3.0 of a package named FOO, we must create the branch named release-FOO-2.3.x.
 And when we later release 2.3.1 of FOO, then we'd need to advance the release-FOO-2.3.x branch to point at the commit being released as FOO-2.3.1.
+See the "Release Branch Example" below for a more thorough example.
 
 There are two kinds of work on release branches.
 Most of the time, that work is immitating some work that was done on the main branch.
@@ -45,13 +46,13 @@ EG Consider the following possible timeline.
 - We release FOO-2.3.7 on Wednesday.
 
 *Remark*.
-Not every first-parent commit in the history of the release branch is a release commit.
+Not every first-parent commit in the history of the release branch was announced as a release of a package.
 We will be merging multiple PRs into the release branch in order to prepare the next release from it, so some commits will just be the intermediates between two releases.
 
 *Remark*.
 The release branch for the greatest MAJOR.MINOR version of a package is somewhat degenerate.
 It's either equal to or a prefix of the main branch.
-The only time it MUST be updated to the tip of the main branch is when we cut a release of the package from the main branch, to satisfy the rule above about all X.Y.Z release commits being on the release-X.Y.x branch.
+The only time it MUST be updated to the tip of the main branch is when we cut a release of the package from the main branch, to satisfy the rule above about all commits that were released as some version X.Y.Z being on the release-X.Y.x branch.
 
 ## Rules for PRs
 
@@ -106,6 +107,7 @@ We prepare that release as follows.
 - RULE: We tag that resulting merge commit as release-PKG-A.B.C; one tag per package PKG that is being released (ie FOO and/or BAR).
 - RULE: If C is 0, then we also create the release branch release-PKG-A.B.x from this new commit.
     - For example, when releasing version 2.3.0 of a package named FOO, we'd create the branch named release-FOO-2.3.x.
+      See the "Release Branch Example" below.
 - RULE: Finally, we announce this commit hash as the new release of these packages.
   EG We insert these package's new versions into Hackage, [CHaP](https://github.com/input-output-hk/cardano-haskell-packages), etc.
 
@@ -142,3 +144,86 @@ The only refinement to the wording in the above sections is that we update the `
 This means some packages will occasionally get vacuous versions bumps.
 That's obnoxious to downstream users and would be easy to interpret as evidence the Consensus team has made a mistake in during that release.
 However, we either mitigate this by choosing our bundle partitioning to make it unlikely (put coupled packages into the same bundle) or else accept the oddity of the vacuous version bumps as an acceptable cost for the bundling's other advantages.
+
+## Some Concrete Examples
+
+Some of the rules above are much easier to internalize via concrete examples.
+
+### Release Branch Example
+
+Consider just one package, FOO.
+Suppose we have released the following versions: 1.0.0 and 2.0.0.
+The commit history might look like the following linear chain, with the tags and branch pointers annotated.
+
+`
+D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.0.x, branch: main)
+C - replace that confusing feature with much nicer one
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
+A - ...
+`
+
+If we subsequently merge a PR that fixes a minor bug present in 2.0.0, it'd then look like this.
+
+`
+E - fix that off-by-one error (branch: main)
+D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.0.x)
+C - replace that confusing feature with much nicer one
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
+A - ...
+`
+
+We could have also advanced `release-FOO-2.0.x`, but the relevent RULES above do not _require_ doing so until we release version 2.0.1.
+Once we do that, we'd have the following.
+
+`
+F - the release of FOO-2.0.1 (tag: release-FOO-2.0.1, branch: release-FOO-2.0.x, branch: main)
+E - fix that off-by-one error
+D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0)
+C - replace that confusing feature with much nicer one
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
+A - ...
+`
+
+We must advance release-FOO-2.0.x to the F commit, because we released F as a version 2.0.X and so the RULE above requires that the F commit is included in the first-parent history of release-FOO-2.0.x.
+
+Suppose we then find a bad bug in feature that commit C had replace.
+We might want to fix it because our users aren't yet ready to integrate the new feature from 2.0 version into their code.
+Thus, we'd merge a bugfix PR directly into the release-1.0.x branch.
+Note that we should merge bugfixes into main branch and then backport them onto a release branch when we can, but in this example the buggy feature no longer exists on the main branch.
+
+`
+G - fix confusion in the old logic (branch: release-FOO-1.0.x)
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
+A - ...
+`
+
+Once that patch passes validation, we could then release 1.0.1.
+
+`
+H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1, branch: release-FOO-1.0.x)
+G - fix confusion in the old logic
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
+A - ...
+`
+
+Now suppose we could have easily backported E onto 1.0.x as well.
+If we're making another release of the 1.0 version, our users would likely appreciate us including as many bugfixes as we can.
+
+`
+I - cherry-pick of E (branch: release-FOO-1.0.x)
+H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1)
+G - fix confusion in the old logic
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
+A - ...
+`
+
+And shortly the following.
+
+`
+J - the release of FOO-1.0.2 (tag: release-FOO-1.0.2, branch: release-FOO-1.0.x)
+I - cherry-pick of E
+H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1)
+G - fix confusion in the old logic
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
+A - ...
+`

--- a/ouroboros-consensus/docs/ReleaseProcess.md
+++ b/ouroboros-consensus/docs/ReleaseProcess.md
@@ -29,9 +29,9 @@ EG If we were currently maintaining a 2.3 version and a 2.4 version simultaneous
 
 A _release branch_ is a branch dedicated to the maintenance of some older release of a package.
 
-RULE: If we have released a package FOO-X.Y.Z, then the release-FOO-X.Y.x branch MUST exist and its first-parent history MUST include the commit released as FOO-X.Y.Z.
-For example, when releasing version 2.3.0 of a package named FOO, we must create the branch named release-FOO-2.3.x.
-And when we later release 2.3.1 of FOO, then we'd need to advance the release-FOO-2.3.x branch to point at the commit being released as FOO-2.3.1.
+RULE: If we have released a package FOO-X.Y.Z, then the release-FOO-X.x.x branch MUST exist and its first-parent history MUST include the commit released as FOO-X.Y.Z.
+For example, when releasing version 2.0.0 of a package named FOO, we must create the branch named release-FOO-2.x.x.
+And when we later release 2.3.1 of FOO (and we've never released a 2.Y.Z with Y>3), then we'd need to advance the release-FOO-2.x.x branch to point at the commit being released as FOO-2.3.1.
 See the "Release Branch Example" below for a more thorough example.
 
 There are two kinds of work on release branches.
@@ -52,7 +52,7 @@ We will be merging multiple PRs into the release branch in order to prepare the 
 *Remark*.
 The release branch for the greatest MAJOR.MINOR version of a package is somewhat degenerate.
 It's either equal to or a prefix of the main branch.
-The only time it MUST be updated to the tip of the main branch is when we cut a release of the package from the main branch, to satisfy the rule above about all commits that were released as some version X.Y.Z being on the release-X.Y.x branch.
+The only time it MUST be updated to the tip of the main branch is when we cut a release of the package from the main branch, to satisfy the rule above about all commits that were released as some version X.Y.Z being on the release-X.x.x branch.
 
 ## Rules for PRs
 
@@ -105,8 +105,8 @@ We prepare that release as follows.
     - RULE: It updates the versions of the packages being released as described above.
     - RULE: It flushes the pending changelog entries of each package being released into the `CHANGELOG.md` file for that package.
 - RULE: We tag that resulting merge commit as release-PKG-A.B.C; one tag per package PKG that is being released (ie FOO and/or BAR).
-- RULE: If C is 0, then we also create the release branch release-PKG-A.B.x from this new commit.
-    - For example, when releasing version 2.3.0 of a package named FOO, we'd create the branch named release-FOO-2.3.x.
+- RULE: If C is 0, then we also create the release branch release-PKG-A.x.x from this new commit.
+    - For example, when releasing version 2.0.0 of a package named FOO, we'd create the branch named release-FOO-2.x.x.
       See the "Release Branch Example" below.
 - RULE: Finally, we announce this commit hash as the new release of these packages.
   EG We insert these package's new versions into Hackage, [CHaP](https://github.com/input-output-hk/cardano-haskell-packages), etc.
@@ -156,9 +156,9 @@ Suppose we have released the following versions: 1.0.0 and 2.0.0.
 The commit history might look like the following linear chain, with the tags and branch pointers annotated.
 
 ```
-D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.0.x, branch: main)
+D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.x.x, branch: main)
 C - replace that confusing feature with much nicer one
-B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.x.x)
 A - ...
 ```
 
@@ -166,33 +166,33 @@ If we subsequently merge a PR that fixes a minor bug present in 2.0.0, it'd then
 
 ```
 E - fix that off-by-one error (branch: main)
-D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.0.x)
+D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0, branch: release-FOO-2.x.x)
 C - replace that confusing feature with much nicer one
-B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.x.x)
 A - ...
 ```
 
-We could have also advanced the release-FOO-2.0.x branch, but the relevant RULES above do not _require_ doing so until we release version 2.0.1.
+We could have also advanced the release-FOO-2.x.x branch, but the relevant RULES above do not _require_ doing so until we release version 2.0.1.
 Once we do that, we'd have the following.
 
 ```
-F - the release of FOO-2.0.1 (tag: release-FOO-2.0.1, branch: release-FOO-2.0.x, branch: main)
+F - the release of FOO-2.0.1 (tag: release-FOO-2.0.1, branch: release-FOO-2.x.x, branch: main)
 E - fix that off-by-one error
 D - the release of FOO-2.0.0 (tag: release-FOO-2.0.0)
 C - replace that confusing feature with much nicer one
-B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
+B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.x.x)
 A - ...
 ```
 
-We must advance release-FOO-2.0.x to the F commit, because we released F as a version 2.0.X and so the RULE above requires that the F commit is included in the first-parent history of release-FOO-2.0.x.
+We must advance release-FOO-2.x.x to the F commit, because we released F as a version 2.0.X and so the RULE above requires that the F commit is included in the first-parent history of release-FOO-2.x.x.
 
 Suppose we then find a bad bug in feature that commit C had replaced.
 We might want to fix it because our users aren't yet ready to integrate the new feature from 2.0 version into their code.
-Thus, we'd merge a bugfix PR directly into the release-1.0.x branch.
+Thus, we'd merge a bugfix PR directly into the release-1.x.x branch.
 Note that we should merge bugfixes into the main branch and then backport them onto a release branch when that is possible, but in this case the buggy feature no longer exists on the main branch.
 
 ```
-G - fix confusion in the old logic (branch: release-FOO-1.0.x)
+G - fix confusion in the old logic (branch: release-FOO-1.x.x)
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
 ```
@@ -200,17 +200,17 @@ A - ...
 Once that patch passes validation, we could then release 1.0.1.
 
 ```
-H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1, branch: release-FOO-1.0.x)
+H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1, branch: release-FOO-1.x.x)
 G - fix confusion in the old logic
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
 ```
 
-Now suppose we belatedly realized we can easily backport E onto 1.0.x as well.
+Now suppose we belatedly realized we can easily backport E onto 1.x.x as well.
 If we're making another release of the 1.0 version, our users would likely appreciate us including as many bugfixes as we can.
 
 ```
-I - cherry-pick of E (branch: release-FOO-1.0.x)
+I - cherry-pick of E (branch: release-FOO-1.x.x)
 H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1)
 G - fix confusion in the old logic
 B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
@@ -220,7 +220,7 @@ A - ...
 And shortly the following.
 
 ```
-J - the release of FOO-1.0.2 (tag: release-FOO-1.0.2, branch: release-FOO-1.0.x)
+J - the release of FOO-1.0.2 (tag: release-FOO-1.0.2, branch: release-FOO-1.x.x)
 I - cherry-pick of E
 H - the release of FOO-1.0.1 (tag: release-FOO-1.0.1)
 G - fix confusion in the old logic

--- a/ouroboros-consensus/docs/ReleaseProcess.md
+++ b/ouroboros-consensus/docs/ReleaseProcess.md
@@ -172,7 +172,7 @@ B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0, branch: release-FOO-1.0.x)
 A - ...
 ```
 
-We could have also advanced release-FOO-2.0.x, but the relevent RULES above do not _require_ doing so until we release version 2.0.1.
+We could have also advanced the release-FOO-2.0.x branch, but the relevant RULES above do not _require_ doing so until we release version 2.0.1.
 Once we do that, we'd have the following.
 
 ```
@@ -186,10 +186,10 @@ A - ...
 
 We must advance release-FOO-2.0.x to the F commit, because we released F as a version 2.0.X and so the RULE above requires that the F commit is included in the first-parent history of release-FOO-2.0.x.
 
-Suppose we then find a bad bug in feature that commit C had replace.
+Suppose we then find a bad bug in feature that commit C had replaced.
 We might want to fix it because our users aren't yet ready to integrate the new feature from 2.0 version into their code.
 Thus, we'd merge a bugfix PR directly into the release-1.0.x branch.
-Note that we should merge bugfixes into main branch and then backport them onto a release branch when we can, but in this example the buggy feature no longer exists on the main branch.
+Note that we should merge bugfixes into the main branch and then backport them onto a release branch when that is possible, but in this case the buggy feature no longer exists on the main branch.
 
 ```
 G - fix confusion in the old logic (branch: release-FOO-1.0.x)
@@ -206,7 +206,7 @@ B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
 ```
 
-Now suppose we could have easily backported E onto 1.0.x as well.
+Now suppose we belatedly realized we can easily backport E onto 1.0.x as well.
 If we're making another release of the 1.0 version, our users would likely appreciate us including as many bugfixes as we can.
 
 ```

--- a/ouroboros-consensus/docs/ReleaseProcess.md
+++ b/ouroboros-consensus/docs/ReleaseProcess.md
@@ -30,6 +30,8 @@ EG We might release FOO-2.4.1 on Monday, release FOO-2.3.7 on Wednesday, and rel
 A _release branch_ is a branch dedicated to the maintenance of some older release of a package.
 
 RULE: If we have released a package FOO-X.Y.Z, then the release-FOO-X.Y.x branch MUST exist and its first-parent history MUST include the commit released as FOO-X.Y.Z.
+For example, when releasing version 2.3.0 of a package named FOO, we must create the branch named release-FOO-2.3.x.
+And when we later release 2.3.1 of FOO, then we'd need to advance the release-FOO-2.3.x branch to point at the commit being released as FOO-2.3.1.
 
 There are two kinds of work on release branches.
 Most of the time, that work is immitating some work that was done on the main branch.
@@ -103,12 +105,14 @@ We prepare that release as follows.
     - RULE: It flushes the pending changelog entries of each package being released into the `CHANGELOG.md` file for that package.
 - RULE: We tag that resulting merge commit as release-PKG-A.B.C; one tag per package PKG that is being released (ie FOO and/or BAR).
 - RULE: If C is 0, then we also create the release branch release-PKG-A.B.x from this new commit.
+    - For example, when releasing version 2.3.0 of a package named FOO, we'd create the branch named release-FOO-2.3.x.
 - RULE: Finally, we announce this commit hash as the new release of these packages.
   EG We insert these package's new versions into Hackage, [CHaP](https://github.com/input-output-hk/cardano-haskell-packages), etc.
 
 *Remark*.
-To explicitly clarify: after a release of a package, there will be zero pending changelog entries for that package; they were destroyed when incorprated into the `CHANGELOG.md` file making the release.
-But there may be pending changelog entries of other packages, those that we're included in this release.
+To explicitly clarify: after a release of a package, there will be zero pending changelog entries for that package.
+When making the release, those entries were first incorporated into the `CHANGELOG.md` file and then the individual files containing those pending entires (see `scriv`'s mechanism) were removed (a la `git rm`).
+But there may be pending changelog entries of other packages, those that were not included in this release.
 
 *Remark*.
 This scheme allows for multiple commits to declare their package has the same version number as some released version, even if those commits have made alterations to the package.

--- a/ouroboros-consensus/docs/ReleaseProcess.md
+++ b/ouroboros-consensus/docs/ReleaseProcess.md
@@ -1,0 +1,140 @@
+# How Consensus Makes Releases
+
+This document explains how the Consensus team uses Pull Requests (PRs), version numbers, and branches to prepare releases of our packages.
+
+Let us assume our repository contains two packages FOO and BAR.
+Two is enough to explain the complexities.
+The resulting rules can be generalized to any number of packages, as explained at the end of the document.
+
+*Remark*.
+If you disagree with the decisions in this document, please consider reviewing our brainstorming notes and discussions, available at [this document's PR](https://github.com/input-output-hk/ouroboros-network/pull/4207).
+Even if you choose not to do so, please share your concern with us.
+
+## Notation
+
+In this document, we will assume each version number is a MAJOR.MINOR.PATCH triple.
+This is easy to generalize to other conventional notations, such as [the PVP](https://pvp.haskell.org/)'s MAJOR.MAJOR.MINOR.PATCH quadruples.
+
+We refer throughout this document to _the main branch_ (aka `master`, aka `main`).
+
+If you search for "RULE:" in this document, you'll find the key statements.
+
+## Rules for Branches
+
+The Consensus team will sometimes be maintaining multiple MAJOR.MINOR versions of the same package simultaneously.
+EG We might release FOO-2.4.1 on Monday, release FOO-2.3.7 on Wednesday, and release FOO-2.4.2 on Friday, etc.
+
+- Whenever we're maintaining only the one greatest-ever MAJOR.MINOR version of a package, then all work on that package will happen on the main branch.
+- Whenever we're also maintaining some lesser MAJOR.MINOR versions of a package, then some work for that package will also be happening on the respective _release branches_.
+
+A _release branch_ is a branch dedicated to the maintenance of some older release of a package.
+
+RULE: If we have released a package FOO-X.Y.Z, then the release-FOO-X.Y.x branch MUST exist and its first-parent history MUST include the commit released as FOO-X.Y.Z.
+
+There are two kinds of work on release branches.
+Most of the time, that work is immitating some work that was done on the main branch.
+EG we fixed a bug on the main branch and we're backporting that fix onto a release branch (hopefully it's a trivial cherry-pick).
+Rarely, though, there will be fresh work done on a release branch.
+EG Consider the following possible timeline.
+
+- We release FOO-2.4.1 on Monday, and FOO-2.4.1 completely reworked some functionality.
+- We then realize on Tuesday that there was a severe bug in the old functionality.
+- We fix the bug by merging a PR that targets the FOO-2.3.x release branch (since the bug no longer exists on the main branch!)
+- We release FOO-2.3.7 on Wednesday.
+
+*Remark*.
+Not every first-parent commit in the history of the release branch is a release commit.
+We will be merging multiple PRs into the release branch in order to prepare the next release from it, so some commits will just be the intermediates between two releases.
+
+*Remark*.
+The release branch for the greatest MAJOR.MINOR version of a package is somewhat degenerate.
+It's either equal to or a prefix of the main branch.
+The only time it MUST be updated to the tip of the main branch is when we cut a release of the package from the main branch, to satisfy the rule above about all X.Y.Z release commits being on the release-X.Y.x branch.
+
+## Rules for PRs
+
+We classify each PR as either a _fresh_ PR or as a _backport_ PR.
+
+- A fresh PR is doing work that has never been done before (new feature, new bugfix, etc).
+  Except in the rare circumstances discussed in the previous section, every fresh PR will target the main branch.
+- The primary objective of a backport PR is merely to immitate some fresh PR.
+
+The rules are then as follows.
+
+- RULE: A fresh PR MUST target the main branch, if possible.
+- RULE: A PR MUST NOT be merged into a branch unless it should be included in the next release from that branch.
+- We maintain a changelog for each package (one for FOO and one for BAR).
+- RULE: A PR MUST add a pending changelog entry for each package that it alters.
+- RULE: Each pending changelog entry MUST at the very least classify the alteration to that package as a _patch_ level change (eg a bugfix), a _minor_ change (eg a non-breaking interface change), or a _major_ change (eg a breaking interface change).
+
+*Remark*.
+Notice that we do not allow merging a PR that should not be included the subsequent release.
+This means some PR may be "done" but still should not be merged.
+When work has been done "prematurely" in this way, it risks requiring duplication of some future work (eg introduces merge conflicts with other simultaneously active PRs).
+Our choice here doesn't create any more duplication, it merely confines that duplication to having to rebase that premature PR.
+Our choice also preserves the intuitive monotonic relationship between releases and the main and releases branches.
+
+We also maintain our changelog in a specific way.
+
+- RULE: We maintain pending changelog entries in the same way that [`scriv`](https://github.com/nedbat/scriv) does, so that they do not generate conflicts and are not lost when rebasing/cherry-picking/etc PRs.
+- RULE: The pending entries MUST NOT assume any specific version number of the previous release or the next release, because the entry may be backported etc.
+
+*Remark*.
+Backporting a PR wouldn't generate any conflicts in the changelog entries (by `scriv`'s design), so the author won't necessarily be prompted to update explicit version numbers.
+Hence we forbid them, via the review process.
+To explicitly clarify: it's fine to refer to historical explicit version numbers, but not in such a way that assumes anything about how many or which versions are between that explicit version and the changelog entry that mentions it.
+
+## Rules for Releases
+
+Infinitely often, the Consensus team will decide that FOO and/or BAR are ready for a next release (either from the main branch or from a release branch).
+IE We will eventually decide that the code of that package on the tip commit of a branch should be the code of our next release of that package from that branch.
+We prepare that release as follows.
+
+- For each package we are including in the release, we review its pending changelog entries.
+- RULE: We update the declared version (ie in its `.cabal` file) of each package we are including in the release based on the content of those pending changelog entries.
+    - (Note that there's at least one package, since otherwise we wouldn't be mkaing a release.)
+    - (Note that there must be some alterations to each package we are including in the release, since otherwise we wouldn't be including it in the release---but mind the _bundles_ mentioned below.)
+    - Let X.Y.Z be the version of the package currently declared on this branch.
+    - RULE: If any alteration was major-level, then we bump to (X+1).0.0.
+    - RULE: Else if any alteration was minor-level, then we bump to X.(Y+1).0.
+    - RULE: Otherwise all alterations were patch-level, so we bump to X.Y.(Z+1).
+- RULE: We merge one final PR, which MUST do exactly the following and nothing more.
+    - RULE: It updates the versions of the packages being released as described above.
+    - RULE: It flushes the pending changelog entries of each package being released into the `CHANGELOG.md` file for that package.
+- RULE: We tag that resulting merge commit as release-PKG-A.B.C; one tag per package PKG that is being released (ie FOO and/or BAR).
+- RULE: If C is 0, then we also create the release branch release-PKG-A.B.x from this new commit.
+- RULE: Finally, we announce this commit hash as the new release of these packages.
+  EG We insert these package's new versions into Hackage, [CHaP](https://github.com/input-output-hk/cardano-haskell-packages), etc.
+
+*Remark*.
+To explicitly clarify: after a release of a package, there will be zero pending changelog entries for that package; they were destroyed when incorprated into the `CHANGELOG.md` file making the release.
+But there may be pending changelog entries of other packages, those that we're included in this release.
+
+*Remark*.
+This scheme allows for multiple commits to declare their package has the same version number as some released version, even if those commits have made alterations to the package.
+This means the mapping from commit hash <-> released version number is unfortunately not one-to-one.
+There is obviously some possibility for confusion there.
+However, we think the probability is low: if users only retrieve our code from the package repositories that we insert our release into, then the mapping will be one-to-one (as enforced by those repositories).
+Despite it being relatively easy to preclude this risk (add an extra `.0` dimension to the just-released versions immediately after announcing them, remove it when preparing the next release, but immediately add it back, etc -- thus between-release commits are always versions MAJOR.MINOR.PATCH.0), we're choosing not to.
+The mitigation is quite simple, but that extra version dimension is unfamiliar to the broader community and so is likely to cause confusion of its own.
+We are, though, ready to try this mitigation if the lack of one-to-one mapping does end up causing enough confusion.
+
+## Generalizing to more packages
+
+In actuality, the Consensus team maintains N-many packages instead of just FOO and BAR.
+We could apply the above rules exactly as is: one changelog per package, independent version numbers per package, one release branch per MAJOR.MINOR.0 release of each package, etc.
+We see some downsides to that.
+
+- That's a lot of bookkeeping; many PRs would have to create multiple changelog entries.
+- There's no easy way to recall which versions of our various packages are compatible with one another.
+- There are multiple changelogs that it might not be easy for downstream users to navigate (ie to know which one to check for the information they're wondering about).
+
+We therefore partition our N-many packages into B-many _bundles_ where B < N.
+
+- RULE: The packages within a bundle always share a single changelog and always declare the exact same version.
+- RULE: So we apply the rules from the above sections to each package bundle instead of to each package independently.
+
+The only refinement to the wording in the above sections is that we update the `.cabal` file's of each package in a bundle being released based on the bundle's changelog entries, _even if that package had no alterations since the previous release of that bundle from this branch_.
+This means some packages will occasionally get vacuous versions bumps.
+That's obnoxious to downstream users and would be easy to interpret as evidence the Consensus team has made a mistake in during that release.
+However, we either mitigate this by choosing our bundle partitioning to make it unlikely (put coupled packages into the same bundle) or else accept the oddity of the vacuous version bumps as an acceptable cost for the bundling's other advantages.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -270,3 +270,17 @@ Cons:
 - The multi-sorted state transition system prevents any explanation from being comparatively small.
 
 - This scheme is certainly not already well-established!
+
+Notes:
+
+- The above state machine is natural for a monorepo, since you wouldn't make a release if nothing had changed.
+  However, in a polyrepo, you might regret updating all the revisions to `A.B.C.2718` if you want to do your next release when some of the packages haven't changed.
+  You can slightly complicate the state machine to avoid that happening.
+
+    - Split the `A.B.C.2718` node into two: `A.B.C.2718` and just `A.B.C`.
+
+    - Transition from `A.B.C` to `A.B.C.2718` only when merging a bugfix/etc PR.
+      Otherwise `A.B.C` has the some outgoing transitions as `A.B.C.2718`.
+
+    - Change all of the `release X.Y.Z` transitions to target `X.Y.Z`.
+      Thus, you set the `main` version to the release version immediately after cutting a release, but _any_ PR affecting that package should increase its `main` version to at least `X.Y.Z.2718`.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -462,4 +462,4 @@ _Remark_.
 You could also add the extra `.0` version component from Proposal Redimensional in a commit immediately _after_ the release.
 That extra `.0` would be naturally removed by the pre-release commit, since you're only releasing a package if its `wip-status` directory is non-empty.
 It suffers the same coarseness of dev revisions as Proposal Redimensional, because every commit between release `A.B.C.D` and release `A.B.(C+1).0` would be versioned `A.B.C.*.0` even if some have more features than the other---and similar for major version bumps and breaking changes.
-But that should be mostly harmless, since development versions (`A.B.C.D.0`) should be visible downstream when developers are very explicitly opting-in to them.
+But that should be mostly harmless, since development versions (`A.B.C.D.0`) should be visible downstream only when developers are very explicitly opting-in to them.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -1,3 +1,7 @@
+TODO "WLOG, suppose the repository contains only one package"
+
+TODO simpler formula for "release a non-`master` commit that declares version ..."
+
 # Choosing a Versioning Schemes
 
 This document records our discussions around choosing how to version our packages.
@@ -65,19 +69,46 @@ The following enrichment adds the minimal amount of additional complexity to avo
 
 Release versions are A.B.C = Major.Minor.Patch (or PVP's Major.Major.Minor.Patch)
 
-Master versions are either Left A.B = Major.Minor OR Right A.B.C.Z = Major.Minor.Patch.666
+Master versions are either A.B = Major.Minor OR A.B.C.Z = Major.Minor.Patch.9001;
+it's four dimensional when the next release is just a patch, and it's two dimensional when the next release is more than a patch.
 
 Any PR that just fixes bug doesn't alter the master versions.
 And any PR that does more than just fix a bug must also update the master versions as follows.
 
-  Right A.B.C.666 -> Left next(A.B)
-  Left  A.B       -> Left A.B          -- NB you're free to choose (A+n).(B+n) if you wanted
+  A.B.C.9001 -> next(A.B)
+  A.B        -> A.B
 
-To cut a significant release from master version Left A.B, release a non-`master` commit that declares version A.B.0.
-Also immediately update the master version to Left A.B.0.666.
+Of course, you're also free to choose that any PR sets the version to (A+1+n).(B+1+n) even if the above rules do not require it.
 
-To cut a significant release from master version Right A.B.C.666, release a non-`master` commit that declares version A.B.(C+1).
-Also immediately update the master version to Right A.B.(C+1).666.
+To cut a significant release from master version A.B, release a non-`master` commit that declares version A.B.0.
+Also immediately update the master version to A.B.0.9001.
+
+To cut a significant release from master version Right A.B.C.9001, release a non-`master` commit that declares version A.B.(C+1).
+Also immediately update the master version to Right A.B.(C+1).9001.
+
+The following labelled transition system rules captures how the master version evolves.
+
+```
+  st          --------[patch PR]-------> st
+
+  A.B.C.9001  ---[more-than-patch PR]--> next(A.B)
+  A.B         ---[more-than-patch PR]--> A.B
+
+  A.B.C.9001  ---[release A.B.(C+1)]---> A.B.(C+1).9001
+  A.B         -----[release A.B.0]-----> A.B.0.9001
+```
+
+Pro:
+
+- It enforces all desired invariants.
+
+- It's a very mechanical state machine, easy to execute and also easy to immediately recognize which state it's in.
+
+Cons:
+
+- The state machine prevents any explanation from being comparatively small.
+
+- This scheme is certainly not already well-established!
 
 This only thing this scheme does not track bugfix changes within master versions;
 but that isn't even on of our desiderata.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -1,0 +1,41 @@
+# Choosing a Versioning Schemes
+
+This document records our discussions around choosing how to version our packages.
+
+## Desiderata
+
+- *Simplicity and Familiarity*. We'd like the versioning scheme to be simple to explain, and ideally already well-established.
+
+- *Ease of execution*. We'd like the process of cutting a release to merely involve following a very simple checklist. We'd like it to require as few inputs, discussions, decisions, etc.
+
+- *Distinguished development versions*. We'd like to distinguish between the two possible semantics of version number.
+
+    - The version of a released thing identifies some immutable thing, which is always somehow more refined than any release that has a lesser version number.
+
+    - A development version refers to some _mutable_ thing that is improving during the time between two releases, eg the version on master. IE there will usually be multiple different commits that all have the same development version number.
+
+## Proposal Simplest
+
+To cut a release, merely create branch release/XXX pointing at the desired commit on master and also immediately create a subsequent master commit that advances all the appropriate versions.
+
+## Proposal Parity
+
+Minor versions will be odd for packages on master and even for releases (like the GHC Team's scheme).
+To cut a release, create branch release/XXX pointing at the desired master commit and then add a commit to release/XXX that bumps all versions to the next even number, and also immediately create a subsequent master commit that advances all the appropriate versions to the next odd number.
+
+## Proposal NonZero
+
+Master always has degenerate versions on it: everything is version 0.
+To cut a release, create branch release/XXX pointing at the desired master commit and then add a commit to release/XXX that advances all appropriate versions COMPARED TO their value in the previous release branch.
+
+## Proposal Dimension
+
+FYI
+
+```
+Prelude Data.Version> makeVersion [1,2,0] `compare` makeVersion [1,2]
+GT
+```
+
+Master versions only have two dimensions: major.minor.
+Release have at least three major.minor.patch, where patch can be 0. To cut a release, create branch release/XXX pointing at the desired master commit and then add a .0 patch dimension to the existing major.minor and immediately create a subsequent master commit that advances all appropriate versions to the next greater major.minor pair.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -14,11 +14,11 @@ This document should eventually specify that level of detail as well.
 - *Simplicity and Familiarity*.
   We'd like the versioning scheme to be simple to explain, and ideally already well-established.
 
-- *Ease of execution*.
+- *Ease of Execution*.
   We'd like the process of cutting a release to merely involve following a very simple checklist.
   We'd like it to require as few inputs, discussions, decisions, etc.
 
-- *Distinguished development versions*.
+- *Distinguished Development Versions*.
   We'd like to distinguish between the two possible semantics of a version number.
 
     - The version of a released thing identifies some immutable thing, which is always somehow more refined than any release that has a lesser version number.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -57,3 +57,27 @@ GT
 Master versions only have two dimensions: `A.B`.
 Release versions have at least three `A.B.C`, where `C` can be `0`.
 To cut a new significant release, create branch `release/foo-A.B.x` pointing at the desired `master` commit and then add a `.0` `C` dimension to the existing `A.B` and immediately create a subsequent `master` commit that advances all appropriate versions to the next greater `A.B` pair.
+
+## Proposal Dimension24
+
+Proposal Dimension above has the downside of spurious increments of Major.Minor.
+The following enrichment adds the minimal amount of additional complexity to avoid that without losing any invariants.
+
+Release versions are A.B.C = Major.Minor.Patch (or PVP's Major.Major.Minor.Patch)
+
+Master versions are either Left A.B = Major.Minor OR Right A.B.C.Z = Major.Minor.Patch.666
+
+Any PR that just fixes bug doesn't alter the master versions.
+And any PR that does more than just fix a bug must also update the master versions as follows.
+
+  Right A.B.C.666 -> Left next(A.B)
+  Left  A.B       -> Left A.B          -- NB you're free to choose (A+n).(B+n) if you wanted
+
+To cut a significant release from master version Left A.B, release a non-`master` commit that declares version A.B.0.
+Also immediately update the master version to Left A.B.0.666.
+
+To cut a significant release from master version Right A.B.C.666, release a non-`master` commit that declares version A.B.(C+1).
+Also immediately update the master version to Right A.B.(C+1).666.
+
+This only thing this scheme does not track bugfix changes within master versions;
+but that isn't even on of our desiderata.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -369,6 +369,26 @@ This suggests the following proposal.
       (In a monorepo, there's just the one.
       But in a polyrepo, there may be packages that haven't changed since the previous release.)
 
+## Proposal EasierRedimensional
+
+There is a variant of the above that means no only release PRs alter the version, which is more scalable.
+
+- Each release version is `A.B.C`.
+- Each dev version is either `A`, `A.B`, or `A.B.C.0`.
+    - (We have fixed `.D` at `.0`, so that each PR doesn't need to alter it.
+      This unfortunately does increase the risks of backports/rebases/cherry-picking/etc failing to bump the version.)
+- Typical development PRs do not alter versions.
+- Cut a new release as follows.
+    - Merge a fresh PR that doesn't alter the package but does bump dev version `A.B.C.0` to the next release version, depending on the contents of the relevant PRs since the previous release:
+      `(A+1).0.0` if there were breaking changes, else `A.(B+1).0` if there were some new features, else `A.B.(C+1)`.
+      (Note that `.0` is present, so at least one version-influencing change was made.
+      If the version in the commit was still `A.B.C`, why are you announcing a new release?)
+    - Announce that commit as a release of the packages that have changed since the previous release.
+      (In a monorepo, there's just the one.
+      But in a polyrepo, there may be packages that haven't changed since the previous release.)
+    - Immediately merge another fresh PR that adds the `.0` component to the versions of the just released packages.
+      So what was `A.B.C.0` before the release, became either `(A+1).0.0`, `A.(B+1).0`, or `A.B.(C+1)` after the first PR and know becomes either `(A+1).0.0.0`, `A.(B+1).0.0`, or `A.B.(C+1).0` after the second PR.
+
 ## Proposal Redimensional124
 
 Recall that the motivation for Proposal Redimensional dismisses the concern that people and/or tools will be confused by `A.B.C.D` possible having more features or breaking changes compared to `A.B.C`.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -50,6 +50,8 @@ Cons:
 
 - `main` versions and release versions are not distinguished.
 
+- Cutting a release requires assessing all the changes on `main` since the last release.
+
 ## Proposal FallingEdgePatch
 
 A patch PR doesn't alter the `main` version.
@@ -68,16 +70,16 @@ Cons:
 
 Each `main` version `A.B.C` has an odd `B`.
 Each release version `A.B.C` has an even `B`.
-(This is similar to the GHC Team's scheme.)
+This is similar to the GHC Team's scheme.
 
 PRs do not alter the `main` version.
 
-To cut a release from a commit COMMIT on `main` that declares version `A.B` (where `B` is necessarily odd), announce a new non-`main` commit that extends COMMIT merely to declare version `next(A.B)`.
-Also immediately update the `main` version to `A.(B+2)`.
+To cut a release from a commit COMMIT on `main` that declares version `A.B` (where `B` is necessarily odd), announce a new non-`main` commit that extends COMMIT merely to declare version `X.Y = next(A.B)` (where `Y` is necessarily even).
+Also immediately update the `main` version to the next `X.(Y+2)`.
 
 Cons:
 
-- Commits on `main` that only include patches since the previous commit would still spuriously include the `A.(B+2)` increment.
+- Commits on `main` that only include patches since the previous release would still spuriously include the `+2` increase in the `B` dimension.
 
 ## Proposal NonZero
 
@@ -95,6 +97,8 @@ The only requirement is that they are inherently distinguished from release vers
 Cons:
 
 - `main` versions would always be less than some older released version, which could cause confusion (among people and/or tools).
+
+- Cutting a release requires assessing all the changes on `main` since the last release.
 
 ## Proposal Dimension
 

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -365,7 +365,9 @@ This suggests the following proposal.
       `(A+1).0.0` if there were breaking changes, else `A.(B+1).0` if there were some new features, else `A.B.(C+1)`.
       (Note that `.D` is present, so at least one version-influencing change was made.
       If the version in the commit was still `A.B.C`, why are you announcing a new release?)
-    - Announce that commit.
+    - Announce that commit as a release of the packages that have changed since the previous release.
+      (In a monorepo, there's just the one.
+      But in a polyrepo, there may be packages that haven't changed since the previous release.)
 
 ## Proposal Redimensional124
 
@@ -394,4 +396,7 @@ Those not ready to dismiss that concern can consider the following proposal, whi
         - Bump `A` to `A.0.0`.
         - Bump `A.B` to `A.B.0`.
         - Bump `A.B.C.0` to `A.B.(C+1)`.
+    - Announce that commit as a release of the packages that have changed since the previous release.
+      (In a monorepo, there's just the one.
+      But in a polyrepo, there may be packages that haven't changed since the previous release.)
     - Announce that commit.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -8,6 +8,9 @@ This document should eventually specify that level of detail as well.
 
 ## Desiderata
 
+- *Conventional Version Number*.
+  We'd like our release versions to have the standard shape of `A.B.C`, where in particular increments of `C` principally represent bugfixes.
+
 - *Simplicity and Familiarity*.
   We'd like the versioning scheme to be simple to explain, and ideally already well-established.
 
@@ -25,17 +28,17 @@ This document should eventually specify that level of detail as well.
 
 ## Proposal Simplest
 
-To cut a release, merely create branch `release/XXX` pointing at the desired commit on the `master` branch and also immediately create a subsequent `master` commit that advances all the appropriate versions.
+To cut a new significant release, merely create branch `release/foo-A.B.x` pointing at the desired commit on the `master` branch and also immediately create a subsequent `master` commit that advances all the appropriate versions.
 
 ## Proposal Parity
 
 Minor versions will be odd for packages on the `master` branch and even for releases (like the GHC Team's scheme).
-To cut a release, create branch `release/XXX` pointing at the desired `master` commit and then add a commit to `release/XXX` that bumps all versions to the next even number, and also immediately create a subsequent `master` commit that advances all the appropriate versions to the next odd number.
+To cut a new significant release, create branch `release/foo-A.B.x` pointing at the desired `master` commit and then add a commit to `release/foo-A.B.x` that bumps all versions to the next even number, and also immediately create a subsequent `master` commit that advances all the appropriate versions to the next odd number.
 
 ## Proposal NonZero
 
-Master always has degenerate versions on it: everything is version 0.
-To cut a release, create branch `release/XXX` pointing at the desired `master` commit and then add a commit to `release/XXX` that advances all appropriate versions COMPARED TO their value in the previous release branch.
+Master always has degenerate versions on it: everything is version `0`.
+To cut a new significant release, create branch `release/foo-A.B.x` pointing at the desired `master` commit and then add a commit to `release/foo-A.B.x` that advances all appropriate versions COMPARED TO their value in the previous release branch.
 
 ## Proposal Dimension
 
@@ -46,6 +49,6 @@ Prelude Data.Version> makeVersion [1,2,0] `compare` makeVersion [1,2]
 GT
 ```
 
-Master versions only have two dimensions: `major.minor`.
-Release versions have at least three `major.minor.patch`, where patch can be `0`.
-To cut a release, create branch `release/XXX` pointing at the desired `master` commit and then add a `.0` patch dimension to the existing `major.minor` and immediately create a subsequent `master` commit that advances all appropriate versions to the next greater `major.minor` pair.
+Master versions only have two dimensions: `A.B`.
+Release versions have at least three `A.B.C`, where `C` can be `0`.
+To cut a new significant release, create branch `release/foo-A.B.x` pointing at the desired `master` commit and then add a `.0` `C` dimension to the existing `A.B` and immediately create a subsequent `master` commit that advances all appropriate versions to the next greater `A.B` pair.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -371,7 +371,7 @@ This suggests the following proposal.
 
 ## Proposal EasierRedimensional
 
-There is a variant of the above that means no only release PRs alter the version, which is more scalable.
+There is a variant of the above that means only release PRs alter the version, which is more scalable.
 
 - Each release version is `A.B.C`.
 - Each dev version is either `A`, `A.B`, or `A.B.C.0`.
@@ -387,7 +387,7 @@ There is a variant of the above that means no only release PRs alter the version
       (In a monorepo, there's just the one.
       But in a polyrepo, there may be packages that haven't changed since the previous release.)
     - Immediately merge another fresh PR that adds the `.0` component to the versions of the just released packages.
-      So what was `A.B.C.0` before the release, became either `(A+1).0.0`, `A.(B+1).0`, or `A.B.(C+1)` after the first PR and know becomes either `(A+1).0.0.0`, `A.(B+1).0.0`, or `A.B.(C+1).0` after the second PR.
+      So what was `A.B.C.0` before the release became either `(A+1).0.0`, `A.(B+1).0`, or `A.B.(C+1)` after the first PR and now becomes either `(A+1).0.0.0`, `A.(B+1).0.0`, or `A.B.(C+1).0` after the second PR.
 
 ## Proposal Redimensional124
 

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -1,97 +1,143 @@
-TODO "WLOG, suppose the repository contains only one package"
-
-TODO simpler formula for "release a non-`master` commit that declares version ..."
-
 # Choosing a Versioning Schemes
 
 This document records our discussions around choosing how to version our packages.
 
-In its current state, the document is primarily focused on one question: for each individual package, how should the version listed in the .cabal file on the `master` branch relate to the version in the .cabal file in the latest release?
-In particular, I think this question is almost entirely independent of usings `git` branches versus `git` tags, SemVer versus PVP, etc.
+In its current state, the document is primarily focused on one question: for each individual package, how should the version listed in the .cabal file on the main integration branch relate to the version in the .cabal file in the latest release?
+In particular, I think this question is almost entirely independent of usings `git` branches versus `git` tags for releases, SemVer versus PVP, etc.
 This document should eventually specify that level of detail as well.
+
+Given its current focus, Without loss of generality, suppose the repository contains only one package while considering the proposals below.
 
 ## Desiderata
 
-- *Conventional Version Number*.
-  We'd like our release versions to have the standard shape of `A.B.C`, where in particular increments of `C` principally represent bugfixes.
+- *Conventional Version Numbers*.
+  We'd like our release versions to have the standard shape of `A.B.C`, where in particular increments of `C` principally represent bugfixes/documentation improvements/etc; we'll call that kind of change a _patch PR_.
+  (Note, in the context of [the PVP](https://pvp.haskell.org/) eg, our `A` here would denote a pair.)
+
+    - Our proposal here discuss when to increment `B`, but they never discuss incrementing `A`.
+      You are of course free to decide any PR should advance to `(A+1).0...` or `A.(B+1)...` even if the proposed rules do not require it.
 
 - *Simplicity and Familiarity*.
-  We'd like the versioning scheme to be simple to explain, and ideally already well-established.
+  We'd like the versioning scheme to be simple to explain and ideally already well-established.
 
 - *Ease of Execution*.
   We'd like the process of cutting a release to merely involve following a very simple checklist.
-  We'd like it to require as few inputs, discussions, decisions, etc.
+  We'd like it to require as few inputs, discussions, decisions, etc as possible.
 
 - *Distinguished Development Versions*.
   We'd like to distinguish between the two possible semantics of a version number.
 
-    - The version of a released thing identifies some immutable thing, which is always somehow more refined than any release that has a lesser version number.
+    - The version of a released thing identifies some immutable thing, which is always somehow more refined than any thing---but especially another _released_ thing---that has a lesser version number.
+      We denote this by "release version" below.
 
-    - A development version refers to some _mutable_ thing that is improving during the time between two releases, eg the version on the `master` branch.
-      IE there will usually be multiple different commits that all have the same development version number.
+    - A development version refers to some mutable thing that is improving during the time between two releases, eg the version on the main integration branch.
+      Note in particular that there will usually be multiple different commits that all have the same development version number.
+      We denote this by "`main` version" below.
 
-## Proposal Simplest
+The main integration branch is typically named `main` in fresh GitHub repositories, so that's what we'll use in this document.
 
-To cut a new significant release, merely create branch `release/foo-A.B.x` pointing at the desired commit on the `master` branch and also immediately create a subsequent `master` commit that advances all the appropriate versions.
+## Proposal AdvanceJustInTime
+
+PRs do not alter the `main` version.
+
+To cut a release from a commit COMMIT1 on `main` that declares version `A.B.C`, add to `main` a commit COMMIT2 that extends COMMIT1 merely to declare the version `A.(B+1).0` or `A.B.(C+1)` depending on what has changed on `main` since the previous release, and announce COMMIT2.
+
+Cons:
+
+- `main` versions and release versions are not distinguished.
+
+## Proposal AdvanceImmediately
+
+A patch PR doesn't alter the `main` version.
+A more-than-patch PR must update the `main` version from `A.B.C` to `A.(B+1).0`.
+
+To cut a release from a commit COMMIT on `main` that declares `A.B.C`, announce COMMIT.
+Also immediately update the `main` version to `A.B.(C+1)`.
+
+Cons:
+
+- `main` versions and release versions are not distinguished.
+
+- Some `main` commits will declare version `A.B.(C+1)`, even if that version is never officially released or is created only later by backporting _different_ patch commits to a previous release branch.
 
 ## Proposal Parity
 
-Minor versions will be odd for packages on the `master` branch and even for releases (like the GHC Team's scheme).
-To cut a new significant release, create branch `release/foo-A.B.x` pointing at the desired `master` commit and then add a commit to `release/foo-A.B.x` that bumps all versions to the next even number, and also immediately create a subsequent `master` commit that advances all the appropriate versions to the next odd number.
+Each `main` version `A.B.C` has an odd `B`.
+Each release version `A.B.C` has an even `B`.
+(This is similar to the GHC Team's scheme.)
+
+PRs do not alter the `main` version.
+
+To cut a release from a commit COMMIT on `main` that declares version `A.B` (where `B` is necessarily odd), announce a new non-`main` commit that extends COMMIT merely to declare version `A.(B+1)`.
+Also immediately update the `main` version to `A.(B+2)`.
+
+Cons:
+
+- Commits on `main` that only include patches since the previous commit would still spuriously include the `A.(B+2)` increment.
 
 ## Proposal NonZero
 
-Master always has degenerate versions on it: everything is version `0`.
+Each `main` version is degenerate; eg it is always version `0`.
+Each release version is the usual `A.B.C`.
 
-To cut a new significant release, tag a commit _not on `master`_ that advances all appropriate versions COMPARED TO their value in the previous release branch.
+PRs do not alter the `main` version.
+
+To cut a release from a commit COMMIT on `main` (that necessarily declares version `0`), announce a new non-`main` commit that extends COMMIT merely to declare the version to be `A.(B+1).0`, or `A.B.(C+1)` depending on what has changed on `main` since the previous release.
 
 Note that the degenerate versions could carry information.
 EG they could be just a single number.
 The only requirement is that they are inherently distinguished from release versions.
+
+Cons:
+
+- `main` versions would always be less than some older released version, which could cause confusion (among people and/or tools).
 
 ## Proposal Dimension
 
 FYI
 
 ```
-Prelude Data.Version> makeVersion [1,2,0] `compare` makeVersion [1,2]
-GT
+Prelude Data.Version> makeVersion [1,2] < makeVersion [1,2,0]
+True
 ```
 
-Master versions only have two dimensions: `A.B`.
-Release versions have at least three `A.B.C`, where `C` can be `0`.
-To cut a new significant release, create branch `release/foo-A.B.x` pointing at the desired `master` commit and then add a `.0` `C` dimension to the existing `A.B` and immediately create a subsequent `master` commit that advances all appropriate versions to the next greater `A.B` pair.
+Each `main` version has only two dimensions: `A.B`.
+Each release version has at least three `A.B.C`, where `C` can be `0`.
+
+PRs do not alter the `main` version.
+
+To cut a release from a commit COMMIT on `main` that declares version `A.B`, announce a new non-`main` commit that extends COMMIT merely to declare version `A.B.0`.
+Also immediately update the `main` version to `A.(B+1)`.
 
 ## Proposal Dimension24
 
-Proposal Dimension above has the downside of spurious increments of Major.Minor.
+Proposal Dimension above has the downside that it incur spurious increments of `A.B` when the only differences between two releases were patch PRs.
 The following enrichment adds the minimal amount of additional complexity to avoid that without losing any invariants.
 
-Release versions are A.B.C = Major.Minor.Patch (or PVP's Major.Major.Minor.Patch)
+Each release version is three-dimensional, `A.B.C`.
+Each `main` version is either two-dimensional `A.B` or four-dimensional `A.B.C.9001`;
+it's four-dimensional when the next release is just a patch, and it's two-dimensional when the next release is more than a patch.
 
-Master versions are either A.B = Major.Minor OR A.B.C.Z = Major.Minor.Patch.9001;
-it's four dimensional when the next release is just a patch, and it's two dimensional when the next release is more than a patch.
+A patch PR doesn't alter the `main` version.
+A more-than-patch PR must update the `main` version as follows.
 
-Any PR that just fixes bug doesn't alter the master versions.
-And any PR that does more than just fix a bug must also update the master versions as follows.
-
-  A.B.C.9001 -> next(A.B)
+```
+  A.B.C.9001 -> A.(B+1)
   A.B        -> A.B
+```
 
-Of course, you're also free to choose that any PR sets the version to (A+1+n).(B+1+n) even if the above rules do not require it.
+To cut a release from a commit COMMIT on `main` that declares version `A.B`, announce a new non-`main` commit that extends COMMIT merely to declare version `A.B.0`.
+Also immediately update the `main` version to `A.B.0.9001`.
 
-To cut a significant release from master version A.B, release a non-`master` commit that declares version A.B.0.
-Also immediately update the master version to A.B.0.9001.
+To cut a release from a commit COMMIT on `main` that declares version `A.B.C.9001`, announce a new non-`main` commit that extends COMMIT merely to declare version `A.B.(C+1)`.
+Also immediately update the `main` version to `A.B.(C+1).9001`.
 
-To cut a significant release from master version Right A.B.C.9001, release a non-`master` commit that declares version A.B.(C+1).
-Also immediately update the master version to Right A.B.(C+1).9001.
-
-The following labelled transition system rules captures how the master version evolves.
+The following labelled transition system rules captures how the `main` version evolves.
 
 ```
   st          --------[patch PR]-------> st
 
-  A.B.C.9001  ---[more-than-patch PR]--> next(A.B)
+  A.B.C.9001  ---[more-than-patch PR]--> A.(B+1)
   A.B         ---[more-than-patch PR]--> A.B
 
   A.B.C.9001  ---[release A.B.(C+1)]---> A.B.(C+1).9001
@@ -110,5 +156,4 @@ Cons:
 
 - This scheme is certainly not already well-established!
 
-This only thing this scheme does not track bugfix changes within master versions;
-but that isn't even on of our desiderata.
+This only thing this scheme does not track is changes between `main` versions beyond the escalation from patch-level changes to more-than-patch level.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -420,3 +420,46 @@ Those not ready to dismiss that concern can consider the following proposal, whi
       (In a monorepo, there's just the one.
       But in a polyrepo, there may be packages that haven't changed since the previous release.)
     - Announce that commit.
+
+## Proposal ScrivvyRedimensional
+
+Maintain a `wip-status` directory for each package.
+
+When merging a PR, add one of these empty files as appropriate to each package the PR alters.
+
+- `<package>/wip-status/major/<scriv-id>`
+- `<package>/wip-status/minor/<scriv-id>`
+- `<package>/wip-status/patch/<scriv-id>`
+
+(`<scriv-id>` is the timestamp, commit handle, and branch name, [like `scriv`](https://github.com/nedbat/scriv/blob/cd79a2a618eb752075bbf45e93ad6b7576a2924a/docs/index.rst#getting-started).)
+
+In particular, if the PR should add `wip-status/minor/<this-PR-id>`, then it should do so even if `wip-status/major` is non-empty.
+That would ensure that backporting this PR onto a branch with an empty `major` directory would still appropriately alter the `wip-status` directory.
+
+Immediately before announcing the release of some package, merge a commit that does both of the following.
+
+- Bump each package version according to the contents of its `wip-status` (leave it unchaged if the directory is empty).
+- Remove all files from the three `wip-status/{major,minor,patch}` directories.
+
+_Remark_.
+If you maintain a separate changelog per package, then `scriv`'s [Categories](https://github.com/nedbat/scriv/blob/cd79a2a618eb752075bbf45e93ad6b7576a2924a/docs/concepts.rst#categories) can be leveraged for this, instead of these empty files.
+
+Pros:
+
+- A PR's contribution to the subsequent release's version bump is judged when reviewing the PR instead of being assessed (many days) later.
+
+- It does not have distinct dev version and release versions, but inspecting the contents of a specific commit would let you determine whether its actually the release version it declares or else some evolution of it.
+  But that requires inspecting the special files, which users, downstream devs, and standard tools won't do.
+  (However, see the Remark below.)
+
+Cons:
+
+- It requires the additional consideration/discussion of which of the three `wip-status/{major,minor,patch}` directories to add the empty file in for each package the PR touches.
+  This makes it a little harder to merge a PR, but not as much as writing the changelog entry would.
+  (It avoids merge/rebase conflicts the same way that `scriv` does.)
+
+_Remark_.
+You could also add the extra `.0` version component from Proposal Redimensional in a commit immediately _after_ the release.
+That extra `.0` would be naturally removed by the pre-release commit, since you're only releasing a package if its `wip-status` directory is non-empty.
+It suffers the same coarseness of dev revisions as Proposal Redimensional, because every commit between release `A.B.C.D` and release `A.B.(C+1).0` would be versioned `A.B.C.*.0` even if some have more features than the other---and similar for major version bumps and breaking changes.
+But that should be mostly harmless, since development versions (`A.B.C.D.0`) should be visible downstream when developers are very explicitly opting-in to them.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -38,7 +38,12 @@ To cut a new significant release, create branch `release/foo-A.B.x` pointing at 
 ## Proposal NonZero
 
 Master always has degenerate versions on it: everything is version `0`.
-To cut a new significant release, create branch `release/foo-A.B.x` pointing at the desired `master` commit and then add a commit to `release/foo-A.B.x` that advances all appropriate versions COMPARED TO their value in the previous release branch.
+
+To cut a new significant release, tag a commit _not on `master`_ that advances all appropriate versions COMPARED TO their value in the previous release branch.
+
+Note that the degenerate versions could carry information.
+EG they could be just a single number.
+The only requirement is that they are inherently distinguished from release versions.
 
 ## Proposal Dimension
 

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -2,11 +2,11 @@
 
 This document records our discussions around choosing how to version our packages.
 
-In its current state, the document is primarily focused on one question: for each individual package, how should the version listed in the .cabal file on the main integration branch relate to the version in the .cabal file in the latest release?
+In its current state, the document is primarily focused on one question: for each individual package, how should the version listed in the `.cabal` file on the main integration branch relate to the version in the `.cabal` file in the latest release?
 In particular, I think this question is almost entirely independent of usings `git` branches versus `git` tags for releases, SemVer versus PVP, etc.
 This document should eventually specify that level of detail as well.
 
-Given its current focus, Without loss of generality, suppose the repository contains only one package while considering the proposals below.
+Given its current focus, without loss of generality, suppose the repository contains only one package while considering the proposals below.
 
 ## Desiderata
 

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -14,8 +14,9 @@ Given its current focus, without loss of generality, suppose the repository cont
   We'd like our release versions to have the standard shape of `A.B.C`, where in particular increments of `C` principally represent bugfixes/documentation improvements/etc; we'll call that kind of change a _patch PR_.
   (Note, in the context of [the PVP](https://pvp.haskell.org/) eg, our `A` here would denote a pair.)
 
-    - Our proposal here discuss when to increment `B`, but they never discuss incrementing `A`.
-      You are of course free to decide any PR should advance to `(A+1).0...` or `A.(B+1)...` even if the proposed rules do not require it.
+    - Our proposals here discuss when to increment `B`, but they never discuss incrementing `A`.
+      You are of course free to decide any PR should advance to `(A+1+n).0...` or `A.(B+1+n)...` even if the proposed rules do not require it.
+      They only risk of doing so is confusing downstream users.
 
 - *Simplicity and Familiarity*.
   We'd like the versioning scheme to be simple to explain and ideally already well-established.
@@ -28,15 +29,15 @@ Given its current focus, without loss of generality, suppose the repository cont
   We'd like to distinguish between the two possible semantics of a version number.
 
     - The version of a released thing identifies some immutable thing, which is always somehow more refined than any thing---but especially another _released_ thing---that has a lesser version number.
-      We denote this by "release version" below.
+      We denote this kind of version by "release version" below.
 
     - A development version refers to some mutable thing that is improving during the time between two releases, eg the version on the main integration branch.
       Note in particular that there will usually be multiple different commits that all have the same development version number.
-      We denote this by "`main` version" below.
+      We denote this kind of version by "`main` version" below.
 
 The main integration branch is typically named `main` in fresh GitHub repositories, so that's what we'll use in this document.
 
-## Proposal AdvanceJustInTime
+## Proposal RisingEdge
 
 PRs do not alter the `main` version.
 
@@ -46,10 +47,10 @@ Cons:
 
 - `main` versions and release versions are not distinguished.
 
-## Proposal AdvanceImmediately
+## Proposal FallingEdgePatch
 
 A patch PR doesn't alter the `main` version.
-A more-than-patch PR must update the `main` version from `A.B.C` to `A.(B+1).0`.
+Each more-than-patch PR must update the `main` version from `A.B.C` to `A.(B+1).0` unless `A.B.0 is already greater than the previous release.
 
 To cut a release from a commit COMMIT on `main` that declares `A.B.C`, announce COMMIT.
 Also immediately update the `main` version to `A.B.(C+1)`.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -2,35 +2,40 @@
 
 This document records our discussions around choosing how to version our packages.
 
-In its current state, the document is primarily focused on one question: for each individual package, how should the version listed in the .cabal file on the master branch relate to the version in the .cabal file in the latest release?
+In its current state, the document is primarily focused on one question: for each individual package, how should the version listed in the .cabal file on the `master` branch relate to the version in the .cabal file in the latest release?
 In particular, I think this question is almost entirely independent of usings `git` branches versus `git` tags, SemVer versus PVP, etc.
 This document should eventually specify that level of detail as well.
 
 ## Desiderata
 
-- *Simplicity and Familiarity*. We'd like the versioning scheme to be simple to explain, and ideally already well-established.
+- *Simplicity and Familiarity*.
+  We'd like the versioning scheme to be simple to explain, and ideally already well-established.
 
-- *Ease of execution*. We'd like the process of cutting a release to merely involve following a very simple checklist. We'd like it to require as few inputs, discussions, decisions, etc.
+- *Ease of execution*.
+  We'd like the process of cutting a release to merely involve following a very simple checklist.
+  We'd like it to require as few inputs, discussions, decisions, etc.
 
-- *Distinguished development versions*. We'd like to distinguish between the two possible semantics of version number.
+- *Distinguished development versions*.
+  We'd like to distinguish between the two possible semantics of a version number.
 
     - The version of a released thing identifies some immutable thing, which is always somehow more refined than any release that has a lesser version number.
 
-    - A development version refers to some _mutable_ thing that is improving during the time between two releases, eg the version on master. IE there will usually be multiple different commits that all have the same development version number.
+    - A development version refers to some _mutable_ thing that is improving during the time between two releases, eg the version on the `master` branch.
+      IE there will usually be multiple different commits that all have the same development version number.
 
 ## Proposal Simplest
 
-To cut a release, merely create branch release/XXX pointing at the desired commit on master and also immediately create a subsequent master commit that advances all the appropriate versions.
+To cut a release, merely create branch `release/XXX` pointing at the desired commit on the `master` branch and also immediately create a subsequent `master` commit that advances all the appropriate versions.
 
 ## Proposal Parity
 
-Minor versions will be odd for packages on master and even for releases (like the GHC Team's scheme).
-To cut a release, create branch release/XXX pointing at the desired master commit and then add a commit to release/XXX that bumps all versions to the next even number, and also immediately create a subsequent master commit that advances all the appropriate versions to the next odd number.
+Minor versions will be odd for packages on the `master` branch and even for releases (like the GHC Team's scheme).
+To cut a release, create branch `release/XXX` pointing at the desired `master` commit and then add a commit to `release/XXX` that bumps all versions to the next even number, and also immediately create a subsequent `master` commit that advances all the appropriate versions to the next odd number.
 
 ## Proposal NonZero
 
 Master always has degenerate versions on it: everything is version 0.
-To cut a release, create branch release/XXX pointing at the desired master commit and then add a commit to release/XXX that advances all appropriate versions COMPARED TO their value in the previous release branch.
+To cut a release, create branch `release/XXX` pointing at the desired `master` commit and then add a commit to `release/XXX` that advances all appropriate versions COMPARED TO their value in the previous release branch.
 
 ## Proposal Dimension
 
@@ -41,5 +46,6 @@ Prelude Data.Version> makeVersion [1,2,0] `compare` makeVersion [1,2]
 GT
 ```
 
-Master versions only have two dimensions: major.minor.
-Release have at least three major.minor.patch, where patch can be 0. To cut a release, create branch release/XXX pointing at the desired master commit and then add a .0 patch dimension to the existing major.minor and immediately create a subsequent master commit that advances all appropriate versions to the next greater major.minor pair.
+Master versions only have two dimensions: `major.minor`.
+Release versions have at least three `major.minor.patch`, where patch can be `0`.
+To cut a release, create branch `release/XXX` pointing at the desired `master` commit and then add a `.0` patch dimension to the existing `major.minor` and immediately create a subsequent `master` commit that advances all appropriate versions to the next greater `major.minor` pair.

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -11,12 +11,15 @@ Given its current focus, without loss of generality, suppose the repository cont
 ## Desiderata
 
 - *Conventional Version Numbers*.
-  We'd like our release versions to have the standard shape of `A.B.C`, where in particular increments of `C` principally represent bugfixes/documentation improvements/etc; we'll call that kind of change a _patch PR_.
-  (Note, in the context of [the PVP](https://pvp.haskell.org/) eg, our `A` here would denote a pair.)
+  We'd like our release versions to have the standard shape of `A.B.C`, and the standard rules that `A` must increase for breaking changes, `B` must increase for backwards-compatible changes, and `C` must increase for anything else (eg bugfixes/documentation/etc aka "patches").
 
-    - Our proposals here discuss when to increment `B`, but they never discuss incrementing `A`.
-      You are of course free to decide any PR should advance to `(A+1+n).0...` or `A.(B+1+n)...` even if the proposed rules do not require it.
-      They only risk of doing so is confusing downstream users.
+    - Some of our proposals below don't care about the distinction between `A` and `B`.
+      Instead of repeating the semantics of `A` and `B` in each proposal, we refer to `next(A.B)` with the intention that the developer's determine whether to increment `A` or `B`.
+
+    - You are of course free to decide any PR should increment `A` or `B` even if the proposed rules do not require it.
+      Ultimately, the only risk of such spurious increases is confusing/inconveniencing downstream users.
+
+    - Note, in the context of [the PVP](https://pvp.haskell.org/) eg, our `A` dimension here would itself denote a pair.
 
 - *Simplicity and Familiarity*.
   We'd like the versioning scheme to be simple to explain and ideally already well-established.
@@ -41,7 +44,7 @@ The main integration branch is typically named `main` in fresh GitHub repositori
 
 PRs do not alter the `main` version.
 
-To cut a release from a commit COMMIT1 on `main` that declares version `A.B.C`, add to `main` a commit COMMIT2 that extends COMMIT1 merely to declare the version `A.(B+1).0` or `A.B.(C+1)` depending on what has changed on `main` since the previous release, and announce COMMIT2.
+To cut a release from a commit COMMIT1 on `main` that declares version `A.B.C`, add to `main` a commit COMMIT2 that extends COMMIT1 merely to declare the version `next(A.B).0` or `A.B.(C+1)` depending on what has changed on `main` since the previous release, and announce COMMIT2.
 
 Cons:
 
@@ -50,7 +53,7 @@ Cons:
 ## Proposal FallingEdgePatch
 
 A patch PR doesn't alter the `main` version.
-Each more-than-patch PR must update the `main` version from `A.B.C` to `A.(B+1).0` unless `A.B.0 is already greater than the previous release.
+Each more-than-patch PR must update the `main` version from `A.B.C` to `next(A.B).0` unless `A.B.0` is already greater than the previous release.
 
 To cut a release from a commit COMMIT on `main` that declares `A.B.C`, announce COMMIT.
 Also immediately update the `main` version to `A.B.(C+1)`.
@@ -69,7 +72,7 @@ Each release version `A.B.C` has an even `B`.
 
 PRs do not alter the `main` version.
 
-To cut a release from a commit COMMIT on `main` that declares version `A.B` (where `B` is necessarily odd), announce a new non-`main` commit that extends COMMIT merely to declare version `A.(B+1)`.
+To cut a release from a commit COMMIT on `main` that declares version `A.B` (where `B` is necessarily odd), announce a new non-`main` commit that extends COMMIT merely to declare version `next(A.B)`.
 Also immediately update the `main` version to `A.(B+2)`.
 
 Cons:
@@ -83,7 +86,7 @@ Each release version is the usual `A.B.C`.
 
 PRs do not alter the `main` version.
 
-To cut a release from a commit COMMIT on `main` (that necessarily declares version `0`), announce a new non-`main` commit that extends COMMIT merely to declare the version to be `A.(B+1).0`, or `A.B.(C+1)` depending on what has changed on `main` since the previous release.
+To cut a release from a commit COMMIT on `main` (that necessarily declares version `0`), announce a new non-`main` commit that extends COMMIT merely to declare the version to be `next(A.B).0`, or `A.B.(C+1)` depending on what has changed on `main` since the previous release.
 
 Note that the degenerate versions could carry information.
 EG they could be just a single number.
@@ -108,7 +111,7 @@ Each release version has at least three `A.B.C`, where `C` can be `0`.
 PRs do not alter the `main` version.
 
 To cut a release from a commit COMMIT on `main` that declares version `A.B`, announce a new non-`main` commit that extends COMMIT merely to declare version `A.B.0`.
-Also immediately update the `main` version to `A.(B+1)`.
+Also immediately update the `main` version to `next(A.B)`.
 
 ## Proposal Dimension24
 
@@ -123,7 +126,7 @@ A patch PR doesn't alter the `main` version.
 A more-than-patch PR must update the `main` version as follows.
 
 ```
-  A.B.C.9001 -> A.(B+1)
+  A.B.C.9001 -> next(A.B)
   A.B        -> A.B
 ```
 
@@ -138,7 +141,7 @@ The following labelled transition system rules captures how the `main` version e
 ```
   st          --------[patch PR]-------> st
 
-  A.B.C.9001  ---[more-than-patch PR]--> A.(B+1)
+  A.B.C.9001  ---[more-than-patch PR]--> next(A.B)
   A.B         ---[more-than-patch PR]--> A.B
 
   A.B.C.9001  ---[release A.B.(C+1)]---> A.B.(C+1).9001

--- a/ouroboros-consensus/docs/VersioningSchemeDecision.md
+++ b/ouroboros-consensus/docs/VersioningSchemeDecision.md
@@ -2,6 +2,10 @@
 
 This document records our discussions around choosing how to version our packages.
 
+In its current state, the document is primarily focused on one question: for each individual package, how should the version listed in the .cabal file on the master branch relate to the version in the .cabal file in the latest release?
+In particular, I think this question is almost entirely independent of usings `git` branches versus `git` tags, SemVer versus PVP, etc.
+This document should eventually specify that level of detail as well.
+
 ## Desiderata
 
 - *Simplicity and Familiarity*. We'd like the versioning scheme to be simple to explain, and ideally already well-established.


### PR DESCRIPTION
Closes #4204

I wrote the `ReleaseProcessDecision.md` to capture and edit the notes from the various couple sync calls where we discussed how to version our packages.

Those discussions expanded a bit into how to maintain/prepare releases. That results in the `ReleaseProcess.md` file, which documents our process---it's not just a record of/catalyst for discussion like `ReleaseProcessDecision.md` was.