### PR TITLE
cabal-lint: add tool

### DIFF
--- a/cabal-lint/README.md
+++ b/cabal-lint/README.md
@@ -1,0 +1,19 @@
+The IOG Consensus team uses this `cabal-lint` tool to ensures some invariants among its `.cabal` files.
+
+The invariants are one-to-one with the possible constructors of values in the `Cabal.Lint.UX.Output.Message` type that `messageSeverity` maps to `ErrorSeverity`.
+Currently, those are:
+
+- Component-level errors
+    - `RepeatDeps` - a component's `build-depends` fields list the same library multiple times
+    - `RepeatOptions` - a component's `ghc-options` fields list the same option multiple times
+    - `MissingOptions` - a component's `ghc-options` fields do not necessarily list every option we require (see `Cabal.Lint.Main.requiredOptions`)
+    - `NonEmptyDefaultExtensions` - a component's `default-extensions` field isn't empty
+- Package-level errors
+    - `NonEmptyForeignLibraries` - a package declares a `foreign-library` component
+    - `CouldNotParse` - the `.cabal` file could not be parsed
+- Project-level errors (the _project_ is all `.cabal` file paths passed to the tool at once)
+    - `EmptyProject` - there are no `.cabal` files listed on the command-line
+    - `InconsistentVersionRanges` - the `build-depends` fields of components declared in the given `.cabal` files constrain the same library to different version ranges
+    - `InconsistentDefaultLanguages` - the `default-language` fields of components declared in the given `.cabal` files list different values
+
+Conditionals in the `.cabal` files are handled in a naive-but-reasonable way: the tool requires that all invariants are definitely respected regardless of the conditions' values, assuming only that the two branches of any one conditional are exclusive.

--- a/cabal-lint/cabal-lint.cabal
+++ b/cabal-lint/cabal-lint.cabal
@@ -30,7 +30,7 @@ library
 
   default-language:    Haskell2010
 
-  build-depends:       base              >=4.9 && <4.15
+  build-depends:       base              >=4.9 && <4.17
 
                      , async
                      , bytestring

--- a/cabal-lint/cabal-lint.cabal
+++ b/cabal-lint/cabal-lint.cabal
@@ -1,0 +1,64 @@
+cabal-version:       3.0
+name:                cabal-lint
+version:             0.0.0.1
+synopsis:            IOG Consensus team's invariant checker for .cabal files
+-- description:
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:           2022 Input Output (Hong Kong) Ltd.
+author:              IOHK Engineering Team
+maintainer:          operations@iohk.io
+category:            Network
+build-type:          Simple
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Cabal.Lint
+                       Cabal.Lint.Ids
+                       Cabal.Lint.Main
+                       Cabal.Lint.Ord
+                       Cabal.Lint.Summygroup
+                       Cabal.Lint.UX.Output
+
+  default-language:    Haskell2010
+
+  build-depends:       base              >=4.9 && <4.15
+
+                     , async
+                     , bytestring
+                     , Cabal-syntax
+                     , containers
+
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+
+executable cabal-lint
+  hs-source-dirs:      exe-src
+  main-is:             Main.hs
+  build-depends:       cabal-lint
+  default-language:    Haskell2010
+
+  ghc-options:         -threaded -rtsopts
+
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists

--- a/cabal-lint/exe-src/Main.hs
+++ b/cabal-lint/exe-src/Main.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Main (main) where
+
+import Cabal.Lint.Main (main)

