### PR TITLE
Fix missing `liblmdb-dev` depency in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         ghcup run -- pacman --noconfirm -S `
            mingw-w64-x86_64-pkg-config `
            mingw-w64-x86_64-libsodium `
+           mingw-w64-x86_64-lmdb `
            base-devel `
            autoconf-wrapper `
            autoconf `
@@ -40,7 +41,7 @@ jobs:
     # above. It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and
     # as such we'd need pacman.exe instead.
     - name: Setup Haskell
-      run: |        
+      run: |
         # Use GHCUP to manage ghc/cabal
         ghcup install ghc --set ${{ matrix.ghc }}
         ghcup install cabal --set 3.6.2.0
@@ -60,11 +61,11 @@ jobs:
         # https://github.com/msys2/MINGW-packages/issues/10837#issuecomment-1047105402
         # https://gitlab.haskell.org/ghc/ghc/-/issues/21111
         # if we _do_ want them, this would be the lines to add below
-        
+
         $ghcMingwDir = Join-Path -Path $(ghc --print-libdir) `
                                  -ChildPath ../mingw/x86_64-*-mingw32/lib/ `
                                  -Resolve
-        
+
         cabal user-config -a "extra-prog-path: C:/msys64/mingw64/bin, C:/msys64/usr/bin" `
                           -a "extra-include-dirs: C:/msys64/mingw64/include" `
                           -a ("extra-lib-dirs: {0}, C:/msys64/mingw64/lib" -f $ghcMingwDir) `
@@ -76,13 +77,13 @@ jobs:
       if: runner.os != 'Windows'
       run: |
         echo "cabal-store=/home/runner/.cabal/store" >> $GITHUB_OUTPUT
-        
+
     - name: "OUTPUT Record cabal-store (Windows)"
       id: win-setup-haskell
       shell: bash
       if: runner.os == 'Windows'
       run: |
-        echo "cabal-store=C:\\cabal\\store" >> $GITHUB_OUTPUT     
+        echo "cabal-store=C:\\cabal\\store" >> $GITHUB_OUTPUT
 
     - name: "[OUTPUT] cache keys: version, weeknum"
       id: cache-keys
@@ -97,6 +98,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install libsodium23 libsodium-dev
         sudo apt-get -y install libsystemd0 libsystemd-dev
+        sudo apt-get -y install liblmdb-dev
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 
@@ -124,7 +126,7 @@ jobs:
       env:
         CI_SECP_FLAGS: "--prefix=/usr"
         CI_SECP_INSTALL_CMD: sudo
-      run: bash .github/workflows/build-secp256k1.bash 
+      run: bash .github/workflows/build-secp256k1.bash
 
     - name: "Configure cabal.project.local"
       if: runner.os != 'Windows'


### PR DESCRIPTION
# Description

CI was missing a `liblmdb-dev` dependency. Also remove trailing whitespace in the workflow file.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
