### PR TITLE
Tweak Cicero CI: bigger timeouts, more RAM

### DIFF
--- a/nix/cells/automation/pipelines.nix
+++ b/nix/cells/automation/pipelines.nix
@@ -23,11 +23,11 @@
         nix-systems -i |
         jq 'with_entries(select(.value))' # filter out systems that we cannot build for
       '';
-      each.text = ''nix build -L .#hydraJobs."$1".required'';
+      each.text = ''nix build -L .#hydraJobs."$1".required --max-silent-time 1800'';
       skippedDescription = lib.escapeShellArg "No nix builder available for this system";
     };
 
-    memory = 1024 * 8;
+    memory = 1024 * 16;
     nomad.resources.cpu = 10000;
   };
 }


### PR DESCRIPTION
# Description

For some reason, the CI setup that worked in #4108 is no longer working (see e.g. in #4218). This PR tries two things:

 - Bigger timeouts when tests don't print anything, as observed on x86_64-darwin
 - More RAM, as x86_64-linux is failing with
   ```
   2022-12-07T14:42:49.728770921+00:00 stderr F /nix/store/40zifdshp27bzzx8a3vrsarxfjyaa6az-github-status-report-bulk-each/bin/github-status-report-bulk-each: line 9:  3979 Killed                  nix build -L .#hydraJobs."$1".required
   ```

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