--- a/cabal-lint/src/Cabal/Lint.hs
+++ b/cabal-lint/src/Cabal/Lint.hs
@@ -1,0 +1,257 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | The core analyses of the tool.
+
+module Cabal.Lint (
+  -- *
+  LintConfig (..),
+  ResultP (ResultP),
+  Summary,
+  lintPackageDescription,
+  lintProject,
+  ) where
+
+import           Data.Maybe (maybeToList)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Distribution.Compat.NonEmptySet as NES
+import           Cabal.Lint.Ids
+import           Cabal.Lint.Ord
+import           Cabal.Lint.Summygroup
+import           Cabal.Lint.UX.Output
+
+import qualified Distribution.Compiler                                     as C
+import qualified Distribution.Package                                      as C
+import qualified Distribution.Types.Benchmark                              as C
+import qualified Distribution.Types.BuildInfo                              as C
+import qualified Distribution.Types.ComponentName                          as C
+import qualified Distribution.Types.CondTree                               as C
+import qualified Distribution.Types.Executable                             as C
+import qualified Distribution.Types.GenericPackageDescription              as C
+import qualified Distribution.Types.Library                                as C
+import qualified Distribution.Types.LibraryName                            as C
+import qualified Distribution.Types.TestSuite                              as C
+
+-----
+
+-- | A multiplicity
+--
+-- Example use: if a component constrains a dependency more than once, the
+-- linter emits a 'RepeatDeps' for that component.
+--
+-- INVARIANT: The values are always >0.
+newtype Multiplicity = Multiplicity Int
+  deriving (Eq, Ord)
+
+oneMultiplicity :: Multiplicity
+oneMultiplicity = Multiplicity 1
+
+instance Semigroup  Multiplicity where Multiplicity l <> Multiplicity r = Multiplicity $ l + r
+instance Summygroup Multiplicity where Multiplicity l <+> Multiplicity r = Multiplicity $ max l r
+
+-----
+
+newtype PerDep a = PerDep (Map DepId a)
+  deriving (Eq, Ord)
+
+instance Semigroup a => Monoid     (PerDep a) where mempty = PerDep Map.empty
+instance Semigroup a => Semigroup  (PerDep a) where PerDep l <> PerDep r = PerDep $ Map.unionWith (<>) l r
+
+-- | TODO in the future, we might sometimes want 'Map.intersectionWith' here, but for now we always want 'Map.unionWith'
+instance Summygroup a => Summygroup (PerDep a) where PerDep l <+> PerDep r = PerDep $ Map.unionWith (<+>) l r
+
+-----
+
+data LintConfig puid = LintConfig {
+    -- | The package being linted
+    thisPackage :: PrjPkgId puid
+  ,
+    requiredOptions :: Set String
+  }
+
+-----
+
+-- | Check for 'ProjectMessage'
+lintProject :: Ord puid => Summary puid -> Set (ProjectMessage puid)
+lintProject (Summary (PerDep m1, Occurrences m2)) =
+         mempty
+      <> mconcat
+         [ Set.singleton $ case Map.minViewWithKey m of
+              -- there's just this one
+              Just ((vrange, _), rest) | Map.null rest -> ConsistentVersionRange dep vrange
+              _                                        -> InconsistentVersionRanges dep (Occurrences m)
+         | (dep, Occurrences m) <- Map.toList m1
+         ]
+      <> ( Set.singleton $ case Map.minViewWithKey m2 of
+              Just ((mbLang, _), rest) | Map.null rest -> ConsistentDefaultLanguage mbLang
+              _                                        -> InconsistentDefaultLanguages (Occurrences m2)
+         )
+
+-----
+
+newtype Summary puid =
+    Summary
+        ( PerDep (Occurrences MyVersionRange puid)
+        , Occurrences (Maybe MyLanguage) puid
+        )
+  deriving (Monoid, Semigroup, Summygroup) 
+
+-- | Result of analyzing a component within a package
+data ResultC puid = ResultC (Summary puid) (Set ComponentError)
+
+instance Ord puid => Monoid    (ResultC puid) where mempty = ResultC mempty mempty
+instance Ord puid => Semigroup (ResultC puid) where ResultC depsL errsL <> ResultC depsR errsR = ResultC (depsL <> depsR) (errsL `Set.union` errsR)
+
+-- | Result of analyzing a package
+data ResultP puid =
+    ResultP
+        (Summary puid)
+        (Set PackageError)
+        (Map C.ComponentName (NES.NonEmptySet ComponentError))
+
+instance Ord puid => Monoid    (ResultP puid) where mempty = ResultP mempty mempty mempty
+instance Ord puid => Semigroup (ResultP puid) where ResultP depsL errsL cerrsL <> ResultP depsR errsR cerrsR = ResultP (depsL <> depsR) (Set.union errsL errsR) (Map.unionWith (<>) cerrsL cerrsR)
+
+-- | Check for 'PackageError's and 'ComponentError's and also collect the
+-- summary info necessary for 'lintProject'
+lintPackageDescription :: forall puid. Ord puid => LintConfig puid -> C.GenericPackageDescription -> ResultP puid
+lintPackageDescription cfg gpd =
+       ResultP mempty (NonEmptyForeignLibraries `ifJust` mkNES (Set.fromList (map fst forLibs))) mempty
+    <> foldMap (\     x  -> go (C.CLibName C.LMainLibName    ) (fmap C.libBuildInfo       x)) mbLib
+    <> foldMap (\(cn, x) -> go (C.CLibName (C.LSubLibName cn)) (fmap C.libBuildInfo       x)) subLibs
+    <> foldMap (\(cn, x) -> go (C.CExeName                cn ) (fmap C.buildInfo          x)) exes
+    <> foldMap (\(cn, x) -> go (C.CTestName               cn ) (fmap C.testBuildInfo      x)) tests
+    <> foldMap (\(cn, x) -> go (C.CBenchName              cn ) (fmap C.benchmarkBuildInfo x)) benchs
+  where
+    LintConfig _ _dummy_cfg = cfg
+    LintConfig {
+        thisPackage = puid
+      ,
+        requiredOptions = options0
+      } = cfg
+
+    C.GenericPackageDescription _ _ _ _ _ _ _ _ _dummy_gpd = gpd
+    C.GenericPackageDescription {
+        C.packageDescription = _
+      ,
+        C.gpdScannedVersion = _
+      ,
+        C.condLibrary = mbLib
+      ,
+        C.condSubLibraries = subLibs
+      ,
+        C.condForeignLibs = forLibs
+      ,
+        C.condExecutables = exes
+      ,
+        C.condTestSuites = tests
+      ,
+        C.condBenchmarks = benchs
+      } = gpd
+
+    go :: C.ComponentName -> C.CondTree v c C.BuildInfo -> ResultP puid
+    go cname tree =
+      let ResultC deps cerrs =
+            (goDepends <> goGhcOptions <> goLanguage)
+              (CompId puid cname)
+              tree
+      in
+        ResultP deps mempty
+      $ Map.fromList [ (cname, x) | x <- maybeToList (mkNES cerrs) ]
+
+    getDepends :: CompId puid -> C.BuildInfo -> PerDep (Occurrences MyVersionRange puid, Multiplicity)
+    getDepends me bi =
+          PerDep
+        $ Map.fromListWith (<>)
+        $ [ ( DepId pname libname
+            , ( oneOccurrence (MyVersionRange vrange) me
+              , oneMultiplicity
+              )
+            )
+          | C.Dependency pname vrange libnames <- C.targetBuildDepends bi
+          , libname <- NES.toList libnames
+          ]
+
+    goDepends :: CompId puid -> C.CondTree v c C.BuildInfo -> ResultC puid
+    goDepends me tree =
+        let PerDep m     = goTree $ fmap (getDepends me) tree
+            repeatedDeps = Map.keysSet $ Map.filter ((> oneMultiplicity) . snd) m
+        in
+        ResultC
+          (Summary (PerDep (Map.map fst m), mempty))
+          (RepeatDeps `ifJust` mkNES repeatedDeps)
+
+    getGhcOptions :: C.BuildInfo -> Always String
+    getGhcOptions bi =
+          mconcat
+        $ [ oneAlways opt
+          | (C.GHC, opts) <- C.perCompilerFlavorToList (C.options bi)
+          , opt <- opts
+          ]
+
+    goGhcOptions :: CompId puid -> C.CondTree v c C.BuildInfo -> ResultC puid
+    goGhcOptions _me tree =
+        let Always counts = goTree $ fmap getGhcOptions tree
+        in
+          ResultC mempty
+        $    mempty
+          <> (RepeatOptions  `ifJust` mkNES (Map.keysSet $ Map.filter (> 1) counts))
+          <> (MissingOptions `ifJust` mkNES (Set.difference options0 (Map.keysSet counts)))
+
+    getLanguage :: CompId puid -> C.BuildInfo -> (Occurrences (Maybe MyLanguage) puid, Sometimes ComponentError)
+    getLanguage me bi =
+        ( oneOccurrence (MyLanguage <$> C.defaultLanguage bi) me
+        ,   mconcat
+          $ [ oneSometimes $ NonEmptyDefaultExtensions exts'
+            | exts' <- maybeToList $ mkNES $ Set.fromList $ C.defaultExtensions bi
+            ]
+        )
+
+    goLanguage :: CompId puid -> C.CondTree v c C.BuildInfo -> ResultC puid
+    goLanguage me tree =
+        let (defaultLanguages, Sometimes errs) =
+                goTree $ fmap (getLanguage me) tree
+        in
+        ResultC (Summary (mempty, defaultLanguages)) (Map.keysSet errs)
+
+-----
+
+goTree :: (Monoid m, Summygroup m) => C.CondTree v c m -> m
+goTree tree =
+    let C.CondNode _ _ _dummy = tree
+        C.CondNode {
+            C.condTreeData = x
+          ,
+            C.condTreeConstraints = _
+          ,
+            C.condTreeComponents = subtrees
+          } = tree
+    in
+    foldr (<>) x (map goBranch subtrees)
+
+goBranch :: (Monoid m, Summygroup m) => C.CondBranch v c m -> m
+goBranch branch =
+    let C.CondBranch _ _ _dummy = branch
+        C.CondBranch {
+            C.condBranchCondition = _
+          ,
+            C.condBranchIfTrue = tree
+          ,
+            C.condBranchIfFalse = mbTree
+          } = branch
+    in
+    goTree tree <+> maybe mempty goTree mbTree
+
+-----
+
+ifJust :: (a -> b) -> Maybe a -> Set b
+ifJust mkErr mb = maybe Set.empty (Set.singleton . mkErr) mb
+
+mkNES :: Ord a => Set a -> Maybe (NES.NonEmptySet a)
+mkNES xs = case Set.minView xs of
+    Nothing       -> Nothing
+    Just (x, xs') -> Just $ foldr NES.insert (NES.singleton x) xs'

--- a/cabal-lint/src/Cabal/Lint.hs
+++ b/cabal-lint/src/Cabal/Lint.hs
@@ -206,8 +206,8 @@ lintPackageDescription cfg gpd =
     getLanguage me bi =
         ( oneOccurrence (MyLanguage <$> C.defaultLanguage bi) me
         ,   mconcat
-          $ [ oneSometimes $ NonEmptyDefaultExtensions exts'
-            | exts' <- maybeToList $ mkNES $ Set.fromList $ C.defaultExtensions bi
+          $ [ oneSometimes $ NonEmptyExtensions exts'
+            | exts' <- maybeToList $ mkNES $ Set.fromList $ (C.defaultExtensions <> C.otherExtensions) bi
             ]
         )
 

--- a/cabal-lint/src/Cabal/Lint/Ids.hs
+++ b/cabal-lint/src/Cabal/Lint/Ids.hs
@@ -1,0 +1,27 @@
+-- | Names used in this tool and its UX
+
+module Cabal.Lint.Ids (
+  CompId (..),
+  DepId (..),
+  PrjPkgId (..),
+  ) where
+
+import qualified Distribution.Types.ComponentName                          as C
+import qualified Distribution.Types.LibraryName                            as C
+import qualified Distribution.Types.PackageName                            as C
+
+-----
+
+-- | The global name of a dependency, ie something that occurs within a
+-- `build-depends` field
+data DepId = DepId C.PackageName C.LibraryName
+  deriving (Eq, Ord)
+
+-- | The global name of a component, ie something that has its own
+-- `build-depends` field
+data CompId puid = CompId (PrjPkgId puid) C.ComponentName
+  deriving (Eq, Ord)
+
+-- | The global name of a package in this project, ie a .cabal file being linted
+data PrjPkgId puid = PrjPkgId {unPrjPkgId :: puid}
+  deriving (Eq, Ord)

--- a/cabal-lint/src/Cabal/Lint/Main.hs
+++ b/cabal-lint/src/Cabal/Lint/Main.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- | The exe's entrypoint
+
+module Cabal.Lint.Main (main) where
+
+import           Control.Concurrent.Async (forConcurrently_)
+import           Control.Monad (when)
+import qualified Data.ByteString as BS
+import           Data.Foldable (forM_)
+import qualified GHC.Conc as STM
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import           Data.Void (absurd)
+import           System.Environment (getArgs)
+import           System.Exit (die, exitFailure, exitSuccess)
+
+import qualified Cabal.Lint                                             as Lint
+import qualified Cabal.Lint.Ids                                         as Lint
+import qualified Cabal.Lint.UX.Output                                   as Lint
+
+import qualified Distribution.PackageDescription.Parsec                    as C
+
+main :: IO ()
+main = do
+    cabalPaths <- getArgs
+
+    when (null cabalPaths) $ do
+        die $ Lint.renderMessageOneLine (absurd . Lint.unPrjPkgId) (Lint.ProjectMessage Lint.EmptyProject)
+
+    accSummary  <- STM.newTVarIO (mempty :: Lint.Summary FilePath)
+    accSeverity <- STM.newTVarIO (mempty :: Lint.MessageSeverity)
+
+    let showMessage :: Lint.Message FilePath -> IO ()
+        showMessage msg = do
+            putStrLn $ Lint.renderMessageOneLine Lint.unPrjPkgId msg
+            modifyTVarIO accSeverity (<> Lint.messageSeverity msg)
+
+    -- analyze each .cabal file path given on the command line
+    --
+    -- Every message is printed as a single line, so concurrent printing is
+    -- fine.
+    forConcurrently_ cabalPaths $ \path -> do
+        let puid = Lint.PrjPkgId path
+        bytes <- BS.readFile path
+        case C.parseGenericPackageDescriptionMaybe bytes of
+            Nothing -> die $ Lint.renderMessageOneLine Lint.unPrjPkgId (Lint.PackageMessage puid Lint.CouldNotParse)
+            Just x -> do
+                let cfg = Lint.LintConfig {
+                        Lint.thisPackage = puid
+                      ,
+                        Lint.requiredOptions = Set.fromList requiredOptions
+                      }
+                    Lint.ResultP summary perrs cerrs = Lint.lintPackageDescription cfg x
+
+                modifyTVarIO accSummary (<> summary)
+
+                forM_ perrs $ \perr -> showMessage $ Lint.PackageMessage puid perr
+
+                forM_ (Map.assocs cerrs) $ \(cname, errs) ->
+                    forM_ errs $ \err ->
+                        showMessage $ Lint.ComponentMessage (Lint.CompId puid cname) err
+
+    -- analyze the given .cabal files together as a project
+    do
+        summary <- STM.readTVarIO accSummary
+        forM_ (Lint.lintProject summary) $ \msg -> showMessage $ Lint.ProjectMessage msg
+
+    STM.readTVarIO accSeverity >>= \case
+        Lint.InfoSeverity  -> exitSuccess
+        Lint.ErrorSeverity -> exitFailure
+
+modifyTVarIO :: STM.TVar a -> (a -> a) -> IO ()
+modifyTVarIO tvar f = STM.atomically $ do
+    a <- STM.readTVar tvar
+    STM.writeTVar tvar (f a)
+
+-----
+
+-- | Every component must certinaly include at least these in `ghc-options'
+requiredOptions :: [String]
+requiredOptions = words "\
+  \-Wall\n\
+  \-Wcompat\n\
+  \-Widentities\n\
+  \-Wincomplete-record-updates\n\
+  \-Wincomplete-uni-patterns\n\
+  \-Wmissing-export-lists\n\
+  \-Wpartial-fields\n\
+  \-Wredundant-constraints\n\
+  \"
+
+{-
+    -- parse the list of allowed dependencies
+    cfg <- do
+        let ss = filter (not . null) allowedBounds
+        myDepss <- forM ss $ \s ->
+            case C.explicitEitherParsec (parseOneDep <* C.eof) s of
+                Left err -> die $ "could not parse bounds: " <> s <> "; " <> show err
+                Right deps -> pure deps
+        let _ = myDepss :: [NES.NonEmptySet MyDep]
+        pure LintConfig {
+            bounds = foldMap NES.toSet myDepss
+          ,
+            options = Set.fromList requiredOptions
+          }
+-}
+
+{-
+parseOneDep :: C.ParsecParser (NES.NonEmptySet MyDep)
+parseOneDep =
+    f <$> C.parsec
+  where
+    f (C.Dependency pname vrange libnames) =
+      NES.map (\libname -> MyDep pname libname vrange) libnames
+-}

--- a/cabal-lint/src/Cabal/Lint/Ord.hs
+++ b/cabal-lint/src/Cabal/Lint/Ord.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- | This module defines wrappers with arbitrary 'Ord' instances around types
+-- for which @Cabal@ does not derive 'Ord'; we only use these to put these
+-- types in maps, sets, etc.
+
+module Cabal.Lint.Ord (
+  MyVersionRange (..),
+  MyLanguage (..),
+  ) where
+
+import qualified Distribution.Types.VersionRange.Internal                  as C
+import qualified Language.Haskell.Extension                                as C
+
+-----
+
+newtype MyVersionRange = MyVersionRange {unMyVersionRange :: C.VersionRange}
+  deriving (Eq)
+
+instance Ord MyVersionRange where
+  compare = (\f (MyVersionRange x) (MyVersionRange y) -> f (x, y)) $ \case
+      (C.ThisVersion l, C.ThisVersion r) -> compare l r
+      (C.ThisVersion{}, _              ) -> LT
+      (_, C.ThisVersion{}              ) -> GT
+
+      (C.LaterVersion l, C.LaterVersion r) -> compare l r
+      (C.LaterVersion{}, _               ) -> LT
+      (_, C.LaterVersion{}               ) -> GT
+
+      (C.OrLaterVersion l, C.OrLaterVersion r) -> compare l r
+      (C.OrLaterVersion{}, _                 ) -> LT
+      (_, C.OrLaterVersion{}                 ) -> GT
+
+      (C.EarlierVersion l, C.EarlierVersion r) -> compare l r
+      (C.EarlierVersion{}, _                 ) -> LT
+      (_, C.EarlierVersion{}                 ) -> GT
+
+      (C.OrEarlierVersion l, C.OrEarlierVersion r) -> compare l r
+      (C.OrEarlierVersion{}, _                   ) -> LT
+      (_, C.OrEarlierVersion{}                   ) -> GT
+
+      (C.MajorBoundVersion l, C.MajorBoundVersion r) -> compare l r
+      (C.MajorBoundVersion{}, _                    ) -> LT
+      (_, C.MajorBoundVersion{}                    ) -> GT
+
+      (C.UnionVersionRanges l1 l2, C.UnionVersionRanges r1 r2) -> cmp l1 r1 <> cmp l2 r2
+      (C.UnionVersionRanges{}, _                             ) -> LT
+      (_, C.UnionVersionRanges{}                             ) -> GT
+
+      (C.IntersectVersionRanges l1 l2, C.IntersectVersionRanges r1 r2) -> cmp l1 r1 <> cmp l2 r2
+    where
+      cmp x y = compare (MyVersionRange x) (MyVersionRange y)
+
+-----
+
+newtype MyLanguage = MyLanguage C.Language
+  deriving (Eq)
+
+instance Ord MyLanguage where
+  compare = (\f (MyLanguage x) (MyLanguage y) -> f (x, y)) $ \case
+    (C.Haskell98, C.Haskell98) -> EQ
+    (C.Haskell98, _          ) -> LT
+    (_          , C.Haskell98) -> GT
+
+    (C.Haskell2010, C.Haskell2010) -> EQ
+    (C.Haskell2010, _            ) -> LT
+    (_            , C.Haskell2010) -> GT
+
+    (C.GHC2021, C.GHC2021) -> EQ
+    (C.GHC2021, _        ) -> LT
+    (_        , C.GHC2021) -> GT
+
+    (C.UnknownLanguage l, C.UnknownLanguage r) -> compare l r

--- a/cabal-lint/src/Cabal/Lint/Summygroup.hs
+++ b/cabal-lint/src/Cabal/Lint/Summygroup.hs
@@ -22,6 +22,9 @@ import qualified Data.Map as Map
 -- This abstraction is a semiring without the additive identity; we don't think
 -- there's an effective established name for that, so we keep the cheeky
 -- @Summygroup@.
+--
+-- This class does not constrain how 'mempty' and @<+>@ relate when @m@ is a 'Monoid'.
+-- EG it annihilates for 'Always' and is neutral for 'Sometimes'.
 class Semigroup m => Summygroup m where (<+>) :: m -> m -> m
 
 instance Summygroup b => Summygroup (a -> b) where

--- a/cabal-lint/src/Cabal/Lint/Summygroup.hs
+++ b/cabal-lint/src/Cabal/Lint/Summygroup.hs
@@ -1,0 +1,51 @@
+module Cabal.Lint.Summygroup (
+  -- *
+  Summygroup (..),
+  -- *
+  Always (..),
+  Sometimes (..),
+  oneAlways,
+  oneSometimes,
+  ) where
+
+import           Data.Map (Map)
+import qualified Data.Map as Map
+
+-----
+
+-- | Like 'Semigroup', but for disjunction instead of conjunction
+class Summygroup m where (<+>) :: m -> m -> m
+
+instance Summygroup b => Summygroup (a -> b) where
+  f <+> g = \x -> f x <+> g x
+
+instance (Summygroup m, Summygroup n) => Summygroup (m, n) where
+  (l1, l2) <+> (r1, r2) = (l1 <+> r1, l2 <+> r2)
+
+-----
+
+-- | A multi-set using the lesser count from either side of '<+>'
+--
+-- INVARIANT: all elements >0.
+newtype Always a = Always {getAlways :: Map a Int}
+
+oneAlways :: a -> Always a
+oneAlways x = Always $ Map.singleton x 1
+
+instance Ord a => Monoid     (Always a) where mempty                = Always Map.empty
+instance Ord a => Semigroup  (Always a) where Always l <>  Always r = Always $ Map.unionWith (+) l r
+instance Ord a => Summygroup (Always a) where Always l <+> Always r = Always $ Map.intersectionWith min l r
+
+-----
+
+oneSometimes :: a -> Sometimes a
+oneSometimes x = Sometimes $ Map.singleton x 1
+
+-- | A multi-set using the larger count from either side of '<+>'
+--
+-- INVARIANT: all elements >0.
+newtype Sometimes a = Sometimes {getSometimes :: Map a Int}
+
+instance Ord a => Monoid     (Sometimes a) where mempty                      = Sometimes Map.empty
+instance Ord a => Semigroup  (Sometimes a) where Sometimes l <>  Sometimes r = Sometimes $ Map.unionWith (+) l r
+instance Ord a => Summygroup (Sometimes a) where Sometimes l <+> Sometimes r = Sometimes $ Map.unionWith max l r

--- a/cabal-lint/src/Cabal/Lint/Summygroup.hs
+++ b/cabal-lint/src/Cabal/Lint/Summygroup.hs
@@ -13,8 +13,16 @@ import qualified Data.Map as Map
 
 -----
 
--- | Like 'Semigroup', but for disjunction instead of conjunction
-class Summygroup m where (<+>) :: m -> m -> m
+-- | Given a semigroup interpreted here as multiplication, this class adds an additive operator with distributivity.
+--
+-- > (a <+> b) <+> c = a <+> (b <+> c)
+--
+-- > (a <+> b) <> x = (a <> x) <+> (b <> x)
+--
+-- This abstraction is a semiring without the additive identity; we don't think
+-- there's an effective established name for that, so we keep the cheeky
+-- @Summygroup@.
+class Semigroup m => Summygroup m where (<+>) :: m -> m -> m
 
 instance Summygroup b => Summygroup (a -> b) where
   f <+> g = \x -> f x <+> g x

--- a/cabal-lint/src/Cabal/Lint/UX/Output.hs
+++ b/cabal-lint/src/Cabal/Lint/UX/Output.hs
@@ -68,7 +68,7 @@ data ComponentError =
   |
     MissingOptions (NES.NonEmptySet String)
   |
-    NonEmptyDefaultExtensions (NES.NonEmptySet C.Extension)
+    NonEmptyExtensions (NES.NonEmptySet C.Extension)
   deriving (Eq, Ord)
 
 -- | Error at the package scope
@@ -145,7 +145,7 @@ classifyMessage = \case
         RepeatDeps{} -> "RepeatDeps"
         RepeatOptions{} -> "RepeatOptions"
         MissingOptions{} -> "MissingOptions"
-        NonEmptyDefaultExtensions{} -> "DefaultExtensions"
+        NonEmptyExtensions{} -> "Extensions"
 
 -- | The user-readable meaning of a 'Message'
 renderMessageOneLineText :: forall puid. (PrjPkgId puid -> String) -> Message puid -> String
@@ -163,7 +163,7 @@ renderMessageOneLineText sho e = case e of
         RepeatDeps pkgnames -> "repeats dependencies in its `build-depends' fields: " <> intercalate ", " [ C.prettyShow pname <> ":" <> C.prettyShow (C.CLibName libname) | DepId pname libname <- NES.toList pkgnames ]
         RepeatOptions opt -> "repeats options in its `ghc-options' fields: " <> unwords (NES.toList opt)
         MissingOptions opts -> "is missing required options in its `ghc-options' fields: " <> unwords (NES.toList opts)
-        NonEmptyDefaultExtensions exts -> "declares default language extensions: " <> unwords (map C.prettyShow $ NES.toList exts)
+        NonEmptyExtensions exts -> "declares `default-extensions' and/or `other-extensions': " <> unwords (map C.prettyShow $ NES.toList exts)
   where
     prettyV vrange =
         if C.anyVersion == vrange

--- a/cabal-lint/src/Cabal/Lint/UX/Output.hs
+++ b/cabal-lint/src/Cabal/Lint/UX/Output.hs
@@ -18,6 +18,7 @@ module Cabal.Lint.UX.Output (
 import           Cabal.Lint.Ids
 import           Cabal.Lint.Ord
 import           Cabal.Lint.Summygroup
+import           Control.Monad (join)
 import           Data.List (intercalate)
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -26,6 +27,7 @@ import qualified Distribution.Compat.NonEmptySet as NES
 import qualified Distribution.Pretty                                       as C
 import qualified Distribution.Types.ComponentName                          as C
 import qualified Distribution.Types.UnqualComponentName                    as C
+import qualified Distribution.Types.Version                                as C
 import qualified Distribution.Types.VersionRange.Internal                  as C
 import qualified Language.Haskell.Extension                                as C
 
@@ -152,7 +154,7 @@ renderMessageOneLineText sho e = case e of
         EmptyProject -> "There were no .cabal files to analyze; pass at least one command-line argument, each a path to a .cabal file"
         ConsistentVersionRange (DepId pname libname) (MyVersionRange vrange) -> "Dependency " <> C.prettyShow pname <> ":" <> C.prettyShow (C.CLibName libname) <> " is consistently " <> prettyV vrange
         ConsistentDefaultLanguage mbLang -> "The default language is consistently " <> prettyL mbLang
-        InconsistentVersionRanges (DepId pname libname) (Occurrences m) -> "Dependency " <> C.prettyShow pname <> ":" <> C.prettyShow (C.CLibName libname) <> " is " <> differences (prettyV . unMyVersionRange) m
+        InconsistentVersionRanges (DepId pname libname) (Occurrences m) -> "Dependency " <> C.prettyShow pname <> ":" <> C.prettyShow (C.CLibName libname) <> " is " <> differences (prettyV . unMyVersionRange) m <> "; " <> theIntersection (Occurrences m)
         InconsistentDefaultLanguages (Occurrences m) -> "The default language is " <> differences prettyL m
     PackageMessage puid err -> case err of
         CouldNotParse -> "Package " <> sho puid <> " could not be parsed as a `.cabal` file"
@@ -181,3 +183,103 @@ renderMessageOneLineText sho e = case e of
             ]
         | (k, comps) <- Map.toList m
         ]
+
+    theIntersection (Occurrences m) =
+        let cons (MyVersionRange x) y = intersection <$> versionRangeToInterval x <*> y
+            nil                       = Just full
+        in
+        case foldr cons nil (Map.keys m) of
+            Nothing   -> "those constraints are not all simple intervals"
+            Just ival -> "the intersection of those constraints as simple intervals is " <> C.prettyShow (intervalToVersionRange ival)
+
+-----
+
+bottom :: C.Version
+bottom = C.version0   -- not C.nullVersion = C.mkVersion [] because our lower bound is inclusive
+
+next :: C.Version -> C.Version
+next = C.mkVersion . (++ [0]) . C.versionNumbers
+
+-- | Partial because the predecessor of @V.1@ could
+-- be @V.0.xyz@ where @xyz@ can be arbitrarily long
+--
+-- INVARIANT: @'prev' y = Just x@ if and only if @y = 'next' x@
+prev :: C.Version -> Maybe C.Version
+prev =
+    fmap C.mkVersion . go . C.versionNumbers
+  where
+    go = \case
+        [0]  -> Just []
+        x:xs -> (x:) <$> go xs
+        _    -> Nothing
+
+-----
+
+-- | A type that is either zero or negative epsilon
+--
+-- We use this to simplify the handling of strict upper bounds. If 'prev' were
+-- total, we could use that instead, and 'Nudge' would be unnecessary.
+data Nudge = LessEpsilon | NoNudge
+  deriving (Eq, Ord, Show)
+
+-- | An enriched type for the upper bound
+--
+-- The extra structure represents unboundedness and the distinction between @<@
+-- and @<=@ (see 'Nudge').
+data Upper a = Middle a Nudge | Top
+  deriving (Eq, Ord, Show)
+
+-- | Lower is inclusive, upper is exclusive
+data Interval a = Interval a (Upper a)
+  deriving (Show)
+
+empty :: a -> Interval a
+empty x = x `Interval` Middle x LessEpsilon
+
+intersection :: Ord a => Interval a -> Interval a -> Interval a
+intersection (loL `Interval` hiL) (loR `Interval` hiR)
+    | hiL < Middle loR NoNudge = empty loR   -- they don't abut
+    | hiR < Middle loL NoNudge = empty loR   -- they don't abut
+    | otherwise                = max loL loR `Interval` min hiL hiR
+
+-- | Fails when they don't abut
+union :: Ord a => Interval a -> Interval a -> Maybe (Interval a)
+union (loL `Interval` hiL) (loR `Interval` hiR)
+    | hiL < Middle loR NoNudge = Nothing   -- they don't abut
+    | hiR < Middle loL NoNudge = Nothing   -- they don't abut
+    | otherwise                = Just $ min loL loR `Interval` max hiL hiR
+
+-----
+
+full :: Interval C.Version
+full = bottom `Interval` Top
+
+intervalToVersionRange :: Interval C.Version -> C.VersionRange
+intervalToVersionRange (lo `Interval` ehi) = case ehi of
+    Middle hi nudge -> case compare lo hi of
+        LT -> (if lo == bottom then id else C.IntersectVersionRanges lower) $ case nudge of
+            NoNudge     -> C.OrEarlierVersion hi
+            LessEpsilon -> C.EarlierVersion   hi
+        EQ -> case nudge of
+            NoNudge     -> C.ThisVersion lo
+            LessEpsilon -> C.noVersion
+        GT -> C.noVersion
+
+    Top -> lower
+  where
+    lower = case prev lo of
+            Just v -> C.LaterVersion v
+            _      -> C.OrLaterVersion lo
+
+-- | Fails if there's a union of intervals that do not abut
+versionRangeToInterval :: C.VersionRange -> Maybe (Interval C.Version)
+versionRangeToInterval = \case
+    C.ThisVersion       v -> Just $ v      `Interval` Middle v NoNudge
+    C.LaterVersion      v -> Just $ next v `Interval` Top
+    C.OrLaterVersion    v -> Just $ v      `Interval` Top
+    C.EarlierVersion    v -> Just $ bottom `Interval` Middle v LessEpsilon
+    C.OrEarlierVersion  v -> Just $ bottom `Interval` Middle v NoNudge
+    C.MajorBoundVersion v -> Just $ v      `Interval` Middle (C.majorUpperBound v) LessEpsilon
+
+    C.UnionVersionRanges     l r -> join $ union        <$> versionRangeToInterval l <*> versionRangeToInterval r
+    C.IntersectVersionRanges l r ->        intersection <$> versionRangeToInterval l <*> versionRangeToInterval r

--- a/cabal-lint/src/Cabal/Lint/UX/Output.hs
+++ b/cabal-lint/src/Cabal/Lint/UX/Output.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cabal.Lint.UX.Output (
+  -- *
+  Occurrences (..),
+  oneOccurrence,
+  -- *
+  ComponentError (..),
+  Message (..),
+  MessageSeverity (..),
+  PackageError (..),
+  ProjectMessage (..),
+  messageSeverity,
+  renderMessageOneLine,
+  ) where
+
+import           Cabal.Lint.Ids
+import           Cabal.Lint.Ord
+import           Cabal.Lint.Summygroup
+import           Data.List (intercalate)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Distribution.Compat.NonEmptySet as NES
+
+import qualified Distribution.Pretty                                       as C
+import qualified Distribution.Types.ComponentName                          as C
+import qualified Distribution.Types.UnqualComponentName                    as C
+import qualified Distribution.Types.VersionRange.Internal                  as C
+import qualified Language.Haskell.Extension                                as C
+
+-----
+
+-- | A map from values (eg a default language) to the components in which they
+-- occur
+--
+-- Example use: a mapping @vrange |-> comps@ means each of those the components
+-- might constrain the dependency to that range. If it's possible a dependency
+-- is constrained to more than one range, the linter raises an error about the
+-- components not obviously agreeing.
+newtype Occurrences a puid = Occurrences (Map a (NES.NonEmptySet (CompId puid)))
+  deriving (Eq, Ord)
+
+oneOccurrence :: a -> CompId puid -> Occurrences a puid
+oneOccurrence a cid = Occurrences $ Map.singleton a $ NES.singleton cid
+
+instance (Ord a, Ord puid) => Monoid (Occurrences a puid) where
+  mempty = Occurrences Map.empty
+
+-- | @unionWith (<>)@
+instance (Ord a, Ord puid) => Semigroup (Occurrences a puid) where
+  Occurrences l <> Occurrences r = Occurrences $ Map.unionWith (<>) l r
+
+-- | Note that @(<+>) = (<>)@
+instance (Ord a, Ord puid) => Summygroup (Occurrences a puid) where (<+>) = (<>)
+
+-----
+
+-- | Error at the component scope
+--
+-- See definition of 'renderMessageOneLineText'
+data ComponentError =
+    RepeatDeps (NES.NonEmptySet DepId)
+  |
+    RepeatOptions (NES.NonEmptySet String)
+  |
+    MissingOptions (NES.NonEmptySet String)
+  |
+    NonEmptyDefaultExtensions (NES.NonEmptySet C.Extension)
+  deriving (Eq, Ord)
+
+-- | Error at the package scope
+--
+-- See definition of 'renderMessageOneLineText'
+data PackageError =
+    NonEmptyForeignLibraries (NES.NonEmptySet C.UnqualComponentName)
+  |
+    CouldNotParse
+  deriving (Eq, Ord)
+
+-- | Error at the project scope
+--
+-- See definition of 'renderMessageOneLineText'
+data ProjectMessage puid =
+    EmptyProject
+  |
+    ConsistentVersionRange DepId MyVersionRange
+  |
+    ConsistentDefaultLanguage (Maybe MyLanguage)
+  |
+    InconsistentVersionRanges DepId (Occurrences MyVersionRange puid)
+      -- ^ INVARIANT: non-empty
+      --
+      -- INVARIANT: all contained 'Occurrences' have multiple entries
+  |
+    InconsistentDefaultLanguages (Occurrences (Maybe MyLanguage) puid)
+      -- ^ INVARIANT: multiple entries
+  deriving (Eq, Ord)
+
+-- | All errors the linter can raise
+data Message puid =
+    ProjectMessage (ProjectMessage puid)
+  |
+    PackageMessage (PrjPkgId puid) PackageError
+  |
+    ComponentMessage (CompId puid) ComponentError
+
+-- | How severe is the message?
+data MessageSeverity = InfoSeverity | ErrorSeverity
+
+instance Monoid    MessageSeverity where mempty = InfoSeverity
+instance Semigroup MessageSeverity where
+    InfoSeverity <> InfoSeverity = InfoSeverity
+    _            <> _            = ErrorSeverity
+
+-----
+
+renderMessageOneLine :: (PrjPkgId puid -> String) -> Message puid -> String
+renderMessageOneLine sho msg =
+    "[" <> severityText <> "-" <> code <> "] " <> renderMessageOneLineText sho msg
+  where
+    (severity, code) = classifyMessage msg
+    severityText = case severity of
+        InfoSeverity  -> "I"
+        ErrorSeverity -> "E"
+
+messageSeverity :: Message puid -> MessageSeverity
+messageSeverity = fst . classifyMessage
+
+-- | The severity and code of a 'Message'
+classifyMessage :: Message puid -> (MessageSeverity, String)
+classifyMessage = \case
+    ProjectMessage msg -> case msg of
+        EmptyProject{} -> (ErrorSeverity, "EmptyProject")
+        ConsistentVersionRange{} -> (InfoSeverity, "ConsistentVersions")
+        ConsistentDefaultLanguage{} -> (InfoSeverity, "ConsistentLanguages")
+        InconsistentVersionRanges{} -> (ErrorSeverity, "InconsistentVersions")
+        InconsistentDefaultLanguages{} -> (ErrorSeverity, "InconsistentLanguages")
+    PackageMessage _puid msg -> (,) ErrorSeverity $ case msg of
+        CouldNotParse{} -> "NoParse"
+        NonEmptyForeignLibraries{} -> "ForeignLibs"
+    ComponentMessage _cid msg -> (,) ErrorSeverity $ case msg of
+        RepeatDeps{} -> "RepeatDeps"
+        RepeatOptions{} -> "RepeatOptions"
+        MissingOptions{} -> "MissingOptions"
+        NonEmptyDefaultExtensions{} -> "DefaultExtensions"
+
+-- | The user-readable meaning of a 'Message'
+renderMessageOneLineText :: forall puid. (PrjPkgId puid -> String) -> Message puid -> String
+renderMessageOneLineText sho e = case e of
+    ProjectMessage err -> case err of
+        EmptyProject -> "There were no .cabal files to analyze; pass at least one command-line argument, each a path to a .cabal file"
+        ConsistentVersionRange (DepId pname libname) (MyVersionRange vrange) -> "Dependency " <> C.prettyShow pname <> ":" <> C.prettyShow (C.CLibName libname) <> " is consistently " <> prettyV vrange
+        ConsistentDefaultLanguage mbLang -> "The default language is consistently " <> prettyL mbLang
+        InconsistentVersionRanges (DepId pname libname) (Occurrences m) -> "Dependency " <> C.prettyShow pname <> ":" <> C.prettyShow (C.CLibName libname) <> " is " <> differences (prettyV . unMyVersionRange) m
+        InconsistentDefaultLanguages (Occurrences m) -> "The default language is " <> differences prettyL m
+    PackageMessage puid err -> case err of
+        CouldNotParse -> "Package " <> sho puid <> " could not be parsed as a `.cabal` file"
+        NonEmptyForeignLibraries cnames -> "Package " <> sho puid <> " declares foreign libraries: " <> intercalate ", " (map C.prettyShow (NES.toList cnames))
+    ComponentMessage (CompId puid cname) err -> "Component " <> C.prettyShow cname <> " in package " <> sho puid <> " " <> case err of
+        RepeatDeps pkgnames -> "repeats dependencies in its `build-depends' fields: " <> intercalate ", " [ C.prettyShow pname <> ":" <> C.prettyShow (C.CLibName libname) | DepId pname libname <- NES.toList pkgnames ]
+        RepeatOptions opt -> "repeats options in its `ghc-options' fields: " <> unwords (NES.toList opt)
+        MissingOptions opts -> "is missing required options in its `ghc-options' fields: " <> unwords (NES.toList opts)
+        NonEmptyDefaultExtensions exts -> "declares default language extensions: " <> unwords (map C.prettyShow $ NES.toList exts)
+  where
+    prettyV vrange =
+        if C.anyVersion == vrange
+        then "unconstrained"
+        else "constrained to " <> C.prettyShow vrange
+
+    prettyL = \case
+        Nothing                -> "unset"
+        Just (MyLanguage lang) -> "set to " <> show lang
+
+    differences :: (k -> String) -> Map k (NES.NonEmptySet (CompId puid)) -> String
+    differences prettyK m =
+        intercalate "; but "
+        [ prettyK k <> " in " <> intercalate ", "
+            [ "component " <> C.prettyShow cname <> " of package " <> sho puid
+            | CompId puid cname <- NES.toList comps
+            ]
+        | (k, comps) <- Map.toList m
+        ]

--- a/cabal.project
+++ b/cabal.project
@@ -41,6 +41,7 @@ packages: ./ouroboros-network-testing
           ./ouroboros-consensus-cardano-tools
           ./ouroboros-consensus-diffusion
           ./cardano-client
+          ./cabal-lint
 
 tests: True
 


### PR DESCRIPTION
This PR adds the `cabal-lint` tool. The Consensus team is going to use this to enforce invariants amongst our `.cabal` files that will help us maintain them given our new reliance on [CHaP](https://github.com/input-output-hk/cardano-haskell-packages).