### PR TITLE
UTxO-HD: Move TableStuff to its own module

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -39,6 +39,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -20,6 +20,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -41,6 +41,8 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -48,6 +48,7 @@ import           Ouroboros.Consensus.HeaderValidation (AnnTip (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.PBFT.State (PBftState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as PBftState
 

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -41,7 +41,7 @@ import qualified Cardano.Crypto as Crypto
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      ProtocolInfo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
@@ -40,7 +40,7 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -35,6 +35,8 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -79,6 +79,8 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Util (ShowProxy (..), (..:))
 
 import           Ouroboros.Consensus.Byron.Ledger.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -69,6 +69,7 @@ import qualified Cardano.Chain.ValidationMode as CC
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Util (ShowProxy (..))
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -30,6 +30,8 @@ import qualified Control.State.Transition as Spec
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util ((..:))
 

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -16,8 +16,8 @@ import           Codec.Serialise
 import           GHC.Generics (Generic)
 import           NoThunks.Class (AllowThunk (..), NoThunks)
 
-import           Ouroboros.Consensus.Ledger.Basics (polyEmptyLedgerTables)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables.Utils (polyEmptyLedgerTables)
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Block
 import           Ouroboros.Consensus.ByronSpec.Ledger.GenTx

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -34,11 +34,11 @@ import           Ouroboros.Network.Block (Serialised (..))
 import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK, IsMapKind,
-                     ValuesMK)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query (SomeQuery (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK, IsMapKind,
+                     ValuesMK)
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Counting (Exactly (..))

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -49,6 +49,8 @@ import           NoThunks.Class (NoThunks)
 import           Cardano.Binary (fromCBOR, toCBOR)
 
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.TypeFamilyWrappers

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -26,8 +26,10 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
                      (currentState, getHardForkState)
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Tele
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig, LedgerState,
-                     TickedLedgerState, ValuesMK, applyChainTick,
-                     applyLedgerTablesDiffsTicked, forgetLedgerTables)
+                     TickedLedgerState, applyChainTick)
+import           Ouroboros.Consensus.Ledger.Tables (ValuesMK)
+import           Ouroboros.Consensus.Ledger.Tables.Utils
+                     (applyLedgerTablesDiffsTicked, forgetLedgerTables)
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 
 import           Cardano.Crypto (toVerification)

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Translation.hs
@@ -54,8 +54,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
                      (TranslateLedgerState (translateLedgerStateWith))
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
                      (RequiringBoth, provideBoth)
-import           Ouroboros.Consensus.Ledger.Basics (ApplyMapKind' (..), DiffMK,
-                     EmptyMK, LedgerCfg, LedgerConfig, LedgerState)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerCfg, LedgerConfig,
+                     LedgerState)
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Protocol.Praos.Common
                      (MaxMajorProtVer (..))

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -35,6 +35,8 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol (..))
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import qualified Ouroboros.Consensus.Util.IOLike as IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -60,6 +60,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol.Praos.Translate ()

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/HasAnalysis.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/HasAnalysis.hs
@@ -15,6 +15,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import qualified Ouroboros.Consensus.Node.Run as Node
 import           Ouroboros.Consensus.Storage.Serialisation (SizeInBytes)

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -28,6 +28,8 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Protocol.Abstract (ChainDepState,
                      tickChainDepState)
 import           Ouroboros.Consensus.Storage.ChainDB.API as ChainDB (ChainDB,

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -78,6 +78,8 @@ import           Ouroboros.Consensus.HardFork.History (Bound (boundSlot),
                      addSlots)
 import           Ouroboros.Consensus.HardFork.Simple
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq as DS
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (eitherToMaybe)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -63,9 +63,10 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
-import           Ouroboros.Consensus.Ledger.Basics (StowableLedgerTables (..),
-                     ValuesMK, forgetLedgerTables)
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables (StowableLedgerTables (..),
+                     ValuesMK)
+import           Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-cardano/tools/ledger-db-backends-checker/Main.hs
+++ b/ouroboros-consensus-cardano/tools/ledger-db-backends-checker/Main.hs
@@ -24,8 +24,8 @@ import           Cardano.Ledger.Crypto
 import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
 
 import           Ouroboros.Consensus.Cardano
-import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Storage.FS.API as FS
 import qualified Ouroboros.Consensus.Storage.FS.API.Types as FS
 import qualified Ouroboros.Consensus.Storage.FS.IO as FS

--- a/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
@@ -30,6 +30,8 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (hashFromBytesE)
 

--- a/ouroboros-consensus-mock-test/src/Test/ThreadNet/TxGen/Mock.hs
+++ b/ouroboros-consensus-mock-test/src/Test/ThreadNet/TxGen/Mock.hs
@@ -12,7 +12,7 @@ import qualified Data.Set as Set
 import           Data.Typeable
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Mock.Ledger
 
 import           Test.QuickCheck hiding (elements)

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -96,6 +96,8 @@ import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.State
 import qualified Ouroboros.Consensus.Mock.Ledger.UTxO as Mock

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -25,6 +25,7 @@ import           Ouroboros.Consensus.HeaderValidation (AnnTip,
                      defaultDecodeAnnTip, defaultEncodeAnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Node.Run

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -37,11 +37,11 @@ import qualified Cardano.Protocol.TPraos.BHeader as SL
 import           Data.Coerce (coerce)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
-import           Ouroboros.Consensus.Ledger.Basics
-                     (ApplyMapKind' (ApplyEmptyMK))
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Protocol.Praos (Praos)
 import           Ouroboros.Consensus.Protocol.Praos.Header
                      (HeaderBody (HeaderBody))
@@ -55,7 +55,6 @@ import           Ouroboros.Consensus.Storage.Serialisation
 
 import           Test.Cardano.Ledger.Shelley.Orphans ()
 
-import qualified Ouroboros.Consensus.Ledger.Basics as Basics
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.HFEras
 import           Ouroboros.Consensus.Shelley.Ledger
@@ -160,7 +159,7 @@ fromShelleyLedgerExamples ShelleyLedgerExamples {
                        ledgerState
                        (genesisHeaderState chainDepState)
     ledgerTables = ShelleyLedgerTables
-                 $ Basics.ApplyValuesMK
+                 $ ApplyValuesMK
                  $ DS.Values
                  $ Map.fromList
                  $ zip exampleTxIns exampleTxOuts
@@ -269,7 +268,7 @@ fromShelleyLedgerExamplesPraos ShelleyLedgerExamples {
                                   }
     , shelleyLedgerState      = sleNewEpochState
     , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
-    , shelleyLedgerTables = Basics.polyEmptyLedgerTables
+    , shelleyLedgerTables     = polyEmptyLedgerTables
     }
     chainDepState = translateChainDepState @(TPraos (EraCrypto era)) @(Praos (EraCrypto era))
       $ TPraosState (NotOrigin 1) sleChainDepState
@@ -277,7 +276,7 @@ fromShelleyLedgerExamplesPraos ShelleyLedgerExamples {
                        ledgerState
                        (genesisHeaderState chainDepState)
     ledgerTables = ShelleyLedgerTables
-                 $ Basics.ApplyValuesMK
+                 $ ApplyValuesMK
                  $ DS.Values
                  $ Map.fromList
                  $ zip exampleTxIns exampleTxOuts

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -18,6 +18,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
 
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.PParams as SL

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -21,6 +21,8 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 
 import qualified Cardano.Ledger.Shelley.API as SL
 

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
@@ -20,6 +20,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -84,6 +84,8 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq as DS
 import           Ouroboros.Consensus.Util ((..:))
 import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -58,6 +58,8 @@ import           Cardano.Ledger.Alonzo.Scripts (ExUnits, ExUnits',
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool.TxLimits
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq as DS
 import           Ouroboros.Consensus.Util (ShowProxy (..))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -59,6 +59,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
+import           Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq as DS
 import           Ouroboros.Consensus.Util (ShowProxy (..))
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
@@ -31,6 +31,8 @@ import           Ouroboros.Consensus.HardFork.History.Util
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol (..))
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Protocol.Praos (Praos)
 import qualified Ouroboros.Consensus.Protocol.Praos as Praos
 import qualified Ouroboros.Consensus.Protocol.Praos.Views as Praos

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -30,9 +30,10 @@ import           Ouroboros.Consensus.Config (SecurityParam (SecurityParam),
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
                      (HeaderState (HeaderState))
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerConfig, ValuesMK,
-                     polyEmptyLedgerTables)
+import           Ouroboros.Consensus.Ledger.Abstract (LedgerConfig)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
+import           Ouroboros.Consensus.Ledger.Tables (ValuesMK)
+import           Ouroboros.Consensus.Ledger.Tables.Utils (polyEmptyLedgerTables)
 import           Ouroboros.Consensus.Mempool.TxLimits
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node (ProtocolInfo (..))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -18,8 +18,8 @@ import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Storage.Serialisation

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -58,6 +58,8 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool.TxLimits (TxLimits)
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -59,6 +59,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
 import           Ouroboros.Consensus.HardFork.History (Bound (boundSlot))
 import           Ouroboros.Consensus.HardFork.Simple
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import qualified Ouroboros.Consensus.Util.SOP as SOP

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -84,6 +84,8 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -112,10 +114,8 @@ import           Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import           Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore
                      (RangeQuery (RangeQuery))
-import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
-                     (BackingStoreSelector (..), LedgerBackingStoreValueHandle,
-                     LedgerDB', mkDiskLedgerView)
+                     (BackingStoreSelector (..), mkDiskLedgerView)
 import           Ouroboros.Consensus.Util.Enclose (pattern FallingEdge)
 
 import           Test.ThreadNet.TxGen

--- a/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
@@ -21,6 +21,7 @@ import           Test.QuickCheck (Gen)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Util.SOP

--- a/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
@@ -25,6 +25,7 @@ import           Ouroboros.Consensus.HardFork.History.EraParams (EraParams,
                      eraEpochSize)
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB hiding
                      (TraceFollowerEvent (..))

--- a/ouroboros-consensus-test/src/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus-test/src/Test/Util/LedgerStateOnlyTables.hs
@@ -21,7 +21,8 @@ import           NoThunks.Class (NoThunks)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
-import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 
 {-------------------------------------------------------------------------------
   Simple ledger state

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
@@ -19,6 +19,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
@@ -58,14 +58,14 @@ import           Ouroboros.Consensus.Block (BlockProtocol, CodecConfig, Header,
                      HeaderHash, SlotNo)
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK, LedgerTables,
-                     TableStuff, ValuesMK, valuesMKEncoder)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState,
                      encodeExtLedgerState)
 import           Ouroboros.Consensus.Ledger.Query (BlockQuery, QueryVersion,
                      SomeQuery, nodeToClientVersionToQueryVersion)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx,
                      GenTxId)
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK, LedgerTables,
+                     TableStuff, ValuesMK, valuesMKEncoder)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                      (HasNetworkProtocolVersion (..),
                      SupportedNetworkProtocolVersion (..))

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -50,12 +50,12 @@ import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import           Ouroboros.Consensus.Ledger.Query (BlockQuery, Query (..),
                      QueryVersion)
 import qualified Ouroboros.Consensus.Ledger.Query as Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx,
                      GenTxId)
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run (SerialiseNodeToClientConstraints,
                      SerialiseNodeToNodeConstraints (..))

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -122,6 +122,8 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -43,6 +43,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -81,6 +81,8 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -68,6 +68,8 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -41,6 +41,8 @@ import           Control.Tracer (Tracer (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Mock.Ledger hiding (TxId)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/StateMachine.hs
@@ -48,6 +48,8 @@ import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool hiding (getTxSize)
 import           Ouroboros.Consensus.Mempool.Impl.Types (ForgeLedgerState (..),
                      tickLedgerState)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Util.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Util.hs
@@ -38,6 +38,8 @@ import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mock.Ledger hiding (TxId)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.Protocol.BFT

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -55,6 +55,7 @@ import           Ouroboros.Consensus.HeaderStateHistory
 import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended hiding (ledgerState)
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -27,11 +27,11 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
-import           Ouroboros.Consensus.Ledger.Basics (DiskLedgerView (..),
-                     convertMapKind, getTip)
+import           Ouroboros.Consensus.Ledger.Basics (DiskLedgerView (..), getTip)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query (Query (..),
                      QueryWithSomeFootprintL (..))
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -110,6 +110,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.MockChainSel
 import           Ouroboros.Consensus.Util (repeatedly)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -18,7 +18,7 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Ledger.Basics (convertMapKind)
+import           Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Util.AnchoredFragment as AF
 
 import           Ouroboros.Consensus.Storage.ChainDB.API (StreamFrom (..),

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -76,6 +76,8 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (split)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/DbChangelog.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/DbChangelog.hs
@@ -40,6 +40,7 @@ import qualified Ouroboros.Network.Point as Point
 
 import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
 import           Ouroboros.Consensus.Ledger.Basics hiding (LedgerState)
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq as DS
 
 import           Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary ()

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/BackingStore.hs
@@ -45,7 +45,8 @@ import           Test.QuickCheck.Monadic (PropertyM)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck (QuickCheckTests (..), testProperty)
 
-import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Storage.FS.API hiding (Handle)
 import           Ouroboros.Consensus.Storage.FS.API.Types hiding (Handle)
 import           Ouroboros.Consensus.Storage.FS.IO (ioHasFS)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
@@ -28,7 +28,8 @@ import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Slotting.Slot (WithOrigin (At))
 
 import           Ouroboros.Consensus.Block (SlotNo, WithOrigin (Origin))
-import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (SomeHasFS))
 import           Ouroboros.Consensus.Storage.FS.API.Types
                      (MountPoint (MountPoint))

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -27,6 +27,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Util
 
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -81,6 +81,8 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.IOLike
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -98,6 +98,8 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId

--- a/ouroboros-consensus/docs/utxo-hd/report.tex
+++ b/ouroboros-consensus/docs/utxo-hd/report.tex
@@ -156,8 +156,8 @@ has ledger tables attached to it which share the particular choice of \htt{MapKi
 views). The ledger tables of a ledger state can be accessed via \htt{projectLedgerTables} and new tables can be attached to a ledger state via \htt{withLedgerTables}.
 
 \begin{code}
-projectLedgerTables :: IsApplyMapKind mk => l mk  -> LedgerTables l mk
-withLedgerTables    :: IsApplyMapKind mk => l any -> LedgerTables l mk -> l mk
+projectLedgerTables :: IsMapKind mk => l mk  -> LedgerTables l mk
+withLedgerTables    :: IsMapKind mk => l any -> LedgerTables l mk -> l mk
 \end{code}
 
 This is then concretized by the \htt{ApplyMapKind'} GADT which represents each

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -122,6 +122,8 @@ library
                        Ouroboros.Consensus.Ledger.SupportsMempool
                        Ouroboros.Consensus.Ledger.SupportsPeerSelection
                        Ouroboros.Consensus.Ledger.SupportsProtocol
+                       Ouroboros.Consensus.Ledger.Tables
+                       Ouroboros.Consensus.Ledger.Tables.Utils
                        Ouroboros.Consensus.Mempool
                        Ouroboros.Consensus.Mempool.API
                        Ouroboros.Consensus.Mempool.Impl

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Consensus.BlockchainTime.WallClock.HardFork (
     BackoffDelay (..)
@@ -22,6 +19,7 @@ import           Ouroboros.Consensus.BlockchainTime.WallClock.Util
 import           Ouroboros.Consensus.HardFork.Abstract
 import qualified Ouroboros.Consensus.HardFork.History as HF
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.Time

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -38,6 +38,7 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -5,15 +5,11 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE Rank2Types                 #-}
-{-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.Basics (
     -- * Hard fork protocol, block, and ledger state
@@ -54,6 +50,7 @@ import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (ShowProxy)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -1,13 +1,12 @@
-{-# LANGUAGE DataKinds                #-}
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE EmptyCase                #-}
-{-# LANGUAGE FlexibleContexts         #-}
-{-# LANGUAGE FlexibleInstances        #-}
-{-# LANGUAGE GADTs                    #-}
-{-# LANGUAGE RecordWildCards          #-}
-{-# LANGUAGE ScopedTypeVariables      #-}
-{-# LANGUAGE TypeApplications         #-}
-{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE EmptyCase           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
 module Ouroboros.Consensus.HardFork.Combinator.Embed.Nary (
     Inject (..)
   , inject'
@@ -32,6 +31,8 @@ import           Ouroboros.Consensus.HeaderValidation (AnnTip, HeaderState (..),
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import           Ouroboros.Consensus.Ledger.Query
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util ((.:))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -56,6 +56,8 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense
@@ -213,11 +215,10 @@ instance (SingleEraBlock x, TableStuff (LedgerState x)) => TableStuff (LedgerSta
   withLedgerTables st (LedgerTablesOne tables) =
       withOneState st $ projectOneState st `withLedgerTables` tables
 
-  traverseLedgerTables f (LedgerTablesOne tables) =
-      LedgerTablesOne <$> traverseLedgerTables f tables
-
   pureLedgerTables  f = coerce $ pureLedgerTables  @(LedgerState x) f
   mapLedgerTables   f = coerce $ mapLedgerTables   @(LedgerState x) f
+  traverseLedgerTables f (LedgerTablesOne tables) =
+      LedgerTablesOne <$> traverseLedgerTables f tables
   zipLedgerTables   f = coerce $ zipLedgerTables   @(LedgerState x) f
   zipLedgerTables2  f = coerce $ zipLedgerTables2  @(LedgerState x) f
   foldLedgerTables  f = coerce $ foldLedgerTables  @(LedgerState x) f

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -1,20 +1,18 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE EmptyCase             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -58,6 +56,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.TypeFamilyWrappers (WrapChainDepState (..))
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.Counting (getExactly)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -1,19 +1,15 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -37,6 +33,7 @@ import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.SOP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -7,7 +6,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage () where
 
 import           Data.SOP.Strict
 
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK)
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK)
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Util.SOP
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -2,11 +2,8 @@
 {-# LANGUAGE EmptyCase               #-}
 {-# LANGUAGE FlexibleContexts        #-}
 {-# LANGUAGE GADTs                   #-}
-{-# LANGUAGE KindSignatures          #-}
-{-# LANGUAGE LambdaCase              #-}
 {-# LANGUAGE OverloadedStrings       #-}
 {-# LANGUAGE RankNTypes              #-}
-{-# LANGUAGE RecordWildCards         #-}
 {-# LANGUAGE ScopedTypeVariables     #-}
 {-# LANGUAGE StandaloneDeriving      #-}
 {-# LANGUAGE TypeApplications        #-}
@@ -86,9 +83,9 @@ import           Cardano.Binary (enforceSize)
 import           Ouroboros.Network.Block (Serialised)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Ledger.Basics
-                     (SufficientSerializationForAnyBackingStore)
 import           Ouroboros.Consensus.Ledger.Query
+import           Ouroboros.Consensus.Ledger.Tables
+                     (SufficientSerializationForAnyBackingStore)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Storage.Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -22,7 +20,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
                      (Flip (..))
 import           Ouroboros.Consensus.HeaderValidation
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK,
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK,
                      SufficientSerializationForAnyBackingStore)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util ((.:))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE NamedFieldPuns       #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
 
 -- | Intended for qualified import
 --
@@ -39,6 +35,8 @@ import           Data.SOP.Strict hiding (shape)
 import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract hiding (getTip)
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.Counting (getExactly)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.State.Types (
@@ -30,8 +27,9 @@ import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.History (Bound)
-import           Ouroboros.Consensus.Ledger.Basics (DiffMK, EmptyMK,
-                     LedgerState, LedgerTables)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import           Ouroboros.Consensus.Ledger.Tables (DiffMK, EmptyMK,
+                     LedgerTables)
 import           Ouroboros.Consensus.Ticked
 
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -42,6 +41,8 @@ import qualified Data.List.NonEmpty as NE
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -1,14 +1,7 @@
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
 
 -- | Interface to the ledger layer
 module Ouroboros.Consensus.Ledger.Abstract (
@@ -40,6 +33,8 @@ import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM, (..:))
 
@@ -110,10 +105,6 @@ class ( IsLedger l
 
   -- | Given a block, get the key-sets that we need to apply it to a ledger
   -- state.
-  --
-  -- TODO: this might not be the best place to define this function. Maybe we
-  -- want to make the on-disk ledger state storage concern orthogonal to the
-  -- ledger state transformation concern.
   getBlockKeySets :: blk -> LedgerTables l KeysMK
 
 -- | Interaction with the ledger layer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -1,26 +1,21 @@
-{-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE DerivingVia                #-}
-{-# LANGUAGE EmptyCase                  #-}
-{-# LANGUAGE EmptyDataDeriving          #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE UndecidableSuperClasses    #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE EmptyDataDeriving     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Ouroboros.Consensus.Ledger.Dual (
     Bridge (..)
@@ -90,6 +85,8 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Util (ShowProxy (..))
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -45,6 +44,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Ticked
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
+
 module Ouroboros.Consensus.Ledger.Query (
     BlockQuery
   , ConfigSupportsNode (..)
@@ -75,6 +76,8 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query.Version
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                      (BlockNodeToClientVersion)
 import           Ouroboros.Consensus.Node.Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies     #-}
 
@@ -21,6 +20,7 @@ import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Util.IOLike
 
 -- | Generalized transaction
@@ -124,10 +124,6 @@ class ( UpdateLedger blk
 
   -- | Given a transaction, get the key-sets that we need to apply it to a
   -- ledger state.
-  --
-  -- TODO: this might not be the best place to define this function. Maybe we
-  -- want to make the on-disk ledger state storage concern orthogonal to the
-  -- ledger state transformation concern.
   getTransactionKeySets :: GenTx blk -> LedgerTables (LedgerState blk) KeysMK
 
 -- | A generalized transaction, 'GenTx', identifier.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol (..)) where
 
@@ -11,6 +9,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 
 -- | Link protocol to ledger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
@@ -1,0 +1,546 @@
+{-# LANGUAGE ConstraintKinds    #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DefaultSignatures  #-}
+{-# LANGUAGE DerivingVia        #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE Rank2Types         #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
+
+-- | The Ledger Tables represent the portion of the data on disk that has been
+-- pulled from disk and attached to the in-memory Ledger State or that will
+-- eventually be written to disk.
+--
+-- With UTxO-HD and the split of the Ledger State into the in-memory part and
+-- the on-disk part, this splitting was reflected in the new type parameter
+-- added to the Ledger State, to which we refer as "the MapKind" or @mk@.
+--
+-- Every @'LedgerState'@ is associated with a @'LedgerTables'@ and they both
+-- share the @mk@. They both are of kind @'LedgerStateKind'@. @'LedgerTables'@
+-- is just a way to refer /only/ to a partial view of the on-disk data without
+-- having the rest of the in-memory Ledger State in scope.
+--
+-- The @mk@ can be instantiated to anything that is map-like, i.e. that expects
+-- two type parameters, the key and the value. In particular, we provide here
+-- the usual structures that we expect to deal with, namely:
+--
+-- - @'ValuesMK'@: a map of keys to values
+--
+-- - @'KeysMK'@: a set of keys
+--
+-- - @'DiffMK'@: a map of keys to value differences
+--
+-- - @'TrackingMK'@: the product of both @'ValuesMK'@ and @'DiffMK'@
+--
+-- - @'SeqDiffMK'@: an efficient sequence of differences
+--
+-- - @'CodecMK'@: @CBOR@ encoder and decoder for the key and value
+--
+-- Using the @'TableStuff'@ class, we can manipulate the @mk@ on the Ledger
+-- Tables, and we can extract Ledger Tables from a Ledger State which will share
+-- the same @mk@, or we can replace the Ledger Tables associated to a particular
+-- in-memory Ledger State.
+--
+-- The general idea is that we keep a @'SeqDiffMK'@ on the @'DbChangelog'@ and
+-- by reading values from the backing store and then forwarding them through the
+-- sequence of diffs, we obtain partial (or total but that would be pointlessly
+-- inefficient) views on the Ledger State as if the data was not split (see
+-- @'withBlockReadSets'@).
+--
+-- The @'DbChangelog'@ keeps also a sequence of @'LedgerState' blk 'EmptyMK'@
+-- which represent only the in-memory side. Then when applying a Ledger rule on
+-- top of a Ledger State, we:
+--
+-- 1. Take the appropriate in-memory Ledger State from the @'DbChangelog'@, (by
+--    means of @'ledgerDbPrefix'@).
+--
+-- 2. Consult the disk for the values needed by the rule (for example if
+--    applying a block, we only need the TxIns of the transactions in the block)
+--    (see @'getBlockKeySets'@ and @'readDb'@).
+--
+-- 3. Forward the values read from the disk through the @'SeqDiffMK'@ up until
+--    the desired Ledger State (see @'forwardValues'@).
+--
+-- 4. Associate the Ledger State from (1) and the forwarded tables of (3) and
+--    then call the Ledger rule.
+--
+-- 5. Get back a @'DiffMK'@ with differences to the provided values that will
+--    then have to be stored in the @'DbChangelog'@ (see the type of
+--    @'applyBlockLedgerResult'@).
+module Ouroboros.Consensus.Ledger.Tables (
+    -- * Kinds
+    LedgerStateKind
+  , MapKind
+    -- * Basic LedgerState classes
+  , ShowLedgerState (..)
+  , StowableLedgerTables (..)
+  , TableStuff (..)
+  , TickedTableStuff (..)
+  , mapOverLedgerTables
+  , mapOverLedgerTablesTicked
+  , overLedgerTables
+  , overLedgerTablesTicked
+  , zipOverLedgerTables
+  , zipOverLedgerTablesTicked
+    -- * Concrete Ledger tables
+  , ApplyMapKind
+  , ApplyMapKind' (..)
+  , showsApplyMapKind
+  , CodecMK (..)
+  , DiffMK
+  , EmptyMK
+  , IsMapKind (..)
+  , KeysMK
+  , NameMK (..)
+  , QueryMK
+  , SeqDiffMK
+  , TrackingMK
+  , ValuesMK
+    -- * Serialization
+  , SufficientSerializationForAnyBackingStore (..)
+  , valuesMKDecoder
+  , valuesMKEncoder
+    -- * Special classes
+  , InMemory (..)
+  ) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Control.Exception as Exn
+import           Data.Kind (Type)
+import qualified Data.Map as Map
+import           Data.Monoid (Sum (..))
+import           NoThunks.Class (NoThunks (..))
+import qualified NoThunks.Class as NoThunks
+
+import           Ouroboros.Consensus.Ticked
+
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq
+
+{-------------------------------------------------------------------------------
+  Basic LedgerState classes
+-------------------------------------------------------------------------------}
+
+class ShowLedgerState (l :: LedgerStateKind) where
+  showsLedgerState :: l (ApplyMapKind' mk) -> ShowS
+
+class ( ShowLedgerState (LedgerTables l)
+      , Eq (l EmptyMK)
+      , Eq (LedgerTables l DiffMK)
+      , Eq (LedgerTables l ValuesMK)
+      ) => TableStuff (l :: LedgerStateKind) where
+
+  data family LedgerTables l :: LedgerStateKind
+
+  -- | Extract the ledger tables from a ledger state
+  --
+  -- NOTE: This 'IsMapKind' constraint is necessary because the 'CardanoBlock'
+  -- instance uses 'mapMK'.
+  projectLedgerTables :: IsMapKind mk => l mk -> LedgerTables l mk
+
+  -- | Overwrite the tables in some ledger state.
+  --
+  -- The contents of the tables should not be /younger/ than the content of the
+  -- ledger state. In particular, for a
+  -- 'Ouroboros.Consensus.HardFork.Combinator.Basics.HardForkBlock' ledger, the
+  -- tables argument should not contain any data from eras that succeed the
+  -- current era of the ledger state argument.
+  --
+  -- NOTE: This 'IsMapKind' constraint is necessary because the
+  -- 'CardanoBlock' instance uses 'mapMK'.
+  withLedgerTables :: IsMapKind mk => l any -> LedgerTables l mk -> l mk
+
+  pureLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+       )
+    -> LedgerTables l mk
+
+  mapLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+
+  traverseLedgerTables ::
+       Applicative f
+    => (forall k v .
+           (Ord k, Eq v)
+        =>    mk1 k v
+        -> f (mk2 k v)
+       )
+    ->    LedgerTables l mk1
+    -> f (LedgerTables l mk2)
+
+  zipLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+
+  zipLedgerTables2 ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> mk4 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> LedgerTables l mk4
+
+  zipLedgerTablesA ::
+       Applicative f
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> f (mk3 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> f (LedgerTables l mk3)
+
+  zipLedgerTables2A ::
+       Applicative f
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> f (mk4 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> f (LedgerTables l mk4)
+
+  foldLedgerTables ::
+       Monoid m
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+         -> m
+       )
+    -> LedgerTables l mk
+    -> m
+
+  foldLedgerTables2 ::
+       Monoid m
+    => (forall k v.
+           (Ord k, Eq v)
+        => mk1 k v
+        -> mk2 k v
+        -> m
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> m
+
+  namesLedgerTables :: LedgerTables l NameMK
+
+overLedgerTables ::
+     (TableStuff l, IsMapKind mk1, IsMapKind mk2)
+  => (LedgerTables l mk1 -> LedgerTables l mk2)
+  -> l mk1
+  -> l mk2
+overLedgerTables f l = withLedgerTables l $ f $ projectLedgerTables l
+
+mapOverLedgerTables ::
+     (TableStuff l, IsMapKind mk1, IsMapKind mk2)
+  => (forall k v.
+          (Ord k, Eq v)
+       => mk1 k v
+       -> mk2 k v
+     )
+  -> l mk1
+  -> l mk2
+mapOverLedgerTables f = overLedgerTables $ mapLedgerTables f
+
+zipOverLedgerTables ::
+     (TableStuff l, IsMapKind mk1, IsMapKind mk3)
+  => (forall k v.
+          (Ord k, Eq v)
+       => mk1 k v
+       -> mk2 k v
+       -> mk3 k v
+     )
+  ->              l mk1
+  -> LedgerTables l mk2
+  ->              l mk3
+zipOverLedgerTables f l tables2 =
+    overLedgerTables
+      (\tables1 -> zipLedgerTables f tables1 tables2)
+      l
+
+class TableStuff l => TickedTableStuff (l :: LedgerStateKind) where
+  -- | NOTE: The 'IsMapKind' constraint is here for the same reason
+  -- it's on 'projectLedgerTables'
+  projectLedgerTablesTicked :: IsMapKind mk => Ticked1 l mk  -> LedgerTables l mk
+  -- | NOTE: The 'IsMapKind' constraint is here for the same reason
+  -- it's on 'withLedgerTables'
+  withLedgerTablesTicked    :: IsMapKind mk => Ticked1 l any -> LedgerTables l mk -> Ticked1 l mk
+
+overLedgerTablesTicked ::
+     (TickedTableStuff l, IsMapKind mk1, IsMapKind mk2)
+  => (LedgerTables l mk1 -> LedgerTables l mk2)
+  -> Ticked1 l mk1
+  -> Ticked1 l mk2
+overLedgerTablesTicked f l =
+    withLedgerTablesTicked l $ f $ projectLedgerTablesTicked l
+
+mapOverLedgerTablesTicked ::
+     (TickedTableStuff l, IsMapKind mk1, IsMapKind mk2)
+  => (forall k v.
+         (Ord k, Eq v)
+      => mk1 k v
+      -> mk2 k v
+     )
+  -> Ticked1 l mk1
+  -> Ticked1 l mk2
+mapOverLedgerTablesTicked f = overLedgerTablesTicked $ mapLedgerTables f
+
+zipOverLedgerTablesTicked ::
+     (TickedTableStuff l, IsMapKind mk1, IsMapKind mk3)
+  => (forall k v.
+         (Ord k, Eq v)
+      => mk1 k v
+      -> mk2 k v
+      -> mk3 k v
+     )
+  -> Ticked1      l mk1
+  -> LedgerTables l mk2
+  -> Ticked1      l mk3
+zipOverLedgerTablesTicked f l tables2 =
+    overLedgerTablesTicked
+      (\tables1 -> zipLedgerTables f tables1 tables2)
+      l
+
+class StowableLedgerTables (l :: LedgerStateKind) where
+  stowLedgerTables     :: l ValuesMK -> l EmptyMK
+  unstowLedgerTables   :: l EmptyMK  -> l ValuesMK
+
+{-------------------------------------------------------------------------------
+  Concrete ledger tables
+-------------------------------------------------------------------------------}
+
+type MapKind         = {- key -} Type -> {- value -} Type -> Type
+type LedgerStateKind = MapKind -> Type
+
+data MapKind' = DiffMK'
+              | EmptyMK'
+              | KeysMK'
+              | QueryMK'
+              | SeqDiffMK'
+              | TrackingMK'
+              | ValuesMK'
+
+type DiffMK     = ApplyMapKind' DiffMK'
+type EmptyMK    = ApplyMapKind' EmptyMK'
+type KeysMK     = ApplyMapKind' KeysMK'
+type QueryMK    = ApplyMapKind' QueryMK'
+type SeqDiffMK  = ApplyMapKind' SeqDiffMK'
+type TrackingMK = ApplyMapKind' TrackingMK'
+type ValuesMK   = ApplyMapKind' ValuesMK'
+
+-- | A codec 'MapKind' that will be used to refer to @'LedgerTables' l CodecMK@
+-- as the codecs that can encode every key and value in the @'LedgerTables' l
+-- mk@.
+data CodecMK k v = CodecMK
+                     (k -> CBOR.Encoding)
+                     (v -> CBOR.Encoding)
+                     (forall s . CBOR.Decoder s k)
+                     (forall s . CBOR.Decoder s v)
+
+newtype NameMK k v = NameMK String
+
+type ApplyMapKind mk = mk
+
+data ApplyMapKind' :: MapKind' -> Type -> Type -> Type where
+  ApplyDiffMK     :: !(Diff    k v)                -> ApplyMapKind' DiffMK'       k v
+  ApplyEmptyMK    ::                                  ApplyMapKind' EmptyMK'      k v
+  ApplyKeysMK     :: !(Keys    k v)                -> ApplyMapKind' KeysMK'       k v
+  ApplySeqDiffMK  :: !(DiffSeq k v)                -> ApplyMapKind' SeqDiffMK'    k v
+  ApplyTrackingMK :: !(Values  k v) -> !(Diff k v) -> ApplyMapKind' TrackingMK'   k v
+  ApplyValuesMK   :: !(Values  k v)                -> ApplyMapKind' ValuesMK'     k v
+
+  ApplyQueryAllMK  ::                ApplyMapKind' QueryMK' k v
+  ApplyQuerySomeMK :: !(Keys k v) -> ApplyMapKind' QueryMK' k v
+
+-- | A general interface to mapkinds.
+--
+-- In some cases where @mk@ is not specialised to a concrete mapkind like
+-- @'ValuesMK'@, there are often still a number of operations that we can
+-- perform for this @mk@ that make sense regardless of the concrete mapkind. For
+-- example, we should always be able to map over a mapkind to change the type of
+-- values that it contains. This class is an interface to mapkinds that provides
+-- such common functions.
+class IsMapKind (mk :: MapKind) where
+  emptyMK :: forall k v. (Ord k, Eq v) => mk k v
+  default emptyMK :: forall k v. Monoid (mk k v) => mk k v
+  emptyMK = mempty
+
+  mapMK :: forall k v v'. (Ord k, Eq v, Eq v') => (v -> v') -> mk k v -> mk k v'
+  default mapMK :: forall k v v'. (Functor (mk k)) => (v -> v') -> mk k v -> mk k v'
+  mapMK = fmap
+
+instance IsMapKind EmptyMK where
+  emptyMK = ApplyEmptyMK
+  mapMK _ ApplyEmptyMK = ApplyEmptyMK
+
+instance IsMapKind KeysMK where
+  emptyMK = ApplyKeysMK mempty
+  mapMK f (ApplyKeysMK ks) = ApplyKeysMK $ fmap f ks
+
+instance IsMapKind ValuesMK where
+  emptyMK = ApplyValuesMK mempty
+  mapMK f (ApplyValuesMK vs) = ApplyValuesMK $ fmap f vs
+
+instance IsMapKind TrackingMK where
+  emptyMK = ApplyTrackingMK mempty mempty
+  mapMK f (ApplyTrackingMK vs d) = ApplyTrackingMK (fmap f vs) (fmap f d)
+
+instance IsMapKind DiffMK where
+  emptyMK = ApplyDiffMK mempty
+
+instance IsMapKind SeqDiffMK where
+  emptyMK = ApplySeqDiffMK empty
+  mapMK f (ApplySeqDiffMK ds) = ApplySeqDiffMK $ mapDiffSeq f ds
+
+instance IsMapKind (ApplyMapKind' QueryMK') where
+  emptyMK = ApplyQuerySomeMK mempty
+  mapMK f qmk = case qmk of
+    ApplyQuerySomeMK ks -> ApplyQuerySomeMK $ fmap f ks
+    ApplyQueryAllMK     -> ApplyQueryAllMK
+
+instance Ord k => Semigroup (ApplyMapKind' KeysMK' k v) where
+  ApplyKeysMK l <> ApplyKeysMK r = ApplyKeysMK (l <> r)
+
+instance Ord k => Monoid (ApplyMapKind' KeysMK' k v) where
+  mempty = ApplyKeysMK mempty
+
+instance Functor (DiffMK k) where
+  fmap f (ApplyDiffMK d) = ApplyDiffMK $ fmap f d
+
+instance (Ord k, Eq v) => Eq (ApplyMapKind' mk k v) where
+  ApplyEmptyMK          == _                     = True
+  ApplyKeysMK   l       == ApplyKeysMK   r       = l == r
+  ApplyValuesMK l       == ApplyValuesMK r       = l == r
+  ApplyTrackingMK l1 l2 == ApplyTrackingMK r1 r2 = l1 == r1 && l2 == r2
+  ApplyDiffMK l         == ApplyDiffMK r         = l == r
+  ApplySeqDiffMK l      == ApplySeqDiffMK r      = l == r
+  ApplyQueryAllMK       == ApplyQueryAllMK       = True
+  ApplyQuerySomeMK l    == ApplyQuerySomeMK r    = l == r
+  _                     == _                     = False
+
+instance (Ord k, NoThunks k, NoThunks v) => NoThunks (ApplyMapKind' mk k v) where
+  wNoThunks ctxt   = NoThunks.allNoThunks . \case
+    ApplyEmptyMK         -> []
+    ApplyKeysMK ks       -> [noThunks ctxt ks]
+    ApplyValuesMK vs     -> [noThunks ctxt vs]
+    ApplyTrackingMK vs d -> [noThunks ctxt vs, noThunks ctxt d]
+    ApplyDiffMK d        -> [noThunks ctxt d]
+    ApplySeqDiffMK ds    -> [noThunks ctxt ds]
+    ApplyQueryAllMK      -> []
+    ApplyQuerySomeMK ks  -> [noThunks ctxt ks]
+
+  showTypeOf _ = "ApplyMapKind"
+
+showsApplyMapKind :: (Show k, Show v) => ApplyMapKind' mk k v -> ShowS
+showsApplyMapKind = \case
+    ApplyEmptyMK             -> showString "ApplyEmptyMK"
+    ApplyKeysMK keys         -> showParen True $ showString "ApplyKeysMK " . shows keys
+    ApplyValuesMK values     -> showParen True $ showString "ApplyValuesMK " . shows values
+    ApplyTrackingMK values d -> showParen True $ showString "ApplyTrackingMK " . shows values . showString " " . shows d
+    ApplyDiffMK d            -> showParen True $ showString "ApplyDiffMK " . shows d
+    ApplySeqDiffMK sq        -> showParen True $ showString "ApplySeqDiffMK " . shows sq
+
+    ApplyQueryAllMK       -> showParen True $ showString "ApplyQueryAllMK"
+    ApplyQuerySomeMK keys -> showParen True $ showString "ApplyQuerySomeMK " . shows keys
+
+instance (Show k, Show v) => Show (ApplyMapKind' mk k v) where
+  show = flip showsApplyMapKind ""
+
+{-------------------------------------------------------------------------------
+  Serialization Codecs
+-------------------------------------------------------------------------------}
+
+-- | This class provides a 'CodecMK' that can be used to encode/decode keys and
+-- values on @'LedgerTables' l mk@
+class SufficientSerializationForAnyBackingStore (l :: LedgerStateKind) where
+  codecLedgerTables :: LedgerTables l CodecMK
+
+-- | Default encoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
+-- in-memory backing store.
+valuesMKEncoder ::
+     ( TableStuff l
+     , SufficientSerializationForAnyBackingStore l
+     )
+  => LedgerTables l ValuesMK
+  -> CBOR.Encoding
+valuesMKEncoder tables =
+       CBOR.encodeListLen (getSum (foldLedgerTables (\_ -> Sum 1) tables))
+    <> foldLedgerTables2 go codecLedgerTables tables
+  where
+    go :: CodecMK k v -> ApplyMapKind ValuesMK k v -> CBOR.Encoding
+    go (CodecMK encK encV _decK _decV) (ApplyValuesMK (Values m)) =
+         CBOR.encodeMapLen (fromIntegral $ Map.size m)
+      <> Map.foldMapWithKey (\k v -> encK k <> encV v) m
+
+-- | Default encoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
+-- in-memory backing store.
+--
+-- TODO: we need to make sure there are tests that exercise this function.
+valuesMKDecoder ::
+     ( TableStuff l
+     , SufficientSerializationForAnyBackingStore l
+     )
+  => CBOR.Decoder s (LedgerTables l ValuesMK)
+valuesMKDecoder = do
+    numTables <- CBOR.decodeListLen
+    if numTables == 0
+      then
+        return $ pureLedgerTables emptyMK
+      else do
+        mapLen <- CBOR.decodeMapLen
+        ret    <- traverseLedgerTables (go mapLen) codecLedgerTables
+        Exn.assert ((getSum (foldLedgerTables (\_ -> Sum 1) ret)) == numTables)
+          $ return ret
+ where
+  go :: Ord k
+     => Int
+     -> CodecMK k v
+     -> CBOR.Decoder s (ApplyMapKind ValuesMK k v)
+  go len (CodecMK _encK _encV decK decV) =
+        ApplyValuesMK . Values . Map.fromList
+    <$> sequence (replicate len ((,) <$> decK <*> decV))
+
+{-------------------------------------------------------------------------------
+  Special classes of ledger states
+-------------------------------------------------------------------------------}
+
+class InMemory (l :: LedgerStateKind) where
+
+  -- | If the ledger state is always in memory, then l mk will be isomorphic to
+  -- l mk' for all mk, mk'. As a result, we can convert between ledgers states
+  -- indexed by different map kinds.
+  --
+  -- This function is useful to combine functions that operate on functions that
+  -- transform the map kind on a ledger state (eg applyChainTickLedgerResult).
+  convertMapKind :: l mk -> l mk'
+

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+module Ouroboros.Consensus.Ledger.Tables.Utils (
+    applyLedgerTablesDiffs
+  , applyLedgerTablesDiffsTicked
+  , attachAndApplyDiffsTicked
+  , calculateAdditions
+  , calculateDifference
+  , calculateDifferenceTicked
+  , emptyLedgerTables
+  , forgetLedgerTables
+  , forgetLedgerTablesDiffs
+  , forgetLedgerTablesDiffsTicked
+  , forgetLedgerTablesValues
+  , forgetLedgerTablesValuesTicked
+  , noNewTickingDiffs
+  , polyEmptyLedgerTables
+  , prependLedgerTablesDiffs
+  , prependLedgerTablesDiffsFromTicked
+  , prependLedgerTablesDiffsRaw
+  , prependLedgerTablesDiffsTicked
+  , prependLedgerTablesTrackingDiffs
+  , rawReapplyTracking
+  , reapplyTrackingTicked
+    -- * Testing
+  , rawApplyDiffs
+  , rawCalculateDifference
+  , rawForgetValues
+  , rawPrependTrackingDiffs
+  ) where
+
+import           Ouroboros.Consensus.Ticked
+
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq
+
+-- | When applying a block that is not on an era transition, ticking won't
+-- generate new values, so this function can be used to wrap the call to the
+-- ledger rules that perform the tick.
+noNewTickingDiffs :: TickedTableStuff l
+                   => l any
+                   -> l DiffMK
+noNewTickingDiffs l = withLedgerTables l polyEmptyLedgerTables
+
+{-------------------------------------------------------------------------------
+  Utils aliases
+-------------------------------------------------------------------------------}
+
+emptyLedgerTables :: TableStuff l => LedgerTables l EmptyMK
+emptyLedgerTables = polyEmptyLedgerTables
+
+-- | Empty values for every table
+polyEmptyLedgerTables :: forall mk l. (TableStuff l, IsMapKind mk) => LedgerTables l mk
+polyEmptyLedgerTables = pureLedgerTables emptyMK
+
+-- Forget all
+
+forgetLedgerTables :: TableStuff l => l mk -> l EmptyMK
+forgetLedgerTables l = withLedgerTables l emptyLedgerTables
+
+-- Forget values
+
+rawForgetValues :: TrackingMK k v -> DiffMK k v
+rawForgetValues (ApplyTrackingMK _vs d) = ApplyDiffMK d
+
+forgetLedgerTablesValues :: TableStuff l => l TrackingMK -> l DiffMK
+forgetLedgerTablesValues = mapOverLedgerTables rawForgetValues
+
+forgetLedgerTablesValuesTicked :: TickedTableStuff l => Ticked1 l TrackingMK -> Ticked1 l DiffMK
+forgetLedgerTablesValuesTicked = mapOverLedgerTablesTicked rawForgetValues
+
+
+-- Forget diffs
+
+rawForgetDiffs :: TrackingMK k v -> ValuesMK k v
+rawForgetDiffs (ApplyTrackingMK vs _ds) = ApplyValuesMK vs
+
+forgetLedgerTablesDiffs       ::       TableStuff l =>         l TrackingMK ->         l ValuesMK
+forgetLedgerTablesDiffsTicked :: TickedTableStuff l => Ticked1 l TrackingMK -> Ticked1 l ValuesMK
+forgetLedgerTablesDiffs       = mapOverLedgerTables rawForgetDiffs
+forgetLedgerTablesDiffsTicked = mapOverLedgerTablesTicked rawForgetDiffs
+
+-- Prepend diffs
+
+rawPrependDiffs ::
+     (Ord k, Eq v)
+  => DiffMK k v -- ^ Earlier differences
+  -> DiffMK k v -- ^ Later differences
+  -> DiffMK k v
+rawPrependDiffs (ApplyDiffMK d1) (ApplyDiffMK d2) = ApplyDiffMK (d1 <> d2)
+
+prependLedgerTablesDiffsRaw        ::       TableStuff l => LedgerTables l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffs           ::       TableStuff l =>              l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffsFromTicked :: TickedTableStuff l => Ticked1      l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffsTicked     :: TickedTableStuff l =>              l DiffMK -> Ticked1 l DiffMK -> Ticked1 l DiffMK
+prependLedgerTablesDiffsRaw        = flip (zipOverLedgerTables rawPrependDiffs)
+prependLedgerTablesDiffs           = prependLedgerTablesDiffsRaw . projectLedgerTables
+prependLedgerTablesDiffsFromTicked = prependLedgerTablesDiffsRaw . projectLedgerTablesTicked
+prependLedgerTablesDiffsTicked     = flip (zipOverLedgerTablesTicked rawPrependDiffs) . projectLedgerTables
+
+-- Apply diffs
+
+rawApplyDiffs ::
+     Ord k
+  => ValuesMK k v -- ^ Values to which differences are applied
+  -> DiffMK   k v -- ^ Differences to apply
+  -> ValuesMK k v
+rawApplyDiffs (ApplyValuesMK vals) (ApplyDiffMK diffs) = ApplyValuesMK (applyDiff vals diffs)
+
+applyLedgerTablesDiffs       ::       TableStuff l => l ValuesMK ->         l DiffMK ->         l ValuesMK
+applyLedgerTablesDiffsTicked :: TickedTableStuff l => l ValuesMK -> Ticked1 l DiffMK -> Ticked1 l ValuesMK
+applyLedgerTablesDiffs       = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . projectLedgerTables
+applyLedgerTablesDiffsTicked = flip (zipOverLedgerTablesTicked $ flip rawApplyDiffs) . projectLedgerTables
+
+-- Calculate differences
+
+rawCalculateDifference ::
+     (Ord k, Eq v)
+  => ValuesMK   k v
+  -> ValuesMK   k v
+  -> TrackingMK k v
+rawCalculateDifference (ApplyValuesMK before) (ApplyValuesMK after) = ApplyTrackingMK after (diff before after)
+
+calculateAdditions        ::       TableStuff l =>         l ValuesMK ->                               l TrackingMK
+calculateDifference       :: TickedTableStuff l => Ticked1 l ValuesMK ->         l ValuesMK ->         l TrackingMK
+calculateDifferenceTicked :: TickedTableStuff l => Ticked1 l ValuesMK -> Ticked1 l ValuesMK -> Ticked1 l TrackingMK
+calculateAdditions               after = zipOverLedgerTables       (flip rawCalculateDifference) after polyEmptyLedgerTables
+calculateDifference       before after = zipOverLedgerTables       (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
+calculateDifferenceTicked before after = zipOverLedgerTablesTicked (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
+
+rawAttachAndApplyDiffs ::
+     Ord k
+  => DiffMK     k v
+  -> ValuesMK   k v
+  -> TrackingMK k v
+rawAttachAndApplyDiffs (ApplyDiffMK d) (ApplyValuesMK v) = ApplyTrackingMK (applyDiff v d) d
+
+-- | Replace the tables in the first parameter with the tables of the second
+-- parameter after applying the differences in the first parameter to them
+attachAndApplyDiffsTicked ::
+     TickedTableStuff l
+  => Ticked1 l DiffMK
+  ->         l ValuesMK
+  -> Ticked1 l TrackingMK
+attachAndApplyDiffsTicked after before =
+    zipOverLedgerTablesTicked rawAttachAndApplyDiffs after
+  $ projectLedgerTables before
+
+rawPrependTrackingDiffs ::
+      (Ord k, Eq v)
+   => TrackingMK k v
+   -> TrackingMK k v
+   -> TrackingMK k v
+rawPrependTrackingDiffs (ApplyTrackingMK v d2) (ApplyTrackingMK _v d1) =
+  ApplyTrackingMK v (d1 <> d2)
+
+-- | Mappend the differences in the ledger tables. Keep the ledger state of the
+-- first one.
+prependLedgerTablesTrackingDiffs ::
+     TickedTableStuff l
+  => Ticked1 l TrackingMK
+  -> Ticked1 l TrackingMK
+  -> Ticked1 l TrackingMK
+prependLedgerTablesTrackingDiffs after before =
+    zipOverLedgerTablesTicked rawPrependTrackingDiffs after
+  $ projectLedgerTablesTicked before
+
+rawReapplyTracking ::
+     Ord k
+  => TrackingMK k v
+  -> ValuesMK   k v
+  -> TrackingMK k v
+rawReapplyTracking (ApplyTrackingMK _v d) (ApplyValuesMK v) = ApplyTrackingMK (applyDiff v d) d
+
+-- | Replace the tables in the first parameter with the tables of the second
+-- parameter after applying the differences in the first parameter to them
+reapplyTrackingTicked ::
+     TickedTableStuff l
+  => Ticked1 l TrackingMK
+  ->         l ValuesMK
+  -> Ticked1 l TrackingMK
+reapplyTrackingTicked after before =
+    zipOverLedgerTablesTicked rawReapplyTracking after
+  $ projectLedgerTables before

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -27,6 +27,7 @@ import           Ouroboros.Network.Protocol.TxSubmission2.Type (TxSizeInBytes)
 import           Ouroboros.Consensus.Block (Point, SlotNo)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Mempool.Impl.Types
 import           Ouroboros.Consensus.Util.IOLike
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -41,6 +41,8 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Mempool.Impl.Pure
 import           Ouroboros.Consensus.Mempool.Impl.Types

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -18,6 +18,7 @@ import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Mempool.API (TxSizeInBytes)
 import           Ouroboros.Consensus.Mempool.Impl.Types
 import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxTicket (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
@@ -57,6 +57,8 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool.TxSeq (MempoolSize, TicketNo,
                      TxSeq (..), TxTicket (..), zeroTicketNo)
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -34,6 +34,7 @@ import qualified Ouroboros.Consensus.HardFork.Abstract as History
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.AnchoredFragment
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -71,9 +71,9 @@ import           Ouroboros.Consensus.HeaderStateHistory
                      (HeaderStateHistory (..), validateHeader)
 import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
 import           Ouroboros.Consensus.HeaderValidation hiding (validateHeader)
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -90,8 +88,8 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
-import           Ouroboros.Consensus.Ledger.Basics (ValuesMK)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
+import           Ouroboros.Consensus.Ledger.Tables (ValuesMK)
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
 import           Ouroboros.Consensus.Node.DbLock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros.Consensus.Node.ProtocolInfo (
     NumCoreNodes (..)
@@ -16,8 +12,8 @@ import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Ledger.Basics (ValuesMK)
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables (ValuesMK)
 import           Ouroboros.Consensus.NodeId
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -1,15 +1,9 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
 
 module Ouroboros.Consensus.NodeKernel (
     -- * Node kernel
@@ -62,6 +56,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.Node.Run

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -1,16 +1,11 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DeriveTraversable    #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Storage.ChainDB.API (
@@ -78,6 +73,7 @@ import           Ouroboros.Consensus.HeaderStateHistory
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Util (StaticEither (..), (..:))
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE DataKinds                 #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Args (
     ChainDbArgs (..)
@@ -21,8 +18,8 @@ import           Control.Tracer (Tracer, contramap, nullTracer)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture)
-import           Ouroboros.Consensus.Ledger.Basics (ValuesMK)
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables (ValuesMK)
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -1,15 +1,9 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE MultiWayIf           #-}
-{-# LANGUAGE NamedFieldPuns       #-}
-{-# LANGUAGE PatternSynonyms      #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Operations involving chain selection: the initial chain selection and
 -- adding a block.
@@ -55,6 +49,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.AnchoredFragment
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
@@ -77,6 +76,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 -- | Intended for qualified import
 --
@@ -14,6 +13,7 @@ import           Prelude hiding (map)
 
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
@@ -39,7 +38,7 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Slotting.Slot (SlotNo, WithOrigin (At))
 
-import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Storage.FS.API as FS
 import qualified Ouroboros.Consensus.Storage.FS.API.Types as FS
 import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore as HD

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB/Bridge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/LMDB/Bridge.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE Rank2Types #-}
 
-
 {-| Alternatives to LMDB operations that do not rely on @'Serialise'@ instances
 
   We cannot (easily and without runtime overhead) satisfy the @'Serialise'@
@@ -53,7 +52,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import           Foreign (Ptr, Storable (peek, poke), castPtr)
 
-import           Ouroboros.Consensus.Ledger.Basics (CodecMK (..))
+import           Ouroboros.Consensus.Ledger.Tables
 
 import           Database.LMDB.Raw (MDB_val (MDB_val), mdb_reserve')
 import           Database.LMDB.Simple (Database, ReadWrite, Transaction)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -2,13 +2,11 @@
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE EmptyDataDeriving          #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE QuantifiedConstraints      #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -99,6 +97,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Extended as Extended
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq
 import           Ouroboros.Consensus.Storage.LedgerDB.Types (PushGoal (..),
                      PushStart (..), Pushing (..),

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE RankNTypes                 #-}
@@ -182,6 +180,8 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr,
                      readIncremental)
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -21,6 +20,7 @@ import           Data.Word
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
 
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.InMemory as LedgerDB


### PR DESCRIPTION
# Description

The definitions related only to UTxO-HD have been moved to `Ouroboros.Consensus.Ledger.Tables` and `Ouroboros.Consensus.Ledger.Tables.Utils`, and imports have been fixed everywhere.