### PR TITLE
Add a boolean query flag to request supported versions

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -103,5 +103,5 @@ versionedProtocols networkMagic supportedVersions callback =
     applyVersion (version, blockVersion) =
       versionedNodeToClientProtocols
         version
-        (NodeToClientVersionData networkMagic)
+        (NodeToClientVersionData networkMagic False)
         (callback version blockVersion)

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -35,6 +35,7 @@ library
                         network-mux                  ^>=0.4,
                         tdigest                      ^>=0.3,
                         text                          >=1.2.4    && <2.1,
+                        transformers                  >=0.5      && <0.6,
 
                         -- The Windows version of network-3.1.2 is missing
                         -- functions, see

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -23,6 +23,7 @@ import           Control.Exception (bracket)
 import           Control.Monad (replicateM, unless, when)
 import           Control.Concurrent.Class.MonadSTM.Strict ( MonadSTM(atomically), takeTMVar, StrictTMVar )
 import           Control.Monad.Class.MonadTime.SI (UTCTime, diffTime, MonadMonotonicTime(getMonotonicTime), MonadTime(getCurrentTime), Time)
+import           Control.Monad.Trans.Except
 import           Control.Tracer (Tracer (..), nullTracer, traceWith)
 import           Data.Aeson (Value, ToJSON(toJSON), object, encode, KeyValue((.=)))
 import           Data.Bits (clearBit, setBit, testBit)
@@ -53,6 +54,8 @@ data PingOpts = PingOpts
     -- ^ Number of messages to send to the server
   , pingOptsHost     :: Maybe String
     -- ^ The host to connect to
+  , pingOptsHandshakeQuery :: Bool
+    -- ^ Whether to send a query during the handshake to request the available protocol versions
   , pingOptsUnixSock :: Maybe String
     -- ^ The unix socket to connect to
   , pingOptsPort     :: String
@@ -103,6 +106,7 @@ supportedNodeToNodeVersions magic =
   , NodeToNodeVersionV8  magic False
   , NodeToNodeVersionV9  magic False
   , NodeToNodeVersionV10 magic False
+  , NodeToNodeVersionV11 magic False
   ]
 
 supportedNodeToClientVersions :: Word32 -> [NodeVersion]
@@ -113,6 +117,7 @@ supportedNodeToClientVersions magic =
   , NodeToClientVersionV12 magic
   , NodeToClientVersionV13 magic
   , NodeToClientVersionV14 magic
+  , NodeToClientVersionV15 magic
   ]
 
 data NodeVersion
@@ -122,6 +127,7 @@ data NodeVersion
   | NodeToClientVersionV12 Word32
   | NodeToClientVersionV13 Word32
   | NodeToClientVersionV14 Word32
+  | NodeToClientVersionV15 Word32
   | NodeToNodeVersionV1    Word32
   | NodeToNodeVersionV2    Word32
   | NodeToNodeVersionV3    Word32
@@ -132,6 +138,7 @@ data NodeVersion
   | NodeToNodeVersionV8    Word32 Bool
   | NodeToNodeVersionV9    Word32 Bool
   | NodeToNodeVersionV10   Word32 Bool
+  | NodeToNodeVersionV11   Word32 Bool
   deriving (Eq, Ord, Show)
 
 keepAliveReqEnc :: NodeVersion -> Word16 -> CBOR.Encoding
@@ -156,9 +163,9 @@ keepAliveDone _ =
       CBOR.encodeWord 2
 
 
-handshakeReqEnc :: [NodeVersion] -> CBOR.Encoding
-handshakeReqEnc [] = error "null version list"
-handshakeReqEnc versions =
+handshakeReqEnc :: [NodeVersion] -> Bool -> CBOR.Encoding
+handshakeReqEnc [] _ = error "null version list"
+handshakeReqEnc versions query =
       CBOR.encodeListLen 2
   <>  CBOR.encodeWord 0
   <>  CBOR.encodeMapLen (fromIntegral $ L.length versions)
@@ -185,6 +192,9 @@ handshakeReqEnc versions =
     encodeVersion (NodeToClientVersionV14 magic) =
           CBOR.encodeWord (14 `setBit` nodeToClientVersionBit)
       <>  CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToClientVersionV15 magic) =
+          CBOR.encodeWord (15 `setBit` nodeToClientVersionBit)
+      <>  nodeToClientDataWithQuery magic
     encodeVersion (NodeToNodeVersionV1 magic) =
           CBOR.encodeWord 1
       <>  CBOR.encodeInt (fromIntegral magic)
@@ -201,7 +211,13 @@ handshakeReqEnc versions =
     encodeVersion (NodeToNodeVersionV8  magic mode) = encodeWithMode 8  magic mode
     encodeVersion (NodeToNodeVersionV9  magic mode) = encodeWithMode 9  magic mode
     encodeVersion (NodeToNodeVersionV10 magic mode) = encodeWithMode 10 magic mode
+    encodeVersion (NodeToNodeVersionV11 magic mode) = encodeWithModeAndQuery 11 magic mode
 
+    nodeToClientDataWithQuery :: Word32 -> CBOR.Encoding
+    nodeToClientDataWithQuery magic
+      =  CBOR.encodeListLen 2
+      <> CBOR.encodeInt (fromIntegral magic)
+      <> CBOR.encodeBool query
 
     encodeWithMode :: Word -> Word32 -> Bool -> CBOR.Encoding
     encodeWithMode vn magic mode =
@@ -210,9 +226,17 @@ handshakeReqEnc versions =
       <>  CBOR.encodeInt (fromIntegral magic)
       <>  CBOR.encodeBool mode
 
-handshakeReq :: [NodeVersion] -> ByteString
-handshakeReq []       = LBS.empty
-handshakeReq versions = CBOR.toLazyByteString $ handshakeReqEnc versions
+    encodeWithModeAndQuery :: Word -> Word32 -> Bool -> CBOR.Encoding
+    encodeWithModeAndQuery vn magic mode =
+          CBOR.encodeWord vn
+       <> CBOR.encodeListLen 2
+       <> CBOR.encodeInt (fromIntegral magic)
+       <> CBOR.encodeBool mode
+       <> CBOR.encodeBool query
+
+handshakeReq :: [NodeVersion] -> Bool -> ByteString
+handshakeReq []       _     = LBS.empty
+handshakeReq versions query = CBOR.toLazyByteString $ handshakeReqEnc versions query
 
 data HandshakeFailure
   = UnknownVersionInRsp Word
@@ -239,12 +263,15 @@ keepAliveRspDec _ = do
     1 -> Right <$> CBOR.decodeWord16
     k -> return $ Left $ KeepAliveFailureKey k
 
-handshakeDec :: CBOR.Decoder s (Either HandshakeFailure NodeVersion)
+handshakeDec :: CBOR.Decoder s (Either HandshakeFailure [NodeVersion])
 handshakeDec = do
   _ <- CBOR.decodeListLen
   key <- CBOR.decodeWord
   case key of
-    1 -> decodeVersion
+    0 -> do
+      decodeVersions
+    1 -> do
+      fmap pure <$> decodeVersion
     2 -> do
       _ <- CBOR.decodeListLen
       tag <- CBOR.decodeWord
@@ -262,9 +289,22 @@ handshakeDec = do
           msg <- unpack <$> CBOR.decodeString
           return $ Left $ Refused vn msg
         _ -> return $ Left $ UnknownTag tag
+    3 -> do -- MsgQueryReply
+      decodeVersions
 
     k -> return $ Left $ UnknownKey k
   where
+    decodeVersions :: CBOR.Decoder s (Either HandshakeFailure [NodeVersion])
+    decodeVersions = do
+        len <- CBOR.decodeMapLen
+        runExceptT $ go len []
+      where
+        go :: Int -> [NodeVersion] -> ExceptT HandshakeFailure (CBOR.Decoder s) [NodeVersion]
+        go 0 acc = return acc
+        go i acc = do
+          version <- ExceptT decodeVersion
+          go (pred i) $ version:acc
+
     decodeVersion :: CBOR.Decoder s (Either HandshakeFailure NodeVersion)
     decodeVersion = do
       version <- CBOR.decodeWord
@@ -275,12 +315,14 @@ handshakeDec = do
         (8,  False) -> decodeWithMode NodeToNodeVersionV8
         (9,  False) -> decodeWithMode NodeToNodeVersionV9
         (10, False) -> decodeWithMode NodeToNodeVersionV10
+        (11, False) -> decodeWithModeAndQuery NodeToNodeVersionV11
         (9,  True)  -> Right . NodeToClientVersionV9 <$> CBOR.decodeWord32
         (10, True)  -> Right . NodeToClientVersionV10 <$> CBOR.decodeWord32
         (11, True)  -> Right . NodeToClientVersionV11 <$> CBOR.decodeWord32
         (12, True)  -> Right . NodeToClientVersionV12 <$> CBOR.decodeWord32
         (13, True)  -> Right . NodeToClientVersionV13 <$> CBOR.decodeWord32
         (14, True)  -> Right . NodeToClientVersionV14 <$> CBOR.decodeWord32
+        (15, True) -> Right . NodeToClientVersionV15 <$> (CBOR.decodeListLen *> CBOR.decodeWord32 <* CBOR.decodeBool)
         _           -> return $ Left $ UnknownVersionInRsp version
 
     decodeWithMode :: (Word32 -> Bool -> NodeVersion) -> CBOR.Decoder s (Either HandshakeFailure NodeVersion)
@@ -288,6 +330,15 @@ handshakeDec = do
       _ <- CBOR.decodeListLen
       magic <- CBOR.decodeWord32
       Right . vnFun magic <$> CBOR.decodeBool
+
+    decodeWithModeAndQuery :: (Word32 -> Bool -> NodeVersion)
+                           -> CBOR.Decoder s (Either HandshakeFailure NodeVersion)
+    decodeWithModeAndQuery vnFun = do
+        _len <- CBOR.decodeListLen
+        magic <- CBOR.decodeWord32
+        mode <- CBOR.decodeBool
+        _query <- CBOR.decodeBool
+        return $ Right $ vnFun magic mode
 
 wrap :: MiniProtocolNum -> MiniProtocolDir -> LBS.ByteString -> MuxSDU
 wrap ptclNum ptclDir blob = MuxSDU
@@ -360,7 +411,7 @@ toStatPoint ts host cookie sample td =
     stddev' = fromMaybe 0 (stddev td)
 
 pingClient :: Tracer IO LogMsg -> Tracer IO String -> PingOpts -> [NodeVersion] -> AddrInfo -> IO ()
-pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount} versions peer = bracket
+pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount, pingOptsHandshakeQuery} versions peer = bracket
   (Socket.socket (Socket.addrFamily peer) Socket.Stream Socket.defaultProtocol)
   Socket.close
   (\sd -> withTimeoutSerial $ \timeoutfn -> do
@@ -381,23 +432,56 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount} ve
     let timeout = 30
     bearer <- getBearer makeSocketBearer timeout nullTracer sd
 
-    !t1_s <- write bearer timeoutfn $ wrap handshakeNum InitiatorDir (handshakeReq versions)
+    !t1_s <- write bearer timeoutfn $ wrap handshakeNum InitiatorDir (handshakeReq versions pingOptsHandshakeQuery)
     (msg, !t1_e) <- nextMsg bearer timeoutfn handshakeNum
     unless pingOptsQuiet $ printf "%s handshake rtt: %s\n" peerStr (show $ diffTime t1_e t1_s)
 
     case CBOR.deserialiseFromBytes handshakeDec msg of
       Left err -> eprint $ printf "%s Decoding error %s" peerStr (show err)
       Right (_, Left err) -> eprint $ printf "%s Protocol error %s" peerStr (show err)
-      Right (_, Right version) -> do
-        unless pingOptsQuiet $ printf "%s Negotiated version %s\n" peerStr (show version)
-        keepAlive bearer timeoutfn peerStr version (tdigest []) 0
-        -- send terminating message
-        _ <- write bearer timeoutfn $ wrap keepaliveNum InitiatorDir (keepAliveDone version)
-        -- protocol idle timeout
-        MT.threadDelay 5
+      Right (_, Right recVersions) -> do
+        when (pingOptsHandshakeQuery && not pingOptsQuiet) $ printf "%s Queried versions %s\n" peerStr (show recVersions)
+        case acceptVersions recVersions of
+          Left err ->
+            eprint $ printf "%s Version negotiation error %s\n" peerStr err
+          Right version -> do
+            unless pingOptsQuiet $ printf "%s Negotiated version %s\n" peerStr (show version)
+            keepAlive bearer timeoutfn peerStr version (tdigest []) 0
+            -- send terminating message
+            _ <- write bearer timeoutfn $ wrap keepaliveNum InitiatorDir (keepAliveDone version)
+            -- protocol idle timeout
+            MT.threadDelay 5
 
   )
   where
