### PR TITLE
Generalise `IsApplyMapKind` to any mapkind instead of only `ApplyMapkind' mk`.

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -185,7 +185,7 @@ instance IsLedger (LedgerState ByronBlock) where
         }
 
 instance ShowLedgerState (LedgerState ByronBlock) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance TableStuff (LedgerState ByronBlock) where
   data LedgerTables (LedgerState ByronBlock) mk = NoByronLedgerTables
@@ -220,7 +220,7 @@ instance TickedTableStuff (LedgerState ByronBlock) where
   withLedgerTablesTicked st NoByronLedgerTables = convertMapKind st
 
 instance ShowLedgerState (LedgerTables (LedgerState ByronBlock)) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance StowableLedgerTables (LedgerState ByronBlock) where
   stowLedgerTables     = convertMapKind

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -119,7 +119,7 @@ instance IsLedger (LedgerState ByronSpecBlock) where
           }
 
 instance ShowLedgerState (LedgerState ByronSpecBlock) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance TableStuff (LedgerState ByronSpecBlock) where
   data LedgerTables (LedgerState ByronSpecBlock) mk = NoByronSpecLedgerTables
@@ -153,7 +153,7 @@ instance InMemory (Ticked1 (LedgerState ByronSpecBlock)) where
   convertMapKind TickedByronSpecLedgerState{..} = TickedByronSpecLedgerState{..}
 
 instance ShowLedgerState (LedgerTables (LedgerState ByronSpecBlock)) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance StowableLedgerTables (LedgerState ByronSpecBlock) where
   stowLedgerTables     = convertMapKind

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Network.Block (Serialised (..))
 import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
