### PR TITLE
Revive links to design and spec documents

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -29,6 +29,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: cachix/install-nix-action@v18
+    - name: Build documents
+      run: |
+        for res in $(nix-build -A network-docs -A consensus-docs); do
+          for pdf in $res/*.pdf; do
+            PDF_DIR=pdfs/$(basename $pdf .pdf)
+            mkdir -p $PDF_DIR
+            echo '<!DOCTYPE html>' > $PDF_DIR/index.html
+            echo -n '<!DOCTYPE html><meta http-equiv="refresh" content="0; URL=' >> $PDF_DIR/index.html
+            echo -n $(basename $pdf) >> $PDF_DIR/index.html
+            echo '">' >> $PDF_DIR/index.html
+            cp $pdf $PDF_DIR/
+          done
+        done
+
     - name: Select build directory
       run: |
         CABAL_BUILDDIR="dist-newstyle"

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Libraries:
 We have two documents which describe various levels of the networking layer of
 the Cardano Shelley implementation:
 
-* [Introduction to the design of Data Diffusion and Networking of Cardano Shelley](https://hydra.iohk.io/job/Cardano/ouroboros-network/native.network-docs.x86_64-linux/latest/download/1)
+* [Introduction to the design of Data Diffusion and Networking of Cardano Shelley](https://input-output-hk.github.io/ouroboros-network/pdfs/network-design)
 
   This document explains the technical requirements and key constraints for the networking
   layer of the _Cardano Shelley_ implementation of _Ouroboros Praos_.  This is
   a design document.
 
-* [The Shelley Networking Protocol](https://hydra.iohk.io/job/Cardano/ouroboros-network/native.network-docs.x86_64-linux/latest/download/2)
+* [The Shelley Networking Protocol](https://input-output-hk.github.io/ouroboros-network/pdfs/network-spec)
 
   This document is a technical specification of the networking protocol.  It
   includes serialisation formats, necessary details of multiplexer and
@@ -91,7 +91,7 @@ The `ouroboros-consensus/docs` folder contains documentation about the
 consensus layer. Start with the
 [README.md](https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/README.md).
 
-* [The Cardano Consensus and Storage Layer](https://hydra.iohk.io/job/Cardano/ouroboros-network/native.consensus-docs.x86_64-linux/latest/download/1)
+* [The Cardano Consensus and Storage Layer](https://input-output-hk.github.io/ouroboros-network/pdfs/report)
 
   This technical report explains the design of the consensus and storage layer.
 

--- a/docs/network-design/network-design.tex
+++ b/docs/network-design/network-design.tex
@@ -25,7 +25,7 @@
        Data Diffusion and Networking for
        Cardano Shelley\footnote{Supplemented by a Part 2 which is a
        Reference Document aimed at implementers of Shelly.
-  \href{https://hydra.iohk.io/build/1011577/download/1/network.pdf}{{https://hydra.iohk.io/build/1011577/download/1/network.pdf}}} \\
+  \url{https://input-output-hk.github.io/ouroboros-network/pdfs/network-spec}} \\
        {\large \sc An IOHK technical report}
   }
 \date{Version 1.9, August 2020}
@@ -3676,7 +3676,7 @@ Resulting design decisions include:
 \end{itemize}
 
 Details of these protocols can be found in the
-\href{https://hydra.iohk.io/build/1011577/download/1/network.pdf}{{second
+\href{https://input-output-hk.github.io/ouroboros-network/pdfs/network-spec}{{second
 part of the design documentation}}.
 
 \subsubsection{Protocol polymorphism}

--- a/docs/network-spec/connection-manager.tex
+++ b/docs/network-spec/connection-manager.tex
@@ -192,7 +192,7 @@
 
 \section{Introduction}
 
-As described in the \href{https://hydra.iohk.io/build/5866649/download/1/network-design.pdf}{Network Design} document, the goal is to transition to a more
+As described in the \href{https://input-output-hk.github.io/ouroboros-network/pdfs/network-design}{Network Design} document, the goal is to transition to a more
 decentralized network. To make that happen, a plan was designed to come up with a P2P
 network that is capable to achieve desired network properties. One key component of
 such design is the \ptopgov{}, which is responsible for managing the \cold{}/\warm{}/\hot{}

--- a/network-mux/src/Network/Mux/Bearer.hs
+++ b/network-mux/src/Network/Mux/Bearer.hs
@@ -40,12 +40,12 @@ import           Network.Mux.Bearer.NamedPipe
 newtype MakeBearer m fd = MakeBearer {
     getBearer
       :: DiffTime
-      -- ^ timeout for reading an SDUMux segment, if negative no
+      -- timeout for reading an SDUMux segment, if negative no
       -- timeout is applied.
       -> Tracer m MuxTrace
-      -- ^ tracer
+      -- tracer
       -> fd
-      -- ^ file descriptor
+      -- file descriptor
       -> m (MuxBearer m)
   }
 


### PR DESCRIPTION
# Description

Closes #4209

Instead of linking directly to the PDF files, I created proxy HTML files which redirect to them such that we can later change the URL without breaking existing links.

Also fixes some invalid Haddock markup for the nightly site deploy to actually go through, cf. https://github.com/input-output-hk/ouroboros-network/actions/workflows/github-page.yml

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