+
+    acceptVersions :: [NodeVersion] -> Either String NodeVersion
+    acceptVersions recVersions =
+      let intersects = L.intersectBy isSameVersionAndMagic recVersions versions in
+      case intersects of
+          [] -> Left $ "No overlapping versions with " <> show versions
+          vs -> Right $ foldr1 max vs
+
+    isSameVersionAndMagic :: NodeVersion -> NodeVersion -> Bool
+    isSameVersionAndMagic (NodeToClientVersionV9 m1)  (NodeToClientVersionV9 m2)  = m1 == m2
+    isSameVersionAndMagic (NodeToClientVersionV10 m1) (NodeToClientVersionV10 m2) = m1 == m2
+    isSameVersionAndMagic (NodeToClientVersionV11 m1) (NodeToClientVersionV11 m2) = m1 == m2
+    isSameVersionAndMagic (NodeToClientVersionV12 m1) (NodeToClientVersionV12 m2) = m1 == m2
+    isSameVersionAndMagic (NodeToClientVersionV13 m1) (NodeToClientVersionV13 m2) = m1 == m2
+    isSameVersionAndMagic (NodeToClientVersionV14 m1) (NodeToClientVersionV14 m2) = m1 == m2
+    isSameVersionAndMagic (NodeToClientVersionV15 m1) (NodeToClientVersionV15 m2) = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV1 m1)    (NodeToNodeVersionV1 m2)    = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV2 m1)    (NodeToNodeVersionV2 m2)    = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV3 m1)    (NodeToNodeVersionV3 m2)    = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV4 m1 _)  (NodeToNodeVersionV4 m2 _)  = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV5 m1 _)  (NodeToNodeVersionV5 m2 _)  = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV6 m1 _)  (NodeToNodeVersionV6 m2 _)  = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV7 m1 _)  (NodeToNodeVersionV7 m2 _)  = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV8 m1 _)  (NodeToNodeVersionV8 m2 _)  = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV9 m1 _)  (NodeToNodeVersionV9 m2 _)  = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV10 m1 _) (NodeToNodeVersionV10 m2 _) = m1 == m2
+    isSameVersionAndMagic (NodeToNodeVersionV11 m1 _) (NodeToNodeVersionV11 m2 _) = m1 == m2
+    isSameVersionAndMagic _ _ = False
 
     peerString :: IO String
     peerString =

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -229,9 +229,10 @@ handshakeReqEnc versions query =
     encodeWithModeAndQuery :: Word -> Word32 -> Bool -> CBOR.Encoding
     encodeWithModeAndQuery vn magic mode =
           CBOR.encodeWord vn
-       <> CBOR.encodeListLen 2
+       <> CBOR.encodeListLen 4
        <> CBOR.encodeInt (fromIntegral magic)
        <> CBOR.encodeBool mode
+       <> CBOR.encodeInt 0 -- NoPeerSharing
        <> CBOR.encodeBool query
 
 handshakeReq :: [NodeVersion] -> Bool -> ByteString
@@ -337,6 +338,7 @@ handshakeDec = do
         _len <- CBOR.decodeListLen
         magic <- CBOR.decodeWord32
         mode <- CBOR.decodeBool
+        _peerSharing <- CBOR.decodeWord32
         _query <- CBOR.decodeBool
         return $ Right $ vnFun magic mode
 

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -463,25 +463,26 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount, pi
           vs -> Right $ foldr1 max vs
 
     isSameVersionAndMagic :: NodeVersion -> NodeVersion -> Bool
-    isSameVersionAndMagic (NodeToClientVersionV9 m1)  (NodeToClientVersionV9 m2)  = m1 == m2
-    isSameVersionAndMagic (NodeToClientVersionV10 m1) (NodeToClientVersionV10 m2) = m1 == m2
-    isSameVersionAndMagic (NodeToClientVersionV11 m1) (NodeToClientVersionV11 m2) = m1 == m2
-    isSameVersionAndMagic (NodeToClientVersionV12 m1) (NodeToClientVersionV12 m2) = m1 == m2
-    isSameVersionAndMagic (NodeToClientVersionV13 m1) (NodeToClientVersionV13 m2) = m1 == m2
-    isSameVersionAndMagic (NodeToClientVersionV14 m1) (NodeToClientVersionV14 m2) = m1 == m2
-    isSameVersionAndMagic (NodeToClientVersionV15 m1) (NodeToClientVersionV15 m2) = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV1 m1)    (NodeToNodeVersionV1 m2)    = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV2 m1)    (NodeToNodeVersionV2 m2)    = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV3 m1)    (NodeToNodeVersionV3 m2)    = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV4 m1 _)  (NodeToNodeVersionV4 m2 _)  = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV5 m1 _)  (NodeToNodeVersionV5 m2 _)  = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV6 m1 _)  (NodeToNodeVersionV6 m2 _)  = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV7 m1 _)  (NodeToNodeVersionV7 m2 _)  = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV8 m1 _)  (NodeToNodeVersionV8 m2 _)  = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV9 m1 _)  (NodeToNodeVersionV9 m2 _)  = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV10 m1 _) (NodeToNodeVersionV10 m2 _) = m1 == m2
-    isSameVersionAndMagic (NodeToNodeVersionV11 m1 _) (NodeToNodeVersionV11 m2 _) = m1 == m2
-    isSameVersionAndMagic _ _ = False
+    isSameVersionAndMagic v1 v2 = extract v1 == extract v2
+      where extract :: NodeVersion -> (Int, Word32)
+            extract (NodeToClientVersionV9 m)  = (-9, m)
+            extract (NodeToClientVersionV10 m) = (-10, m)
+            extract (NodeToClientVersionV11 m) = (-11, m)
+            extract (NodeToClientVersionV12 m) = (-12, m)
+            extract (NodeToClientVersionV13 m) = (-13, m)
+            extract (NodeToClientVersionV14 m) = (-14, m)
+            extract (NodeToClientVersionV15 m) = (-15, m)
+            extract (NodeToNodeVersionV1 m)    = (1, m)
+            extract (NodeToNodeVersionV2 m)    = (2, m)
+            extract (NodeToNodeVersionV3 m)    = (3, m)
+            extract (NodeToNodeVersionV4 m _)  = (4, m)
+            extract (NodeToNodeVersionV5 m _)  = (5, m)
+            extract (NodeToNodeVersionV6 m _)  = (6, m)
+            extract (NodeToNodeVersionV7 m _)  = (7, m)
+            extract (NodeToNodeVersionV8 m _)  = (8, m)
+            extract (NodeToNodeVersionV9 m _)  = (9, m)
+            extract (NodeToNodeVersionV10 m _) = (10, m)
+            extract (NodeToNodeVersionV11 m _) = (11, m)
 
     peerString :: IO String
     peerString =

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -83,8 +83,8 @@ nodeToClientVersionBit = 15
 data LogMsg = LogMsg ByteString
             | LogEnd
 
-logger :: StrictTMVar IO LogMsg -> Bool -> IO ()
-logger msgQueue json = go True
+logger :: StrictTMVar IO LogMsg -> Bool -> Bool -> IO ()
+logger msgQueue json query = go True
   where
     go first = do
       msg <- atomically $ takeTMVar  msgQueue
@@ -98,7 +98,7 @@ logger msgQueue json = go True
 
           LBS.Char.putStr bs'
           go False
-        LogEnd -> when json $ IO.putStrLn "] }"
+        LogEnd -> when (json && not query) $ IO.putStrLn "] }"
 
 supportedNodeToNodeVersions :: Word32 -> [NodeVersion]
 supportedNodeToNodeVersions magic =
@@ -448,9 +448,11 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount, pi
             eprint $ printf "%s Version negotiation error %s\n" peerStr err
           Right version -> do
             unless pingOptsQuiet $ printf "%s Negotiated version %s\n" peerStr (show version)
-            keepAlive bearer timeoutfn peerStr version (tdigest []) 0
-            -- send terminating message
-            _ <- write bearer timeoutfn $ wrap keepaliveNum InitiatorDir (keepAliveDone version)
+            unless pingOptsHandshakeQuery $ do
+              keepAlive bearer timeoutfn peerStr version (tdigest []) 0
+              -- send terminating message
+              _ <- write bearer timeoutfn $ wrap keepaliveNum InitiatorDir (keepAliveDone version)
+              return ()
             -- protocol idle timeout
             MT.threadDelay 5
 

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -32,6 +32,7 @@ library
                        Ouroboros.Network.CodecCBORTerm
                        Ouroboros.Network.ControlMessage
                        Ouroboros.Network.Handshake.Acceptable
+                       Ouroboros.Network.Handshake.Queryable
                        Ouroboros.Network.Magic
                        Ouroboros.Network.NodeToClient.Version
                        Ouroboros.Network.NodeToNode.Version

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -31,6 +31,7 @@ library
 
                        Ouroboros.Network.CodecCBORTerm
                        Ouroboros.Network.ControlMessage
+                       Ouroboros.Network.Handshake
                        Ouroboros.Network.Handshake.Acceptable
                        Ouroboros.Network.Handshake.Queryable
                        Ouroboros.Network.Magic

--- a/ouroboros-network-api/src/Ouroboros/Network/Handshake.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/Handshake.hs
@@ -1,7 +1,5 @@
 
-module Ouroboros.Network.Handshake
-  ( HandshakeCallbacks (..)
-  ) where
+module Ouroboros.Network.Handshake (HandshakeCallbacks (..)) where
 
 import           Ouroboros.Network.Handshake.Acceptable (Accept)
 

--- a/ouroboros-network-api/src/Ouroboros/Network/Handshake.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/Handshake.hs
@@ -1,0 +1,13 @@
+
+module Ouroboros.Network.Handshake
+  ( HandshakeCallbacks (..)
+  ) where
+
+import           Ouroboros.Network.Handshake.Acceptable (Accept)
+
+-- | A record that holds handshake callbacks.
+--
+data HandshakeCallbacks vData = HandshakeCallbacks {
+    acceptCb :: vData -> vData -> Accept vData
+  , queryCb  :: vData -> Bool
+  }

--- a/ouroboros-network-api/src/Ouroboros/Network/Handshake/Queryable.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/Handshake/Queryable.hs
@@ -1,6 +1,4 @@
-module Ouroboros.Network.Handshake.Queryable
-  ( Queryable (..)
-  ) where
+module Ouroboros.Network.Handshake.Queryable (Queryable (..)) where
 
 class Queryable v where
   -- | Whether or not there was a query for the supported version.

--- a/ouroboros-network-api/src/Ouroboros/Network/Handshake/Queryable.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/Handshake/Queryable.hs
@@ -1,0 +1,7 @@
+module Ouroboros.Network.Handshake.Queryable
+  ( Queryable (..)
+  ) where
+
+class Queryable v where
+  -- | Whether or not there was a query for the supported version.
+  queryVersion :: v -> Bool

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -16,6 +16,7 @@ import           Data.Typeable (Typeable)
 import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Handshake.Acceptable (Accept (..),
                      Acceptable (..))
+import           Ouroboros.Network.Handshake.Queryable (Queryable (..))
 import           Ouroboros.Network.Magic
 
 
@@ -96,6 +97,9 @@ instance Acceptable NodeToClientVersionData where
       | otherwise =  Refuse $ T.pack $ "version data mismatch: "
                                     ++ show local
                                     ++ " /= " ++ show remote
+
+instance Queryable NodeToClientVersionData where
+    queryVersion = query
 
 nodeToClientCodecCBORTerm :: NodeToClientVersion -> CodecCBORTerm Text NodeToClientVersionData
 nodeToClientCodecCBORTerm _ = CodecCBORTerm {encodeTerm, decodeTerm}

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -80,14 +80,19 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
 
 -- | Version data for NodeToClient protocol v1
 --
-newtype NodeToClientVersionData = NodeToClientVersionData
-  { networkMagic :: NetworkMagic }
+data NodeToClientVersionData = NodeToClientVersionData
+  { networkMagic :: !NetworkMagic
+  , query        :: !Bool
+  }
   deriving (Eq, Show, Typeable)
 
 instance Acceptable NodeToClientVersionData where
     acceptableVersion local remote
-      | local == remote
-      = Accept local
+      | networkMagic local == networkMagic remote
+      = Accept NodeToClientVersionData
+          { networkMagic  = networkMagic local
+          , query         = query local || query remote
+          }
       | otherwise =  Refuse $ T.pack $ "version data mismatch: "
                                     ++ show local
                                     ++ " /= " ++ show remote
@@ -96,10 +101,20 @@ nodeToClientCodecCBORTerm :: NodeToClientVersion -> CodecCBORTerm Text NodeToCli
 nodeToClientCodecCBORTerm _ = CodecCBORTerm {encodeTerm, decodeTerm}
     where
       encodeTerm :: NodeToClientVersionData -> CBOR.Term
-      encodeTerm NodeToClientVersionData { networkMagic } =
-        CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
+      encodeTerm NodeToClientVersionData { networkMagic, query }
+        | query
+        = CBOR.TList [CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic), CBOR.TBool query]
+        | otherwise
+        = CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
 
       decodeTerm :: CBOR.Term -> Either Text NodeToClientVersionData
-      decodeTerm (CBOR.TInt x) | x >= 0 && x <= 0xffffffff = Right (NodeToClientVersionData $ NetworkMagic $ fromIntegral x)
-                               | otherwise                 = Left $ T.pack $ "networkMagic out of bound: " <> show x
-      decodeTerm t             = Left $ T.pack $ "unknown encoding: " ++ show t
+      decodeTerm (CBOR.TInt x)
+        = decoder x False
+      decodeTerm (CBOR.TList [CBOR.TInt x, CBOR.TBool query])
+        = decoder x query
+      decodeTerm t
+        = Left $ T.pack $ "unknown encoding: " ++ show t
+
+      decoder :: Int -> Bool -> Either Text NodeToClientVersionData
+      decoder x query | x >= 0 && x <= 0xffffffff = Right (NodeToClientVersionData (NetworkMagic $ fromIntegral x) query)
+                      | otherwise                 = Left $ T.pack $ "networkMagic out of bound: " <> show x

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -54,6 +54,7 @@ data NodeToNodeVersion
     --   This version is needed to support the new  Peer Sharing miniprotocol
     --   older versions that are negotiated will appear as not participating
     --   in Peer Sharing to newer versions.
