### PR TITLE
mux: MakeBearer interface

### DIFF
--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -37,8 +37,7 @@ library
                         network                       >= 3.1.2.2  && < 3.2,
 
   if os(windows)
-    build-depends:      Win32                         >= 2.5.4.1  && < 3.0,
-                        Win32-network                 >= 0.1      && < 0.2,
+    build-depends:      Win32                         >= 2.5.4.1  && < 3.0
 
   if flag(asserts)
      ghc-options:       -fno-ignore-asserts

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -31,7 +31,7 @@ import           Data.Maybe (fromMaybe,)
 import           Data.TDigest (insert, maximumValue, minimumValue, tdigest, mean, quantile, stddev, TDigest)
 import           Data.Text (unpack)
 import           Data.Word (Word16, Word32)
-import           Network.Mux.Bearer.Socket (socketAsMuxBearer)
+import           Network.Mux.Bearer (MakeBearer (..), makeSocketBearer)
 import           Network.Mux.Timeout (TimeoutFn, withTimeoutSerial)
 import           Network.Mux.Types (MuxSDUHeader(MuxSDUHeader, mhTimestamp, mhDir, mhLength, mhNum), MiniProtocolNum(..), MiniProtocolDir(InitiatorDir), MuxBearer(read, write), MuxSDU(..), RemoteClockModel(RemoteClockModel))
 import           Network.Socket (AddrInfo, StructLinger (..))
@@ -372,7 +372,7 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount} ve
     unless pingOptsQuiet $ printf "%s network rtt: %.3f\n" peerStr $ toSample t0_e t0_s
 
     let timeout = 30
-        bearer = socketAsMuxBearer timeout nullTracer sd
+    bearer <- getBearer makeSocketBearer timeout nullTracer sd
 
     !t1_s <- write bearer timeoutfn $ wrap handshakeNum InitiatorDir (handshakeReq versions)
     (msg, !t1_e) <- nextMsg bearer timeoutfn handshakeNum

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -85,6 +85,7 @@ library
                        Network.Mux.Timeout
                        Network.Mux.Types
                        Network.Mux.Trace
+                       Network.Mux.Bearer
                        Network.Mux.Bearer.AttenuatedChannel
                        Network.Mux.Bearer.Pipe
                        Network.Mux.Bearer.Queues

--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -23,10 +23,13 @@ module Network.Mux
   , MiniProtocolLimits (..)
     -- * Running the Mux
   , runMux
-  , MuxBearer
   , runMiniProtocol
   , StartOnDemandOrEagerly (..)
   , stopMux
+    -- * Bearer
+  , MuxBearer
+  , MakeBearer (..)
+  , SDUSize (..)
     -- * Monitoring
   , miniProtocolStateMap
   , muxStopped
@@ -59,6 +62,7 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer hiding (timeout)
 import           Control.Tracer
 
+import           Network.Mux.Bearer
 import           Network.Mux.Channel
 import           Network.Mux.Egress as Egress
 import           Network.Mux.Ingress as Ingress

