### PR TITLE
Purge `strict-containers` and replace by `cardano-strict-containers`

### DIFF
--- a/anti-diff/anti-diff.cabal
+++ b/anti-diff/anti-diff.cabal
@@ -63,7 +63,7 @@ library
                      , nothunks          >=0.1.2 && <0.2
                      , QuickCheck
                      , semigroupoid
-                     , strict-containers
+                     , cardano-strict-containers
                      , tasty
                      , tasty-quickcheck
 
@@ -92,7 +92,7 @@ test-suite test
                      , nonempty-containers
                      , groups
                      , QuickCheck
-                     , strict-containers
+                     , cardano-strict-containers
                      , tasty
                      , tasty-quickcheck
 

--- a/cabal.project
+++ b/cabal.project
@@ -96,7 +96,7 @@ constraints:
   , cardano-slotting  == 0.1.0.0
   , measures == 0.1.0.0
   , orphans-deriving-via == 0.1.0.0
-  , strict-containers == 0.1.0.0
+  , cardano-strict-containers == 0.1.1.0
   , plutus-core == 1.0.0.1
   , plutus-ledger-api == 1.0.0.1
   , plutus-tx == 1.0.0.0

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -53,7 +53,7 @@ library
                      , cardano-protocol-tpraos
                      , cardano-slotting
 
-                     , strict-containers
+                     , cardano-strict-containers
 
                      , ouroboros-network
                      , ouroboros-consensus

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -354,7 +354,7 @@ benchmark bench-storage
                      , mtl
                      , QuickCheck
                      , QuickCheck-GenT
-                     , strict-containers
+                     , cardano-strict-containers
                      , tasty-bench <= 0.3.1
                      , tasty-quickcheck
 

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/NFData.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/NFData.hs
@@ -15,6 +15,7 @@ import           Data.Foldable
 import           Data.Sequence (Seq)
 import           Data.Sequence.NonEmpty (NESeq)
 
+import qualified Data.FingerTree.RootMeasured.Strict as RMFT
 import qualified Data.FingerTree.Strict as FT
 import           Data.Map.Diff.Strict (Diff (..), DiffEntry (..),
                      DiffHistory (..), Keys (..), NEDiffHistory (..),
@@ -23,9 +24,9 @@ import           Ouroboros.Consensus.Storage.LedgerDB.HD (SeqUtxoDiff (..),
                      SudElement (..), SudMeasure (..), UtxoDiff (..),
                      UtxoEntryDiff (..), UtxoEntryDiffState (..), UtxoKeys (..),
                      UtxoValues (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (Element (..),
-                     InternalMeasure (..), Length (..), RootMeasure (..),
-                     SlotNoLB (..), SlotNoUB (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (DiffSeq (..),
+                     Element (..), InternalMeasure (..), Length (..),
+                     RootMeasure (..), SlotNoLB (..), SlotNoUB (..))
 
 {------------------------------------------------------------------------------
   StrictFingerTree
@@ -56,8 +57,8 @@ deriving newtype instance (Ord k, NFData k, NFData v) => NFData (SeqUtxoDiff k v
   DiffSeq
 -------------------------------------------------------------------------------}
 
--- deriving anyclass instance (NFData vt, NFData (FT.StrictFingerTree vi a)
---                            ) => NFData (RMFT.StrictFingerTree vt vi a)
+deriving anyclass instance (NFData vt, NFData vi, NFData a, FT.Measured vi a
+                           ) => NFData (RMFT.StrictFingerTree vt vi a)
 
 deriving anyclass instance NFData v => NFData (DiffEntry v)
 deriving newtype instance NFData v => NFData (UnsafeDiffHistory Seq v)
@@ -75,4 +76,4 @@ deriving newtype instance NFData SlotNoLB
 deriving anyclass instance (NFData k, NFData v) => NFData (RootMeasure k v)
 deriving anyclass instance (NFData k, NFData v) => NFData (InternalMeasure k v)
 deriving anyclass instance (NFData k, NFData v) => NFData (Element k v)
---deriving newtype instance (NFData k, NFData v) => NFData (DiffSeq k v)
+deriving newtype instance (NFData k, NFData v) => NFData (DiffSeq k v)


### PR DESCRIPTION
# Description

Some parts of the code depend on `strict-containers`, whereas most parts of the code depend on `cardano-strict-containers`, which is the renamed version of `strict-containers` that lives in the `cardano-base` repository. I've replaced all occurrences of `strict-containers` with `cardano-strict-containers`. 

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