+    -- * Adds `query` to NodeToClientVersionData.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -21,6 +21,7 @@ import           Ouroboros.Network.BlockFetch.ConsensusInterface
 import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Handshake.Acceptable (Accept (..),
                      Acceptable (..))
+import           Ouroboros.Network.Handshake.Queryable (Queryable (..))
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
@@ -128,6 +129,8 @@ instance Acceptable NodeToNodeVersionData where
                        ++ show local
                        ++ " /= " ++ show remote
 
+instance Queryable NodeToNodeVersionData where
+    queryVersion = query
 
 nodeToNodeCodecCBORTerm :: NodeToNodeVersion -> CodecCBORTerm Text NodeToNodeVersionData
 nodeToNodeCodecCBORTerm version

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -69,7 +69,7 @@ import           Ouroboros.Network.Protocol.Handshake
 import           Ouroboros.Network.Protocol.Handshake.Codec
                      (timeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Unversioned
-import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..))
+import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Queryable (..))
 import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.Server.RateLimiting
                      (AcceptedConnectionsLimit (..))
@@ -254,6 +254,7 @@ withBidirectionalConnectionManager snocket makeBearer socket
               haHandshakeCodec = unversionedHandshakeCodec,
               haVersionDataCodec = unversionedProtocolDataCodec,
               haAcceptVersion = acceptableVersion,
+              haQueryVersion = queryVersion,
               haTimeLimits = timeLimitsHandshake
             }
           (unversionedProtocol

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -69,7 +69,8 @@ import           Ouroboros.Network.Protocol.Handshake
 import           Ouroboros.Network.Protocol.Handshake.Codec
                      (timeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Unversioned
-import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Queryable (..))
+import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..),
+                     Queryable (..))
 import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.Server.RateLimiting
                      (AcceptedConnectionsLimit (..))

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -114,8 +114,7 @@ clientPingPong pipelined =
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
       nullNetworkConnectTracers
