### PR TITLE
PBT for laws on TableStuff and StowableLedgerTables

### DIFF
--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -75,6 +75,7 @@ test-suite test
   main-is:             Main.hs
   other-modules:
                        Test.Consensus.Byron.Golden
+                       Test.Consensus.Byron.LedgerTables
                        Test.Consensus.Byron.Serialisation
                        Test.ThreadNet.Byron
                        Test.ThreadNet.DualByron

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -276,7 +276,7 @@ instance Arbitrary CC.Del.Map where
 instance Arbitrary ByronTransition where
   arbitrary = ByronTransitionInfo . Map.fromList <$> arbitrary
 
-instance Arbitrary (LedgerState ByronBlock EmptyMK) where
+instance Arbitrary (LedgerState ByronBlock mk) where
   arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
 
 -- | Generator for a Byron ledger state in which the tip of the ledger given by
@@ -297,6 +297,9 @@ genByronLedgerState = do
       case cvsPreviousHash of
         Left _  -> pure Origin
         Right _ -> At <$> arbitrary
+
+instance Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
+  arbitrary = pure NoByronLedgerTables
 
 genByronLedgerConfig :: Gen Byron.Config
 genByronLedgerConfig = hedgehog $ CC.genConfig protocolMagicId

--- a/ouroboros-consensus-byron-test/test/Main.hs
+++ b/ouroboros-consensus-byron-test/test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import           Test.Tasty
 
 import qualified Test.Consensus.Byron.Golden (tests)
+import qualified Test.Consensus.Byron.LedgerTables (tests)
 import qualified Test.Consensus.Byron.Serialisation (tests)
 import qualified Test.ThreadNet.Byron (tests)
 import qualified Test.ThreadNet.DualByron (tests)