--- a/network-mux/src/Network/Mux/Bearer.hs
+++ b/network-mux/src/Network/Mux/Bearer.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE CPP                    #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE NumericUnderscores     #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE UndecidableInstances   #-}
+
+module Network.Mux.Bearer
+  ( MakeBearer (..)
+  , makeSocketBearer
+  , makePipeChannelBearer
+  , makeQueueChannelBearer
+#if defined(mingw32_HOST_OS)
+  , makeNamedPipeBearer
+#endif
+  ) where
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Tracer (Tracer)
+
+import           Network.Socket (Socket)
+#if defined(mingw32_HOST_OS)
+import           System.Win32 (HANDLE)
+#endif
+
+import           Network.Mux.Bearer.Pipe
+import           Network.Mux.Bearer.Queues
+import           Network.Mux.Bearer.Socket
+import           Network.Mux.Trace
+import           Network.Mux.Types hiding (sduSize)
+#if defined(mingw32_HOST_OS)
+import           Network.Mux.Bearer.NamedPipe
+#endif
+
+newtype MakeBearer m fd = MakeBearer {
+    getBearer
+      :: DiffTime
+      -- ^ timeout for reading an SDUMux segment, if negative no
+      -- timeout is applied.
+      -> Tracer m MuxTrace
+      -- ^ tracer
+      -> fd
+      -- ^ file descriptor
+      -> m (MuxBearer m)
+  }
+
+
+pureBearer :: Applicative m
+           => (DiffTime -> Tracer m MuxTrace -> fd ->    MuxBearer m)
+           ->  DiffTime -> Tracer m MuxTrace -> fd -> m (MuxBearer m)
+pureBearer f = \sduTimeout tr fd -> pure (f sduTimeout tr fd)
+
+makeSocketBearer :: MakeBearer IO Socket
+makeSocketBearer = MakeBearer $ pureBearer (socketAsMuxBearer size)
+  where
+    size = SDUSize 12_288
+
+makePipeChannelBearer :: MakeBearer IO PipeChannel
+makePipeChannelBearer = MakeBearer $ pureBearer (\_ -> pipeAsMuxBearer size)
+  where
+    size = SDUSize 32_768
+
+makeQueueChannelBearer :: ( MonadSTM   m
+                          , MonadTime  m
+                          , MonadThrow m
+                          )
+                       => MakeBearer m (QueueChannel m)
+makeQueueChannelBearer = MakeBearer $ pureBearer (\_ -> queueChannelAsMuxBearer size)
+  where
+    size = SDUSize 1_280
+
+#if defined(mingw32_HOST_OS)
+makeNamedPipeBearer :: MakeBearer IO HANDLE
+makeNamedPipeBearer = MakeBearer $ pureBearer (\_ -> namedPipeAsBearer size)
+  where
+    size = SDUSize 24_576
+#endif

--- a/network-mux/src/Network/Mux/Bearer/NamedPipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/NamedPipe.hs
@@ -14,7 +14,6 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Tracer
 
-import qualified Network.Mux as Mx
 import qualified Network.Mux.Codec as Mx
 import qualified Network.Mux.Time as Mx
 import qualified Network.Mux.Timeout as Mx
@@ -30,14 +29,15 @@ import qualified System.Win32.Async as Win32.Async
 -- | Named pipe bearer.  The 'HANDLE' must be associated with IO completion port
 -- using 'System.Win32.Async.associateWithIOCompletionPort'.
 --
-namedPipeAsBearer :: Tracer IO MuxTrace
+namedPipeAsBearer :: Mx.SDUSize
+                  -> Tracer IO MuxTrace
                   -> HANDLE
                   -> MuxBearer IO
-namedPipeAsBearer tracer h =
+namedPipeAsBearer sduSize tracer h =
     Mx.MuxBearer {
         Mx.read    = readNamedPipe,
         Mx.write   = writeNamedPipe,
-        Mx.sduSize = Mx.SDUSize 24576
+        Mx.sduSize = sduSize
       }
   where
     readNamedPipe :: Mx.TimeoutFn IO -> IO (Mx.MuxSDU, Time)

--- a/network-mux/src/Network/Mux/Bearer/Pipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/Pipe.hs
@@ -28,7 +28,6 @@ import qualified System.Win32.Types as Win32 (HANDLE)
 import qualified System.Win32.Async as Win32.Async
 #endif
 
-import qualified Network.Mux as Mx
 import           Network.Mux.Types (MuxBearer)
 import qualified Network.Mux.Types as Mx
 import qualified Network.Mux.Trace as Mx