-      acceptableVersion
-      queryVersion
+      (HandshakeCallbacks acceptableVersion queryVersion)
       (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr
@@ -158,8 +157,7 @@ serverPingPong =
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
-      acceptableVersion
-      queryVersion
+      (HandshakeCallbacks acceptableVersion queryVersion)
       (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->
@@ -218,8 +216,7 @@ clientPingPong2 =
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
       nullNetworkConnectTracers
-      acceptableVersion
-      queryVersion
+      (HandshakeCallbacks acceptableVersion queryVersion)
       (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr
@@ -275,8 +272,7 @@ serverPingPong2 =
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
-      acceptableVersion
-      queryVersion
+      (HandshakeCallbacks acceptableVersion queryVersion)
       (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -115,6 +115,7 @@ clientPingPong pipelined =
       unversionedProtocolDataCodec
       nullNetworkConnectTracers
       acceptableVersion
+      queryVersion
       (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr
@@ -158,6 +159,7 @@ serverPingPong =
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
       acceptableVersion
+      queryVersion
       (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->
@@ -217,6 +219,7 @@ clientPingPong2 =
       unversionedProtocolDataCodec
       nullNetworkConnectTracers
       acceptableVersion
+      queryVersion
       (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr
@@ -273,6 +276,7 @@ serverPingPong2 =
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
       acceptableVersion
+      queryVersion
       (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE KindSignatures            #-}
 {-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE NumericUnderscores        #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TypeOperators             #-}
@@ -280,7 +279,7 @@ makeConnectionHandler muxTracer singMuxMode
                 atomically $ writePromise (Left (HandleHandshakeClientError err))
                 traceWith tracer (TrHandshakeClientError err)
 
-              Right (HandshakeNegotiationResult (app, versionNumber, agreedOptions)) ->
+              Right (HandshakeNegotiationResult app versionNumber agreedOptions) ->
                 unmask $ do
                   traceWith tracer (TrHandshakeSuccess versionNumber agreedOptions)
                   controlMessageBundle
@@ -352,7 +351,7 @@ makeConnectionHandler muxTracer singMuxMode
               Left !err -> do
                 atomically $ writePromise (Left (HandleHandshakeServerError err))
                 traceWith tracer (TrHandshakeServerError err)
-              Right (HandshakeNegotiationResult (app, versionNumber, agreedOptions)) ->
+              Right (HandshakeNegotiationResult app versionNumber agreedOptions) ->
                 unmask $ do
                   traceWith tracer (TrHandshakeSuccess versionNumber agreedOptions)
                   controlMessageBundle
@@ -380,7 +379,7 @@ makeConnectionHandler muxTracer singMuxMode
                 atomically $ writePromise (Right HandshakeConnectionQuery)
                 traceWith tracer $ TrHandshakeQuery vMap
                 -- Wait 20s for client to receive response, who should close the connection.
-                threadDelay 20_000_000
+                threadDelay 20
 
 
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
@@ -178,6 +178,7 @@ makeConnectionHandler
     :: forall peerAddr muxMode socket versionNumber versionData m a b.
        ( Alternative (STM m)
        , MonadAsync m
+       , MonadDelay m
        , MonadFork  m
        , MonadLabelledSTM m
        , MonadThrow (STM m)

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -768,7 +768,7 @@ withConnectionManager ConnectionManagerArguments {
       -> MutableConnState peerAddr handle handleError version m
       -> socket
       -> ConnectionId peerAddr
-      -> PromiseWriter m (Either handleError (handle, (version, versionData)))
+      -> PromiseWriter m (Either handleError (HandshakeConnectionResult handle (version, versionData)))
       -> ConnectionHandlerFn handlerTrace socket peerAddr handle handleError (version, versionData) m
       -> m (Async m ())
     forkConnectionHandler stateVar
@@ -1081,81 +1081,12 @@ withConnectionManager ConnectionManagerArguments {
             res <- atomically $ readPromise reader
             case res of
               Left handleError -> do
-                transitions <- atomically $ do
-                  connState <- readTVar connVar
+                terminateInboundWithErrorOrQuery connId connVar connThread peerAddr stateVar mutableConnState $ Just handleError
 
-                  let connState' =
-                        case classifyHandleError handleError of
-                          HandshakeFailure ->
-                            TerminatingState connId connThread
-                                            (Just handleError)
-                          HandshakeProtocolViolation ->
-                            TerminatedState (Just handleError)
-                      transition = mkTransition connState connState'
-                      absConnState = abstractState (Known connState)
-                      shouldTrace = absConnState /= TerminatedSt
+              Right HandshakeConnectionQuery -> do
+                terminateInboundWithErrorOrQuery connId connVar connThread peerAddr stateVar mutableConnState Nothing
 
-                  updated <-
-                    modifyTMVarSTM
-                      stateVar
-                      ( \state ->
-                        case Map.lookup peerAddr state of
-                          Nothing -> return (state, False)
-                          Just mutableConnState'  ->
-                            if mutableConnState' == mutableConnState
-                              then do
-                                -- 'handleError' might be either a handshake
-                                -- negotiation a protocol failure (an IO
-                                -- exception, a timeout or codec failure).  In
-                                -- the first case we should not reset the
-                                -- connection as this is not a protocol error.
-                                --
-                                -- If we are deleting the connState from the
-                                -- state then connState' can be TerminatingSt in
-                                -- which case we are going to transition
-                                -- TerminatingSt -> TerminatedSt. Otherwise,
-                                -- Connection Manager cleanup will take care of
-                                -- tracing accordingly.
-                                writeTVar connVar connState'
-
-                                return (Map.delete peerAddr state , True)
-                              else return (state                  , False)
-                      )
-
-                  if updated
-                     then
-                    -- Key was present in the dictionary (stateVar) and
-                    -- removed so we trace the removal.
-                      return $
-                        if shouldTrace
-                           then [ transition
-                                , Transition
-                                   { fromState = Known (TerminatedState Nothing)
-                                   , toState   = Unknown
-                                   }
-                                ]
-                           else [ Transition
-                                   { fromState = Known (TerminatedState Nothing)
-                                   , toState   = Unknown
-                                   }
-                                ]
-                    -- Key was not present in the dictionary (stateVar),
-                    -- so we do not trace anything as it was already traced upon
-                    -- deletion.
-                    --
-                    -- OR
-                    --
-                    -- Key was overwritten in the dictionary (stateVar),
-                    -- so we do not trace anything as it was already traced upon
-                    -- overwriting.
-                     else return [ ]
-
-                traverse_ (traceWith trTracer . TransitionTrace peerAddr) transitions
-                traceCounters stateVar
-
-                return (Disconnected connId (Just handleError))
-
-              Right (handle, (version, versionData)) -> do
+              Right (HandshakeConnectionResult handle (version, versionData)) -> do
                 let dataFlow = connectionDataFlow version versionData
                 mbTransition <- atomically $ do
                   connState <- readTVar connVar
@@ -1241,6 +1172,85 @@ withConnectionManager ConnectionManagerArguments {
                                        (ControlChannel.NewConnection Inbound connId dataFlow handle)
                       NotInResponderMode -> return ()
                     return $ Connected connId dataFlow handle
+
+    terminateInboundWithErrorOrQuery connId connVar connThread peerAddr stateVar mutableConnState handleErrorM = do
+        transitions <- atomically $ do
+          connState <- readTVar connVar
+
+          let connState' =
+                case classifyHandleError <$> handleErrorM of
+                  Just HandshakeFailure ->
+                    TerminatingState connId connThread
+                                    handleErrorM
+                  Just HandshakeProtocolViolation ->
+                    TerminatedState handleErrorM
+                  -- On inbound query, connection is terminating.
+                  Nothing ->
+                    TerminatingState connId connThread
+                                    handleErrorM
+              transition = mkTransition connState connState'
+              absConnState = abstractState (Known connState)
+              shouldTrace = absConnState /= TerminatedSt
+
+          updated <-
+            modifyTMVarSTM
+              stateVar
+              ( \state ->
+                case Map.lookup peerAddr state of
+                  Nothing -> return (state, False)
+                  Just mutableConnState'  ->
+                    if mutableConnState' == mutableConnState
+                      then do
+                        -- 'handleError' might be either a handshake
+                        -- negotiation a protocol failure (an IO
+                        -- exception, a timeout or codec failure).  In
+                        -- the first case we should not reset the
+                        -- connection as this is not a protocol error.
+                        --
+                        -- If we are deleting the connState from the
+                        -- state then connState' can be TerminatingSt in
+                        -- which case we are going to transition
+                        -- TerminatingSt -> TerminatedSt. Otherwise,
+                        -- Connection Manager cleanup will take care of
+                        -- tracing accordingly.
+                        writeTVar connVar connState'
+
+                        return (Map.delete peerAddr state , True)
+                      else return (state                  , False)
+              )
+
+          if updated
+             then
+            -- Key was present in the dictionary (stateVar) and
+            -- removed so we trace the removal.
+              return $
+                if shouldTrace
+                   then [ transition
+                        , Transition
+                           { fromState = Known (TerminatedState Nothing)
+                           , toState   = Unknown
+                           }
+                        ]
+                   else [ Transition
+                           { fromState = Known (TerminatedState Nothing)
+                           , toState   = Unknown
+                           }
+                        ]
+            -- Key was not present in the dictionary (stateVar),
+            -- so we do not trace anything as it was already traced upon
+            -- deletion.
+            --
+            -- OR
+            --
+            -- Key was overwritten in the dictionary (stateVar),
+            -- so we do not trace anything as it was already traced upon
+            -- overwriting.
+             else return [ ]
+
+        traverse_ (traceWith trTracer . TransitionTrace peerAddr) transitions
+        traceCounters stateVar
+
+        return (Disconnected connId handleErrorM)
 
     -- We need 'mask' in order to guarantee that the traces are logged if an
     -- async exception lands between the successful STM action and the logging
@@ -1711,73 +1721,12 @@ withConnectionManager ConnectionManagerArguments {
             res <- atomically (readPromise reader)
             case res of
               Left handleError -> do
-                transitions <- atomically $ do
-                  connState <- readTVar connVar
+                terminateOutboundWithErrorOrQuery connId connVar connThread peerAddr stateVar mutableConnState $ Just handleError
 
-                  let connState' =
-                        case classifyHandleError handleError of
-                          HandshakeFailure ->
-                            TerminatingState connId connThread
-                                            (Just handleError)
-                          HandshakeProtocolViolation ->
-                            TerminatedState (Just handleError)
-                      transition = mkTransition connState connState'
-                      absConnState = abstractState (Known connState)
-                      shouldTrace = absConnState /= TerminatedSt
+              Right HandshakeConnectionQuery -> do
+                terminateOutboundWithErrorOrQuery connId connVar connThread peerAddr stateVar mutableConnState Nothing
 
-                  -- 'handleError' might be either a handshake negotiation
-                  -- a protocol failure (an IO exception, a timeout or
-                  -- codec failure).  In the first case we should not reset
-                  -- the connection as this is not a protocol error.
-                  writeTVar connVar connState'
-
-                  updated <-
-                    modifyTMVarPure
-                      stateVar
-                      ( \state ->
-                        case Map.lookup peerAddr state of
-                          Nothing -> (state, False)
-                          Just mutableConnState'  ->
-                            if mutableConnState' == mutableConnState
-                              then (Map.delete peerAddr state , True)
-                              else (state                     , False)
-                      )
-
-                  if updated
-                     then
-                    -- Key was present in the dictionary (stateVar) and
-                    -- removed so we trace the removal.
-                      return $
-                        if shouldTrace
-                           then [ transition
-                                , Transition
-                                   { fromState = Known (TerminatedState Nothing)
-                                   , toState   = Unknown
-                                   }
-                                ]
-                           else [ Transition
-                                   { fromState = Known (TerminatedState Nothing)
-                                   , toState   = Unknown
-                                   }
-                                ]
-                    -- Key was not present in the dictionary (stateVar),
-                    -- so we do not trace anything as it was already traced upon
-                    -- deletion.
-                    --
-                    -- OR
-                    --
-                    -- Key was overwritten in the dictionary (stateVar),
-                    -- so we do not trace anything as it was already traced upon
-                    -- overwriting.
-                     else return [ ]
-
-
-                traverse_ (traceWith trTracer . TransitionTrace peerAddr) transitions
-                traceCounters stateVar
-
-                return (Disconnected connId (Just handleError))
-
-              Right (handle, (version, versionData)) -> do
+              Right (HandshakeConnectionResult handle (version, versionData)) -> do
                 let dataFlow = connectionDataFlow version versionData
                 -- We can safely overwrite the state: after successful
                 -- `connect` it's not possible to have a race condition
@@ -1919,6 +1868,85 @@ withConnectionManager ConnectionManagerArguments {
           Right (Here connected) -> do
             traceCounters stateVar
             return connected
+
+    terminateOutboundWithErrorOrQuery
+        :: ConnectionId peerAddr
+        -> StrictTVar m (ConnectionState peerAddr handle handleError version m)
+        -> Async m ()
+        -> peerAddr
+        -> StrictTMVar m (ConnectionManagerState peerAddr handle handleError version m)
+        -> MutableConnState peerAddr handle handleError version m
+        -> Maybe handleError
+        -> m (Connected peerAddr handle handleError)
+    terminateOutboundWithErrorOrQuery connId connVar connThread peerAddr stateVar mutableConnState handleErrorM = do
+        transitions <- atomically $ do
+          connState <- readTVar connVar
+
+          let connState' =
+                case classifyHandleError <$> handleErrorM of
+                  Just HandshakeFailure ->
+                    TerminatingState connId connThread
+                                    handleErrorM
+                  Just HandshakeProtocolViolation ->
+                    TerminatedState handleErrorM
+                  -- On outbound query, connection is terminated.
+                  Nothing ->
+                    TerminatedState handleErrorM
+              transition = mkTransition connState connState'
+              absConnState = abstractState (Known connState)
+              shouldTrace = absConnState /= TerminatedSt
+
+          -- 'handleError' might be either a handshake negotiation
+          -- a protocol failure (an IO exception, a timeout or
+          -- codec failure).  In the first case we should not reset
+          -- the connection as this is not a protocol error.
+          writeTVar connVar connState'
+
+          updated <-
+            modifyTMVarPure
+              stateVar
+              ( \state ->
+                case Map.lookup peerAddr state of
+                  Nothing -> (state, False)
+                  Just mutableConnState'  ->
+                    if mutableConnState' == mutableConnState
+                      then (Map.delete peerAddr state , True)
+                      else (state                     , False)
+              )
+
+          if updated
+             then
+            -- Key was present in the dictionary (stateVar) and
+            -- removed so we trace the removal.
+              return $
+                if shouldTrace
+                   then [ transition
+                        , Transition
+                           { fromState = Known (TerminatedState Nothing)
+                           , toState   = Unknown
+                           }
+                        ]
+                   else [ Transition
+                           { fromState = Known (TerminatedState Nothing)
+                           , toState   = Unknown
+                           }
+                        ]
+            -- Key was not present in the dictionary (stateVar),
+            -- so we do not trace anything as it was already traced upon
+            -- deletion.
+            --
+            -- OR
+            --
+            -- Key was overwritten in the dictionary (stateVar),
+            -- so we do not trace anything as it was already traced upon
+            -- overwriting.
+             else return [ ]
+
+
+        traverse_ (traceWith trTracer . TransitionTrace peerAddr) transitions
+        traceCounters stateVar
+
+        return (Disconnected connId handleErrorM)
 
 
     unregisterOutboundConnectionImpl

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -100,6 +100,7 @@ module Ouroboros.Network.ConnectionManager.Types
   , Inactive (..)
   , ExceptionInHandler (..)
   , HandleErrorType (..)
+  , HandshakeConnectionResult (..)
     -- ** Prune Policy
   , PrunePolicy
   , simplePrunePolicy
@@ -342,12 +343,20 @@ newtype MaskedAction m a = MaskedAction {
 --
 type ConnectionHandlerFn handlerTrace socket peerAddr handle handleError version m
      = socket
-    -> PromiseWriter m (Either handleError (handle, version))
+    -> PromiseWriter m (Either handleError (HandshakeConnectionResult handle version))
     -> Tracer m handlerTrace
     -> ConnectionId peerAddr
     -> (DiffTime -> socket -> m (MuxBearer m))
     -> MaskedAction m ()
 
+data HandshakeConnectionResult handle version
+  -- | Handshake saw a query.
+  --
+  = HandshakeConnectionQuery
+
+  -- | Handshake resulted in a connection and version.
+  --
+  | HandshakeConnectionResult handle version
 
 -- | Connection handler action.  It is index by @muxMode :: 'MuxMode'@.
 -- There's one 'ConnectionHandlerFn' per provenance, possibly limited by

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -97,6 +97,9 @@ data HandshakeArguments connectionId vNumber vData m = HandshakeArguments {
       -- argument is the remote version data.
       haAcceptVersion :: vData -> vData -> Accept vData,
 
+      -- | Whether version data requested a query of support version.
+      haQueryVersion :: vData -> Bool,
+
       -- | 'Driver' timeouts for 'Handshake' protocol.
       --
       haTimeLimits
@@ -165,6 +168,7 @@ runHandshakeServer bearer
                      haHandshakeCodec,
                      haVersionDataCodec,
                      haAcceptVersion,
+                     haQueryVersion,
                      haTimeLimits
                    }
                    versions  =
@@ -176,4 +180,4 @@ runHandshakeServer bearer
           byteLimitsHandshake
           haTimeLimits
           (fromChannel (muxBearerAsChannel bearer handshakeProtocolNum ResponderDir))
-          (handshakeServerPeer haVersionDataCodec haAcceptVersion versions))
+          (handshakeServerPeer haVersionDataCodec haAcceptVersion haQueryVersion versions))

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -98,6 +98,7 @@ data HandshakeArguments connectionId vNumber vData m = HandshakeArguments {
       haAcceptVersion :: vData -> vData -> Accept vData,
 
       -- | Whether version data requested a query of support version.
+      --
       haQueryVersion :: vData -> Bool,
 
       -- | 'Driver' timeouts for 'Handshake' protocol.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -7,6 +7,7 @@
 
 module Ouroboros.Network.Protocol.Handshake.Client
   ( handshakeClientPeer
+  , encodeVersions
   , acceptOrRefuse
   ) where
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -52,8 +52,8 @@ handshakeClientPeer codec@VersionDataCodec {encodeData, decodeData}
         -- simultaneous open; 'accept' will choose version (the greatest common
         -- version), and check if we can accept received version data.
         Done TokDone $ case acceptOrRefuse codec acceptVersion versions vMap of
-          Right r      -> Right $ HandshakeNegotiationResult r
-          Left vReason -> Left (HandshakeError vReason)
+          Right (r, vNumber, vData) -> Right $ HandshakeNegotiationResult r vNumber vData
+          Left vReason              -> Left (HandshakeError vReason)
 
       MsgQueryReply vMap ->
         Done TokDone $ Right $ decodeQueryResult decodeData vMap
@@ -76,10 +76,9 @@ handshakeClientPeer codec@VersionDataCodec {encodeData, decodeData}
               Right vData' ->
                 case acceptVersion vData vData' of
                   Accept agreedData ->
-                    Done TokDone $ Right $ HandshakeNegotiationResult $ ( app agreedData
-                                                                        , vNumber
-                                                                        , agreedData
-                                                                        )
+                    Done TokDone $ Right $ HandshakeNegotiationResult (app agreedData)
+                                                                      vNumber
+                                                                      agreedData
                   Refuse err ->
                     Done TokDone (Left (InvalidServerSelection vNumber err))
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -93,6 +93,8 @@ handshakeClientPeerTestVersions VersionDataCodec {encodeData, decodeData}
   Yield (ClientAgency TokPropose) (MsgProposeVersions $ encodeVersions encodeData versions) $
 
     Await (ServerAgency TokConfirm) $ \msg -> case msg of
+      MsgQueryReply vMap ->
+        Done TokDone $ eitherToMaybe $ sequence $ Map.mapWithKey decodeData vMap
       MsgReplyVersions vMap ->
         Done TokDone $ eitherToMaybe $ sequence $ Map.mapWithKey decodeData vMap
       MsgRefuse _vReason ->

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
@@ -141,6 +141,8 @@ codecHandshake versionNumberCodec = mkCodecCborLazyBS encodeMsg decodeMsg
         <> CBOR.encodeWord 0
         <> encodeVersions versionNumberCodec vs
 
+      -- Although `MsgReplyVersions` shall not be sent, for testing purposes it
+      -- is useful to have an encoder for it.
       encodeMsg (ServerAgency TokConfirm) (MsgReplyVersions vs)
         = CBOR.encodeListLen 2
         <> CBOR.encodeWord 0
@@ -156,6 +158,11 @@ codecHandshake versionNumberCodec = mkCodecCborLazyBS encodeMsg decodeMsg
            CBOR.encodeListLen 2
         <> CBOR.encodeWord 2
         <> encodeRefuseReason versionNumberCodec vReason
+
+      encodeMsg (ServerAgency TokConfirm) (MsgQueryReply vs)
+        = CBOR.encodeListLen 2
+        <> CBOR.encodeWord 3
+        <> encodeVersions versionNumberCodec vs
 
       decodeMsg :: forall (pr :: PeerRole) s (st :: Handshake vNumber CBOR.Term).
                    PeerHasAgency pr st
@@ -183,6 +190,10 @@ codecHandshake versionNumberCodec = mkCodecCborLazyBS encodeMsg decodeMsg
                 SomeMessage . MsgAcceptVersion vNumber <$> CBOR.decodeTerm
           (ServerAgency TokConfirm, 2, 2) ->
             SomeMessage . MsgRefuse <$> decodeRefuseReason versionNumberCodec
+          (ServerAgency TokConfirm, 3, 2) -> do
+            l  <- CBOR.decodeMapLen
+            vMap <- decodeVersions versionNumberCodec l
+            pure $ SomeMessage $ MsgQueryReply vMap
 
           (ClientAgency TokPropose, _, _) ->
             fail $ printf "codecHandshake (%s) unexpected key (%d, %d)" (show stok) key len

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
@@ -141,8 +141,6 @@ codecHandshake versionNumberCodec = mkCodecCborLazyBS encodeMsg decodeMsg
         <> CBOR.encodeWord 0
         <> encodeVersions versionNumberCodec vs
 
-      -- Although `MsgReplyVersions` shall not be sent, for testing purposes it
-      -- is useful to have an encoder for it.
       encodeMsg (ServerAgency TokConfirm) (MsgReplyVersions vs)
         = CBOR.encodeListLen 2
         <> CBOR.encodeWord 0

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -10,7 +10,7 @@ import qualified Codec.CBOR.Term as CBOR
 
 import           Network.TypedProtocol.Core
 
-import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse, encodeVersions)
+import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse, decodeQueryResult, encodeVersions)
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
@@ -28,21 +28,21 @@ handshakeServerPeer
   -> Versions vNumber vData r
   -> Peer (Handshake vNumber CBOR.Term)
           AsServer StPropose m
-          (Either (HandshakeProtocolError vNumber) (r, vNumber, vData))
-handshakeServerPeer codec@VersionDataCodec {encodeData} acceptVersion query versions =
+          (HandshakeResult r vNumber vData)
+handshakeServerPeer codec@VersionDataCodec {encodeData, decodeData} acceptVersion query versions =
     Await (ClientAgency TokPropose) $ \msg -> case msg of
       MsgProposeVersions vMap  ->
         case acceptOrRefuse codec acceptVersion versions vMap of
           (Right r@(_, vNumber, agreedData)) ->
-            let response = if query agreedData then
-                    MsgQueryReply $ encodeVersions encodeData versions
+            let (response, r') = if query agreedData then
+                    (MsgQueryReply $ encodeVersions encodeData versions, decodeQueryResult decodeData vMap)
                   else
-                    MsgAcceptVersion vNumber $ encodeData vNumber agreedData
+                    (MsgAcceptVersion vNumber $ encodeData vNumber agreedData, HandshakeNegotiationResult r)
             in
             Yield (ServerAgency TokConfirm)
                   response
-                  (Done TokDone (Right r))
+                  (Done TokDone r')
           (Left vReason) ->
             Yield (ServerAgency TokConfirm)
                   (MsgRefuse vReason)
-                  (Done TokDone (Left (HandshakeError vReason)))
+                  (Done TokDone (HandshakeResultError (HandshakeError vReason)))

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -10,7 +10,7 @@ import qualified Codec.CBOR.Term as CBOR
 
 import           Network.TypedProtocol.Core
 
-import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse)
+import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse, encodeVersions)
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
@@ -24,17 +24,23 @@ handshakeServerPeer
      )
   => VersionDataCodec CBOR.Term vNumber vData
   -> (vData -> vData -> Accept vData)
+  -> (vData -> Bool)
   -> Versions vNumber vData r
   -> Peer (Handshake vNumber CBOR.Term)
           AsServer StPropose m
           (Either (HandshakeProtocolError vNumber) (r, vNumber, vData))
-handshakeServerPeer codec@VersionDataCodec {encodeData} acceptVersion versions =
+handshakeServerPeer codec@VersionDataCodec {encodeData} acceptVersion query versions =
     Await (ClientAgency TokPropose) $ \msg -> case msg of
       MsgProposeVersions vMap  ->
         case acceptOrRefuse codec acceptVersion versions vMap of
           (Right r@(_, vNumber, agreedData)) ->
+            let response = if query agreedData then
+                    (MsgReplyVersions $ encodeVersions encodeData versions)
+                  else
+                    (MsgAcceptVersion vNumber (encodeData vNumber agreedData))
+            in
             Yield (ServerAgency TokConfirm)
-                  (MsgAcceptVersion vNumber (encodeData vNumber agreedData))
+                  response
                   (Done TokDone (Right r))
           (Left vReason) ->
             Yield (ServerAgency TokConfirm)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -10,7 +10,8 @@ import qualified Codec.CBOR.Term as CBOR
 
 import           Network.TypedProtocol.Core
 
-import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse, decodeQueryResult, encodeVersions)
+import           Ouroboros.Network.Protocol.Handshake.Client (acceptOrRefuse,
+                     decodeQueryResult, encodeVersions)
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -28,7 +28,9 @@ handshakeServerPeer
   -> Versions vNumber vData r
   -> Peer (Handshake vNumber CBOR.Term)
           AsServer StPropose m
-          (HandshakeResult r vNumber vData)
+          (Either
+            (HandshakeProtocolError vNumber)
+            (HandshakeResult r vNumber vData))
 handshakeServerPeer codec@VersionDataCodec {encodeData, decodeData} acceptVersion query versions =
     Await (ClientAgency TokPropose) $ \msg -> case msg of
       MsgProposeVersions vMap  ->
@@ -41,8 +43,8 @@ handshakeServerPeer codec@VersionDataCodec {encodeData, decodeData} acceptVersio
             in
             Yield (ServerAgency TokConfirm)
                   response
-                  (Done TokDone r')
+                  (Done TokDone (Right r'))
           (Left vReason) ->
             Yield (ServerAgency TokConfirm)
                   (MsgRefuse vReason)
-                  (Done TokDone (HandshakeResultError (HandshakeError vReason)))
+                  (Done TokDone (Left (HandshakeError vReason)))

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -35,11 +35,11 @@ handshakeServerPeer codec@VersionDataCodec {encodeData, decodeData} acceptVersio
     Await (ClientAgency TokPropose) $ \msg -> case msg of
       MsgProposeVersions vMap  ->
         case acceptOrRefuse codec acceptVersion versions vMap of
-          (Right r@(_, vNumber, agreedData)) ->
+          (Right (r, vNumber, agreedData)) ->
             let (response, r') = if query agreedData then
                     (MsgQueryReply $ encodeVersions encodeData versions, decodeQueryResult decodeData vMap)
                   else
-                    (MsgAcceptVersion vNumber $ encodeData vNumber agreedData, HandshakeNegotiationResult r)
+                    (MsgAcceptVersion vNumber $ encodeData vNumber agreedData, HandshakeNegotiationResult r vNumber agreedData)
             in
             Yield (ServerAgency TokConfirm)
                   response

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -35,7 +35,7 @@ handshakeServerPeer codec@VersionDataCodec {encodeData} acceptVersion query vers
         case acceptOrRefuse codec acceptVersion versions vMap of
           (Right r@(_, vNumber, agreedData)) ->
             let response = if query agreedData then
-                    MsgReplyVersions $ encodeVersions encodeData versions
+                    MsgQueryReply $ encodeVersions encodeData versions
                   else
                     MsgAcceptVersion vNumber $ encodeData vNumber agreedData
             in

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -35,9 +35,9 @@ handshakeServerPeer codec@VersionDataCodec {encodeData} acceptVersion query vers
         case acceptOrRefuse codec acceptVersion versions vMap of
           (Right r@(_, vNumber, agreedData)) ->
             let response = if query agreedData then
-                    (MsgReplyVersions $ encodeVersions encodeData versions)
+                    MsgReplyVersions $ encodeVersions encodeData versions
                   else
-                    (MsgAcceptVersion vNumber (encodeData vNumber agreedData))
+                    MsgAcceptVersion vNumber $ encodeData vNumber agreedData
             in
             Yield (ServerAgency TokConfirm)
                   response

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -31,6 +31,7 @@ import           Data.Text (Text)
 import           Data.Typeable (Typeable)
 
 import           Network.TypedProtocol.Core
+import           Ouroboros.Network.Driver.Limits
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 -- |
@@ -159,8 +160,9 @@ data HandshakeProtocolError vNumber
 --
 data HandshakeResult r vNumber vData
   = HandshakeNegotiationResult (r, vNumber, vData)
-  | HandshakeQueryResult (Map vNumber vData) -- vParams)
+  | HandshakeQueryResult (Map vNumber vData)
   | HandshakeResultError (HandshakeProtocolError vNumber)
+  | HandshakeProtocolLimit ProtocolLimitFailure
 
 instance (Typeable vNumber, Show vNumber)
     => Exception (HandshakeProtocolError vNumber)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -81,11 +81,20 @@ instance Protocol (Handshake vNumber vParams) where
 
       -- |
       -- `MsgReplyVersions` received as a response to 'MsgProposeVersions'.  It
-      -- is only explicitly sent when a version query was received. Previously, it
-      -- could only be received as a copy of 'MsgProposeVersions' in a simultaneous
-      -- open scenario.
+      -- is not supported to explicitly send this message. It can only be
+      -- received as a copy of 'MsgProposeVersions' in a simultaneous open
+      -- scenario.
       --
       MsgReplyVersions
+        :: Map vNumber vParams
+        -> Message (Handshake vNumber vParams) StConfirm StDone
+
+      -- |
+      -- `MsgQueryReply` received as a response to 'MsgProposeVersions'.  It
+      -- is only sent when a version query was received. This will cause the
+      -- connection to terminate.
+      --
+      MsgQueryReply
         :: Map vNumber vParams
         -> Message (Handshake vNumber vParams) StConfirm StDone
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -153,13 +153,13 @@ data HandshakeProtocolError vNumber
   = HandshakeError (RefuseReason vNumber)
   | NotRecognisedVersion vNumber
   | InvalidServerSelection vNumber Text
-  | QueryNotSupportedInThisVersion
+  | QueryNotSupported
   deriving (Eq, Show)
 
 -- | The result of a handshake.
 --
 data HandshakeResult r vNumber vData
-  = HandshakeNegotiationResult (r, vNumber, vData)
+  = HandshakeNegotiationResult r vNumber vData
   | HandshakeQueryResult (Map vNumber (Either Text vData))
 
 instance (Typeable vNumber, Show vNumber)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -31,7 +31,6 @@ import           Data.Text (Text)
 import           Data.Typeable (Typeable)
 
 import           Network.TypedProtocol.Core
-import           Ouroboros.Network.Driver.Limits
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 -- |
@@ -160,9 +159,7 @@ data HandshakeProtocolError vNumber
 --
 data HandshakeResult r vNumber vData
   = HandshakeNegotiationResult (r, vNumber, vData)
-  | HandshakeQueryResult (Map vNumber vData)
-  | HandshakeResultError (HandshakeProtocolError vNumber)
-  | HandshakeProtocolLimit ProtocolLimitFailure
+  | HandshakeQueryResult (Map vNumber (Either Text vData))
 
 instance (Typeable vNumber, Show vNumber)
     => Exception (HandshakeProtocolError vNumber)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -81,9 +81,9 @@ instance Protocol (Handshake vNumber vParams) where
 
       -- |
       -- `MsgReplyVersions` received as a response to 'MsgProposeVersions'.  It
-      -- is not supported to explicitly send this message. It can only be
-      -- received as a copy of 'MsgProposeVersions' in a simultaneous open
-      -- scenario.
+      -- is only explicitly sent when a version query was received. Previously, it
+      -- could only be received as a copy of 'MsgProposeVersions' in a simultaneous
+      -- open scenario.
       --
       MsgReplyVersions
         :: Map vNumber vParams

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -153,6 +153,7 @@ data HandshakeProtocolError vNumber
   = HandshakeError (RefuseReason vNumber)
   | NotRecognisedVersion vNumber
   | InvalidServerSelection vNumber Text
+  | QueryNotSupportedInThisVersion
   deriving (Eq, Show)
 
 -- | The result of a handshake.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -21,6 +21,7 @@ module Ouroboros.Network.Protocol.Handshake.Type
     -- $simultanous-open
   , RefuseReason (..)
   , HandshakeProtocolError (..)
+  , HandshakeResult (..)
   ) where
 
 
@@ -153,6 +154,13 @@ data HandshakeProtocolError vNumber
   | NotRecognisedVersion vNumber
   | InvalidServerSelection vNumber Text
   deriving (Eq, Show)
+
+-- | The result of a handshake.
+--
+data HandshakeResult r vNumber vData
+  = HandshakeNegotiationResult (r, vNumber, vData)
+  | HandshakeQueryResult (Map vNumber vData) -- vParams)
+  | HandshakeResultError (HandshakeProtocolError vNumber)
 
 instance (Typeable vNumber, Show vNumber)
     => Exception (HandshakeProtocolError vNumber)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
@@ -45,6 +45,9 @@ instance Acceptable UnversionedProtocolData where
   acceptableVersion UnversionedProtocolData
                     UnversionedProtocolData = Accept UnversionedProtocolData
 
+instance Queryable UnversionedProtocolData where
+  queryVersion UnversionedProtocolData = False
+
 
 unversionedProtocolDataCodec :: VersionDataCodec CBOR.Term UnversionedProtocol
                                                            UnversionedProtocolData
@@ -77,6 +80,9 @@ newtype DataFlowProtocolData =
 instance Acceptable DataFlowProtocolData where
   acceptableVersion (DataFlowProtocolData local) (DataFlowProtocolData remote) =
     Accept (DataFlowProtocolData $ local `min` remote)
+
+instance Queryable DataFlowProtocolData where
+  queryVersion (DataFlowProtocolData _) = False
 
 dataFlowProtocolDataCodec :: UnversionedProtocol -> CodecCBORTerm Text DataFlowProtocolData
 dataFlowProtocolDataCodec _ = CodecCBORTerm {encodeTerm, decodeTerm}

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
@@ -19,6 +19,7 @@ module Ouroboros.Network.Protocol.Handshake.Version
     -- * Re-exports
   , Accept (..)
   , Acceptable (..)
+  , Queryable (..)
   ) where
 
 import           Data.Foldable (toList)
@@ -28,6 +29,7 @@ import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Network.Handshake.Acceptable (Accept (..),
                      Acceptable (..))
+import           Ouroboros.Network.Handshake.Queryable (Queryable (..))
 
 
 -- | The version map supported by the local agent keyed on the version

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE NumericUnderscores  #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -363,7 +362,7 @@ connectToNode' sn makeBearer handshakeCodec handshakeTimeLimits versionDataCodec
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientError err (diffTime ts_end ts_start)
              throwIO err
 
-         Right (HandshakeNegotiationResult (app, _versionNumber, _agreedOptions)) -> do
+         Right (HandshakeNegotiationResult app _versionNumber _agreedOptions) -> do
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
              bearer <- Mx.getBearer makeBearer sduTimeout muxTracer sd
              Mx.muxStart
@@ -373,7 +372,7 @@ connectToNode' sn makeBearer handshakeCodec handshakeTimeLimits versionDataCodec
 
          Right (HandshakeQueryResult _vMap) -> do
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
-             throwIO (QueryNotSupportedInThisVersion @vNumber)
+             throwIO (QueryNotSupported @vNumber)
 
 
 -- Wraps a Socket inside a Snocket and calls connectToNode'
@@ -494,7 +493,7 @@ beginConnection makeBearer muxTracer handshakeTracer handshakeCodec handshakeTim
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerError err
                  throwIO err
 
-             Right (HandshakeNegotiationResult (SomeResponderApplication app, _versionNumber, _agreedOptions)) -> do
+             Right (HandshakeNegotiationResult (SomeResponderApplication app) _versionNumber _agreedOptions) -> do
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
                  bearer <- Mx.getBearer makeBearer sduTimeout muxTracer' sd
                  Mx.muxStart
@@ -505,7 +504,7 @@ beginConnection makeBearer muxTracer handshakeTracer handshakeCodec handshakeTim
              Right (HandshakeQueryResult _vMap) -> do
                  traceWith muxTracer' Mx.MuxTraceHandshakeServerEnd
                  -- Wait 20s for client to receive response, who should close the connection.
-                 threadDelay 20_000_000
+                 threadDelay 20
 
       RejectConnection st' _peerid -> pure $ Server.Reject st'
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -8,8 +8,8 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
 
 -- it is useful to have 'HasInitiator' constraint on 'connectToNode' & friends.
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -360,13 +360,17 @@ connectToNode' sn makeBearer handshakeCodec handshakeTimeLimits versionDataCodec
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientError err (diffTime ts_end ts_start)
              throwIO err
 
-         Right (app, _versionNumber, _agreedOptions) -> do
+         Right (HandshakeNegotiationResult (app, _versionNumber, _agreedOptions)) -> do
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
              bearer <- Mx.getBearer makeBearer sduTimeout muxTracer sd
              Mx.muxStart
                muxTracer
                (toApplication connectionId (continueForever (Proxy :: Proxy IO)) app)
                bearer
+
+         Right (HandshakeQueryResult vMap) -> do
+             traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
+             error "TODO"
 
 
 -- Wraps a Socket inside a Snocket and calls connectToNode'
@@ -487,13 +491,17 @@ beginConnection makeBearer muxTracer handshakeTracer handshakeCodec handshakeTim
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerError err
                  throwIO err
 
-             Right (SomeResponderApplication app, _versionNumber, _agreedOptions) -> do
+             Right (HandshakeNegotiationResult (SomeResponderApplication app, _versionNumber, _agreedOptions)) -> do
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
                  bearer <- Mx.getBearer makeBearer sduTimeout muxTracer' sd
                  Mx.muxStart
                    muxTracer'
                    (toApplication connectionId (continueForever (Proxy :: Proxy IO)) app)
                    bearer
+
+             Right (HandshakeQueryResult vMap) -> do
+                 traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
+                 error "TODO"
 
       RejectConnection st' _peerid -> pure $ Server.Reject st'
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/ConnectionManager.hs
@@ -611,10 +611,11 @@ mkConnectionHandler snocket =
            labelThisThread ("handler-" ++ show addr ++ "-" ++ show (seIdx se))
            unmask (threadDelay (seHandshakeDelay se))
            atomically (writePromise promise
-                        (Right ( Handle { hScheduleEntry = se
+                        (Right (HandshakeConnectionResult
+                                 Handle { hScheduleEntry = se
                                         , hThreadId = threadId
                                         }
-                               , (Version (seDataFlow se), ())
+                                 (Version (seDataFlow se), ())
                                )))
 
            -- The connection manager throws async exception to kill the

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -100,7 +100,8 @@ import           Ouroboros.Network.Protocol.Handshake.Codec
                      timeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
 import           Ouroboros.Network.Protocol.Handshake.Unversioned
-import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Queryable (..))
+import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..),
+                     Queryable (..))
 import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.Server.RateLimiting
                      (AcceptedConnectionsLimit (..))

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Server2.hs
@@ -100,7 +100,7 @@ import           Ouroboros.Network.Protocol.Handshake.Codec
                      timeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
 import           Ouroboros.Network.Protocol.Handshake.Unversioned
-import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..))
+import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Queryable (..))
 import           Ouroboros.Network.RethrowPolicy
 import           Ouroboros.Network.Server.RateLimiting
                      (AcceptedConnectionsLimit (..))
@@ -379,6 +379,7 @@ withInitiatorOnlyConnectionManager name timeouts trTracer cmTracer snocket makeB
             haHandshakeCodec = unversionedHandshakeCodec,
             haVersionDataCodec = cborTermVersionDataCodec dataFlowProtocolDataCodec,
             haAcceptVersion = acceptableVersion,
+            haQueryVersion = queryVersion,
             haTimeLimits = handshakeTimeLimits
           }
         (dataFlowProtocol Unidirectional clientApplication)
@@ -559,6 +560,7 @@ withBidirectionalConnectionManager name timeouts
               haHandshakeCodec = unversionedHandshakeCodec,
               haVersionDataCodec = cborTermVersionDataCodec dataFlowProtocolDataCodec,
               haAcceptVersion = acceptableVersion,
+              haQueryVersion = queryVersion,
               haTimeLimits = handshakeTimeLimits
             }
           (dataFlowProtocol Duplex serverApplication)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -259,8 +259,7 @@ prop_socket_send_recv initiatorAddr responderAddr configureSock f xs =
         unversionedHandshakeCodec
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
-        acceptableVersion
-        queryVersion
+        (HandshakeCallbacks acceptableVersion queryVersion)
         (unversionedProtocol (SomeResponderApplication responderApp))
         nullErrorPolicies
         $ \_ _ -> do
@@ -272,8 +271,7 @@ prop_socket_send_recv initiatorAddr responderAddr configureSock f xs =
             noTimeLimitsHandshake
             unversionedProtocolDataCodec
             (NetworkConnectTracers activeMuxTracer nullTracer)
-            acceptableVersion
-            queryVersion
+            (HandshakeCallbacks acceptableVersion queryVersion)
             (unversionedProtocol initiatorApp)
             (Just initiatorAddr)
             responderAddr
@@ -518,8 +516,7 @@ prop_socket_client_connect_error _ xs =
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
         nullNetworkConnectTracers
-        acceptableVersion
-        queryVersion
+        (HandshakeCallbacks acceptableVersion queryVersion)
         (unversionedProtocol app)
         (Just $ Socket.addrAddress clientAddr)
         (Socket.addrAddress serverAddr)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -260,6 +260,7 @@ prop_socket_send_recv initiatorAddr responderAddr configureSock f xs =
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
         acceptableVersion
+        queryVersion
         (unversionedProtocol (SomeResponderApplication responderApp))
         nullErrorPolicies
         $ \_ _ -> do
@@ -272,6 +273,7 @@ prop_socket_send_recv initiatorAddr responderAddr configureSock f xs =
             unversionedProtocolDataCodec
             (NetworkConnectTracers activeMuxTracer nullTracer)
             acceptableVersion
+            queryVersion
             (unversionedProtocol initiatorApp)
             (Just initiatorAddr)
             responderAddr
@@ -517,6 +519,7 @@ prop_socket_client_connect_error _ xs =
         unversionedProtocolDataCodec
         nullNetworkConnectTracers
         acceptableVersion
+        queryVersion
         (unversionedProtocol app)
         (Just $ Socket.addrAddress clientAddr)
         (Socket.addrAddress serverAddr)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -602,6 +602,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
         acceptableVersion
+        queryVersion
         (unversionedProtocol (SomeResponderApplication responderApp))
         nullErrorPolicies
         $ \_ _ -> do
@@ -628,6 +629,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
                 unversionedProtocolDataCodec
                 nullNetworkConnectTracers
                 acceptableVersion
+                queryVersion
                 (unversionedProtocol initiatorApp))
 
     res <- atomically $ (,) <$> takeTMVar sv <*> takeTMVar cv
@@ -750,6 +752,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
         acceptableVersion
+        queryVersion
         (unversionedProtocol (SomeResponderApplication (appX rrcfg)))
         nullErrorPolicies
         $ \localAddr _ -> do
@@ -773,6 +776,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
           noTimeLimitsHandshake
           unversionedProtocolDataCodec
           acceptableVersion
+          queryVersion
           (unversionedProtocol (SomeResponderApplication (appX rrcfg)))
           nullErrorPolicies
           $ \localAddr _ -> do
@@ -800,6 +804,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
                   unversionedProtocolDataCodec
                   nullNetworkConnectTracers
                   acceptableVersion
+                  queryVersion
                   (unversionedProtocol (appX rrcfg)))
 
             atomically $ (,) <$> takeTMVar (rrcServerVar rrcfg)
@@ -873,6 +878,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
                 unversionedProtocolDataCodec
                 nullNetworkConnectTracers
                 acceptableVersion
+                queryVersion
                 (unversionedProtocol appReq))
 
     threadDelay 130
@@ -897,6 +903,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
             noTimeLimitsHandshake
             unversionedProtocolDataCodec
             acceptableVersion
+            queryVersion
             (unversionedProtocol (SomeResponderApplication appRsp))
             nullErrorPolicies
             (\_ _ -> threadDelay delay)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -601,8 +601,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
         unversionedHandshakeCodec
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
-        acceptableVersion
-        queryVersion
+        (HandshakeCallbacks acceptableVersion queryVersion)
         (unversionedProtocol (SomeResponderApplication responderApp))
         nullErrorPolicies
         $ \_ _ -> do
@@ -628,8 +627,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
                 noTimeLimitsHandshake
                 unversionedProtocolDataCodec
                 nullNetworkConnectTracers
-                acceptableVersion
-                queryVersion
+                (HandshakeCallbacks acceptableVersion queryVersion)
                 (unversionedProtocol initiatorApp))
 
     res <- atomically $ (,) <$> takeTMVar sv <*> takeTMVar cv
@@ -751,8 +749,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
         unversionedHandshakeCodec
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
-        acceptableVersion
-        queryVersion
+        (HandshakeCallbacks acceptableVersion queryVersion)
         (unversionedProtocol (SomeResponderApplication (appX rrcfg)))
         nullErrorPolicies
         $ \localAddr _ -> do
@@ -775,8 +772,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
           unversionedHandshakeCodec
           noTimeLimitsHandshake
           unversionedProtocolDataCodec
-          acceptableVersion
-          queryVersion
+          (HandshakeCallbacks acceptableVersion queryVersion)
           (unversionedProtocol (SomeResponderApplication (appX rrcfg)))
           nullErrorPolicies
           $ \localAddr _ -> do
@@ -803,8 +799,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
                   noTimeLimitsHandshake
                   unversionedProtocolDataCodec
                   nullNetworkConnectTracers
-                  acceptableVersion
-                  queryVersion
+                  (HandshakeCallbacks acceptableVersion queryVersion)
                   (unversionedProtocol (appX rrcfg)))
 
             atomically $ (,) <$> takeTMVar (rrcServerVar rrcfg)
@@ -877,8 +872,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
                 noTimeLimitsHandshake
                 unversionedProtocolDataCodec
                 nullNetworkConnectTracers
-                acceptableVersion
-                queryVersion
+                (HandshakeCallbacks acceptableVersion queryVersion)
                 (unversionedProtocol appReq))
 
     threadDelay 130
