### PR TITLE
Make it possible to use bors again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - 'bors/*'
+      - 'staging'
+      - 'trying'
 
 jobs:
   build:

--- a/bors.toml
+++ b/bors.toml
@@ -7,7 +7,7 @@ status = [
   "build (9.2.5, ubuntu-latest)",
   "build (9.2.5, windows-latest)",
 ]
-timeout_sec = 7200
+timeout_sec = 10800
 required_approvals = 1
 block_labels = [ "WIP", "DO NOT MERGE" ]
 delete_merged_branches = true

--- a/flake.lock
+++ b/flake.lock
@@ -130,19 +130,24 @@
         "type": "github"
       }
     },
-    "mdbook-kroki-preprocessor": {
-      "flake": false,
+    "incl": {
+      "inputs": {
+        "nixlib": [
+          "std",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1661755005,
-        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
         "type": "github"
       },
       "original": {
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
+        "owner": "divnix",
+        "repo": "incl",
         "type": "github"
       }
     },
@@ -314,6 +319,21 @@
         "type": "github"
       }
     },
+    "nosys": {
+      "locked": {
+        "lastModified": 1667881534,
+        "narHash": "sha256-FhwJ15uPLRsvaxtt/bNuqE/ykMpNAPF0upozFKhTtXM=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "2d0d5207f6a230e9d0f660903f8db9807b54814f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": [
@@ -326,15 +346,19 @@
     },
     "std": {
       "inputs": {
+        "arion": [
+          "std",
+          "blank"
+        ],
         "blank": "blank",
         "devshell": "devshell",
         "dmerge": "dmerge",
         "flake-utils": "flake-utils",
+        "incl": "incl",
         "makes": [
           "std",
           "blank"
         ],
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
         "microvm": [
           "std",
           "blank"
@@ -342,14 +366,15 @@
         "n2c": "n2c",
         "nixago": "nixago",
         "nixpkgs": "nixpkgs",
+        "nosys": "nosys",
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1666722572,
-        "narHash": "sha256-p5hVXgBXnCnXfr06zj5LNJrg7K8a0ng/Pjvpz5rVVG4=",
+        "lastModified": 1673317235,
+        "narHash": "sha256-wrVmvBOaiDIQaYO+oVFCXnu8uLlNpeQSxpR+8JThFWY=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "c8197a5990dae3d5aca005b274f1ac62ab0bee91",
+        "rev": "30b8998b2a15434ba70dd973895accf79bddd641",
         "type": "github"
       },
       "original": {
@@ -368,11 +393,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668711738,
-        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
+        "lastModified": 1673288142,
+        "narHash": "sha256-LrUhUX0rK1tbjNo1tov+ZCDnLWKNM4UjuMvnX7DhBsU=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
+        "rev": "41502706d4bbd299b991ecbe79b4893e69cd5999",
         "type": "github"
       },
       "original": {
@@ -404,11 +429,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660507851,
-        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
+        "lastModified": 1667096281,
+        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
         "owner": "divnix",
         "repo": "yants",
-        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
+        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
         "type": "github"
       },
       "original": {

--- a/nix/cells/automation/pipelines.nix
+++ b/nix/cells/automation/pipelines.nix
@@ -13,6 +13,7 @@
         # so we don't need to fetch the source from GitHub and we don't want to report a GitHub status.
         enable = config.actionRun.facts != {};
         repository = "input-output-hk/ouroboros-network";
+        remote = config.preset.github.lib.readRepository inputs.cells.cloud.library.actionCiInputName null;
         revision = config.preset.github.lib.readRevision inputs.cells.cloud.library.actionCiInputName null;
       };
     };


### PR DESCRIPTION
# Description

As advised by @dermetfan, this updates `std` and `tullia` to make Nix CI run on non-default branches (so in particular on the branches used by bors) and also for forks. Also, the "revived" bors uses different branches for staging and trying, so updating the GH Actions triggers accordingly.

Also, I updated the bors timeout to 3 hours as in the past we repeatedly have been pretty close to hitting the two hour mark, and Cicero is still relatively slow (albeit the upcoming Nix update will improve things here as we have been told).

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