@@ -70,14 +69,15 @@ pipeChannelFromNamedPipe h = PipeChannel {
 #endif
 
 pipeAsMuxBearer
-  :: Tracer IO Mx.MuxTrace
+  :: Mx.SDUSize
+  -> Tracer IO Mx.MuxTrace
   -> PipeChannel
   -> MuxBearer IO
-pipeAsMuxBearer tracer channel =
+pipeAsMuxBearer sduSize tracer channel =
       Mx.MuxBearer {
           Mx.read    = readPipe,
           Mx.write   = writePipe,
-          Mx.sduSize = Mx.SDUSize 32768
+          Mx.sduSize = sduSize
         }
     where
       readPipe :: Mx.TimeoutFn IO -> IO (Mx.MuxSDU, Time)

--- a/network-mux/src/Network/Mux/Bearer/Socket.hs
+++ b/network-mux/src/Network/Mux/Bearer/Socket.hs
@@ -22,7 +22,6 @@ import qualified Network.Socket.ByteString.Lazy as Socket (recv, sendAll)
 import qualified System.Win32.Async.Socket.ByteString.Lazy as Win32.Async
 #endif
 
-import qualified Network.Mux as Mx
 import qualified Network.Mux.Codec as Mx
 import qualified Network.Mux.Time as Mx
 import qualified Network.Mux.Timeout as Mx
@@ -45,15 +44,16 @@ import           Network.Mux.TCPInfo (SocketOption (TCPInfoSocketOption))
 -- 'MuxError'.
 --
 socketAsMuxBearer
-  :: DiffTime
+  :: Mx.SDUSize
+  -> DiffTime
   -> Tracer IO Mx.MuxTrace
   -> Socket.Socket
   -> MuxBearer IO
-socketAsMuxBearer sduTimeout tracer sd =
+socketAsMuxBearer sduSize sduTimeout tracer sd =
       Mx.MuxBearer {
         Mx.read    = readSocket,
         Mx.write   = writeSocket,
-        Mx.sduSize = Mx.SDUSize 12288
+        Mx.sduSize = sduSize
       }
     where
       hdrLenght = 8

--- a/network-mux/src/Network/Mux/Compat.hs
+++ b/network-mux/src/Network/Mux/Compat.hs
@@ -12,6 +12,7 @@ module Network.Mux.Compat
   ( muxStart
     -- * Mux bearers
   , MuxBearer
+  , MakeBearer (..)
     -- * Defining 'MuxApplication's
   , MuxMode (..)
   , HasInitiator
@@ -47,6 +48,7 @@ import           Control.Tracer
 
 import           Network.Mux (StartOnDemandOrEagerly (..), newMux,
                      runMiniProtocol, runMux, stopMux, traceMuxBearerState)
+import           Network.Mux.Bearer
 import           Network.Mux.Channel
 import           Network.Mux.Trace
 import           Network.Mux.Types hiding (MiniProtocolInfo (..))

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -108,6 +108,7 @@ clientPingPong pipelined =
     withIOManager $ \iomgr ->
     connectToNode
       (Snocket.localSnocket iomgr)
+      makeLocalBearer
       mempty
       unversionedHandshakeCodec
       noTimeLimitsHandshake
@@ -147,6 +148,7 @@ serverPingPong =
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
       (Snocket.localSnocket iomgr)
+      makeLocalBearer
       mempty
       nullNetworkServerTracers
       networkState
@@ -208,6 +210,7 @@ clientPingPong2 =
     withIOManager $ \iomgr -> do
     connectToNode
       (Snocket.localSnocket iomgr)
+      makeLocalBearer
       mempty
       unversionedHandshakeCodec
       noTimeLimitsHandshake
@@ -260,6 +263,7 @@ serverPingPong2 =
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
       (Snocket.localSnocket iomgr)
+      makeLocalBearer
       mempty
       nullNetworkServerTracers
       networkState

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -102,6 +102,10 @@ data ConnectionManagerArguments handlerTrace socket peerAddr handle handleError 
         --
         cmSnocket             :: Snocket m socket peerAddr,
 
+        -- | Make MuxBearer.
+        --
+        cmMakeBearer          :: MakeBearer m socket,
+
         -- | Socket configuration.
         --
         cmConfigureSocket     :: socket -> Maybe peerAddr -> m (),
@@ -561,6 +565,7 @@ withConnectionManager ConnectionManagerArguments {
                           cmIPv6Address,
                           cmAddressType,
                           cmSnocket,
+                          cmMakeBearer,
                           cmConfigureSocket,
                           cmTimeWaitTimeout,
                           cmOutboundIdleTimeout,
@@ -776,8 +781,7 @@ withConnectionManager ConnectionManagerArguments {
                      (TrConnectionHandler connId `contramap` tracer)
                      connId
                      (\bearerTimeout ->
-                       toBearer
-                         cmSnocket
+                       getBearer cmMakeBearer
                          bearerTimeout
                          (WithMuxBearer connId `contramap` muxTracer)))
             unmask

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -36,6 +36,7 @@ import qualified Network.Socket as Socket
 import qualified Network.Socket.ByteString.Lazy as Socket (recv, sendAll)
 #endif
 
+import qualified Network.Mux.Bearer as Mx
 --TODO: time utils should come from elsewhere
 import           Network.Mux.Time (microsecondsToDiffTime)
 
@@ -591,6 +592,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
     withDummyServer faultyAddress $
       withServerNode
         sn
+        Mx.makeSocketBearer
         ((. Just) <$> configureSocket)
         nullNetworkServerTracers
         (NetworkMutableState tbl peerStatesVar)
@@ -738,6 +740,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
 
     startPassiveServer iocp tbl stVar responderAddr localAddrVar rrcfg = withServerNode
         (socketSnocket iocp)
+        Mx.makeSocketBearer
         ((. Just) <$> configureSocket)
         nullNetworkServerTracers
         (NetworkMutableState tbl stVar)
@@ -760,6 +763,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
       let sn = socketSnocket iocp
       in withServerNode
           sn
+          Mx.makeSocketBearer
           ((. Just) <$> configureSocket)
           nullNetworkServerTracers
           (NetworkMutableState tbl stVar)
@@ -883,6 +887,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
     spawnServer iocp tbl stVar addr delay =
         void $ async $ withServerNode
             (socketSnocket iocp)
+            Mx.makeSocketBearer
             ((. Just) <$> configureSocket)
             nullNetworkServerTracers
             (NetworkMutableState tbl stVar)

--- a/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/test/Test/Simulation/Network/Snocket.hs
@@ -52,7 +52,7 @@ import           Ouroboros.Network.Driver.Simple
 import           Ouroboros.Network.Snocket
 import           Simulation.Network.Snocket
 
-import           Network.Mux
+import           Network.Mux as Mx
 import           Network.TypedProtocol.Codec.CBOR
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.ReqResp.Client
@@ -225,7 +225,7 @@ clientServerSimulation payloads =
           (accepted, accept1) <- runAccept accept0
           case accepted of
             Accepted fd' remoteAddr -> do
-              bearer <- toBearer snocket 10 nullTracer fd'
+              bearer <- getBearer makeFDBearer 10 nullTracer fd'
               thread <- async $ handleConnection bearer remoteAddr
                                 `finally`
                                close snocket fd'
@@ -306,7 +306,7 @@ clientServerSimulation payloads =
                               (\channel -> runPeer tr codecReqResp
                                                    (fromChannel channel)
                                                    clientPeer)
-                  bearer <- toBearer snocket 10 nullTracer fd
+                  bearer <- Mx.getBearer makeFDBearer 10 nullTracer fd
 
                   -- kill mux as soon as the client returns
                   withAsync

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -34,6 +34,7 @@ import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Tracer (nullTracer)
 
+import qualified Network.Mux.Bearer as Mx
 import           Network.Mux.Types (MiniProtocolDir (..), MiniProtocolNum (..),
                      muxBearerAsChannel)
 import           Network.TypedProtocol.Codec
@@ -1020,13 +1021,13 @@ prop_channel_simultaneous_open_sim codec versionDataCodec
             concurrently_
               (Snocket.connect sn fdConn  addr')
               (Snocket.connect sn fdConn' addr)
-            bearer  <- Snocket.toBearer
-                        sn 1
+            bearer  <- Mx.getBearer makeFDBearer
+                        1
                         nullTracer
                         -- (("client",) `contramap` Tracer Debug.traceShowM)
                         fdConn
-            bearer' <- Snocket.toBearer
-                        sn 1
+            bearer' <- Mx.getBearer makeFDBearer
+                        1
                         nullTracer
                         -- (("server",) `contramap` Tracer Debug.traceShowM)
                         fdConn'

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -157,6 +157,7 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
       threadDelay (50000 * index)
       connectToNode
         (localSnocket iocp)
+        makeLocalBearer
         mempty
         unversionedHandshakeCodec
         noTimeLimitsHandshake
@@ -188,6 +189,7 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
       (localSnocket iocp)
+      makeLocalBearer
       mempty
       nullNetworkServerTracers
       networkState
@@ -374,6 +376,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                     [ async $
                         connectToNode
                           (localSnocket iocp)
+                          makeLocalBearer
                           mempty
                           unversionedHandshakeCodec
                           noTimeLimitsHandshake
@@ -427,6 +430,7 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
     _ <- async $ cleanNetworkMutableState networkState
     withServerNode
       (localSnocket iocp)
+      makeLocalBearer
       mempty
       nullNetworkServerTracers
       networkState

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -241,6 +241,7 @@ connectTo
   -> IO ()
 connectTo snocket tracers versions path =
     connectToNode snocket
+                  makeLocalBearer
                   mempty
                   nodeToClientHandshakeCodec
                   noTimeLimitsHandshake
@@ -269,6 +270,7 @@ withServer
 withServer sn tracers networkState sd versions errPolicies =
   withServerNode'
     sn
+    makeLocalBearer
     tracers
     networkState
     (AcceptedConnectionsLimit maxBound maxBound 0)
@@ -320,6 +322,7 @@ ncSubscriptionWorker
         subscriptionParams
         (connectToNode'
           sn
+          makeLocalBearer
           nodeToClientHandshakeCodec
           noTimeLimitsHandshake
           (cborTermVersionDataCodec nodeToClientCodecCBORTerm)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -405,7 +405,7 @@ connectTo
   -> Socket.SockAddr
   -> IO ()
 connectTo sn tr =
-    connectToNode sn configureOutboundSocket nodeToNodeHandshakeCodec timeLimitsHandshake
+    connectToNode sn makeSocketBearer configureOutboundSocket nodeToNodeHandshakeCodec timeLimitsHandshake
                   (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
                   tr acceptableVersion
 
@@ -435,6 +435,7 @@ withServer
 withServer sn tracers networkState acceptedConnectionsLimit sd versions errPolicies =
   withServerNode'
     sn
+    makeSocketBearer
     tracers
     networkState
     acceptedConnectionsLimit
@@ -482,6 +483,7 @@ ipSubscriptionWorker
         subscriptionParams
         (connectToNode'
           sn
+          makeSocketBearer
           nodeToNodeHandshakeCodec
           timeLimitsHandshake
           (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
@@ -526,6 +528,7 @@ dnsSubscriptionWorker
       subscriptionParams
       (connectToNode'
         sn
+        makeSocketBearer
         nodeToNodeHandshakeCodec
         timeLimitsHandshake
         (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -92,8 +92,8 @@ import           Ouroboros.Network.RethrowPolicy (ErrorCommand (ShutdownNode),
                      muxErrorRethrowPolicy)
 import           Ouroboros.Network.Server.RateLimiting
                      (AcceptedConnectionsLimit (..))
-import           Ouroboros.Network.Snocket (FileDescriptor (..), Snocket,
-                     TestAddress (..))
+import           Ouroboros.Network.Snocket (FileDescriptor (..), MakeBearer,
+                     Snocket, TestAddress (..))
 
 import           Ouroboros.Network.Testing.Data.Script (Script (..))
 
@@ -110,9 +110,11 @@ import           Test.Ouroboros.Network.PeerSelection.RootPeersDNS
 
 data Interfaces m = Interfaces
     { iNtnSnocket        :: Snocket m (NtNFD m) NtNAddr
+    , iNtnBearer         :: MakeBearer m (NtNFD m)
     , iAcceptVersion     :: NtNVersionData -> NtNVersionData -> Accept NtNVersionData
     , iNtnDomainResolver :: LookupReqs -> [DomainAccessPoint] -> m (Map DomainAccessPoint (Set NtNAddr))
     , iNtcSnocket        :: Snocket m (NtCFD m) NtCAddr
+    , iNtcBearer         :: MakeBearer m (NtCFD m)
     , iRng               :: StdGen
     , iDomainMap         :: StrictTVar m (Map Domain [(IP, TTL)])
     , iLedgerPeersConsensusInterface
@@ -186,6 +188,7 @@ run _debugTracer blockGeneratorArgs limits ni na tracersExtra =
                                               m
             interfaces = Diff.P2P.Interfaces
               { Diff.P2P.diNtnSnocket            = iNtnSnocket ni
+              , Diff.P2P.diNtnBearer             = iNtnBearer ni
               , Diff.P2P.diNtnConfigureSocket    = \_ _ -> return ()
               , Diff.P2P.diNtnConfigureSystemdSocket
                                                  = \_ _ -> return ()
@@ -205,6 +208,7 @@ run _debugTracer blockGeneratorArgs limits ni na tracersExtra =
               , Diff.P2P.diNtnToPeerAddr         = \a b -> TestAddress (Node.IPAddr a b)
               , Diff.P2P.diNtnDomainResolver     = iNtnDomainResolver ni
               , Diff.P2P.diNtcSnocket            = iNtcSnocket ni
+              , Diff.P2P.diNtcBearer             = iNtcBearer ni
               , Diff.P2P.diNtcHandshakeArguments =
                   HandshakeArguments
                     { haHandshakeTracer      = nullTracer

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -92,7 +92,7 @@ import           Ouroboros.Network.Testing.Data.Script (Script (..))
 import           Ouroboros.Network.Testing.Utils (WithName (..),
                      genDelayWithPrecision, tracerWithName)
 import           Simulation.Network.Snocket (BearerInfo (..), FD, SnocketTrace,
-                     WithAddr (..), withSnocket)
+                     WithAddr (..), makeFDBearer, withSnocket)
 
 import qualified Test.Ouroboros.Network.Diffusion.Node as NodeKernel
 import           Test.Ouroboros.Network.Diffusion.Node.NodeKernel
@@ -782,9 +782,11 @@ diffusionSimulation
           interfaces =
             NodeKernel.Interfaces
               { NodeKernel.iNtnSnocket        = ntnSnocket
+              , NodeKernel.iNtnBearer         = makeFDBearer
               , NodeKernel.iAcceptVersion     = acceptVersion
               , NodeKernel.iNtnDomainResolver = domainResolver raps dMapVar
               , NodeKernel.iNtcSnocket        = ntcSnocket
+              , NodeKernel.iNtcBearer         = makeFDBearer
               , NodeKernel.iRng               = rng
               , NodeKernel.iDomainMap         = dMapVar
               , NodeKernel.iLedgerPeersConsensusInterface

--- a/ouroboros-network/test/Test/PeerState.hs
+++ b/ouroboros-network/test/Test/PeerState.hs
@@ -243,7 +243,7 @@ instance Arbitrary SnocketType where
       , pure WorkingSnocket
       ]
 
--- | 'addrFamily', 'accept' and 'toBearer' are not needed to run the test suite.
+-- | 'addrFamily', 'accept' is not needed to run the test suite.
 --
 mkSnocket :: MonadThrow m
           => SnocketType
@@ -261,7 +261,6 @@ mkSnocket (AllocateError e) _localAddr _remoteAddr = Snocket {
   , listen = \_ -> pure ()
   , accept = \_ -> error "not supported"
   , close = \_ -> pure ()
-  , toBearer = \_ _ -> error "not supported"
   }
 mkSnocket (ConnectError e) localAddr remoteAddr = Snocket {
     getLocalAddr = \Sock{localAddr = addr} -> pure addr
@@ -274,7 +273,6 @@ mkSnocket (ConnectError e) localAddr remoteAddr = Snocket {
   , bind = \_ _ -> pure ()
   , listen = \_ -> pure ()
   , close = \_ -> pure ()
-  , toBearer = \_ _ -> error "not supported"
   }
 mkSnocket WorkingSnocket localAddr remoteAddr = Snocket {
     getLocalAddr = \Sock{localAddr = addr} -> pure addr
@@ -287,7 +285,6 @@ mkSnocket WorkingSnocket localAddr remoteAddr = Snocket {
   , listen = \_ -> pure ()
   , accept = \_ -> error "not supported"
   , close = \_ -> pure ()
-  , toBearer = \_ _ -> error "not supported"
   }
 
 data ArbApp addr = ArbApp (Maybe ArbException) (Sock addr -> IO ())

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -25,6 +25,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Control.Tracer
 
+import qualified Network.Mux.Bearer as Mx
 import qualified Network.Mux.Bearer.Pipe as Mx
 import qualified Network.Mux.Compat as Mx (muxStart)
 import           Ouroboros.Network.Mux
@@ -186,8 +187,8 @@ demo chain0 updates = do
                                                   (encodeTip encode) (decodeTip decode))
                         (ChainSync.chainSyncServerPeer server)
 
-        let clientBearer = Mx.pipeAsMuxBearer activeTracer chan1
-            serverBearer = Mx.pipeAsMuxBearer activeTracer chan2
+        clientBearer <- Mx.getBearer Mx.makePipeChannelBearer (-1) activeTracer chan1
+        serverBearer <- Mx.getBearer Mx.makePipeChannelBearer (-1) activeTracer chan2
 
         _ <- async $
               Mx.muxStart

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -153,6 +153,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
 
     withServerNode
       (socketSnocket iocp)
+      makeSocketBearer
       ((. Just) <$> configureSocket)
       nullNetworkServerTracers
       networkState
@@ -173,6 +174,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
       withAsync
         (connectToNode
           (socketSnocket iocp)
+          makeSocketBearer
           (flip configureSocket Nothing)
           nodeToNodeHandshakeCodec
           noTimeLimitsHandshake

--- a/scripts/ci/check-stylish-network.sh
+++ b/scripts/ci/check-stylish-network.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 export LC_ALL=C.UTF-8
 # TODO CPP pragmas in export lists are not supported by stylish-haskell
-fd . './network-mux' -e hs -E Setup.hs -E TCPInfo.hs -E Pipe.hs -E Channel.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
+fd . './network-mux' -e hs -E Setup.hs -E TCPInfo.hs -E Pipe.hs -E Channel.hs -E Bearer.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 fd . './ouroboros-network-api' -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 fd . './ouroboros-network-framework' -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i
 fd . './ouroboros-network-mock' -e hs -E Setup.hs -X stylish-haskell -c .stylish-haskell-network.yaml -i


### PR DESCRIPTION
Provide a `Bearer` type class.  The main function is `makeBearer`
which constructs a `MuxBearer` with the `defaultSDUSize`.  The
`makeBearer'` function is useful for testing preposes.  Although all
instances are pure, we need to return a monadic action to accommodate
bearer for simulated snocket in `Simulation.Network.Snocket`.

The goal is to remove `toBearer` method from `Snocket` interface.

TODO:
* [ ] Update `CHANGELOG.md` files