-import           Ouroboros.Consensus.Ledger.Basics (EmptyMK, IsApplyMapKind,
+import           Ouroboros.Consensus.Ledger.Basics (EmptyMK, IsMapKind,
                      ValuesMK)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query (SomeQuery (..))
@@ -178,7 +178,7 @@ injectWrapLedgerTables _startBounds idx (WrapLedgerTables (ExtLedgerStateTables 
     WrapLedgerTables $ ExtLedgerStateTables $ injectLedgerTables lt
   where
     injectLedgerTables ::
-         (IsApplyMapKind mk)
+         (IsMapKind mk)
       => LedgerTables (LedgerState                  x) mk
       -> LedgerTables (LedgerState (HardForkBlock xs)) mk
     injectLedgerTables = applyInjectLedgerTables

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -269,7 +269,7 @@ instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
 -------------------------------------------------------------------------------}
 
 projectLedgerTablesHelper :: forall proto1 era1 proto2 era2 fmk mk.
-     (ShelleyBasedHardForkConstraints proto1 era1 proto2 era2, IsApplyMapKind mk)
+     (ShelleyBasedHardForkConstraints proto1 era1 proto2 era2, IsMapKind mk)
   => (forall x.
          TickedTableStuff (LedgerState x)
       => fmk x -> LedgerTables (LedgerState x) mk
@@ -308,7 +308,7 @@ instance (SL.Crypto (Snd a) ~ SL.Crypto c, ShelleyBasedEra (Snd a)) => SndShelle
 -- 'projectLedgerTablesHelper'
 withLedgerTablesHelper ::
   forall proto1 era1 proto2 era2 mk fany fmk.
-     (ShelleyBasedHardForkConstraints proto1 era1 proto2 era2, IsApplyMapKind mk)
+     (ShelleyBasedHardForkConstraints proto1 era1 proto2 era2, IsMapKind mk)
   => (forall x.
          TickedTableStuff (LedgerState x)
       => fany x -> LedgerTables (LedgerState x) mk -> fmk x

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -299,7 +299,7 @@ projectLedgerTablesHelper prj (HardForkState tele) =
         inj ::
              ApplyMapKind mk (SL.TxIn (EraCrypto era1)) (Core.TxOut (Snd a))
           -> ApplyMapKind mk (SL.TxIn (EraCrypto era1)) (ShelleyTxOut (MapSnd '[ '(proto1, era1), '(proto2, era2)]))
-        inj = mapValuesAppliedMK (ShelleyTxOut . SOP.injectNS (castSndIdx idx) . TxOutWrapper)
+        inj = mapMK (ShelleyTxOut . SOP.injectNS (castSndIdx idx) . TxOutWrapper)
 
 class (SL.Crypto (Snd a) ~ SL.Crypto c, ShelleyBasedEra (Snd a)) => SndShelleyBasedEra c a
 instance (SL.Crypto (Snd a) ~ SL.Crypto c, ShelleyBasedEra (Snd a)) => SndShelleyBasedEra c a
@@ -338,7 +338,7 @@ withLedgerTablesHelper with (HardForkState tele) (ShelleyBasedHardForkLedgerTabl
             newInnerSt =
                 with innerSt
               $ ShelleyLedgerTables
-              $ mapValuesAppliedMK
+              $ mapMK
                   (unTxOutWrapper . SOP.apFn translate . SOP.K . unShelleyTxOut)
                   appliedMK
         in UncurryComp $ current{HFC.currentState = newInnerSt}
@@ -414,7 +414,7 @@ deriving instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2 => NoT
 
 instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
       => ShowLedgerState (LedgerTables (LedgerState (ShelleyBasedHardForkBlock proto1 era1 proto2 era2))) where
-  showsLedgerState _mk (ShelleyBasedHardForkLedgerTables utxo) =
+  showsLedgerState (ShelleyBasedHardForkLedgerTables utxo) =
         showParen True
       $ showString "ShelleyBasedHardForkLedgerTables " . showsApplyMapKind utxo
 
@@ -452,7 +452,7 @@ instance
       shelley idx =
           InjectLedgerTables
         $ \(ShelleyLedgerTables lt) ->
-            ShelleyBasedHardForkLedgerTables $ mapValuesAppliedMK (ShelleyTxOut . SOP.injectNS (castSndIdx idx) . TxOutWrapper) lt
+            ShelleyBasedHardForkLedgerTables $ mapMK (ShelleyTxOut . SOP.injectNS (castSndIdx idx) . TxOutWrapper) lt
 
 {-------------------------------------------------------------------------------
   Protocol info

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -413,7 +413,7 @@ instance IsShelleyTele xs => IsShelleyTele ('(x, y) ': xs) where
 -- TickedTableStuff for every x, so hardcoding the stronger constraint is
 -- easier than parameterizing this helper over the constraint.
 projectLedgerTablesHelper :: forall c mk fmk.
-     (CardanoHardForkConstraints c, IsApplyMapKind mk)
+     (CardanoHardForkConstraints c, IsMapKind mk)
   => (forall blk.
          TickedTableStuff (LedgerState blk)
       => fmk blk -> LedgerTables (LedgerState blk) mk
@@ -460,7 +460,7 @@ instance (SL.Crypto (Snd a) ~ c, ShelleyBasedEra (Snd a)) => SndShelleyBasedEra 
 -- 'projectLedgerTablesHelper'
 withLedgerTablesHelper ::
   forall c mk fany fmk.
-     (CardanoHardForkConstraints c, IsApplyMapKind mk)
+     (CardanoHardForkConstraints c, IsMapKind mk)
   => (forall x.
          TickedTableStuff (LedgerState x)
       => fany x -> LedgerTables (LedgerState x) mk -> fmk x

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -451,7 +451,7 @@ projectLedgerTablesHelper prjLT (HardForkState st) =
         inj ::
              mk (SL.TxIn c) (Core.TxOut (Snd a))
           -> mk (SL.TxIn c) (CardanoTxOut c)
-        inj = mapValuesAppliedMK (ShelleyTxOut . injectNS (castSndIdx idx) . TxOutWrapper)
+        inj = mapMK (ShelleyTxOut . injectNS (castSndIdx idx) . TxOutWrapper)
 
 class (SL.Crypto (Snd a) ~ c, ShelleyBasedEra (Snd a)) => SndShelleyBasedEra c a
 instance (SL.Crypto (Snd a) ~ c, ShelleyBasedEra (Snd a)) => SndShelleyBasedEra c a
@@ -504,7 +504,7 @@ withLedgerTablesHelper withLT (HardForkState st) (CardanoLedgerTables appliedMK)
                 newInnerSt =
                   withLT innerSt
                   $ ShelleyLedgerTables
-                  $ mapValuesAppliedMK
+                  $ mapMK
                       (unTxOutWrapper . apFn translate . K)
                       appliedMK
             in UncurryComp $ current{currentState = newInnerSt})
@@ -573,7 +573,7 @@ deriving newtype instance (Praos.PraosCrypto c, TPraos.PraosCrypto c, DSignable 
 deriving newtype instance (Praos.PraosCrypto c, TPraos.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody)) => NoThunks (LedgerTables (LedgerState (CardanoBlock c)) SeqDiffMK)
 
 instance (TPraos.PraosCrypto c, Praos.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody)) => ShowLedgerState (LedgerTables (LedgerState (CardanoBlock c))) where
-  showsLedgerState _mk (CardanoLedgerTables utxo) =
+  showsLedgerState (CardanoLedgerTables utxo) =
         showParen True
       $ showString "CardanoLedgerTables " . showsApplyMapKind utxo
 
@@ -674,7 +674,7 @@ instance CardanoHardForkConstraints c => LedgerTablesCanHardFork (CardanoEras c)
         -> InjectLedgerTables (CardanoEras c) (ShelleyBlock proto era)
       shelley idx =
           InjectLedgerTables
-        $ \(ShelleyLedgerTables lt) -> CardanoLedgerTables $ mapValuesAppliedMK f lt
+        $ \(ShelleyLedgerTables lt) -> CardanoLedgerTables $ mapMK f lt
         where
           f :: Core.TxOut era -> CardanoTxOut c
           f = ShelleyTxOut . injectNS idx . TxOutWrapper

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -398,21 +398,21 @@ data instance LedgerState (SimpleBlock c ext) mk = SimpleLedgerState {
     }
   deriving stock   (Generic)
 
-instance (SimpleCrypto c, Typeable ext, IsApplyMapKind mk)
-      => Show (LedgerState (SimpleBlock c ext) mk) where
-  show st = showsLedgerState sMapKind st ""
+instance (SimpleCrypto c, Typeable ext)
+      => Show (LedgerState (SimpleBlock c ext) (ApplyMapKind' mk)) where
+  show st = showsLedgerState st ""
 
-deriving instance (SimpleCrypto c, Typeable ext, IsApplyMapKind mk)
-            => Eq (LedgerState (SimpleBlock c ext) mk)
-deriving instance (SimpleCrypto c, Typeable ext, IsApplyMapKind mk)
-            => NoThunks (LedgerState (SimpleBlock c ext) mk)
+deriving instance (SimpleCrypto c, Typeable ext)
+            => Eq (LedgerState (SimpleBlock c ext) (ApplyMapKind' mk))
+deriving instance (SimpleCrypto c, Typeable ext)
+            => NoThunks (LedgerState (SimpleBlock c ext) (ApplyMapKind' mk))
 
 instance (SimpleCrypto c, Typeable ext) => ShowLedgerState (LedgerState (SimpleBlock c ext)) where
-  showsLedgerState mk st =
+  showsLedgerState st =
         showParen True
       $   showString "SimpleLedgerState {"
         . showSpace . showString "simpleLedgerState = " . shows simpleLedgerState
-        . showCommaSpace . showString "simpleLedgerTables = " . showsLedgerState mk simpleLedgerTables
+        . showCommaSpace . showString "simpleLedgerTables = " . showsLedgerState simpleLedgerTables
         . showString " }"
     where
       SimpleLedgerState {
@@ -426,17 +426,15 @@ newtype instance Ticked1 (LedgerState (SimpleBlock c ext)) mk = TickedSimpleLedg
     }
   deriving stock   (Generic)
 
-deriving instance (SimpleCrypto c, Typeable ext, IsApplyMapKind mk)
-               => Eq (Ticked1 (LedgerState (SimpleBlock c ext)) mk)
+deriving instance (SimpleCrypto c, Typeable ext)
+               => Eq (Ticked1 (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
 deriving anyclass
-         instance (SimpleCrypto c, Typeable ext, IsApplyMapKind mk)
-               => NoThunks (Ticked1 (LedgerState (SimpleBlock c ext)) mk)
+         instance (SimpleCrypto c, Typeable ext)
+               => NoThunks (Ticked1 (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
 
 deriving anyclass
-         instance IsApplyMapKind mk
-               => NoThunks (LedgerTables (LedgerState (SimpleBlock c ext)) mk)
-deriving instance IsApplyMapKind mk
-               => Eq (LedgerTables (LedgerState (SimpleBlock c ext)) mk)
+         instance NoThunks (LedgerTables (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
+deriving instance Eq (LedgerTables (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
 
 instance (SimpleCrypto c, Typeable ext) => TableStuff (LedgerState (SimpleBlock c ext)) where
   newtype LedgerTables (LedgerState (SimpleBlock c ext)) mk = SimpleLedgerTables {
@@ -490,7 +488,7 @@ instance SufficientSerializationForAnyBackingStore (LedgerState (SimpleBlock c e
     codecLedgerTables = SimpleLedgerTables (CodecMK toCBOR toCBOR fromCBOR fromCBOR)
 
 instance ShowLedgerState (LedgerTables (LedgerState (SimpleBlock c ext))) where
-  showsLedgerState _sing (SimpleLedgerTables tbs) =
+  showsLedgerState (SimpleLedgerTables tbs) =
       showParen True
     $ showString "SimpleLedgerTables " . showsApplyMapKind tbs
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -402,10 +402,10 @@ instance (SimpleCrypto c, Typeable ext)
       => Show (LedgerState (SimpleBlock c ext) (ApplyMapKind' mk)) where
   show st = showsLedgerState st ""
 
-deriving instance (SimpleCrypto c, Typeable ext)
-            => Eq (LedgerState (SimpleBlock c ext) (ApplyMapKind' mk))
-deriving instance (SimpleCrypto c, Typeable ext)
-            => NoThunks (LedgerState (SimpleBlock c ext) (ApplyMapKind' mk))
+deriving instance (SimpleCrypto c, Typeable ext, Eq (mk Mock.TxIn Mock.TxOut))
+            => Eq (LedgerState (SimpleBlock c ext) mk)
+deriving instance (SimpleCrypto c, Typeable ext, NoThunks (mk Mock.TxIn Mock.TxOut))
+            => NoThunks (LedgerState (SimpleBlock c ext) mk)
 
 instance (SimpleCrypto c, Typeable ext) => ShowLedgerState (LedgerState (SimpleBlock c ext)) where
   showsLedgerState st =
@@ -426,15 +426,17 @@ newtype instance Ticked1 (LedgerState (SimpleBlock c ext)) mk = TickedSimpleLedg
     }
   deriving stock   (Generic)
 
-deriving instance (SimpleCrypto c, Typeable ext)
-               => Eq (Ticked1 (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
+deriving instance (SimpleCrypto c, Typeable ext, Eq (mk Mock.TxIn Mock.TxOut))
+               => Eq (Ticked1 (LedgerState (SimpleBlock c ext)) mk)
 deriving anyclass
-         instance (SimpleCrypto c, Typeable ext)
-               => NoThunks (Ticked1 (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
+         instance (SimpleCrypto c, Typeable ext, NoThunks (mk Mock.TxIn Mock.TxOut))
+               => NoThunks (Ticked1 (LedgerState (SimpleBlock c ext)) mk)
 
 deriving anyclass
-         instance NoThunks (LedgerTables (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
-deriving instance Eq (LedgerTables (LedgerState (SimpleBlock c ext)) (ApplyMapKind' mk))
+         instance NoThunks (mk Mock.TxIn Mock.TxOut)
+               => NoThunks (LedgerTables (LedgerState (SimpleBlock c ext)) mk)
+deriving instance Eq (mk Mock.TxIn Mock.TxOut)
+               => Eq (LedgerTables (LedgerState (SimpleBlock c ext)) mk)
 
 instance (SimpleCrypto c, Typeable ext) => TableStuff (LedgerState (SimpleBlock c ext)) where
   newtype LedgerTables (LedgerState (SimpleBlock c ext)) mk = SimpleLedgerTables {

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -88,7 +88,6 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq as DS
 import           Ouroboros.Consensus.Util ((..:))
 import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
                      encodeWithOrigin)
-import           Ouroboros.Consensus.Util.Singletons (SingI)
 import           Ouroboros.Consensus.Util.Versioned
 
 import qualified Cardano.Ledger.BaseTypes as SL (epochInfoPure)
@@ -217,17 +216,17 @@ data instance LedgerState (ShelleyBlock proto era) mk = ShelleyLedgerState {
 deriving instance (ShelleyBasedEra era, Eq       (mk (SL.TxIn (EraCrypto era)) (Core.TxOut era))) => Eq       (LedgerState (ShelleyBlock proto era) mk)
 deriving instance (ShelleyBasedEra era, NoThunks (mk (SL.TxIn (EraCrypto era)) (Core.TxOut era))) => NoThunks (LedgerState (ShelleyBlock proto era) mk)
 
-instance (ShelleyBasedEra era, SingI mk) => Show (LedgerState (ShelleyBlock proto era) (ApplyMapKind' mk)) where
-  showsPrec _prec = showsLedgerState sMapKind
+instance ShelleyBasedEra era => Show (LedgerState (ShelleyBlock proto era) (ApplyMapKind' mk)) where
+  showsPrec _prec = showsLedgerState
 
 instance ShelleyBasedEra era => ShowLedgerState (LedgerState (ShelleyBlock proto era)) where
-  showsLedgerState mk st =
+  showsLedgerState st =
         showParen True
       $   showString "ShelleyLedgerState {"
         . showSpace      . showString "shelleyLedgerTip = " . shows shelleyLedgerTip
         . showCommaSpace . showString "shelleyLedgerState = " . shows shelleyLedgerState
         . showCommaSpace . showString "shelleyLedgerTransition = " . shows shelleyLedgerTransition
-        . showCommaSpace . showString "shelleyLedgerTables = " . showsLedgerState mk shelleyLedgerTables
+        . showCommaSpace . showString "shelleyLedgerTables = " . showsLedgerState shelleyLedgerTables
         . showString " }"
     where
       ShelleyLedgerState _dummy _ _ _ = st
@@ -343,7 +342,7 @@ instance ShelleyBasedEra era => SufficientSerializationForAnyBackingStore (Ledge
     codecLedgerTables = ShelleyLedgerTables (CodecMK toCBOR toCBOR fromCBOR fromCBOR)
 
 instance ShelleyBasedEra era => ShowLedgerState (LedgerTables (LedgerState (ShelleyBlock proto era))) where
-  showsLedgerState _mk (ShelleyLedgerTables utxo) =
+  showsLedgerState (ShelleyLedgerTables utxo) =
         showParen True
       $ showString "ShelleyLedgerTables " . showsApplyMapKind utxo
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -345,6 +345,7 @@ instance ( ShelleyBasedEra era
          , SL.TranslationError era SL.NewEpochState ~ Void
          , SL.TranslationError era TxOutWrapper ~ Void
          , EraCrypto (SL.PreviousEra era) ~ EraCrypto era
+         , IsApplyMapKind (ApplyMapKind' mk)
          ) => SL.TranslateEra era (Flip LedgerState (ApplyMapKind' mk) :.: ShelleyBlock proto) where
   translateEra ctxt (Comp (Flip (ShelleyLedgerState tip state _transition tables))) = do
       tip'   <- mapM (SL.translateEra ctxt) tip
@@ -362,13 +363,14 @@ translateShelleyTables ::
      , EraCrypto (SL.PreviousEra era) ~ EraCrypto era
      , Eq (Cardano.Ledger.Core.TxOut (SL.PreviousEra era))
      , Eq (Cardano.Ledger.Core.TxOut era)
+     , IsApplyMapKind (ApplyMapKind' mk)
      )
   => SL.TranslationContext era
   -> LedgerTables (LedgerState (ShelleyBlock proto (SL.PreviousEra era))) (ApplyMapKind' mk)
   -> LedgerTables (LedgerState (ShelleyBlock proto                 era))  (ApplyMapKind' mk)
 translateShelleyTables ctxt (ShelleyLedgerTables utxoTable) =
       ShelleyLedgerTables
-    $ mapValuesAppliedMK
+    $ mapMK
         (unTxOutWrapper . SL.translateEra' ctxt . TxOutWrapper)
         utxoTable
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -345,7 +345,7 @@ instance ( ShelleyBasedEra era
          , SL.TranslationError era SL.NewEpochState ~ Void
          , SL.TranslationError era TxOutWrapper ~ Void
          , EraCrypto (SL.PreviousEra era) ~ EraCrypto era
-         , IsApplyMapKind (ApplyMapKind' mk)
+         , IsMapKind (ApplyMapKind' mk)
          ) => SL.TranslateEra era (Flip LedgerState (ApplyMapKind' mk) :.: ShelleyBlock proto) where
   translateEra ctxt (Comp (Flip (ShelleyLedgerState tip state _transition tables))) = do
       tip'   <- mapM (SL.translateEra ctxt) tip
@@ -363,7 +363,7 @@ translateShelleyTables ::
      , EraCrypto (SL.PreviousEra era) ~ EraCrypto era
      , Eq (Cardano.Ledger.Core.TxOut (SL.PreviousEra era))
      , Eq (Cardano.Ledger.Core.TxOut era)
-     , IsApplyMapKind (ApplyMapKind' mk)
+     , IsMapKind (ApplyMapKind' mk)
      )
   => SL.TranslationContext era
   -> LedgerTables (LedgerState (ShelleyBlock proto (SL.PreviousEra era))) (ApplyMapKind' mk)

--- a/ouroboros-consensus-test/src/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus-test/src/Test/Util/LedgerStateOnlyTables.hs
@@ -114,4 +114,4 @@ deriving newtype instance NoThunks (mk k v)
 
 instance (Show k, Show v)
       => ShowLedgerState (LedgerTables (OTLedgerState k v)) where
-  showsLedgerState _ = shows
+  showsLedgerState = shows

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -464,7 +464,7 @@ instance ( Typeable ptype
 type instance LedgerCfg (LedgerState TestBlock) = HardFork.EraParams
 
 instance PayloadSemantics ptype => ShowLedgerState (LedgerState (TestBlockWith ptype)) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance TableStuff (LedgerState TestBlock) where
   data LedgerTables (LedgerState TestBlock) mk = NoTestLedgerTables
@@ -494,7 +494,7 @@ instance TickedTableStuff (LedgerState TestBlock) where
       TickedTestLedger $ withLedgerTables st tables
 
 instance ShowLedgerState (LedgerTables (LedgerState TestBlock)) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance StowableLedgerTables (LedgerState TestBlock) where
   stowLedgerTables   (TestLedger p EmptyPLDS) = TestLedger p EmptyPLDS

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -415,7 +415,7 @@ instance InMemory (Ticked1 (LedgerState (HardForkBlock '[BlockA, BlockB]))) wher
           hfstate
 
 instance ShowLedgerState (LedgerTables (LedgerState (HardForkBlock '[BlockA, BlockB]))) where
-  showsLedgerState _mk = shows
+  showsLedgerState = shows
 
 {-------------------------------------------------------------------------------
   Hard fork

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -188,7 +188,7 @@ data instance LedgerState BlockA mk = LgrA {
   deriving NoThunks via OnlyCheckWhnfNamed "LgrA" (LedgerState BlockA mk)
 
 instance ShowLedgerState (LedgerState BlockA) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance InMemory (LedgerState BlockA) where
   convertMapKind LgrA {..} = LgrA {..}
@@ -229,7 +229,7 @@ instance SufficientSerializationForAnyBackingStore (LedgerState BlockA) where
     codecLedgerTables = NoATables
 
 instance (ShowLedgerState (LedgerTables (LedgerState BlockA))) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance TickedTableStuff (LedgerState BlockA) where
   projectLedgerTablesTicked _ = NoATables

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -195,10 +195,10 @@ instance TickedTableStuff (LedgerState BlockB) where
   withLedgerTablesTicked    st NoBTables = convertMapKind st
 
 instance ShowLedgerState (LedgerState BlockB) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance (ShowLedgerState (LedgerTables (LedgerState BlockB))) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 type instance LedgerCfg (LedgerState BlockB) = ()
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -352,7 +352,7 @@ instance Show TestSetup where
   show (TestSetup st tx cap) =
     showParen True
       (showString "TestSetup {"
-        . showSpace      . showString "testLedgerState = " . showsLedgerState sMapKind st
+        . showSpace      . showString "testLedgerState = " . showsLedgerState st
         . showCommaSpace . showString "testInitialTxs = " . shows tx
         . showCommaSpace . showString "testMempoolCapOverride = " . shows cap
         . showString " }"

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/DbChangelog.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/DbChangelog.hs
@@ -101,7 +101,7 @@ nextState dblog = TestLedger {
     nextSlot = At . withOrigin 1 (+1)
 
 
-deriving instance IsApplyMapKind mk => Show (TestLedger mk)
+deriving instance Show (mk Key Int) => Show (TestLedger mk)
 
 instance GetTip (TestLedger mk) where
   getTip = castPoint . tlTip
@@ -117,10 +117,10 @@ deriving instance Eq (LedgerTables TestLedger DiffMK)
 deriving instance Eq (LedgerTables TestLedger ValuesMK)
 
 instance ShowLedgerState (LedgerTables TestLedger) where
-  showsLedgerState _ (TestTables t) = showString "TestTables " . shows t
+  showsLedgerState (TestTables t) = showString "TestTables " . shows t
 
 instance ShowLedgerState TestLedger where
-  showsLedgerState _ TestLedger {tlUtxos, tlTip} =
+  showsLedgerState TestLedger {tlUtxos, tlTip} =
     showString "TestLedger" . showSpace . showString "{" . shows tlUtxos .
     showCommaSpace . shows tlTip . showString "}"
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/HD/LMDB.hs
@@ -162,7 +162,7 @@ deriving instance (Eq (mk Int Bool), Eq (mk Text Word)) => Eq (T mk)
 deriving instance (Eq (mk Int Bool), Eq (mk Text Word)) => (Eq (LedgerTables T mk))
 
 instance ShowLedgerState T where
-  showsLedgerState _ T{seqNo, tbl1, tbl2} = showParen True
+  showsLedgerState T{seqNo, tbl1, tbl2} = showParen True
     $ showString "T { seqNo = "
     . shows seqNo
     . showString ", tbl1 = "
@@ -172,7 +172,7 @@ instance ShowLedgerState T where
     . showString " }"
 
 instance ShowLedgerState (LedgerTables T) where
-  showsLedgerState _ TLedgerTables{lgrTbl1, lgrTbl2} = showParen True
+  showsLedgerState TLedgerTables{lgrTbl1, lgrTbl2} = showParen True
     $ showString "TLedgerTables { lgrTbl1 = "
     . showsApplyMapKind lgrTbl1
     . showString ", lgrTbl2 = "

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -357,7 +357,7 @@ instance TickedTableStuff (LedgerState TestBlock) where
     TickedTestLedger $ withLedgerTables st tables
 
 instance ShowLedgerState (LedgerTables (LedgerState TestBlock)) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance StowableLedgerTables (LedgerState TestBlock) where
   stowLedgerTables     = stowErr "stowLedgerTables"

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -561,7 +561,7 @@ instance IsLedger (LedgerState TestBlock) where
                                  . noNewTickingDiffs
 
 instance ShowLedgerState (LedgerState TestBlock) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance TableStuff (LedgerState TestBlock) where
   data LedgerTables (LedgerState TestBlock) mk = NoTestLedgerTables
@@ -595,7 +595,7 @@ instance TickedTableStuff (LedgerState TestBlock) where
       TickedTestLedger $ withLedgerTables st tables
 
 instance ShowLedgerState (LedgerTables (LedgerState TestBlock)) where
-  showsLedgerState _sing = shows
+  showsLedgerState = shows
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyBlockLedgerResult _ tb@TestBlock{..} (TickedTestLedger TestLedger{..})

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -57,7 +57,6 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (ShowProxy)
-import           Ouroboros.Consensus.Util.Singletons (SingI)
 import           Ouroboros.Consensus.Util.SOP (fn_5)
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
@@ -99,25 +98,24 @@ deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock
 
 deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs) SeqDiffMK)
 
-instance (SingI mk, CanHardFork xs) => Show (LedgerState (HardForkBlock xs) (ApplyMapKind' mk)) where
-  showsPrec p = showParen (p >= 11) . showsLedgerState sMapKind
+instance CanHardFork xs => Show (LedgerState (HardForkBlock xs) (ApplyMapKind' mk)) where
+  showsPrec p = showParen (p >= 11) . showsLedgerState
 
 instance CanHardFork xs => ShowLedgerState (LedgerState (HardForkBlock xs)) where
-  showsLedgerState = \mk (HardForkLedgerState hfstate) ->
+  showsLedgerState = \(HardForkLedgerState hfstate) ->
         showParen True
       $ (showString "HardForkLedgerState " .)
       $ shows
-      $ hcmap proxySingle (showInner mk) hfstate
+      $ hcmap proxySingle showInner hfstate
     where
        showInner ::
             SingleEraBlock x
-         => SMapKind mk
-         -> Flip LedgerState (ApplyMapKind' mk) x
+         => Flip LedgerState (ApplyMapKind' mk) x
          -> AlreadyShown        x
-       showInner mk (Flip st) =
+       showInner (Flip st) =
            AlreadyShown
          $ showParen True
-         $ showString "Flip " . showsLedgerState mk st
+         $ showString "Flip " . showsLedgerState st
 
 newtype AlreadyShown x = AlreadyShown {unAlreadyShown :: ShowS}
 instance Show (AlreadyShown x) where showsPrec _p = unAlreadyShown

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -129,7 +129,7 @@ class LedgerTablesCanHardFork xs where
   hardForkInjectLedgerTablesKeysMK :: NP (InjectLedgerTables xs) xs
 
 newtype InjectLedgerTables xs x = InjectLedgerTables {
-      applyInjectLedgerTables :: forall mk. IsApplyMapKind mk =>
+      applyInjectLedgerTables :: forall mk. IsMapKind mk =>
            LedgerTables (LedgerState                  x) mk
         -> LedgerTables (LedgerState (HardForkBlock xs)) mk
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -267,10 +267,10 @@ instance (SingleEraBlock x) => TickedTableStuff (LedgerState (HardForkBlock '[x]
       current' = current{currentState = FlipTickedLedgerState x'}
 
 instance TableStuff (LedgerState x) => ShowLedgerState (LedgerTables (LedgerState (HardForkBlock '[x]))) where
-  showsLedgerState sing (LedgerTablesOne x) =
+  showsLedgerState (LedgerTablesOne x) =
         showString "LedgerTablesOne"
       . showSpace
-      . showParen True (showsLedgerState sing x)
+      . showParen True (showsLedgerState x)
 
 instance
      ( TableStuff (LedgerState x)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -61,7 +61,7 @@ module Ouroboros.Consensus.Ledger.Basics (
     -- ** Tables values
   , ApplyMapKind
   , ApplyMapKind' (..)
-  , IsApplyMapKind (..)
+  , IsMapKind (..)
   , MapKind
   , showsApplyMapKind
     -- *** Mediators
@@ -227,8 +227,8 @@ type family LedgerCfg (l :: LedgerStateKind) :: Type
 
 class ( -- Requirements on the ledger state itself
         ShowLedgerState                     l
---      , forall mk. IsApplyMapKind mk                => Eq       (l mk)
---      , forall mk. (IsApplyMapKind mk, Typeable mk) => NoThunks (l mk)
+--      , forall mk. IsMapKind mk                => Eq       (l mk)
+--      , forall mk. (IsMapKind mk, Typeable mk) => NoThunks (l mk)
       , Eq       (l EmptyMK)
       , NoThunks (l EmptyMK)
       , Eq       (l DiffMK)
@@ -305,7 +305,7 @@ class ( -- Requirements on the ledger state itself
   -- >    ledgerTipPoint (applyChainTick cfg slot st)
   -- > == ledgerTipPoint st
   --
-  -- NOTE: The 'IsApplyMapKind' constraint is here for the same reason it's on
+  -- NOTE: The 'IsMapKind' constraint is here for the same reason it's on
   -- 'projectLedgerTables'
   applyChainTickLedgerResult ::
        LedgerCfg l
@@ -352,7 +352,7 @@ class ( ShowLedgerState (LedgerTables l)
   -- the 'SingI' constraint. Unfortunately, that is not always the case. The
   -- example we have found in our prototype UTxO HD implementat is that a Byron
   -- ledger state does not determine @mk@, but the Cardano ledger tables do.
-  projectLedgerTables :: IsApplyMapKind mk => l mk -> LedgerTables l mk
+  projectLedgerTables :: IsMapKind mk => l mk -> LedgerTables l mk
 
   -- | Overwrite the tables in some ledger state.
   --
@@ -364,9 +364,9 @@ class ( ShowLedgerState (LedgerTables l)
   --
   -- TODO: reconsider the name: don't we use 'withX' in the context of bracket like functions?
   --
-  -- TODO: This 'IsApplyMapKind' constraint is necessary because the
+  -- TODO: This 'IsMapKind' constraint is necessary because the
   -- 'CardanoBlock' instance uses 'projectLedgerTables'.
-  withLedgerTables :: IsApplyMapKind mk => l any -> LedgerTables l mk -> l mk
+  withLedgerTables :: IsMapKind mk => l any -> LedgerTables l mk -> l mk
 
   pureLedgerTables ::
        (forall k v.
@@ -469,14 +469,14 @@ class ( ShowLedgerState (LedgerTables l)
   namesLedgerTables :: LedgerTables l NameMK
 
 overLedgerTables ::
-     (TableStuff l, IsApplyMapKind mk1, IsApplyMapKind mk2)
+     (TableStuff l, IsMapKind mk1, IsMapKind mk2)
   => (LedgerTables l mk1 -> LedgerTables l mk2)
   -> l mk1
   -> l mk2
 overLedgerTables f l = withLedgerTables l $ f $ projectLedgerTables l
 
 mapOverLedgerTables ::
-     (TableStuff l, IsApplyMapKind mk1, IsApplyMapKind mk2)
+     (TableStuff l, IsMapKind mk1, IsMapKind mk2)
   => (forall k v.
           (Ord k, Eq v)
        => mk1 k v
@@ -487,7 +487,7 @@ mapOverLedgerTables ::
 mapOverLedgerTables f = overLedgerTables $ mapLedgerTables f
 
 zipOverLedgerTables ::
-     (TableStuff l, IsApplyMapKind mk1, IsApplyMapKind mk3)
+     (TableStuff l, IsMapKind mk1, IsMapKind mk3)
   => (forall k v.
           (Ord k, Eq v)
        => mk1 k v
@@ -505,15 +505,15 @@ zipOverLedgerTables f l tables2 =
 -- Separate so that we can have a 'TableStuff' instance for 'Ticked1' without
 -- involving double-ticked types.
 class TableStuff l => TickedTableStuff (l :: LedgerStateKind) where
-  -- | NOTE: The 'IsApplyMapKind mk2' constraint is here for the same reason
+  -- | NOTE: The 'IsMapKind mk2' constraint is here for the same reason
   -- it's on 'projectLedgerTables'
-  projectLedgerTablesTicked :: IsApplyMapKind mk => Ticked1 l mk  -> LedgerTables l mk
-  -- | NOTE: The 'IsApplyMapKind mk2' constraint is here for the same reason
+  projectLedgerTablesTicked :: IsMapKind mk => Ticked1 l mk  -> LedgerTables l mk
+  -- | NOTE: The 'IsMapKind mk2' constraint is here for the same reason
   -- it's on 'withLedgerTables'
-  withLedgerTablesTicked    :: IsApplyMapKind mk => Ticked1 l any -> LedgerTables l mk -> Ticked1 l mk
+  withLedgerTablesTicked    :: IsMapKind mk => Ticked1 l any -> LedgerTables l mk -> Ticked1 l mk
 
 overLedgerTablesTicked ::
-     (TickedTableStuff l, IsApplyMapKind mk1, IsApplyMapKind mk2)
+     (TickedTableStuff l, IsMapKind mk1, IsMapKind mk2)
   => (LedgerTables l mk1 -> LedgerTables l mk2)
   -> Ticked1 l mk1
   -> Ticked1 l mk2
@@ -521,7 +521,7 @@ overLedgerTablesTicked f l =
     withLedgerTablesTicked l $ f $ projectLedgerTablesTicked l
 
 mapOverLedgerTablesTicked ::
-     (TickedTableStuff l, IsApplyMapKind mk1, IsApplyMapKind mk2)
+     (TickedTableStuff l, IsMapKind mk1, IsMapKind mk2)
   => (forall k v.
          (Ord k, Eq v)
       => mk1 k v
@@ -532,7 +532,7 @@ mapOverLedgerTablesTicked ::
 mapOverLedgerTablesTicked f = overLedgerTablesTicked $ mapLedgerTables f
 
 zipOverLedgerTablesTicked ::
-     (TickedTableStuff l, IsApplyMapKind mk1, IsApplyMapKind mk3)
+     (TickedTableStuff l, IsMapKind mk1, IsMapKind mk3)
   => (forall k v.
          (Ord k, Eq v)
       => mk1 k v
@@ -609,7 +609,7 @@ emptyLedgerTables :: TableStuff l => LedgerTables l EmptyMK
 emptyLedgerTables = polyEmptyLedgerTables
 
 -- | Empty values for every table
-polyEmptyLedgerTables :: forall mk l. (TableStuff l, IsApplyMapKind mk) => LedgerTables l mk
+polyEmptyLedgerTables :: forall mk l. (TableStuff l, IsMapKind mk) => LedgerTables l mk
 polyEmptyLedgerTables = pureLedgerTables emptyMK
 
 -- Forget all
@@ -789,7 +789,7 @@ data ApplyMapKind' :: MapKind' -> Type -> Type -> Type where
   ApplyQueryAllMK  ::                ApplyMapKind' QueryMK' k v
   ApplyQuerySomeMK :: !(Keys k v) -> ApplyMapKind' QueryMK' k v
 
-class IsApplyMapKind mk where
+class IsMapKind mk where
   emptyMK :: forall k v. (Ord k, Eq v) => mk k v
   default emptyMK :: forall k v. Monoid (mk k v) => mk k v
   emptyMK = mempty
@@ -798,30 +798,30 @@ class IsApplyMapKind mk where
   default mapMK :: forall k v v'. (Functor (mk k)) => (v -> v') -> mk k v -> mk k v'
   mapMK = fmap
 
-instance IsApplyMapKind EmptyMK where
+instance IsMapKind EmptyMK where
   emptyMK = ApplyEmptyMK
   mapMK _ ApplyEmptyMK = ApplyEmptyMK
 
-instance IsApplyMapKind KeysMK where
+instance IsMapKind KeysMK where
   emptyMK = ApplyKeysMK mempty
   mapMK f (ApplyKeysMK ks) = ApplyKeysMK $ fmap f ks
 
-instance IsApplyMapKind ValuesMK where
+instance IsMapKind ValuesMK where
   emptyMK = ApplyValuesMK mempty
   mapMK f (ApplyValuesMK vs) = ApplyValuesMK $ fmap f vs
 
-instance IsApplyMapKind TrackingMK where
+instance IsMapKind TrackingMK where
   emptyMK = ApplyTrackingMK mempty mempty
   mapMK f (ApplyTrackingMK vs d) = ApplyTrackingMK (fmap f vs) (fmap f d)
 
-instance IsApplyMapKind DiffMK where
+instance IsMapKind DiffMK where
   emptyMK = ApplyDiffMK mempty
 
-instance IsApplyMapKind SeqDiffMK where
+instance IsMapKind SeqDiffMK where
   emptyMK = ApplySeqDiffMK empty
   mapMK f (ApplySeqDiffMK ds) = ApplySeqDiffMK $ mapDiffSeq f ds
 
-instance IsApplyMapKind (ApplyMapKind' QueryMK') where
+instance IsMapKind (ApplyMapKind' QueryMK') where
   emptyMK = ApplyQuerySomeMK mempty
   mapMK f qmk = case qmk of
     ApplyQuerySomeMK ks -> ApplyQuerySomeMK $ fmap f ks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -789,7 +789,15 @@ data ApplyMapKind' :: MapKind' -> Type -> Type -> Type where
   ApplyQueryAllMK  ::                ApplyMapKind' QueryMK' k v
   ApplyQuerySomeMK :: !(Keys k v) -> ApplyMapKind' QueryMK' k v
 
-class IsMapKind mk where
+-- | A general interface to mapkinds.
+--
+-- In some cases where @mk@ is not specialised to a concrete mapkind like
+-- @'ValuesMK'@, there are often still a number of operations that we can
+-- perform for this @mk@ that make sense regardless of the concrete mapkind. For
+-- example, we should always be able to map over a mapkind to change the type of
+-- values that it contains. This class is an interface to mapkinds that provides
+-- such common functions.
+class IsMapKind (mk :: MapKind) where
   emptyMK :: forall k v. (Ord k, Eq v) => mk k v
   default emptyMK :: forall k v. Monoid (mk k v) => mk k v
   emptyMK = mempty

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -566,10 +566,10 @@ instance ( ShowLedgerState (LedgerState m)
          , ShowLedgerState (LedgerState a)
          , Bridge m a
          ) => ShowLedgerState (LedgerState (DualBlock m a)) where
-  showsLedgerState mk st =
+  showsLedgerState st =
       showString "DualLedgerState" . showSpace . showString "{" .
-                             showsLedgerState mk dualLedgerStateMain
-          . showCommaSpace . showsLedgerState mk dualLedgerStateAux
+                             showsLedgerState dualLedgerStateMain
+          . showCommaSpace . showsLedgerState dualLedgerStateAux
           . showCommaSpace . shows dualLedgerStateBridge
           . showString "}"
     where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -83,10 +83,10 @@ deriving instance LedgerSupportsProtocol blk => Show (ExtValidationError    blk)
 deriving instance LedgerSupportsProtocol blk => Eq   (ExtValidationError    blk)
 
 instance LedgerSupportsProtocol blk => ShowLedgerState (ExtLedgerState blk) where
-  showsLedgerState mk st =
+  showsLedgerState st =
       showParen True $ showString "ExtLedgerState {"
-        . showSpace      . showString "headerState = " . shows               headerState
-        . showCommaSpace . showString "ledgerState = " . showsLedgerState mk ledgerState
+        . showSpace      . showString "headerState = " . shows            headerState
+        . showCommaSpace . showString "ledgerState = " . showsLedgerState ledgerState
         . showString " }"
     where
       ExtLedgerState _dummy _ = st


### PR DESCRIPTION
# Description

Closes #4235.

For a description of the problem that this PR tries to solve, see #4235.

The main contribution of this PR is to change the `IsApplyMapKind` constraint to a type class, which allows `TableStuff` functions to be used with any mapkind that implements the type class, instead of only mapkinds of the form `ApplyMapKind' mk`. The `Ledger.Basics` module contains the base changes, whereas the changes in the other modules fix compilation due to the base changes.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