@@ -902,8 +896,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
             unversionedHandshakeCodec
             noTimeLimitsHandshake
             unversionedProtocolDataCodec
-            acceptableVersion
-            queryVersion
+            (HandshakeCallbacks acceptableVersion queryVersion)
             (unversionedProtocol (SomeResponderApplication appRsp))
             nullErrorPolicies
             (\_ _ -> threadDelay delay)

--- a/ouroboros-network-protocols/test-cddl/Main.hs
+++ b/ouroboros-network-protocols/test-cddl/Main.hs
@@ -857,7 +857,7 @@ txSubmissionFix term =
 handshakeFix :: CBOR.Term -> CBOR.Term
 handshakeFix term =
     case term of
-      TList [TInt 0, TMap l] ->
+      TList [TInt x, TMap l] | x == 0 || x == 3 -> 
         TList
           [ TInt 0
           , TMap (sortOn

--- a/ouroboros-network-protocols/test-cddl/Main.hs
+++ b/ouroboros-network-protocols/test-cddl/Main.hs
@@ -430,6 +430,7 @@ genNtNHandshake genVersion = oneof
                 , pure PeerSharingPrivate
                 , pure PeerSharingPublic
                 ]
+          <*> arbitrary
 
     genRefuseReason :: Gen (Handshake.RefuseReason NodeToNodeVersion)
     genRefuseReason = oneof
@@ -497,6 +498,7 @@ instance Arbitrary (AnyMessageAndAgency (Handshake NodeToClientVersion CBOR.Term
         genData :: Gen NodeToClientVersionData
         genData = NodeToClientVersionData
               <$> (NetworkMagic <$> arbitrary)
+              <*> arbitrary
 
         genRefuseReason :: Gen (Handshake.RefuseReason NodeToClientVersion)
         genRefuseReason = oneof

--- a/ouroboros-network-protocols/test-cddl/Main.hs
+++ b/ouroboros-network-protocols/test-cddl/Main.hs
@@ -857,7 +857,7 @@ txSubmissionFix term =
 handshakeFix :: CBOR.Term -> CBOR.Term
 handshakeFix term =
     case term of
-      TList [TInt x, TMap l] | x == 0 || x == 3 -> 
+      TList [TInt x, TMap l] | x == 0 || x == 3 ->
         TList
           [ TInt 0
           , TMap (sortOn

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
@@ -6,20 +6,35 @@ handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
+    / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
-msgAcceptVersion   = [1, versionNumber, nodeToClientVersionData]
+msgAcceptVersion   = [1, oldVersionNumber, oldNodeToClientVersionData]
+                   / [1, versionNumber, nodeToClientVersionData]
 msgRefuse          = [2, refuseReason]
+msgQueryReply      = [3, versionTable]
 
-versionTable = { * versionNumber => nodeToClientVersionData }
+versionTable = { * versionNumber => nodeToNodeVersionData
+               , * oldVersionNumber => oldNodeToNodeVersionData
+               }
+
+
+; Version 15 introduces the version query flag
+; as of version 2 (which is no longer supported) we set 15th bit to 1
+;               15
+versionNumber = 32783
 
 ; as of version 2 (which is no longer supported) we set 15th bit to 1
-;               9     / 10    / 11    / 12    / 13    / 14    / 15
-versionNumber = 32777 / 32778 / 32779 / 32780 / 32781 / 32782 / 32783
+;                  9     / 10    / 11    / 12    / 13    / 14
+oldVersionNumber = 32777 / 32778 / 32779 / 32780 / 32781 / 32782
 
-nodeToClientVersionData = networkMagic
+; As of version 15
+nodeToClientVersionData = [networkMagic, query]
+
+oldNodeToClientVersionData = networkMagic
 
 networkMagic = uint
+query        = bool
 
 refuseReason
     = refuseReasonVersionMismatch

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
@@ -6,7 +6,7 @@ handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
-;   / msgQueryReply
+    / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
 msgAcceptVersion   = [1, oldVersionNumber, oldNodeToClientVersionData]
@@ -14,6 +14,7 @@ msgAcceptVersion   = [1, oldVersionNumber, oldNodeToClientVersionData]
 msgRefuse          = [2, refuseReason]
 msgQueryReply      = [3, versionTable]
 
+; Entries must be sorted by version number. For testing, this is handled in `handshakeFix`.
 versionTable = { * oldVersionNumber => oldNodeToClientVersionData
                , *    versionNumber =>    nodeToClientVersionData
                }

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
@@ -6,7 +6,7 @@ handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
-    / msgQueryReply
+;   / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
 msgAcceptVersion   = [1, oldVersionNumber, oldNodeToClientVersionData]
@@ -14,8 +14,8 @@ msgAcceptVersion   = [1, oldVersionNumber, oldNodeToClientVersionData]
 msgRefuse          = [2, refuseReason]
 msgQueryReply      = [3, versionTable]
 
-versionTable = { * versionNumber => nodeToNodeVersionData
-               , * oldVersionNumber => oldNodeToNodeVersionData
+versionTable = { * oldVersionNumber => oldNodeToClientVersionData
+               , *    versionNumber =>    nodeToClientVersionData
                }
 
 
@@ -27,6 +27,8 @@ versionNumber = 32783
 ; as of version 2 (which is no longer supported) we set 15th bit to 1
 ;                  9     / 10    / 11    / 12    / 13    / 14
 oldVersionNumber = 32777 / 32778 / 32779 / 32780 / 32781 / 32782
+
+anyVersionNumber = versionNumber / oldVersionNumber
 
 ; As of version 15
 nodeToClientVersionData = [networkMagic, query]
@@ -41,6 +43,6 @@ refuseReason
     / refuseReasonHandshakeDecodeError
     / refuseReasonRefused
 
-refuseReasonVersionMismatch      = [0, [ *versionNumber ] ]
-refuseReasonHandshakeDecodeError = [1, versionNumber, tstr]
-refuseReasonRefused              = [2, versionNumber, tstr]
+refuseReasonVersionMismatch      = [0, [ *anyVersionNumber ] ]
+refuseReasonHandshakeDecodeError = [1, anyVersionNumber, tstr]
+refuseReasonRefused              = [2, anyVersionNumber, tstr]

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v11.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v11.cddl
@@ -6,22 +6,25 @@ handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
+    / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
 msgAcceptVersion   = [1, versionNumber, nodeToNodeVersionData]
 msgRefuse          = [2, refuseReason]
+msgQueryReply      = [3, versionTable]
 
 versionTable = { * versionNumber => nodeToNodeVersionData }
 
 versionNumber = 11
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing ]
+nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing, query ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
 initiatorAndResponderDiffusionMode = bool
 ; range between 0 and 2
 peerSharing = 0..2
+query = bool
 
 refuseReason
     = refuseReasonVersionMismatch

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
@@ -6,20 +6,30 @@ handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
+    / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
-msgAcceptVersion   = [1, versionNumber, nodeToNodeVersionData]
+msgAcceptVersion   = [1, oldVersionNumber, oldNodeToNodeVersionData]
+;                   / [1, versionNumber, nodeToNodeVersionData]
 msgRefuse          = [2, refuseReason]
+msgQueryReply      = [3, versionTable]
 
-versionTable = { * versionNumber => nodeToNodeVersionData }
+versionTable = { * oldVersionNumber => oldNodeToNodeVersionData
+;               , * versionNumber => nodeToNodeVersionData
+               }
 
-versionNumber = 7 / 8 / 9 / 10 / 11
+versionNumber = 11
+oldVersionNumber = 7 / 8 / 9 / 10
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
+; As of version 11
+nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, query ]
+
+oldNodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
 initiatorAndResponderDiffusionMode = bool
+query = bool
 
 refuseReason
     = refuseReasonVersionMismatch

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
@@ -6,39 +6,26 @@ handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
-    / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
-msgAcceptVersion   = [1, oldVersionNumber, oldNodeToNodeVersionData]
-                   / [1, versionNumber, nodeToNodeVersionData]
+msgAcceptVersion   = [1, versionNumber, nodeToNodeVersionData]
 msgRefuse          = [2, refuseReason]
-msgQueryReply      = [3, versionTable]
 
-; Entries must be sorted by version number. For testing, this is handled in `handshakeFix`.
-versionTable = { * oldVersionNumber => oldNodeToNodeVersionData
-               , *    versionNumber =>    nodeToNodeVersionData
-               }
+versionTable = { * versionNumber => nodeToNodeVersionData }
 
-versionNumber = 11
-oldVersionNumber = 7 / 8 / 9 / 10
+versionNumber = 7 / 8 / 9 / 10 / 11
 
-anyVersionNumber = oldVersionNumber / versionNumber
-
-; As of version 11
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, query ]
-
-oldNodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
+nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
 initiatorAndResponderDiffusionMode = bool
-query = bool
 
 refuseReason
     = refuseReasonVersionMismatch
     / refuseReasonHandshakeDecodeError
     / refuseReasonRefused
 
-refuseReasonVersionMismatch      = [0, [ *anyVersionNumber ] ]
-refuseReasonHandshakeDecodeError = [1, anyVersionNumber, tstr]
-refuseReasonRefused              = [2, anyVersionNumber, tstr]
+refuseReasonVersionMismatch      = [0, [ *versionNumber ] ]
+refuseReasonHandshakeDecodeError = [1, versionNumber, tstr]
+refuseReasonRefused              = [2, versionNumber, tstr]

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
@@ -14,6 +14,7 @@ msgAcceptVersion   = [1, oldVersionNumber, oldNodeToNodeVersionData]
 msgRefuse          = [2, refuseReason]
 msgQueryReply      = [3, versionTable]
 
+; Entries must be sorted by version number. For testing, this is handled in `handshakeFix`.
 versionTable = { * oldVersionNumber => oldNodeToNodeVersionData
                , *    versionNumber =>    nodeToNodeVersionData
                }

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
@@ -10,16 +10,18 @@ handshakeMessage
 
 msgProposeVersions = [0, versionTable]
 msgAcceptVersion   = [1, oldVersionNumber, oldNodeToNodeVersionData]
-;                   / [1, versionNumber, nodeToNodeVersionData]
+                   / [1, versionNumber, nodeToNodeVersionData]
 msgRefuse          = [2, refuseReason]
 msgQueryReply      = [3, versionTable]
 
 versionTable = { * oldVersionNumber => oldNodeToNodeVersionData
-;               , * versionNumber => nodeToNodeVersionData
+               , *    versionNumber =>    nodeToNodeVersionData
                }
 
 versionNumber = 11
 oldVersionNumber = 7 / 8 / 9 / 10
+
+anyVersionNumber = oldVersionNumber / versionNumber
 
 ; As of version 11
 nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, query ]
@@ -36,6 +38,6 @@ refuseReason
     / refuseReasonHandshakeDecodeError
     / refuseReasonRefused
 
-refuseReasonVersionMismatch      = [0, [ *versionNumber ] ]
-refuseReasonHandshakeDecodeError = [1, versionNumber, tstr]
-refuseReasonRefused              = [2, versionNumber, tstr]
+refuseReasonVersionMismatch      = [0, [ *anyVersionNumber ] ]
+refuseReasonHandshakeDecodeError = [1, anyVersionNumber, tstr]
+refuseReasonRefused              = [2, anyVersionNumber, tstr]

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -461,8 +461,8 @@ prop_connect (ArbitraryVersions clientVersions serverVersions) =
         .&&.
            fromMaybe False serverRes === either (const False) extractRes serverRes'
   where
-    extractRes (HandshakeNegotiationResult (r,_,_)) = r
-    extractRes (HandshakeQueryResult _)             = False
+    extractRes (HandshakeNegotiationResult r _ _) = r
+    extractRes (HandshakeQueryResult _)           = False
 
 --
 -- Properties using a channel
@@ -501,7 +501,7 @@ prop_channel createChannels clientVersions serverVersions =
       case (clientRes', serverRes') of
         -- both succeeded, we just check that the application (which is
         -- a boolean value) is the one that was put inside 'Version'
-        (Right (HandshakeNegotiationResult (c,_,_)), Right (HandshakeNegotiationResult (s,_,_))) ->
+        (Right (HandshakeNegotiationResult c _ _), Right (HandshakeNegotiationResult s _ _)) ->
                Just c === clientRes
           .&&. Just s === serverRes
 
@@ -574,7 +574,7 @@ prop_channel_asymmetric createChannels clientVersions = do
           serverVersions)
     pure $
       case (clientRes', serverRes') of
-        (Right (HandshakeNegotiationResult (c,_,_)), Right (HandshakeNegotiationResult (s,_,_)))
+        (Right (HandshakeNegotiationResult c _ _), Right (HandshakeNegotiationResult s _ _))
                            -> Just c === clientRes
                          .&&. Just s === serverRes
         (Right (HandshakeQueryResult _), Right (HandshakeQueryResult _))
@@ -959,7 +959,7 @@ prop_query_version createChannels codec versionDataCodec clientVersions serverVe
     Left _ ->
       property True
     -- We should receive the queried versions.
-    Right (HandshakeNegotiationResult (_, k, _)) ->
+    Right (HandshakeNegotiationResult _ k _) ->
       -- We will only receive a negotiated result if the negotiated version does not support queries.
       property $ not $ supportsQuery k
     -- On successful handshakes, the received versions should match the server versions (ignoring `query`).
@@ -1099,7 +1099,7 @@ prop_channel_simultaneous_open createChannels codec versionDataCodec clientVersi
       case (clientRes', serverRes') of
         -- both succeeded, we just check that the application (which is
         -- a boolean value) is the one that was put inside 'Version'
-        (Right (HandshakeNegotiationResult (c,_,_)), Right (HandshakeNegotiationResult (s,_,_))) ->
+        (Right (HandshakeNegotiationResult c _ _), Right (HandshakeNegotiationResult s _ _)) ->
           label "both-succeed" $
                Just c === clientRes
           .&&. Just s === serverRes

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -204,6 +204,9 @@ instance Acceptable VersionData where
                                     dataVersion2 = dataVersion2 d
                                                 || dataVersion2 d' }
 
+instance Queryable VersionData where
+    queryVersion _d = False
+
 dataCodecCBORTerm :: VersionNumber -> CodecCBORTerm Text VersionData
 dataCodecCBORTerm Version_0 = CodecCBORTerm {encodeTerm, decodeTerm}
     where
@@ -439,6 +442,7 @@ prop_connect (ArbitraryVersions clientVersions serverVersions) =
               (handshakeServerPeer
                 (cborTermVersionDataCodec dataCodecCBORTerm)
                 acceptableVersion
+                queryVersion
                 serverVersions)) of
       (clientRes', serverRes', TerminalStates TokDone TokDone) ->
            fromMaybe False clientRes === either (const False) (\(a,_,_) -> a) clientRes'
