### PR TITLE
`StaticEither` accessors

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -96,7 +96,8 @@ import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.NodeKernel as NodeKernel
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util (StaticEither (StaticLeft))
+import           Ouroboros.Consensus.Util (StaticEither (StaticLeft),
+                     fromStaticLeft)
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
@@ -1046,8 +1047,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       -- transactions.
       let getValueHandle = do
             bsvh <- ChainDB.getLedgerBackingStoreValueHandle chainDB registry (StaticLeft ())
-            pure $ mkDiskLedgerView $ case bsvh of
-              StaticLeft v -> v
+            pure $ mkDiskLedgerView $ fromStaticLeft bsvh
       forkTxProducer
         coreNodeId
         registry

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -18,7 +18,8 @@ import           Ouroboros.Consensus.Ledger.Query (Query, QueryLedger)
 import qualified Ouroboros.Consensus.Ledger.Query as Query
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
-import           Ouroboros.Consensus.Util (StaticEither (..))
+import           Ouroboros.Consensus.Util (StaticEither (..), fromStaticLeft,
+                     fromStaticRight)
 import           Ouroboros.Consensus.Util.IOLike
 
 localStateQueryServer ::
@@ -52,12 +53,10 @@ localStateQueryServer cfg getDLV =
     handleAcquire mpt = do
         case mpt of
           Nothing -> do
-            o <- getDLV (StaticLeft ())
-            let StaticLeft dlv = o
+            dlv <- fromStaticLeft <$> getDLV (StaticLeft ())
             return $ SendMsgAcquired $ acquired dlv
           Just pt -> do
-            o <- getDLV (StaticRight pt)
-            let StaticRight ei = o
+            ei <- fromStaticRight <$> getDLV (StaticRight pt)
             case ei of
               Left immP
                 | pointSlot pt < pointSlot immP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -453,7 +453,7 @@ instance Bifunctor (StaticEither b) where
   second f (StaticRight r) = StaticRight (f r)
 
 fromStaticLeft :: StaticEither 'False l r -> l
-fromStaticLeft = \case (StaticLeft x) -> x
+fromStaticLeft (StaticLeft x) = x
 
 fromStaticRight :: StaticEither 'True l r -> r
-fromStaticRight = \case (StaticRight x) -> x
+fromStaticRight (StaticRight x) = x

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -18,7 +18,6 @@ module Ouroboros.Consensus.Util (
   , Some (..)
   , SomePair (..)
   , SomeSecond (..)
-  , StaticEither (..)
   , mustBeRight
     -- * Folding variations
   , foldlM'
@@ -74,6 +73,10 @@ module Ouroboros.Consensus.Util (
     -- * Miscellaneous
   , eitherToMaybe
   , fib
+    -- * Static Either
+  , StaticEither (..)
+  , fromStaticLeft
+  , fromStaticRight
   ) where
 
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashFromBytes,
@@ -434,6 +437,10 @@ eitherToMaybe :: Either a b -> Maybe b
 eitherToMaybe (Left _)  = Nothing
 eitherToMaybe (Right x) = Just x
 
+{-------------------------------------------------------------------------------
+  Static Either
+-------------------------------------------------------------------------------}
+
 data StaticEither :: Bool -> Type -> Type -> Type where
   StaticLeft  :: l -> StaticEither False l r
   StaticRight :: r -> StaticEither True  l r
@@ -444,3 +451,9 @@ instance Bifunctor (StaticEither b) where
 
   second _ (StaticLeft l)  = StaticLeft l
   second f (StaticRight r) = StaticRight (f r)
+
+fromStaticLeft :: StaticEither 'False l r -> l
+fromStaticLeft = \case (StaticLeft x) -> x
+
+fromStaticRight :: StaticEither 'True l r -> r
+fromStaticRight = \case (StaticRight x) -> x


### PR DESCRIPTION
# Description

The `StaticEither` datatype encodes its "left-ness" or "right-ness" in a type-level `Bool`.

```haskell
data StaticEither :: Bool -> Type -> Type -> Type where
  StaticLeft  :: l -> StaticEither False l r
  StaticRight :: r -> StaticEither True  l r
```

As a consequence, when the type-level `Bool` becomes concrete (i.e., `'True` or `'False'`), we can only match on one of the constructors.

```haskell
case sl of StaticLeft x -> x
let StaticLeft x = sl
case sr of StaticRight x -> x
let StaticRight x = sr 
```

We add two helper functions, that are analogous to `fromLeft` and `fromRight`, but without the default value that `fromLeft` and `fromRight` require to be total functions.

```haskell
fromStaticLeft :: StaticEither 'False l r -> l
fromStaticLeft = \case (StaticLeft x) -> x

fromStaticRight :: StaticEither 'True l r -> r
fromStaticRight = \case (StaticRight x) -> x
```

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] New tests are added if needed and existing tests are updated
    - [x] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