@@ -16,6 +17,7 @@ tests :: TestTree
 tests =
   testGroup "byron"
   [ Test.Consensus.Byron.Golden.tests
+  , Test.Consensus.Byron.LedgerTables.tests
   , Test.Consensus.Byron.Serialisation.tests
   , Test.ThreadNet.Byron.tests
   , Test.ThreadNet.DualByron.tests

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/LedgerTables.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/LedgerTables.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Consensus.Byron.LedgerTables (tests) where
+
+import           Ouroboros.Consensus.Byron.Ledger
+
+import           Test.Consensus.Byron.Generators ()
+import           Test.LedgerTables
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "LedgerTables"
+  [ testProperty "Stowable laws" (prop_stowable_laws @ByronBlock)
+  , testProperty "TableStuff laws" (prop_tablestuff_laws @ByronBlock)
+  ]

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -86,6 +86,7 @@ test-suite test
   other-modules:
                        Test.Consensus.Cardano.ByronCompatibility
                        Test.Consensus.Cardano.Golden
+                       Test.Consensus.Cardano.LedgerTables
                        Test.Consensus.Cardano.Serialisation
                        Test.Consensus.Cardano.Translation
                        Test.ThreadNet.AllegraMary
@@ -111,6 +112,7 @@ test-suite test
                      , cardano-data
                      , cardano-ledger-alonzo
                      , cardano-ledger-alonzo-test
+                     , cardano-ledger-babbage-test
                      , cardano-ledger-byron
                      , cardano-ledger-byron-test
                      , cardano-ledger-core

--- a/ouroboros-consensus-cardano-test/test/Main.hs
+++ b/ouroboros-consensus-cardano-test/test/Main.hs
@@ -9,6 +9,7 @@ import           Test.Tasty
 
 import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
 import qualified Test.Consensus.Cardano.Golden (tests)
+import qualified Test.Consensus.Cardano.LedgerTables (tests)
 import qualified Test.Consensus.Cardano.Serialisation (tests)
 import qualified Test.Consensus.Cardano.Translation (tests)
 import qualified Test.ThreadNet.AllegraMary (tests)
@@ -30,6 +31,7 @@ tests =
   testGroup "cardano"
   [ Test.Consensus.Cardano.ByronCompatibility.tests
   , Test.Consensus.Cardano.Golden.tests
+  , Test.Consensus.Cardano.LedgerTables.tests
   , Test.Consensus.Cardano.Serialisation.tests
   , testGroup "ThreadNet" [
       Test.ThreadNet.AllegraMary.tests

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/LedgerTables.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/LedgerTables.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Consensus.Cardano.LedgerTables (tests) where
+
+import           Data.Map.Diff.Strict (Values (..))
+import qualified Data.Map.Strict as Map
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Cardano.CanHardFork
+import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
+import           Ouroboros.Consensus.Shelley.HFEras ()
+import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import           Ouroboros.Consensus.Shelley.ShelleyHFC (ShelleyTxOut (..))
+import           Ouroboros.Consensus.Util.SOP
+
+import qualified Cardano.Ledger.Shelley.API as SL
+
+import           Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import           Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+
+import           Test.LedgerTables
+
+import           Test.Consensus.Byron.Generators ()
+import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
+import           Test.Consensus.Shelley.Generators ()
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+type Crypto = MockCryptoCompatByron
+
+tests :: TestTree
+tests = testGroup "LedgerTables"
+  [ testGroup "Cardano"
+    [ testProperty "Stowable laws" (prop_stowable_laws @(CardanoBlock Crypto))
+    , testProperty "TableStuff laws"
+        (\(InSameEra ls tbs) -> prop_tablestuff_laws @(CardanoBlock Crypto) ls tbs)
+    ]
+  ]
+
+instance Arbitrary (LedgerTables (LedgerState (CardanoBlock Crypto)) ValuesMK) where
+  arbitrary = projectLedgerTables . unstowLedgerTables <$> arbitrary
+
+instance Show (LedgerTables (LedgerState (CardanoBlock Crypto)) EmptyMK) where
+  show x = showsLedgerState x ""
+
+instance Show (LedgerTables (LedgerState (CardanoBlock Crypto)) ValuesMK) where
+  show x = showsLedgerState x ""
+
+-- | We need to generate Ledger states and tables in the same era or otherwise
+-- it wouldn't make sense to try to attach them to a hard fork ledger state,
+-- this data definition does just that.
+data InSameEra =
+  InSameEra
+    !(LedgerState (CardanoBlock Crypto) EmptyMK)
+    !(LedgerTables (LedgerState (CardanoBlock Crypto)) ValuesMK)
+  deriving Show
+
+instance Arbitrary InSameEra where
+  arbitrary = do
+    ls <- arbitrary
+    tbs <- arbitrary `suchThat` (sameEra (getHardForkState $ hardForkLedgerStatePerEra ls) . cardanoUTxOTable)
+    pure $ InSameEra ls tbs
+
+-- | This function asserts that:
+--
+-- - Producing a table to be attached to a Byron HardFork State requires the
+--   table to be empty as that is the only kind of table such a state can have.
+--
+-- - Producing a table to be attached to a Shelley HardFork State requires all
+-- - the entries in the map to be on the same era as the state. We do so by
+-- - checking that all of them and the state produce the same index through
+-- - @'nsToIndex'@.
+sameEra ::
+     Telescope (K Past) (Current (Flip LedgerState EmptyMK)) (CardanoEras Crypto)
+  -> ApplyMapKind ValuesMK (SL.TxIn Crypto) (ShelleyTxOut (ShelleyBasedEras Crypto))
+  -> Bool
+sameEra (TZ{})      (ApplyValuesMK (Values m))      = Map.null m
+sameEra (TS _ tele) (ApplyValuesMK (Values values)) =
+    all (nsToIndex (tip tele) ==) $ map (nsToIndex . unShelleyTxOut . snd) (Map.toList values)

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -61,6 +61,7 @@ library
                      , ouroboros-consensus-protocol:ouroboros-consensus-protocol-test
                      , ouroboros-consensus-test
                      , ouroboros-consensus-shelley
+                     , anti-diff
 
                      , microlens
 
@@ -83,6 +84,7 @@ test-suite test
   other-modules:
                        Test.Consensus.Shelley.Coherence
                        Test.Consensus.Shelley.Golden
+                       Test.Consensus.Shelley.LedgerTables
                        Test.Consensus.Shelley.Serialisation
                        Test.ThreadNet.Shelley
 
@@ -100,6 +102,7 @@ test-suite test
                        -- cardano-ledger-specs
                      , cardano-ledger-alonzo
                      , cardano-ledger-alonzo-test
+                     , cardano-ledger-babbage-test
                      , cardano-ledger-core
                      , cardano-ledger-shelley
                      , cardano-protocol-tpraos

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -41,6 +41,7 @@ import           Cardano.Ledger.Era (toTxSeq)
 import qualified Cardano.Protocol.TPraos.API as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import           Data.Coerce (coerce)
+import           Data.Map.Diff.Strict
 import           Ouroboros.Consensus.Protocol.Praos (Praos)
 import qualified Ouroboros.Consensus.Protocol.Praos as Praos
 import qualified Ouroboros.Consensus.Protocol.Praos.Header as Praos
@@ -190,6 +191,13 @@ instance CanMock proto era => Arbitrary (LedgerState (ShelleyBlock proto era) Em
     <*> arbitrary
     <*> arbitrary
     <*> pure (ShelleyLedgerTables ApplyEmptyMK)
+
+instance CanMock proto era => Arbitrary (LedgerState (ShelleyBlock proto era) ValuesMK) where
+  arbitrary = ShelleyLedgerState
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> (ShelleyLedgerTables . ApplyValuesMK . Values <$> arbitrary)
 
 instance CanMock proto era => Arbitrary (AnnTip (ShelleyBlock proto era)) where
   arbitrary = AnnTip

--- a/ouroboros-consensus-shelley-test/test/Main.hs
+++ b/ouroboros-consensus-shelley-test/test/Main.hs
@@ -6,6 +6,7 @@ import           Test.Tasty
 
 import qualified Test.Consensus.Shelley.Coherence (tests)
 import qualified Test.Consensus.Shelley.Golden (tests)
+import qualified Test.Consensus.Shelley.LedgerTables (tests)
 import qualified Test.Consensus.Shelley.Serialisation (tests)
 import qualified Test.ThreadNet.Shelley (tests)
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
@@ -19,6 +20,7 @@ tests =
   testGroup "shelley"
   [ Test.Consensus.Shelley.Coherence.tests
   , Test.Consensus.Shelley.Golden.tests
+  , Test.Consensus.Shelley.LedgerTables.tests
   , Test.Consensus.Shelley.Serialisation.tests
   , Test.ThreadNet.Shelley.tests
   ]

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/LedgerTables.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/LedgerTables.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Consensus.Shelley.LedgerTables (tests) where
+
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Shelley.Eras
+import           Ouroboros.Consensus.Shelley.Ledger
+
+import           Cardano.Crypto.Hash (ShortHash)
+
+import           Ouroboros.Consensus.Protocol.Praos (Praos)
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
+import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
+import           Ouroboros.Consensus.Shelley.HFEras ()
+import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+
+import           Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import           Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+
+import           Test.LedgerTables
+
+import           Test.Consensus.Shelley.Generators ()
+import           Test.Consensus.Shelley.MockCrypto (CanMock, MockCrypto)
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+type Crypto = MockCrypto ShortHash
+type Proto  = TPraos Crypto
+
+tests :: TestTree
+tests = testGroup "LedgerTables"
+  [ testGroup "Shelley"
+    [ testProperty "Stowable laws" (prop_stowable_laws @(ShelleyBlock Proto (ShelleyEra Crypto)))
+    , testProperty "TableStuff laws" (prop_tablestuff_laws @(ShelleyBlock Proto (ShelleyEra Crypto)))
+    ]
+  , testGroup "Allegra"
+    [ testProperty "Stowable laws" (prop_stowable_laws @(ShelleyBlock Proto (AllegraEra Crypto)))
+    , testProperty "TableStuff laws" (prop_tablestuff_laws @(ShelleyBlock Proto (AllegraEra Crypto)))
+    ]
+  , testGroup "Mary"
+    [ testProperty "Stowable laws" (prop_stowable_laws @(ShelleyBlock Proto (MaryEra Crypto)))
+    , testProperty "TableStuff laws" (prop_tablestuff_laws @(ShelleyBlock Proto (MaryEra Crypto)))
+    ]
+  , testGroup "Alonzo"
+    [ testProperty "Stowable laws" (prop_stowable_laws @(ShelleyBlock Proto (AlonzoEra Crypto)))
+    , testProperty "TableStuff laws" (prop_tablestuff_laws @(ShelleyBlock Proto (AlonzoEra Crypto)))
+    ]
+  , testGroup "Babbage"
+    [ testProperty "Stowable laws" (prop_stowable_laws @(ShelleyBlock (Praos StandardCrypto) (BabbageEra StandardCrypto)))
+    , testProperty "TableStuff laws" (prop_tablestuff_laws @(ShelleyBlock (Praos StandardCrypto) (BabbageEra StandardCrypto)))
+    ]
+  ]
+
+
+instance ( CanMock proto era
+         , Arbitrary (LedgerState (ShelleyBlock proto era) EmptyMK)
+         , StowableLedgerTables (LedgerState (ShelleyBlock proto era))
+         ) => Arbitrary (LedgerTables (LedgerState (ShelleyBlock proto era)) ValuesMK) where
+  arbitrary = projectLedgerTables . unstowLedgerTables <$> arbitrary
+
+instance ShelleyBasedEra era
+      => Show (LedgerTables (LedgerState (ShelleyBlock proto era)) EmptyMK) where
+  show x = showsLedgerState x ""
+
+instance ShelleyBasedEra era
+      => Show (LedgerTables (LedgerState (ShelleyBlock proto era)) ValuesMK) where
+  show x = showsLedgerState x ""

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -82,6 +82,8 @@ library
                        Test.Util.Tracer
                        Test.Util.WithEq
 
+                       Test.LedgerTables
+
   build-depends:       base              >=4.9 && <4.15
                      , base16-bytestring
                      , binary

--- a/ouroboros-consensus-test/src/Test/LedgerTables.hs
+++ b/ouroboros-consensus-test/src/Test/LedgerTables.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Test.LedgerTables (
+    prop_stowable_laws
+  , prop_tablestuff_laws
+  ) where
+
+import           Data.Function (on)
+
+import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
+
+import           Test.QuickCheck
+
+-- | We compare the Ledger Tables of the result because the comparison with the
+-- rest of the LedgerState takes considerably more time to run.
+(==?) ::
+  ( IsMapKind mk
+  , TableStuff (LedgerState blk)
+  , Eq (LedgerTables (LedgerState blk) mk)
+  , Show (LedgerTables (LedgerState blk) mk)
+  )
+  => LedgerState blk mk
+  -> LedgerState blk mk
+  -> Property
+(==?) = (===) `on` projectLedgerTables
+
+infixl 9 ==?
+
+-- | The StowableLedgerTables instances should follow these two laws:
+--
+-- > stow . unstow == id
+--
+-- > unstow . stow == id
+prop_stowable_laws ::
+     ( TableStuff (LedgerState blk)
+     , StowableLedgerTables (LedgerState blk)
+     , Eq (LedgerTables (LedgerState blk) EmptyMK)
+     , Show (LedgerTables (LedgerState blk) EmptyMK)
+     , Show (LedgerTables (LedgerState blk) ValuesMK)
+     )
+  => LedgerState blk EmptyMK
+  -> LedgerState blk ValuesMK
+  -> Property
+prop_stowable_laws = \ls ls' ->
+  stowLedgerTables (unstowLedgerTables ls) ==? ls .&&.
+  unstowLedgerTables (stowLedgerTables ls') ==? ls'
+
+-- | The TableStuff instances should follow these two laws:
+--
+-- > with . project == id
+--
+-- > project . with == id
+prop_tablestuff_laws ::
+     ( TableStuff (LedgerState blk)
+     , Eq (LedgerTables (LedgerState blk) EmptyMK)
+     , Show (LedgerTables (LedgerState blk) EmptyMK)
+     , Show (LedgerTables (LedgerState blk) ValuesMK)
+     )
+  => LedgerState blk EmptyMK
+  -> LedgerTables (LedgerState blk) ValuesMK
+  -> Property
+prop_tablestuff_laws = \ls tbs ->
+  (ls `withLedgerTables` (projectLedgerTables ls)) ==? ls .&&.
+  projectLedgerTables (ls `withLedgerTables` tbs) === tbs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
@@ -89,7 +89,6 @@ module Ouroboros.Consensus.Ledger.Tables (
     -- * Concrete Ledger tables
   , ApplyMapKind
   , ApplyMapKind' (..)
-  , showsApplyMapKind
   , CodecMK (..)
   , DiffMK
   , EmptyMK
@@ -100,6 +99,7 @@ module Ouroboros.Consensus.Ledger.Tables (
   , SeqDiffMK
   , TrackingMK
   , ValuesMK
+  , showsApplyMapKind
     -- * Serialization
   , SufficientSerializationForAnyBackingStore (..)
   , valuesMKDecoder


### PR DESCRIPTION
# Description

Implements PBT for laws on `TableStuff` and `StowableLedgerTables` for the Cardano blocks.

Closes #4270 and #4271