@@ -475,6 +479,7 @@ prop_channel createChannels clientVersions serverVersions =
         (handshakeServerPeer
           (cborTermVersionDataCodec dataCodecCBORTerm)
           acceptableVersion
+          queryVersion
           serverVersions)
     pure $
       case (clientRes', serverRes') of
@@ -544,6 +549,7 @@ prop_channel_asymmetric createChannels clientVersions = do
         (handshakeServerPeer
           (cborTermVersionDataCodec dataCodecCBORTerm)
           acceptableVersion
+          queryVersion
           serverVersions)
     pure $
       case (clientRes', serverRes') of
@@ -645,15 +651,21 @@ instance Arbitrary ArbitraryNodeToNodeVersionData where
                           , PeerSharingPrivate
                           , PeerSharingPublic
                           ]
+            <*> arbitrary
     shrink (ArbitraryNodeToNodeVersionData
-             (NodeToNodeVersionData magic mode peerSharing)) =
-        [ ArbitraryNodeToNodeVersionData (NodeToNodeVersionData magic' mode peerSharing')
+             (NodeToNodeVersionData magic mode peerSharing query)) =
+        [ ArbitraryNodeToNodeVersionData (NodeToNodeVersionData magic' mode peerSharing' query)
         | magic' <- NetworkMagic <$> shrink (unNetworkMagic magic)
         , peerSharing' <- shrinkPeerSharing peerSharing
         ]
         ++
-        [ ArbitraryNodeToNodeVersionData (NodeToNodeVersionData magic mode' peerSharing')
+        [ ArbitraryNodeToNodeVersionData (NodeToNodeVersionData magic mode' peerSharing' query)
         | mode' <- shrinkMode mode
+        , peerSharing' <- shrinkPeerSharing peerSharing
+        ]
+        ++
+        [ ArbitraryNodeToNodeVersionData (NodeToNodeVersionData magic mode peerSharing' query')
+        | query' <- shrink query
         , peerSharing' <- shrinkPeerSharing peerSharing
         ]
       where
@@ -705,14 +717,19 @@ newtype ArbitraryNodeToClientVersionData =
     deriving Show
 
 instance Arbitrary ArbitraryNodeToClientVersionData where
-    arbitrary = ( ArbitraryNodeToClientVersionData
+    arbitrary = ( (ArbitraryNodeToClientVersionData .)
                 . NodeToClientVersionData
                 )
             <$> (NetworkMagic <$> arbitrary)
+            <*> arbitrary
     shrink (ArbitraryNodeToClientVersionData
-             (NodeToClientVersionData magic)) =
-        [ ArbitraryNodeToClientVersionData (NodeToClientVersionData magic')
+             (NodeToClientVersionData magic query)) =
+        [ ArbitraryNodeToClientVersionData (NodeToClientVersionData magic' query)
         | magic' <- NetworkMagic <$> shrink (unNetworkMagic magic)
+        ]
+        ++
+        [ ArbitraryNodeToClientVersionData (NodeToClientVersionData magic query')
+        | query' <- shrink query
         ]
 
 newtype ArbitraryNodeToClientVersions =

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -163,8 +163,7 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
         noTimeLimitsHandshake
         unversionedProtocolDataCodec
         nullNetworkConnectTracers
-        acceptableVersion
-        queryVersion
+        (HandshakeCallbacks acceptableVersion queryVersion)
         (simpleSingletonVersions
            UnversionedProtocol
            UnversionedProtocolData
@@ -199,8 +198,7 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
-      acceptableVersion
-      queryVersion
+      (HandshakeCallbacks acceptableVersion queryVersion)
       (simpleSingletonVersions
         UnversionedProtocol
         UnversionedProtocolData
@@ -384,8 +382,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                           noTimeLimitsHandshake
                           unversionedProtocolDataCodec
                           nullNetworkConnectTracers
-                          acceptableVersion
-                          queryVersion
+                          (HandshakeCallbacks acceptableVersion queryVersion)
                           (simpleSingletonVersions
                             UnversionedProtocol
                             UnversionedProtocolData
@@ -442,8 +439,7 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
       unversionedHandshakeCodec
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
-      acceptableVersion
-      queryVersion
+      (HandshakeCallbacks acceptableVersion queryVersion)
       (simpleSingletonVersions
         UnversionedProtocol
         UnversionedProtocolData

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -383,6 +383,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                           unversionedProtocolDataCodec
                           nullNetworkConnectTracers
                           acceptableVersion
+                          queryVersion
                           (simpleSingletonVersions
                             UnversionedProtocol
                             UnversionedProtocolData
@@ -440,6 +441,7 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
       acceptableVersion
+      queryVersion
       (simpleSingletonVersions
         UnversionedProtocol
         UnversionedProtocolData

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -164,6 +164,7 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
         unversionedProtocolDataCodec
         nullNetworkConnectTracers
         acceptableVersion
+        queryVersion
         (simpleSingletonVersions
            UnversionedProtocol
            UnversionedProtocolData
@@ -199,6 +200,7 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
       noTimeLimitsHandshake
       unversionedProtocolDataCodec
       acceptableVersion
+      queryVersion
       (simpleSingletonVersions
         UnversionedProtocol
         UnversionedProtocolData

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1236,6 +1236,7 @@ run tracers tracersExtra args argsExtra apps appsExtra = do
                          cborTermVersionDataCodec
                            NodeToNode.nodeToNodeCodecCBORTerm,
                        haAcceptVersion = acceptableVersion,
+                       haQueryVersion = queryVersion,
                        haTimeLimits = timeLimitsHandshake
                      }
                  diNtcHandshakeArguments =
@@ -1246,6 +1247,7 @@ run tracers tracersExtra args argsExtra apps appsExtra = do
                          cborTermVersionDataCodec
                            NodeToClient.nodeToClientCodecCBORTerm,
                        haAcceptVersion = acceptableVersion,
+                       haQueryVersion = queryVersion,
                        haTimeLimits = noTimeLimitsHandshake
                      }
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -248,8 +248,7 @@ connectTo snocket tracers versions path =
                   noTimeLimitsHandshake
                   (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
                   tracers
-                  acceptableVersion
-                  queryVersion
+                  (HandshakeCallbacks acceptableVersion queryVersion)
                   versions
                   Nothing
                   (localAddressFromPath path)
@@ -280,8 +279,7 @@ withServer sn tracers networkState sd versions errPolicies =
     nodeToClientHandshakeCodec
     noTimeLimitsHandshake
     (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
-    acceptableVersion
-    queryVersion
+    (HandshakeCallbacks acceptableVersion queryVersion)
     (SomeResponderApplication <$> versions)
     errPolicies
     (\_ async -> Async.wait async)
@@ -330,8 +328,7 @@ ncSubscriptionWorker
           noTimeLimitsHandshake
           (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
           (NetworkConnectTracers nsMuxTracer nsHandshakeTracer)
-          acceptableVersion
-          queryVersion
+          (HandshakeCallbacks acceptableVersion queryVersion)
           versions)
 
 -- | 'ErrorPolicies' for client application.  Additional rules can be added by

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -249,6 +249,7 @@ connectTo snocket tracers versions path =
                   (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
                   tracers
                   acceptableVersion
+                  queryVersion
                   versions
                   Nothing
                   (localAddressFromPath path)
@@ -280,6 +281,7 @@ withServer sn tracers networkState sd versions errPolicies =
     noTimeLimitsHandshake
     (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
     acceptableVersion
+    queryVersion
     (SomeResponderApplication <$> versions)
     errPolicies
     (\_ async -> Async.wait async)
@@ -329,6 +331,7 @@ ncSubscriptionWorker
           (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
           (NetworkConnectTracers nsMuxTracer nsHandshakeTracer)
           acceptableVersion
+          queryVersion
           versions)
 
 -- | 'ErrorPolicies' for client application.  Additional rules can be added by

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -450,7 +450,7 @@ connectTo
 connectTo sn tr =
     connectToNode sn makeSocketBearer configureOutboundSocket nodeToNodeHandshakeCodec timeLimitsHandshake
                   (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
-                  tr acceptableVersion
+                  tr acceptableVersion queryVersion
 
 
 -- | A specialised version of @'Ouroboros.Network.Socket.withServerNode'@.
@@ -487,6 +487,7 @@ withServer sn tracers networkState acceptedConnectionsLimit sd versions errPolic
     timeLimitsHandshake
     (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
     acceptableVersion
+    queryVersion
     (SomeResponderApplication <$> versions)
     errPolicies
     (\_ async -> Async.wait async)
@@ -532,6 +533,7 @@ ipSubscriptionWorker
           (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
           (NetworkConnectTracers nsMuxTracer nsHandshakeTracer)
           acceptableVersion
+          queryVersion
           versions)
 
 
@@ -577,6 +579,7 @@ dnsSubscriptionWorker
         (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
         (NetworkConnectTracers ndstMuxTracer ndstHandshakeTracer)
         acceptableVersion
+        queryVersion
         versions)
 
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -450,7 +450,7 @@ connectTo
 connectTo sn tr =
     connectToNode sn makeSocketBearer configureOutboundSocket nodeToNodeHandshakeCodec timeLimitsHandshake
                   (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
-                  tr acceptableVersion queryVersion
+                  tr (HandshakeCallbacks acceptableVersion queryVersion)
 
 
 -- | A specialised version of @'Ouroboros.Network.Socket.withServerNode'@.
@@ -486,8 +486,7 @@ withServer sn tracers networkState acceptedConnectionsLimit sd versions errPolic
     nodeToNodeHandshakeCodec
     timeLimitsHandshake
     (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
-    acceptableVersion
-    queryVersion
+    (HandshakeCallbacks acceptableVersion queryVersion)
     (SomeResponderApplication <$> versions)
     errPolicies
     (\_ async -> Async.wait async)
@@ -532,8 +531,7 @@ ipSubscriptionWorker
           timeLimitsHandshake
           (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
           (NetworkConnectTracers nsMuxTracer nsHandshakeTracer)
-          acceptableVersion
-          queryVersion
+          (HandshakeCallbacks acceptableVersion queryVersion)
           versions)
 
 
@@ -578,8 +576,7 @@ dnsSubscriptionWorker
         timeLimitsHandshake
         (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
         (NetworkConnectTracers ndstMuxTracer ndstHandshakeTracer)
-        acceptableVersion
-        queryVersion
+        (HandshakeCallbacks acceptableVersion queryVersion)
         versions)
 
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -220,6 +220,7 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
                     , haHandshakeCodec       = unversionedHandshakeCodec
                     , haVersionDataCodec     = ntnUnversionedDataCodec
                     , haAcceptVersion        = iAcceptVersion ni
+                    , haQueryVersion         = const False
                     , haTimeLimits           = timeLimitsHandshake
                     }
               , Diff.P2P.diNtnAddressType    = ntnAddressType
@@ -238,6 +239,7 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
                     , haHandshakeCodec       = unversionedHandshakeCodec
                     , haVersionDataCodec     = unversionedProtocolDataCodec
                     , haAcceptVersion        = \_ v -> Accept v
+                    , haQueryVersion         = const False
                     , haTimeLimits           = noTimeLimitsHandshake
                     }
               , Diff.P2P.diNtcGetFileDescriptor  = \_ -> pure (FileDescriptor (-1))

--- a/ouroboros-network/test/Test/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/NodeToClient/Version.hs
@@ -25,7 +25,7 @@ instance Arbitrary VersionAndVersionData where
     arbitrary =
       VersionAndVersionData
         <$> elements [ minBound .. maxBound]
-        <*> (NodeToClientVersionData . NetworkMagic <$> arbitrary)
+        <*> (NodeToClientVersionData . NetworkMagic <$> arbitrary <*> arbitrary)
 
 prop_nodeToClientCodec :: VersionAndVersionData -> Bool
 prop_nodeToClientCodec (VersionAndVersionData vNumber vData) =

--- a/ouroboros-network/test/Test/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/NodeToNode/Version.hs
@@ -36,6 +36,7 @@ instance Arbitrary NodeToNodeVersionData where
                   , pure PeerSharingPrivate
                   , pure PeerSharingPublic
                   ]
+        <*> arbitrary
 
 prop_nodeToNodeCodec :: NodeToNodeVersion -> NodeToNodeVersionData -> Bool
 prop_nodeToNodeCodec ntnVersion ntnData =

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -163,8 +163,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
       nodeToNodeHandshakeCodec
       noTimeLimitsHandshake
       (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
-      acceptableVersion
-      queryVersion
+      (HandshakeCallbacks acceptableVersion queryVersion)
       (simpleSingletonVersions
         NodeToNodeV_7
         (NodeToNodeVersionData {
@@ -184,8 +183,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
           noTimeLimitsHandshake
           (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
           nullNetworkConnectTracers
-          acceptableVersion
-          queryVersion
+          (HandshakeCallbacks acceptableVersion queryVersion)
           (simpleSingletonVersions
             NodeToNodeV_7
             (NodeToNodeVersionData {

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -43,7 +43,7 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Server as ChainSync
 import           Ouroboros.Network.Protocol.Handshake.Codec
                      (cborTermVersionDataCodec, noTimeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Version
-                     (acceptableVersion)
+                     (acceptableVersion, queryVersion)
 import           Ouroboros.Network.Testing.Serialise
 import           Ouroboros.Network.Util.ShowProxy
 
@@ -164,12 +164,14 @@ demo chain0 updates = withIOManager $ \iocp -> do
       noTimeLimitsHandshake
       (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
       acceptableVersion
+      queryVersion
       (simpleSingletonVersions
         NodeToNodeV_7
         (NodeToNodeVersionData {
           networkMagic  = NetworkMagic 0,
           diffusionMode = InitiatorAndResponderDiffusionMode,
-          peerSharing   = NoPeerSharing })
+          peerSharing   = NoPeerSharing,
+          query = False })
         (SomeResponderApplication responderApp))
       nullErrorPolicies
       $ \realProducerAddress _ -> do
@@ -183,12 +185,14 @@ demo chain0 updates = withIOManager $ \iocp -> do
           (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
           nullNetworkConnectTracers
           acceptableVersion
+          queryVersion
           (simpleSingletonVersions
             NodeToNodeV_7
             (NodeToNodeVersionData {
               networkMagic  = NetworkMagic 0,
               diffusionMode = InitiatorOnlyDiffusionMode,
-              peerSharing   = NoPeerSharing })
+              peerSharing   = NoPeerSharing,
+              query = False })
             initiatorApp)
           (Just consumerAddress)
           realProducerAddress)


### PR DESCRIPTION
# Description

This is a WIP PR implementing #3907. Specifically, it adds a boolean query flag to `NodeTo{Node,Client}VersionData` that causes the other party to return their list of supported versions instead of the negotiated version. I still need to do more testing. 

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
