### PR TITLE
Generalize `LedgerState` by adding a new type-parameter

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -208,11 +208,11 @@ bridgeTransactionIds = Spec.Test.transactionIds
 forgeDualByronBlock
   :: HasCallStack
   => TopLevelConfig DualByronBlock
-  -> BlockNo                              -- ^ Current block number
-  -> SlotNo                               -- ^ Current slot number
-  -> TickedLedgerState DualByronBlock     -- ^ Ledger
-  -> [Validated (GenTx DualByronBlock)]   -- ^ Txs to add in the block
-  -> PBftIsLeader PBftByronCrypto         -- ^ Leader proof ('IsLeader')
+  -> BlockNo                                    -- ^ Current block number
+  -> SlotNo                                     -- ^ Current slot number
+  -> TickedLedgerState DualByronBlock Canonical -- ^ Ledger
+  -> [Validated (GenTx DualByronBlock)]         -- ^ Txs to add in the block
+  -> PBftIsLeader PBftByronCrypto               -- ^ Leader proof ('IsLeader')
   -> DualByronBlock
 forgeDualByronBlock cfg curBlockNo curSlotNo tickedLedger vtxs isLeader =
     -- NOTE: We do not /elaborate/ the real Byron block from the spec one, but

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -148,8 +148,8 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params credss =
         configGenesisData  = Impl.configGenesisData translated
         protocolParameters = Impl.gdProtocolParameters configGenesisData
 
-    initAbstractState :: LedgerState ByronSpecBlock
-    initConcreteState :: LedgerState ByronBlock
+    initAbstractState :: LedgerState ByronSpecBlock Canonical
+    initConcreteState :: LedgerState ByronBlock Canonical
 
     initAbstractState = initByronSpecLedgerState abstractGenesis
     initConcreteState = initByronLedgerState     concreteGenesis (Just initUtxo)

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -68,9 +68,9 @@ instance DecodeDiskDep (NestedCtxt Header) DualByronBlock where
                 (NestedCtxt (CtxtDual ctxt)) =
       decodeDiskDep ccfg (NestedCtxt ctxt)
 
-instance EncodeDisk DualByronBlock (LedgerState DualByronBlock) where
+instance EncodeDisk DualByronBlock (LedgerState DualByronBlock Canonical) where
   encodeDisk _ = encodeDualLedgerState encodeByronLedgerState
-instance DecodeDisk DualByronBlock (LedgerState DualByronBlock) where
+instance DecodeDisk DualByronBlock (LedgerState DualByronBlock Canonical) where
   decodeDisk _ = decodeDualLedgerState decodeByronLedgerState
 
 -- | @'ChainDepState' ('BlockProtocol' 'DualByronBlock')@

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -173,7 +173,7 @@ exampleChainDepState = S.fromList signers
   where
     signers = map (`S.PBftSigner` CC.exampleKeyHash) [1..4]
 
-emptyLedgerState :: LedgerState ByronBlock
+emptyLedgerState :: LedgerState ByronBlock Canonical
 emptyLedgerState = ByronLedgerState {
       byronLedgerTipBlockNo = Origin
     , byronLedgerState      = initState
@@ -184,13 +184,13 @@ emptyLedgerState = ByronLedgerState {
     Right initState = runExcept $
       CC.Block.initialChainValidationState ledgerConfig
 
-ledgerStateAfterEBB :: LedgerState ByronBlock
+ledgerStateAfterEBB :: LedgerState ByronBlock Canonical
 ledgerStateAfterEBB =
       reapplyLedgerBlock ledgerConfig exampleEBB
     . applyChainTick ledgerConfig (SlotNo 0)
     $ emptyLedgerState
 
-exampleLedgerState :: LedgerState ByronBlock
+exampleLedgerState :: LedgerState ByronBlock Canonical
 exampleLedgerState =
       reapplyLedgerBlock ledgerConfig exampleBlock
     . applyChainTick ledgerConfig (SlotNo 1)
@@ -199,7 +199,7 @@ exampleLedgerState =
 exampleHeaderState :: HeaderState ByronBlock
 exampleHeaderState = HeaderState (NotOrigin exampleAnnTip) exampleChainDepState
 
-exampleExtLedgerState :: ExtLedgerState ByronBlock
+exampleExtLedgerState :: ExtLedgerState ByronBlock Canonical
 exampleExtLedgerState = ExtLedgerState {
       ledgerState = exampleLedgerState
     , headerState = exampleHeaderState

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -41,6 +41,7 @@ import           Ouroboros.Network.SizeInBytes
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HeaderValidation (AnnTip (..))
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Protocol.PBFT.State (PBftState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as PBftState
@@ -268,7 +269,7 @@ instance Arbitrary CC.Del.Map where
 instance Arbitrary ByronTransition where
   arbitrary = ByronTransitionInfo . Map.fromList <$> arbitrary
 
-instance Arbitrary (LedgerState ByronBlock) where
+instance Arbitrary (LedgerState ByronBlock Canonical) where
   arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary (TipInfoIsEBB ByronBlock) where

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -40,6 +40,7 @@ import qualified Cardano.Crypto as Crypto
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      ProtocolInfo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
@@ -94,7 +95,7 @@ mkUpdateLabels
   -> NodeJoinPlan
   -> NodeTopology
   -> Ref.Result
-  -> Byron.LedgerState ByronBlock
+  -> Byron.LedgerState ByronBlock Canonical
      -- ^ from 'nodeOutputFinalLedger'
   -> (ProtocolVersionUpdateLabel, SoftwareVersionUpdateLabel)
 mkUpdateLabels params numSlots genesisConfig nodeJoinPlan topology result

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
@@ -39,6 +39,7 @@ import qualified Ouroboros.Network.Mock.Chain as Chain
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -974,7 +975,7 @@ prop_simple_real_pbft_convergence TestSetup
     finalChains :: [(NodeId, Chain ByronBlock)]
     finalChains = Map.toList $ nodeOutputFinalChain <$> testOutputNodes testOutput
 
-    finalLedgers :: [(NodeId, Byron.LedgerState ByronBlock)]
+    finalLedgers :: [(NodeId, Byron.LedgerState ByronBlock Canonical)]
     finalLedgers = Map.toList $ nodeOutputFinalLedger <$> testOutputNodes testOutput
 
     pvuLabels :: [(NodeId, ProtocolVersionUpdateLabel)]

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -268,7 +268,7 @@ instance TxGen DualByronBlock where
       -- Stops when the transaction generator cannot produce more txs
       go :: [GenTx DualByronBlock]     -- Accumulator
          -> Integer                    -- Number of txs to still produce
-         -> TickedLedgerState DualByronBlock
+         -> TickedLedgerState DualByronBlock Canonical
          -> Gen [GenTx DualByronBlock]
       go acc 0 _  = return (reverse acc)
       go acc n st = do
@@ -289,7 +289,7 @@ instance TxGen DualByronBlock where
 -- for now. Extending the scope will require integration with the restart/rekey
 -- infrastructure of the Byron tests.
 genTx :: TopLevelConfig DualByronBlock
-      -> Ticked (LedgerState DualByronBlock)
+      -> Ticked1 (LedgerState DualByronBlock) Canonical
       -> Gen (GenTx DualByronBlock)
 genTx cfg st = do
     aux <- sigGen (Rules.ctxtUTXOW cfg') st'

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -51,13 +51,13 @@ import           Ouroboros.Consensus.Byron.Protocol
 forgeByronBlock
   :: HasCallStack
   => TopLevelConfig ByronBlock
-  -> TxLimits.Overrides ByronBlock    -- ^ How to override max tx capacity
-                                      --   defined by ledger
-  -> BlockNo                          -- ^ Current block number
-  -> SlotNo                           -- ^ Current slot number
-  -> TickedLedgerState ByronBlock     -- ^ Current ledger
-  -> [Validated (GenTx ByronBlock)]   -- ^ Txs to consider adding in the block
-  -> PBftIsLeader PBftByronCrypto     -- ^ Leader proof ('IsLeader')
+  -> TxLimits.Overrides ByronBlock          -- ^ How to override max tx capacity
+                                            --   defined by ledger
+  -> BlockNo                                -- ^ Current block number
+  -> SlotNo                                 -- ^ Current slot number
+  -> TickedLedgerState ByronBlock Canonical -- ^ Current ledger
+  -> [Validated (GenTx ByronBlock)]         -- ^ Txs to consider adding in the block
+  -> PBftIsLeader PBftByronCrypto           -- ^ Leader proof ('IsLeader')
   -> ByronBlock
 forgeByronBlock cfg = forgeRegularBlock (configBlock cfg)
 
@@ -128,13 +128,13 @@ initBlockPayloads = BlockPayloads
 forgeRegularBlock
   :: HasCallStack
   => BlockConfig ByronBlock
-  -> TxLimits.Overrides ByronBlock     -- ^ How to override max tx capacity
-                                       --   defined by ledger
-  -> BlockNo                           -- ^ Current block number
-  -> SlotNo                            -- ^ Current slot number
-  -> TickedLedgerState ByronBlock      -- ^ Current ledger
-  -> [Validated (GenTx ByronBlock)]    -- ^ Txs to consider adding in the block
-  -> PBftIsLeader PBftByronCrypto      -- ^ Leader proof ('IsLeader')
+  -> TxLimits.Overrides ByronBlock          -- ^ How to override max tx capacity
+                                            --   defined by ledger
+  -> BlockNo                                -- ^ Current block number
+  -> SlotNo                                 -- ^ Current slot number
+  -> TickedLedgerState ByronBlock Canonical -- ^ Current ledger
+  -> [Validated (GenTx ByronBlock)]         -- ^ Txs to consider adding in the block
+  -> PBftIsLeader PBftByronCrypto           -- ^ Leader proof ('IsLeader')
   -> ByronBlock
 forgeRegularBlock cfg maxTxCapacityOverrides bno sno st txs isLeader =
     forge $

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Inspect.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Inspect.hs
@@ -107,7 +107,7 @@ data UpdateState =
 -- | All proposal updates, from new to old
 protocolUpdates ::
        LedgerConfig ByronBlock
-    -> LedgerState ByronBlock
+    -> LedgerState ByronBlock Canonical
     -> [ProtocolUpdate]
 protocolUpdates genesis st = concat [
       map fromCandidate candidates

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -249,8 +249,8 @@ applyByronGenTx :: CC.ValidationMode
                 -> LedgerConfig ByronBlock
                 -> SlotNo
                 -> GenTx ByronBlock
-                -> TickedLedgerState ByronBlock
-                -> Except (ApplyTxErr ByronBlock) (TickedLedgerState ByronBlock)
+                -> TickedLedgerState ByronBlock Canonical
+                -> Except (ApplyTxErr ByronBlock) (TickedLedgerState ByronBlock Canonical)
 applyByronGenTx validationMode cfg slot genTx st =
     (\state -> st {tickedByronLedgerState = state}) <$>
       CC.applyMempoolPayload

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -28,6 +28,7 @@ import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
@@ -52,9 +53,9 @@ instance EncodeDisk ByronBlock ByronBlock where
 instance DecodeDisk ByronBlock (Lazy.ByteString -> ByronBlock) where
   decodeDisk ccfg = decodeByronBlock (getByronEpochSlots ccfg)
 
-instance EncodeDisk ByronBlock (LedgerState ByronBlock) where
+instance EncodeDisk ByronBlock (LedgerState ByronBlock Canonical) where
   encodeDisk _ = encodeByronLedgerState
-instance DecodeDisk ByronBlock (LedgerState ByronBlock) where
+instance DecodeDisk ByronBlock (LedgerState ByronBlock Canonical) where
   decodeDisk _ = decodeByronLedgerState
 
 -- | @'ChainDepState' ('BlockProtocol' 'ByronBlock')@

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
@@ -21,7 +21,7 @@ import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans ()
 
 forgeByronSpecBlock :: BlockNo
                     -> SlotNo
-                    -> Ticked (LedgerState ByronSpecBlock)
+                    -> Ticked1 (LedgerState ByronSpecBlock) Canonical
                     -> [Validated (GenTx ByronSpecBlock)]
                     -> Spec.VKey
                     -> ByronSpecBlock

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -40,6 +40,7 @@ import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
 import qualified Ouroboros.Consensus.HardFork.Combinator.State.Types as HFC
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 import qualified Ouroboros.Consensus.HardFork.History as History
@@ -159,17 +160,19 @@ instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
       translateLedgerState ::
            InPairs.RequiringBoth
              WrapLedgerConfig
-             (HFC.Translate LedgerState)
+             HFC.TranslateLedgerState
              (ShelleyBlock proto1 era1)
              (ShelleyBlock proto2 era2)
       translateLedgerState =
           InPairs.RequireBoth
-        $ \_cfg1 cfg2 -> HFC.Translate
+        $ \_cfg1 cfg2 -> HFC.TranslateLedgerState
         $ \_epochNo ->
-              unComp
+              unFlip
+            . unComp
             . SL.translateEra'
                 (shelleyLedgerTranslationContext (unwrapLedgerConfig cfg2))
             . Comp
+            . Flip
 
       translateLedgerView ::
            InPairs.RequiringBoth

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -56,6 +56,7 @@ import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock (..),
                      OneEraBlock (..), OneEraHash (..), getHardForkState,
                      hardForkLedgerStatePerEra)
 import           Ouroboros.Consensus.HardFork.Combinator.State (currentState)
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -101,15 +102,15 @@ analyseWithLedgerState f (WithLedgerState cb sb sa) =
     p :: Proxy HasAnalysis
     p = Proxy
 
-    zipLS (Comp (Just sb')) (Comp (Just sa')) (I blk) =
+    zipLS (Comp (Just (Flip sb'))) (Comp (Just (Flip sa'))) (I blk) =
       Comp . Just $ WithLedgerState blk sb' sa'
     zipLS _ _ _ = Comp Nothing
 
     oeb = getOneEraBlock . getHardForkBlock $ cb
 
     goLS ::
-      LedgerState (CardanoBlock StandardCrypto) ->
-      NP (Maybe :.: LedgerState) (CardanoEras StandardCrypto)
+      LedgerState (CardanoBlock StandardCrypto) Canonical ->
+      NP (Maybe :.: (Flip LedgerState Canonical)) (CardanoEras StandardCrypto)
     goLS =
       hexpand (Comp Nothing)
         . hmap (Comp . Just . currentState)

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/HasAnalysis.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/HasAnalysis.hs
@@ -24,8 +24,8 @@ import           Ouroboros.Consensus.Util.Condense (Condense)
 
 data WithLedgerState blk = WithLedgerState
   { wlsBlk         :: blk
-  , wlsStateBefore :: LedgerState blk
-  , wlsStateAfter  :: LedgerState blk
+  , wlsStateBefore :: LedgerState blk Canonical
+  , wlsStateAfter  :: LedgerState blk Canonical
   }
 
 class (HasAnnTip blk, GetPrevHash blk, Condense (HeaderHash blk)) => HasAnalysis blk where

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Run.hs
@@ -16,6 +16,7 @@ import           Control.Tracer (Tracer (..), nullTracer)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as LedgerSupportsMempool
                      (HasTxs)
@@ -145,7 +146,7 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
       (OnlyValidation, _ )             -> VolatileDB.ValidateAll
       _                                -> VolatileDB.NoValidation
 
-    decodeExtLedgerState' :: forall s . TopLevelConfig blk -> Decoder s (ExtLedgerState blk)
+    decodeExtLedgerState' :: forall s . TopLevelConfig blk -> Decoder s (ExtLedgerState blk Canonical)
     decodeExtLedgerState' cfg =
       let ccfg = configCodec cfg
       in decodeExtLedgerState

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -35,6 +35,7 @@ import           Ouroboros.Consensus.Storage.ChainDB.API as ChainDB (ChainDB,
                      getPastLedger)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
                      (noPunishment)
+import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util.IOLike (atomically)
 import           Ouroboros.Network.AnchoredFragment as AF (Anchor (..),
                      AnchoredFragment, AnchoredSeq (..), headPoint)
@@ -151,7 +152,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg = do
           _   -> exitEarly' "NoLeader"
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
-        let tickedLedgerState :: Ticked (LedgerState blk)
+        let tickedLedgerState :: Ticked1 (LedgerState blk) Canonical
             tickedLedgerState =
               applyChainTick
                 (configLedger cfg)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -71,7 +71,7 @@ import           Data.SOP.Strict
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError,
                      TipInfo)
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerError)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr,
                      GenTxId)
 import           Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
@@ -80,6 +80,7 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 
@@ -938,55 +939,55 @@ pattern CardanoLedgerConfig cfgByron cfgShelley cfgAllegra cfgMary cfgAlonzo cfg
 -- 'LedgerState'. We don't give access to those internal details through the
 -- pattern synonyms. This is also the reason the pattern synonyms are not
 -- bidirectional.
-type CardanoLedgerState c = LedgerState (CardanoBlock c)
+type CardanoLedgerState c = LedgerState (CardanoBlock c) Canonical
 
 pattern LedgerStateByron
-  :: LedgerState ByronBlock
+  :: LedgerState ByronBlock Canonical
   -> CardanoLedgerState c
 pattern LedgerStateByron st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleByron (State.Current { currentState = st })))
+        (TeleByron (State.Current { currentState = Flip st })))
 
 pattern LedgerStateShelley
-  :: LedgerState (ShelleyBlock (TPraos c) (ShelleyEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (ShelleyEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateShelley st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleShelley _ (State.Current { currentState = st })))
+        (TeleShelley _ (State.Current { currentState = Flip st })))
 
 pattern LedgerStateAllegra
-  :: LedgerState (ShelleyBlock (TPraos c) (AllegraEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (AllegraEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateAllegra st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleAllegra _ _  (State.Current { currentState = st })))
+        (TeleAllegra _ _  (State.Current { currentState = Flip st })))
 
 pattern LedgerStateMary
-  :: LedgerState (ShelleyBlock (TPraos c) (MaryEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (MaryEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateMary st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleMary _ _ _ (State.Current { currentState = st })))
+        (TeleMary _ _ _ (State.Current { currentState = Flip st })))
 
 pattern LedgerStateAlonzo
-  :: LedgerState (ShelleyBlock (TPraos c) (AlonzoEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (AlonzoEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateAlonzo st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleAlonzo _ _ _ _ (State.Current { currentState = st })))
+        (TeleAlonzo _ _ _ _ (State.Current { currentState = Flip st })))
 
 pattern LedgerStateBabbage
-  :: LedgerState (ShelleyBlock (Praos c) (BabbageEra c))
+  :: LedgerState (ShelleyBlock (Praos c) (BabbageEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateBabbage st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleBabbage _ _ _ _ _ (State.Current { currentState = st })))
+        (TeleBabbage _ _ _ _ _ (State.Current { currentState = Flip st })))
 
 {-# COMPLETE LedgerStateByron
            , LedgerStateShelley

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -63,6 +63,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -833,21 +834,21 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
     -- When the initial ledger state is not in the Byron era, register the
     -- initial staking and initial funds (if provided in the genesis config) in
     -- the ledger state.
-    initExtLedgerStateCardano :: ExtLedgerState (CardanoBlock c)
+    initExtLedgerStateCardano :: ExtLedgerState (CardanoBlock c) Canonical
     initExtLedgerStateCardano = ExtLedgerState {
           headerState = initHeaderState
         , ledgerState = overShelleyBasedLedgerState register initLedgerState
         }
       where
         initHeaderState :: HeaderState (CardanoBlock c)
-        initLedgerState :: LedgerState (CardanoBlock c)
+        initLedgerState :: LedgerState (CardanoBlock c) Canonical
         ExtLedgerState initLedgerState initHeaderState =
           injectInitialExtLedgerState cfg initExtLedgerStateByron
 
         register ::
              (EraCrypto era ~ c, ShelleyBasedEra era)
-          => LedgerState (ShelleyBlock proto era)
-          -> LedgerState (ShelleyBlock proto era)
+          => LedgerState (ShelleyBlock proto era) Canonical
+          -> LedgerState (ShelleyBlock proto era) Canonical
         register st = st {
               Shelley.shelleyLedgerState =
                 -- We must first register the initial funds, because the stake

--- a/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/Node.hs
@@ -90,6 +90,7 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -539,7 +540,7 @@ openChainDB
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
      -- ^ Initial ledger
   -> ChainDbArgs Defaults m blk
   -> (ChainDbArgs Identity m blk -> ChainDbArgs Identity m blk)
@@ -559,7 +560,7 @@ mkChainDbArgs
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
      -- ^ Initial ledger
   -> ChunkInfo
   -> ChainDbArgs Defaults m blk

--- a/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/NodeKernel.hs
@@ -337,7 +337,7 @@ forkBlockForging IS{..} blockForging =
         trace $ TraceNodeIsLeader currentSlot
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
-        let tickedLedgerState :: Ticked (LedgerState blk)
+        let tickedLedgerState :: Ticked1 (LedgerState blk) Canonical
             tickedLedgerState =
               applyChainTick
                 (configLedger cfg)
@@ -586,7 +586,7 @@ getMempoolWriter mempool = Inbound.TxSubmissionMempoolWriter
 getPeersFromCurrentLedger ::
      (IOLike m, LedgerSupportsPeerSelection blk)
   => NodeKernel m remotePeer localPeer blk
-  -> (LedgerState blk -> Bool)
+  -> (LedgerState blk Canonical -> Bool)
   -> STM m (Maybe [(PoolStake, NonEmpty RelayAccessPoint)])
 getPeersFromCurrentLedger kernel p = do
     immutableLedger <-
@@ -612,7 +612,7 @@ getPeersFromCurrentLedgerAfterSlot ::
 getPeersFromCurrentLedgerAfterSlot kernel slotNo =
     getPeersFromCurrentLedger kernel afterSlotNo
   where
-    afterSlotNo :: LedgerState blk -> Bool
+    afterSlotNo :: LedgerState blk Canonical -> Bool
     afterSlotNo st =
       case ledgerTipSlot st of
         Origin        -> False

--- a/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
@@ -27,6 +27,7 @@ import           Test.QuickCheck
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (hashFromBytesE)
@@ -114,7 +115,7 @@ instance Arbitrary (SomeSecond BlockQuery (SimpleBlock c ext)) where
 instance (SimpleCrypto c, Typeable ext) => Arbitrary (SomeResult (SimpleBlock c ext)) where
   arbitrary = SomeResult QueryLedgerTip <$> arbitrary
 
-instance Arbitrary (LedgerState (SimpleBlock c ext)) where
+instance Arbitrary (LedgerState (SimpleBlock c ext) Canonical) where
   arbitrary = SimpleLedgerState <$> arbitrary
 
 instance HashAlgorithm (SimpleHash c) => Arbitrary (AnnTip (SimpleBlock c ext)) where

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -43,10 +43,10 @@ forgeSimple :: forall c ext.
                )
             => ForgeExt c ext
             -> TopLevelConfig (SimpleBlock c ext)
-            -> BlockNo                                   -- ^ Current block number
-            -> SlotNo                                    -- ^ Current slot number
-            -> TickedLedgerState (SimpleBlock c ext)     -- ^ Current ledger
-            -> [GenTx (SimpleBlock c ext)]               -- ^ Txs to include
+            -> BlockNo                                         -- ^ Current block number
+            -> SlotNo                                          -- ^ Current slot number
+            -> TickedLedgerState (SimpleBlock c ext) Canonical -- ^ Current ledger
+            -> [GenTx (SimpleBlock c ext)]                     -- ^ Txs to include
             -> IsLeader (BlockProtocol (SimpleBlock c ext))
             -> SimpleBlock c ext
 forgeSimple ForgeExt { forgeExt } cfg curBlock curSlot tickedLedger txs proof =

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -55,8 +55,8 @@ instance Serialise ext => EncodeDisk (MockBlock ext) (Header (MockBlock ext))
 instance Serialise ext => DecodeDisk (MockBlock ext) (Lazy.ByteString -> Header (MockBlock ext)) where
   decodeDisk _ = const <$> decode
 
-instance EncodeDisk (MockBlock ext) (LedgerState (MockBlock ext))
-instance DecodeDisk (MockBlock ext) (LedgerState (MockBlock ext))
+instance EncodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical)
+instance DecodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical)
 
 instance EncodeDisk (MockBlock ext) (AnnTip (MockBlock ext)) where
   encodeDisk _ = defaultEncodeAnnTip encode

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -182,7 +182,7 @@ instance CanMock proto era=> Arbitrary (ShelleyTip proto era) where
 instance Arbitrary ShelleyTransition where
   arbitrary = ShelleyTransitionInfo <$> arbitrary
 
-instance CanMock proto era => Arbitrary (LedgerState (ShelleyBlock proto era)) where
+instance CanMock proto era => Arbitrary (LedgerState (ShelleyBlock proto era) Canonical) where
   arbitrary = ShelleyLedgerState
     <$> arbitrary
     <*> arbitrary

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -80,7 +80,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (TPraos (MockCrypto h)) (MockShe
 
       go :: [GenTx (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))]  -- ^ Accumulator
          -> Integer  -- ^ Number of txs to still produce
-         -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))
+         -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h)) Canonical
          -> Gen [GenTx (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))]
       go acc 0 _  = return (reverse acc)
       go acc n st = do
@@ -96,7 +96,7 @@ genTx
   :: forall h. HashAlgorithm h
   => TopLevelConfig (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))
   -> SlotNo
-  -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))
+  -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h)) Canonical
   -> Gen.GenEnv (MockShelley h)
   -> Gen (Maybe (GenTx (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))))
 genTx _cfg slotNo TickedShelleyLedgerState { tickedShelleyLedgerState } genEnv =

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
@@ -362,7 +362,7 @@ prop_simple_real_tpraos_convergence TestSetup
             DoGeneratePPUs    -> True
             DoNotGeneratePPUs -> False
 
-        finalLedgers :: [(NodeId, LedgerState (ShelleyBlock Proto Era))]
+        finalLedgers :: [(NodeId, LedgerState (ShelleyBlock Proto Era) Canonical)]
         finalLedgers =
             Map.toList $ nodeOutputFinalLedger <$> testOutputNodes testOutput
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -48,12 +48,12 @@ forgeShelleyBlock ::
   => HotKey (EraCrypto era) m
   -> CanBeLeader proto
   -> TopLevelConfig (ShelleyBlock proto era)
-  -> TxLimits.Overrides (ShelleyBlock proto era)  -- ^ How to override max tx
-                                                  --   capacity defined by ledger
-  -> BlockNo                                      -- ^ Current block number
-  -> SlotNo                                       -- ^ Current slot number
-  -> TickedLedgerState (ShelleyBlock proto era)   -- ^ Current ledger
-  -> [Validated (GenTx (ShelleyBlock proto era))] -- ^ Txs to add in the block
+  -> TxLimits.Overrides (ShelleyBlock proto era)          -- ^ How to override max tx
+                                                          --   capacity defined by ledger
+  -> BlockNo                                              -- ^ Current block number
+  -> SlotNo                                               -- ^ Current slot number
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical -- ^ Current ledger
+  -> [Validated (GenTx (ShelleyBlock proto era))]         -- ^ Txs to add in the block
   -> IsLeader proto
   -> m (ShelleyBlock proto era)
 forgeShelleyBlock

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -106,7 +106,7 @@ data UpdateState c = UpdateState {
 protocolUpdates ::
        forall era proto. ShelleyBasedEra era
     => SL.ShelleyGenesis era
-    -> LedgerState (ShelleyBlock proto era)
+    -> LedgerState (ShelleyBlock proto era) Canonical
     -> [ProtocolUpdate era]
 protocolUpdates genesis st = [
       ProtocolUpdate {

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -73,7 +73,7 @@ import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger
                      (ShelleyLedgerConfig (shelleyLedgerGlobals),
-                     Ticked (TickedShelleyLedgerState, tickedShelleyLedgerState),
+                     Ticked1 (TickedShelleyLedgerState, tickedShelleyLedgerState),
                      getPParams)
 
 data instance GenTx (ShelleyBlock proto era) = ShelleyTx !(SL.TxId (EraCrypto era)) !(Tx era)
@@ -224,9 +224,9 @@ applyShelleyTx :: forall era proto.
   -> WhetherToIntervene
   -> SlotNo
   -> GenTx (ShelleyBlock proto era)
-  -> TickedLedgerState (ShelleyBlock proto era)
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical
   -> Except (ApplyTxErr (ShelleyBlock proto era))
-       ( TickedLedgerState (ShelleyBlock proto era)
+       ( TickedLedgerState (ShelleyBlock proto era) Canonical
        , Validated (GenTx (ShelleyBlock proto era))
        )
 applyShelleyTx cfg wti slot (ShelleyTx _ tx) st = do
@@ -249,8 +249,8 @@ reapplyShelleyTx ::
   => LedgerConfig (ShelleyBlock proto era)
   -> SlotNo
   -> Validated (GenTx (ShelleyBlock proto era))
-  -> TickedLedgerState (ShelleyBlock proto era)
-  -> Except (ApplyTxErr (ShelleyBlock proto era)) (TickedLedgerState (ShelleyBlock proto era))
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical
+  -> Except (ApplyTxErr (ShelleyBlock proto era)) (TickedLedgerState (ShelleyBlock proto era) Canonical)
 reapplyShelleyTx cfg slot vgtx st = do
     mempoolState' <-
         SL.reapplyTx
@@ -275,8 +275,8 @@ set lens inner outer =
 theLedgerLens ::
      Functor f
   => (SL.LedgerState era -> f (SL.LedgerState era))
-  -> TickedLedgerState (ShelleyBlock proto era)
-  -> f (TickedLedgerState (ShelleyBlock proto era))
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical
+  -> f (TickedLedgerState (ShelleyBlock proto era) Canonical)
 theLedgerLens f x =
         (\y -> x{tickedShelleyLedgerState = y})
     <$> SL.overNewEpochState f (tickedShelleyLedgerState x)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
@@ -113,7 +113,7 @@ instance
     mapForecast (translateTickedLedgerView @(TPraos crypto) @(Praos crypto)) $
       ledgerViewForecastAt @(ShelleyBlock (TPraos crypto) era) cfg st'
     where
-      st' :: LedgerState (ShelleyBlock (TPraos crypto) era)
+      st' :: LedgerState (ShelleyBlock (TPraos crypto) era) Canonical
       st' =
         ShelleyLedgerState
           { shelleyLedgerTip = coerceTip <$> shelleyLedgerTip st,

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -17,6 +17,7 @@ import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
@@ -53,9 +54,9 @@ instance ShelleyCompatible proto era => EncodeDisk (ShelleyBlock proto era) (Hea
 instance ShelleyCompatible proto era => DecodeDisk (ShelleyBlock proto era) (Lazy.ByteString -> Header (ShelleyBlock proto era)) where
   decodeDisk _ = decodeShelleyHeader
 
-instance ShelleyCompatible proto era => EncodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era)) where
+instance ShelleyCompatible proto era => EncodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era) Canonical) where
   encodeDisk _ = encodeShelleyLedgerState
-instance ShelleyCompatible proto era => DecodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era)) where
+instance ShelleyCompatible proto era => DecodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era) Canonical) where
   decodeDisk _ = decodeShelleyLedgerState
 
 -- | @'ChainDepState' ('BlockProtocol' ('ShelleyBlock' era))@

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -322,7 +322,7 @@ protocolInfoTPraosShelleyBased ProtocolParamsShelleyBased {
         , shelleyStorageConfigSecurityParam     = tpraosSecurityParam     tpraosParams
         }
 
-    initLedgerState :: LedgerState (ShelleyBlock (TPraos c) era)
+    initLedgerState :: LedgerState (ShelleyBlock (TPraos c) era) Canonical
     initLedgerState = ShelleyLedgerState {
         shelleyLedgerTip        = Origin
       , shelleyLedgerState      =
@@ -335,7 +335,7 @@ protocolInfoTPraosShelleyBased ProtocolParamsShelleyBased {
     initChainDepState = TPraosState Origin $
       SL.initialChainDepState initialNonce (SL.sgGenDelegs genesis)
 
-    initExtLedgerState :: ExtLedgerState (ShelleyBlock (TPraos c) era)
+    initExtLedgerState :: ExtLedgerState (ShelleyBlock (TPraos c) era) Canonical
     initExtLedgerState = ExtLedgerState {
         ledgerState = initLedgerState
       , headerState = genesisHeaderState initChainDepState

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -236,7 +236,7 @@ data ThreadNetworkArgs m blk = ThreadNetworkArgs
 -- context.
 --
 data VertexStatus m blk
-  = VDown (Chain blk) (LedgerState blk)
+  = VDown (Chain blk) (LedgerState blk Canonical)
     -- ^ The vertex does not currently have a node instance; its previous
     -- instance stopped with this chain and ledger state (empty/initial before
     -- first instance)
@@ -588,7 +588,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       -> ResourceRegistry m
       -> (SlotNo -> STM m ())
       -> LedgerConfig blk
-      -> STM m (LedgerState blk)
+      -> STM m (LedgerState blk Canonical)
       -> Mempool m blk TicketNo
       -> [GenTx blk]
          -- ^ valid transactions the node should immediately propagate
@@ -667,7 +667,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                    -> OracularClock m
                    -> TopLevelConfig blk
                    -> Seed
-                   -> STM m (ExtLedgerState blk)
+                   -> STM m (ExtLedgerState blk Canonical)
                       -- ^ How to get the current ledger state
                    -> Mempool m blk TicketNo
                    -> m ()
@@ -685,7 +685,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
     mkArgs :: OracularClock m
            -> ResourceRegistry m
            -> TopLevelConfig blk
-           -> ExtLedgerState blk
+           -> ExtLedgerState blk Canonical
            -> Tracer m (RealPoint blk, ExtValidationError blk)
               -- ^ invalid block tracer
            -> Tracer m (RealPoint blk, BlockNo)
@@ -813,7 +813,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
             -> TopLevelConfig blk
             -> BlockNo
             -> SlotNo
-            -> TickedLedgerState blk
+            -> TickedLedgerState blk Canonical
             -> [Validated (GenTx blk)]
             -> IsLeader (BlockProtocol blk)
             -> m blk
@@ -1451,7 +1451,7 @@ data NodeOutput blk = NodeOutput
   { nodeOutputAdds         :: Map SlotNo (Set (RealPoint blk, BlockNo))
   , nodeOutputCannotForges :: Map SlotNo [CannotForge blk]
   , nodeOutputFinalChain   :: Chain blk
-  , nodeOutputFinalLedger  :: LedgerState blk
+  , nodeOutputFinalLedger  :: LedgerState blk Canonical
   , nodeOutputForges       :: Map SlotNo blk
   , nodeOutputHeaderAdds   :: Map SlotNo [(RealPoint blk, BlockNo)]
   , nodeOutputInvalids     :: Map (RealPoint blk) [ExtValidationError blk]
@@ -1472,7 +1472,7 @@ mkTestOutput ::
     => [( CoreNodeId
         , m (NodeInfo blk MockFS [])
         , Chain blk
-        , LedgerState blk
+        , LedgerState blk Canonical
         )]
     -> m (TestOutput blk)
 mkTestOutput vertexInfos = do

--- a/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
@@ -26,6 +26,8 @@ import           Ouroboros.Consensus.Util.SOP
 
 import           Ouroboros.Consensus.HardFork.Combinator
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 {-------------------------------------------------------------------------------
   TxGen class
@@ -49,7 +51,7 @@ class TxGen blk where
              -> SlotNo
              -> TopLevelConfig blk
              -> TxGenExtra blk
-             -> LedgerState blk
+             -> LedgerState blk Canonical
              -> Gen [GenTx blk]
 
 {-------------------------------------------------------------------------------
@@ -78,7 +80,7 @@ testGenTxsHfc ::
   -> SlotNo
   -> TopLevelConfig (HardForkBlock xs)
   -> NP WrapTxGenExtra xs
-  -> LedgerState (HardForkBlock xs)
+  -> LedgerState (HardForkBlock xs) Canonical
   -> Gen [GenTx (HardForkBlock xs)]
 testGenTxsHfc coreNodeId numCoreNodes curSlotNo cfg extras state =
     hcollapse $
@@ -99,8 +101,8 @@ testGenTxsHfc coreNodeId numCoreNodes curSlotNo cfg extras state =
       => Index xs blk
       -> TopLevelConfig blk
       -> WrapTxGenExtra blk
-      -> LedgerState blk
+      -> Flip LedgerState Canonical blk
       -> K (Gen [GenTx (HardForkBlock xs)]) blk
-    aux index cfg' (WrapTxGenExtra extra') state' = K $
+    aux index cfg' (WrapTxGenExtra extra') (Flip state') = K $
         fmap (injectNS' (Proxy @GenTx) index)
           <$> testGenTxs coreNodeId numCoreNodes curSlotNo cfg' extra' state'

--- a/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
@@ -23,6 +23,7 @@ import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture (..))
 import qualified Ouroboros.Consensus.Fragment.Validated as VF
 import           Ouroboros.Consensus.HardFork.History.EraParams (EraParams,
                      eraEpochSize)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -65,7 +66,7 @@ data MinimalChainDbArgs m blk = MinimalChainDbArgs {
     mcdbTopLevelConfig :: TopLevelConfig blk
   , mcdbChunkInfo      :: ImmutableDB.ChunkInfo
   -- ^ Specifies the layout of the ImmutableDB on disk.
-  , mcdbInitLedger     :: ExtLedgerState blk
+  , mcdbInitLedger     :: ExtLedgerState blk Canonical
   -- ^ The initial ledger state.
   , mcdbRegistry       :: ResourceRegistry m
   -- ^ Keeps track of non-lexically scoped resources.

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
@@ -35,10 +35,10 @@ instance (ToExpr slot, ToExpr hash) => ToExpr (Block slot hash)
   ouroboros-consensus
 -------------------------------------------------------------------------------}
 
-instance ( ToExpr (LedgerState blk)
+instance ( ToExpr (LedgerState blk mk)
          , ToExpr (ChainDepState (BlockProtocol blk))
          , ToExpr (TipInfo blk)
-         ) => ToExpr (ExtLedgerState blk)
+         ) => ToExpr (ExtLedgerState blk mk)
 
 instance ( ToExpr (ChainDepState (BlockProtocol blk))
          , ToExpr (TipInfo blk)

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
@@ -56,7 +56,7 @@ import           Ouroboros.Network.Block (Serialised)
 import           Ouroboros.Consensus.Block (BlockProtocol, CodecConfig, Header,
                      HeaderHash, SlotNo, SomeSecond)
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerState)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState,
                      encodeExtLedgerState)
 import           Ouroboros.Consensus.Ledger.Query (BlockQuery, QueryVersion,
@@ -221,9 +221,9 @@ data Examples blk = Examples {
     , exampleQuery            :: Labelled (SomeSecond BlockQuery blk)
     , exampleResult           :: Labelled (SomeResult blk)
     , exampleAnnTip           :: Labelled (AnnTip blk)
-    , exampleLedgerState      :: Labelled (LedgerState blk)
+    , exampleLedgerState      :: Labelled (LedgerState blk Canonical)
     , exampleChainDepState    :: Labelled (ChainDepState (BlockProtocol blk))
-    , exampleExtLedgerState   :: Labelled (ExtLedgerState blk)
+    , exampleExtLedgerState   :: Labelled (ExtLedgerState blk Canonical)
     , exampleSlotNo           :: Labelled SlotNo
     }
 

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -48,7 +48,7 @@ import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerState)
 import           Ouroboros.Consensus.Ledger.Query (BlockQuery, Query (..),
                      QueryVersion)
 import qualified Ouroboros.Consensus.Ledger.Query as Query
@@ -130,7 +130,7 @@ roundtrip_all
      , Arbitrary' blk
      , Arbitrary' (Header blk)
      , Arbitrary' (HeaderHash blk)
-     , Arbitrary' (LedgerState blk)
+     , Arbitrary' (LedgerState blk Canonical)
      , Arbitrary' (AnnTip blk)
      , Arbitrary' (ChainDepState (BlockProtocol blk))
 
@@ -169,7 +169,7 @@ roundtrip_SerialiseDisk
      ( SerialiseDiskConstraints blk
      , Arbitrary' blk
      , Arbitrary' (Header blk)
-     , Arbitrary' (LedgerState blk)
+     , Arbitrary' (LedgerState blk Canonical)
      , Arbitrary' (AnnTip blk)
      , Arbitrary' (ChainDepState (BlockProtocol blk))
      )
@@ -190,7 +190,7 @@ roundtrip_SerialiseDisk ccfg dictNestedHdr =
       -- Since the 'LedgerState' is a large data structure, we lower the
       -- number of tests to avoid slowing down the testsuite too much
     , adjustOption (\(QuickCheckTests n) -> QuickCheckTests (1 `max` (div n 10))) $
-      rt (Proxy @(LedgerState blk)) "LedgerState"
+      rt (Proxy @(LedgerState blk Canonical)) "LedgerState"
     , rt (Proxy @(AnnTip blk)) "AnnTip"
     , rt (Proxy @(ChainDepState (BlockProtocol blk))) "ChainDepState"
     ]

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -76,6 +76,8 @@ import           Test.ThreadNet.Util.Seed
 import           Test.Util.HardFork.Future
 import           Test.Util.Slots (NumSlots (..))
 
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 import           Test.Consensus.HardFork.Combinator.A
 import           Test.Consensus.HardFork.Combinator.B
 
@@ -230,8 +232,8 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
             topLevelConfig nid
         , pInfoInitLedger = ExtLedgerState {
               ledgerState = HardForkLedgerState $
-                              initHardForkState
-                                initLedgerState
+                              initHardForkState $
+                              Flip initLedgerState
             , headerState = genesisHeaderState $
                               initHardForkState
                                 (WrapChainDepState initChainDepState)
@@ -244,7 +246,7 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
             ]
         }
 
-    initLedgerState :: LedgerState BlockA
+    initLedgerState :: LedgerState BlockA Canonical
     initLedgerState = LgrA {
           lgrA_tip        = GenesisPoint
         , lgrA_transition = Nothing
@@ -411,10 +413,10 @@ instance SerialiseHFC '[BlockA, BlockB]
 ledgerState_AtoB ::
      RequiringBoth
        WrapLedgerConfig
-       (Translate LedgerState)
+       (TranslateLedgerState)
        BlockA
        BlockB
-ledgerState_AtoB = InPairs.ignoringBoth $ Translate $ \_ LgrA{..} -> LgrB {
+ledgerState_AtoB = InPairs.ignoringBoth $ TranslateLedgerState $ \_ LgrA{..} -> LgrB {
       lgrB_tip = castPoint lgrA_tip
     }
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -162,24 +162,24 @@ instance BasicEnvelopeValidation BlockB where
 
 instance ValidateEnvelope BlockB where
 
-data instance LedgerState BlockB = LgrB {
+data instance LedgerState BlockB mk = LgrB {
       lgrB_tip :: Point BlockB
     }
   deriving (Show, Eq, Generic, Serialise)
-  deriving NoThunks via OnlyCheckWhnfNamed "LgrB" (LedgerState BlockB)
+  deriving NoThunks via OnlyCheckWhnfNamed "LgrB" (LedgerState BlockB mk)
 
 type instance LedgerCfg (LedgerState BlockB) = ()
 
 -- | Ticking has no state on the B ledger state
-newtype instance Ticked (LedgerState BlockB) = TickedLedgerStateB {
-      getTickedLedgerStateB :: LedgerState BlockB
+newtype instance Ticked1 (LedgerState BlockB) mk = TickedLedgerStateB {
+      getTickedLedgerStateB :: LedgerState BlockB mk
     }
-  deriving NoThunks via OnlyCheckWhnfNamed "TickedLgrB" (Ticked (LedgerState BlockB))
+  deriving NoThunks via OnlyCheckWhnfNamed "TickedLgrB" (Ticked1 (LedgerState BlockB) mk)
 
-instance GetTip (LedgerState BlockB) where
+instance GetTip (LedgerState BlockB Canonical) where
   getTip = castPoint . lgrB_tip
 
-instance GetTip (Ticked (LedgerState BlockB)) where
+instance GetTip (Ticked1 (LedgerState BlockB) Canonical) where
   getTip = castPoint . getTip . getTickedLedgerStateB
 
 instance IsLedger (LedgerState BlockB) where
@@ -219,7 +219,7 @@ forgeBlockB ::
      TopLevelConfig BlockB
   -> BlockNo
   -> SlotNo
-  -> TickedLedgerState BlockB
+  -> TickedLedgerState BlockB Canonical
   -> [GenTx BlockB]
   -> IsLeader (BlockProtocol BlockB)
   -> BlockB
@@ -382,8 +382,8 @@ instance SerialiseNodeToNodeConstraints   BlockB where
 
 deriving instance Serialise (AnnTip BlockB)
 
-instance EncodeDisk BlockB (LedgerState BlockB)
-instance DecodeDisk BlockB (LedgerState BlockB)
+instance EncodeDisk BlockB (LedgerState BlockB Canonical)
+instance DecodeDisk BlockB (LedgerState BlockB Canonical)
 
 instance EncodeDisk BlockB BlockB
 instance DecodeDisk BlockB (Lazy.ByteString -> BlockB) where

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
@@ -39,6 +39,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Ledger
                      (AnnForecast (..), mkHardForkForecast)
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
                      (InPairs (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
@@ -225,13 +226,13 @@ withinEraForecast maxLookAhead st = Forecast{
 -- | Translations between eras
 translations :: forall xs.
      TestSetup xs
-  -> InPairs (TranslateForecast (K LedgerState) (K LedgerView)) xs
+  -> InPairs (TranslateForecast (K1 LedgerState) (K LedgerView)) xs
 translations TestSetup{..} =
     case isNonEmpty (Proxy @xs) of
       ProofNonEmpty{} -> go testLookahead
   where
     go :: Exactly (x ': xs') MaxLookahead
-       -> InPairs (TranslateForecast (K LedgerState) (K LedgerView)) (x ': xs')
+       -> InPairs (TranslateForecast (K1 LedgerState) (K LedgerView)) (x ': xs')
     go (ExactlyCons _ ExactlyNil) =
         InPairs.PNil
     go (ExactlyCons this rest@(ExactlyCons next _)) =
@@ -239,9 +240,9 @@ translations TestSetup{..} =
 
     tr :: MaxLookahead -- ^ Look-ahead in the current era
        -> MaxLookahead -- ^ Look-ahead in the next era
-       -> TranslateForecast (K LedgerState) (K LedgerView) era era'
+       -> TranslateForecast (K1 LedgerState) (K LedgerView) era era'
     tr thisLookahead nextLookahead =
-        TranslateForecast $ \transition sno (K st) ->
+        TranslateForecast $ \transition sno (K1 st) ->
           assert (sno >= boundSlot transition) $ do
             let tip :: WithOrigin SlotNo
                 tip = ledgerTip st
@@ -283,7 +284,7 @@ acrossErasForecast setup@TestSetup{..} ledgerStates =
         . tickedHardForkLedgerViewPerEra
 
     go :: NonEmpty xs' TestEra
-       -> Telescope (K Past) (Current (AnnForecast (K LedgerState) (K LedgerView))) xs'
+       -> Telescope (K Past) (Current (AnnForecast (K1 LedgerState) (K LedgerView))) xs'
     go (NonEmptyOne era) =
         assert (testEraContains testForecastAt era) $
         TZ $ Current {
@@ -293,7 +294,7 @@ acrossErasForecast setup@TestSetup{..} ledgerStates =
                                      withinEraForecast
                                        (testEraMaxLookahead era)
                                        st
-              , annForecastState = K st
+              , annForecastState = K1 st
               , annForecastTip   = testForecastAt
               , annForecastEnd   = Nothing
               }
@@ -310,7 +311,7 @@ acrossErasForecast setup@TestSetup{..} ledgerStates =
                                        withinEraForecast
                                          (testEraMaxLookahead era)
                                          st
-                , annForecastState = K st
+                , annForecastState = K1 st
                 , annForecastTip   = testForecastAt
                 , annForecastEnd   = Just end
                 }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
@@ -43,6 +43,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Ledger
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
                      (Telescope (..))
@@ -837,14 +838,14 @@ mockHardForkLedgerView = \(HF.Shape pss) (HF.Transitions ts) (Chain ess) ->
               -> Exactly  (x ': xs) HF.EraParams
               -> AtMost         xs  EpochNo
               -> NonEmpty (x ': xs) [Event]
-              -> Telescope (K Past) (Current (AnnForecast (K ()) (K ()))) (x : xs)
+              -> Telescope (K Past) (Current (AnnForecast (K1 ()) (K ()))) (x : xs)
     mockState start (ExactlyCons ps _) ts (NonEmptyOne es) =
         TZ $ Current start $ AnnForecast {
             annForecast      = Forecast {
                 forecastAt  = tip es -- forecast at tip of ledger
               , forecastFor = \_for -> return $ TickedK TickedTrivial
               }
-          , annForecastState = K ()
+          , annForecastState = K1 ()
           , annForecastTip   = tip es
           , annForecastEnd   = HF.mkUpperBound ps start <$> atMostHead ts
           }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -446,7 +446,7 @@ computePastLedger ::
      TopLevelConfig TestBlock
   -> Point TestBlock
   -> Chain TestBlock
-  -> Maybe (ExtLedgerState TestBlock)
+  -> Maybe (ExtLedgerState TestBlock Canonical)
 computePastLedger cfg pt chain
     | pt `elem` validPoints
     = Just $ go testInitExtLedger (Chain.toOldestFirst chain)
@@ -469,7 +469,7 @@ computePastLedger cfg pt chain
     -- matching @pt@, after which we return the resulting ledger.
     --
     -- PRECONDITION: @pt@ is in the list of blocks or genesis.
-    go :: ExtLedgerState TestBlock -> [TestBlock] -> ExtLedgerState TestBlock
+    go :: ExtLedgerState TestBlock Canonical -> [TestBlock] -> ExtLedgerState TestBlock Canonical
     go !st blks
         | castPoint (getTip st) == pt
         = st

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -267,7 +267,7 @@ type TestConstraints blk =
   , LedgerSupportsProtocol            blk
   , InspectLedger                     blk
   , Eq (ChainDepState  (BlockProtocol blk))
-  , Eq (LedgerState                   blk)
+  , Eq (LedgerState                   blk Canonical)
   , Eq                                blk
   , Show                              blk
   , HasHeader                         blk
@@ -704,7 +704,7 @@ deriving instance (TestConstraints blk, Show1 r) => Show (Model blk m r)
 
 -- | Initial model
 initModel :: TopLevelConfig blk
-          -> ExtLedgerState blk
+          -> ExtLedgerState blk Canonical
           -> MaxClockSkew
           -> Model blk m r
 initModel cfg initLedger (MaxClockSkew maxClockSkew) = Model
@@ -1133,7 +1133,7 @@ sm :: TestConstraints blk
    => ChainDBEnv IO blk
    -> BlockGen                  blk IO
    -> TopLevelConfig            blk
-   -> ExtLedgerState            blk
+   -> ExtLedgerState            blk Canonical
    -> MaxClockSkew
    -> StateMachine (Model       blk IO)
                    (At Cmd      blk IO)
@@ -1188,7 +1188,7 @@ deriving instance ( ToExpr blk
                   , ToExpr (HeaderHash blk)
                   , ToExpr (ChainDepState (BlockProtocol blk))
                   , ToExpr (TipInfo blk)
-                  , ToExpr (LedgerState blk)
+                  , ToExpr (LedgerState blk Canonical)
                   , ToExpr (ExtValidationError blk)
                   )
                  => ToExpr (DBModel blk)
@@ -1196,7 +1196,7 @@ deriving instance ( ToExpr blk
                   , ToExpr (HeaderHash  blk)
                   , ToExpr (ChainDepState (BlockProtocol blk))
                   , ToExpr (TipInfo blk)
-                  , ToExpr (LedgerState blk)
+                  , ToExpr (LedgerState blk Canonical)
                   , ToExpr (ExtValidationError blk)
                   )
                  => ToExpr (Model blk IO Concrete)
@@ -1214,7 +1214,7 @@ deriving instance ToExpr TestBodyHash
 deriving instance ToExpr TestBlockError
 deriving instance ToExpr Blk
 deriving instance ToExpr (TipInfoIsEBB Blk)
-deriving instance ToExpr (LedgerState Blk)
+deriving instance ToExpr (LedgerState Blk Canonical)
 deriving instance ToExpr (HeaderError Blk)
 deriving instance ToExpr TestBlockOtherHeaderEnvelopeError
 deriving instance ToExpr (HeaderEnvelopeError Blk)
@@ -1624,7 +1624,7 @@ traceEventName = \case
 mkArgs :: IOLike m
        => TopLevelConfig Blk
        -> ImmutableDB.ChunkInfo
-       -> ExtLedgerState Blk
+       -> ExtLedgerState Blk Canonical
        -> ResourceRegistry m
        -> NodeDBs (StrictTVar m MockFS)
        -> Tracer m (TraceEvent Blk)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -336,6 +336,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wno-unticked-promoted-constructors
 
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus/src/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/Data/SOP/Strict.hs
@@ -1,19 +1,20 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE EmptyCase             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE BangPatterns             #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE EmptyCase                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneDeriving       #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 -- | Strict variant of SOP
 --
@@ -49,7 +50,8 @@ import           Data.SOP.Constraint
   NP
 -------------------------------------------------------------------------------}
 
-data NP :: (k -> Type) -> [k] -> Type where
+type NP :: (k -> Type) -> [k] -> Type
+data NP f xs where
   Nil  :: NP f '[]
   (:*) :: !(f x) -> !(NP f xs) -> NP f (x ': xs)
 
@@ -158,7 +160,8 @@ instance HTrans NP NP where
   NS
 -------------------------------------------------------------------------------}
 
-data NS :: (k -> Type) -> [k] -> Type where
+type NS :: (k -> Type) -> [k] -> Type
+data NS f xs where
   Z :: !(f x) -> NS f (x ': xs)
   S :: !(NS f xs) -> NS f (x ': xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
@@ -144,11 +144,11 @@ data BlockForging m blk = BlockForging {
       -- PRECONDITION: 'checkCanForge' returned @Right ()@.
     , forgeBlock ::
            TopLevelConfig blk
-        -> BlockNo                      -- Current block number
-        -> SlotNo                       -- Current slot number
-        -> TickedLedgerState blk        -- Current ledger state
-        -> [Validated (GenTx blk)]      -- Contents of the mempool
-        -> IsLeader (BlockProtocol blk) -- Proof we are leader
+        -> BlockNo                         -- Current block number
+        -> SlotNo                          -- Current slot number
+        -> TickedLedgerState blk Canonical -- Current ledger state
+        -> [Validated (GenTx blk)]         -- Contents of the mempool
+        -> IsLeader (BlockProtocol blk)    -- Proof we are leader
         -> m blk
     }
 
@@ -163,7 +163,7 @@ data BlockForging m blk = BlockForging {
 takeLargestPrefixThatFits ::
      TxLimits blk
   => TxLimits.Overrides blk
-  -> TickedLedgerState blk
+  -> TickedLedgerState blk Canonical
   -> [Validated (GenTx blk)]
   -> [Validated (GenTx blk)]
 takeLargestPrefixThatFits overrides ledger txs =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
@@ -49,7 +49,7 @@ newtype BackoffDelay = BackoffDelay NominalDiffTime
 data HardForkBlockchainTimeArgs m blk = HardForkBlockchainTimeArgs
   { hfbtBackoffDelay   :: m BackoffDelay
     -- ^ See 'BackoffDelay'
-  , hfbtGetLedgerState :: STM m (LedgerState blk)
+  , hfbtGetLedgerState :: STM m (LedgerState blk Canonical)
   , hfbtLedgerConfig   :: LedgerConfig blk
   , hfbtRegistry       :: ResourceRegistry m
   , hfbtSystemTime     :: SystemTime m
@@ -98,7 +98,7 @@ hardForkBlockchainTime args = do
       , hfbtMaxClockRewind = maxClockRewind
       } = args
 
-    summarize :: LedgerState blk -> HF.Summary (HardForkIndices blk)
+    summarize :: LedgerState blk Canonical -> HF.Summary (HardForkIndices blk)
     summarize st = hardForkSummary cfg st
 
     loop :: HF.RunWithCachedSummary xs m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -50,7 +50,7 @@ data CheckInFuture m blk = CheckInFuture {
        --
        -- > checkInFuture vf >>= \(af, fut) ->
        -- >   validatedFragment vf == af <=> null fut
-       checkInFuture :: ValidatedFragment (Header blk) (LedgerState blk)
+       checkInFuture :: ValidatedFragment (Header blk) (LedgerState blk Canonical)
                      -> m (AnchoredFragment (Header blk), [InFuture m blk])
     }
   deriving NoThunks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
@@ -43,7 +43,7 @@ data ValidatedFragment b l = UnsafeValidatedFragment {
 {-# COMPLETE ValidatedFragment #-}
 
 pattern ValidatedFragment ::
-     (IsLedger l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
+     (GetTip l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
   => AnchoredFragment b -> l -> ValidatedFragment b l
 pattern ValidatedFragment f l <- UnsafeValidatedFragment f l
   where
@@ -54,7 +54,7 @@ validatedTip = AF.headPoint . validatedFragment
 
 invariant ::
      forall l b.
-     (IsLedger l, HasHeader b, HeaderHash b ~ HeaderHash l)
+     (GetTip l, HasHeader b, HeaderHash b ~ HeaderHash l)
   => ValidatedFragment b l
   -> Either String ()
 invariant (ValidatedFragment fragment ledger)
@@ -75,7 +75,7 @@ invariant (ValidatedFragment fragment ledger)
 -- | Constructor for 'ValidatedFragment' that checks the invariant
 new ::
      forall l b.
-     (IsLedger l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
+     (GetTip l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
   => AnchoredFragment b
   -> l
   -> ValidatedFragment b l

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
@@ -49,7 +49,7 @@ pattern ValidatedChainDiff d l <- UnsafeValidatedChainDiff d l
 -- > getTip chainDiff == ledgerTipPoint ledger
 new ::
      forall b l.
-     (IsLedger l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
+     (GetTip l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
   => ChainDiff b
   -> l
   -> ValidatedChainDiff b l
@@ -69,7 +69,7 @@ new chainDiff ledger =
           show chainDiffTip <> " /= " <> show ledgerTip
 
 toValidatedFragment
-  :: (IsLedger l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
+  :: (GetTip l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
   => ValidatedChainDiff b l
   -> ValidatedFragment b l
 toValidatedFragment (UnsafeValidatedChainDiff cs l) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
@@ -50,7 +50,7 @@ class HasHardForkHistory blk where
   -- information, and so this function becomes little more than a projection
   -- (indeed, in this case the 'LedgerState' should be irrelevant).
   hardForkSummary :: LedgerConfig blk
-                  -> LedgerState blk
+                  -> LedgerState blk Canonical
                   -> HardFork.Summary (HardForkIndices blk)
 
 -- | Helper function that can be used to define 'hardForkSummary'
@@ -63,7 +63,7 @@ class HasHardForkHistory blk where
 -- hard fork combinator).
 neverForksHardForkSummary :: (LedgerConfig blk -> HardFork.EraParams)
                           -> LedgerConfig blk
-                          -> LedgerState blk
+                          -> LedgerState blk Canonical
                           -> HardFork.Summary '[blk]
 neverForksHardForkSummary getParams cfg _st =
     HardFork.neverForksSummary eraEpochSize eraSlotLength

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -88,7 +88,7 @@ class ( LedgerSupportsProtocol blk
   singleEraTransition :: PartialLedgerConfig blk
                       -> EraParams -- ^ Current era parameters
                       -> Bound     -- ^ Start of this era
-                      -> LedgerState blk
+                      -> LedgerState blk Canonical
                       -> Maybe EpochNo
 
   -- | Era information (for use in error messages)
@@ -101,7 +101,7 @@ singleEraTransition' :: SingleEraBlock blk
                      => WrapPartialLedgerConfig blk
                      -> EraParams
                      -> Bound
-                     -> LedgerState blk -> Maybe EpochNo
+                     -> LedgerState blk Canonical -> Maybe EpochNo
 singleEraTransition' = singleEraTransition . unwrapPartialLedgerConfig
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -59,6 +59,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.State.Instances ()
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors (Flip)
 
 {-------------------------------------------------------------------------------
   Hard fork protocol, block, and ledger state
@@ -76,13 +77,13 @@ instance Typeable xs => ShowProxy (HardForkBlock xs) where
 type instance BlockProtocol (HardForkBlock xs) = HardForkProtocol xs
 type instance HeaderHash    (HardForkBlock xs) = OneEraHash       xs
 
-newtype instance LedgerState (HardForkBlock xs) = HardForkLedgerState {
-      hardForkLedgerStatePerEra :: HardForkState LedgerState xs
+newtype instance LedgerState (HardForkBlock xs) mk = HardForkLedgerState {
+      hardForkLedgerStatePerEra :: HardForkState (Flip LedgerState mk) xs
     }
 
-deriving stock   instance CanHardFork xs => Show (LedgerState (HardForkBlock xs))
-deriving stock   instance CanHardFork xs => Eq   (LedgerState (HardForkBlock xs))
-deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs))
+deriving stock   instance CanHardFork xs => Show (LedgerState (HardForkBlock xs) Canonical)
+deriving stock   instance CanHardFork xs => Eq   (LedgerState (HardForkBlock xs) Canonical)
+deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs) Canonical)
 
 {-------------------------------------------------------------------------------
   Protocol config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -52,6 +52,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode ()
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 {-------------------------------------------------------------------------------
   Simple patterns
@@ -169,11 +171,11 @@ pattern DegenBlockConfig x <- (project -> x)
 
 pattern DegenLedgerState ::
      NoHardForks b
-  => LedgerState b
-  -> LedgerState (HardForkBlock '[b])
-pattern DegenLedgerState x <- (project -> x)
+  => LedgerState b Canonical
+  -> LedgerState (HardForkBlock '[b]) Canonical
+pattern DegenLedgerState x <- (unFlip . project . Flip -> x)
   where
-    DegenLedgerState x = inject x
+    DegenLedgerState x = unFlip $ inject $ Flip x
 
 {-------------------------------------------------------------------------------
   Dealing with the config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
@@ -22,6 +22,8 @@ import           Ouroboros.Consensus.Util.Counting (exactlyTwo)
 import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
 
 import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 import qualified Ouroboros.Consensus.HardFork.History as History
 
 {-------------------------------------------------------------------------------
@@ -79,7 +81,7 @@ protocolInfoBinary protocolInfo1 eraParams1 toPartialConsensusConfig1 toPartialL
       , pInfoInitLedger = ExtLedgerState {
             ledgerState =
               HardForkLedgerState $
-                initHardForkState initLedgerState1
+                initHardForkState $ Flip initLedgerState1
           , headerState =
               genesisHeaderState $
                 initHardForkState $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.InjectTxs
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger (Ticked (..))
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
@@ -291,7 +291,7 @@ hardForkForgeBlock ::
   -> TopLevelConfig (HardForkBlock xs)
   -> BlockNo
   -> SlotNo
-  -> TickedLedgerState (HardForkBlock xs)
+  -> TickedLedgerState (HardForkBlock xs) Canonical
   -> [Validated (GenTx (HardForkBlock xs))]
   -> HardForkIsLeader xs
   -> m (HardForkBlock xs)
@@ -358,7 +358,7 @@ hardForkForgeBlock blockForging
       -> Product
            (Product
               WrapIsLeader
-              (Ticked :.: LedgerState))
+              (FlipTickedLedgerState Canonical))
            ([] :.: WrapValidatedGenTx)
            blk
       -> m blk
@@ -366,7 +366,7 @@ hardForkForgeBlock blockForging
                   cfg'
                   (Comp mBlockForging')
                   (Pair
-                    (Pair (WrapIsLeader isLeader') (Comp ledgerState'))
+                    (Pair (WrapIsLeader isLeader') (FlipTickedLedgerState ledgerState'))
                     (Comp txs')) =
         forgeBlock
           (fromMaybe

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
@@ -4,12 +4,15 @@ module Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams () wh
 
 import           Data.SOP.Strict
 
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 instance CanHardFork xs => CommonProtocolParams (HardForkBlock xs) where
   maxHeaderSize = askCurrentLedger maxHeaderSize
@@ -17,10 +20,10 @@ instance CanHardFork xs => CommonProtocolParams (HardForkBlock xs) where
 
 askCurrentLedger
   :: CanHardFork xs
-  => (forall blk. CommonProtocolParams blk => LedgerState blk -> a)
-  -> LedgerState (HardForkBlock xs) -> a
+  => (forall blk. CommonProtocolParams blk => LedgerState blk Canonical -> a)
+  -> LedgerState (HardForkBlock xs) Canonical -> a
 askCurrentLedger f =
       hcollapse
-    . hcmap proxySingle (K . f)
+    . hcmap proxySingle (K . f . unFlip)
     . State.tip
     . hardForkLedgerStatePerEra

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/PeerSelection.hs
@@ -9,10 +9,12 @@ import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 instance CanHardFork xs => LedgerSupportsPeerSelection (HardForkBlock xs) where
   getPeers =
         hcollapse
-      . hcmap proxySingle (K . getPeers)
+      . hcmap proxySingle (K . getPeers . unFlip)
       . State.tip
       . hardForkLedgerStatePerEra

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
@@ -14,6 +14,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
 
 instance CanHardFork xs => NodeInitStorage (HardForkBlock xs) where
@@ -59,9 +62,9 @@ instance CanHardFork xs => NodeInitStorage (HardForkBlock xs) where
            SingleEraBlock blk
         => Index xs blk
         -> StorageConfig blk
-        -> LedgerState blk
+        -> Flip LedgerState Canonical blk
         -> K (m ()) blk
-      aux index cfg' currentLedger = K $
+      aux index cfg' (Flip currentLedger) = K $
           nodeInitChainDB cfg' InitChainDB {
               addBlock         = addBlock initChainDB
                                . injectNS' (Proxy @I) index

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -17,9 +17,12 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util ((.:))
 
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 import           Ouroboros.Consensus.Storage.ChainDB
 import           Ouroboros.Consensus.Storage.Serialisation
 
@@ -117,17 +120,17 @@ instance SerialiseHFC xs
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
 
 instance SerialiseHFC xs
-      => EncodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs) )where
+      => EncodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs) Canonical) where
   encodeDisk cfg =
-        encodeTelescope (hcmap pSHFC (fn . (K .: encodeDisk)) cfgs)
+        encodeTelescope (hcmap pSHFC (\cfg' -> fn (K . encodeDisk cfg' . unFlip)) cfgs)
       . hardForkLedgerStatePerEra
     where
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
 
 instance SerialiseHFC xs
-      => DecodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs)) where
+      => DecodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs) Canonical) where
   decodeDisk cfg =
         fmap HardForkLedgerState
-      $ decodeTelescope (hcmap pSHFC (Comp . decodeDisk) cfgs)
+      $ decodeTelescope (hcmap pSHFC (Comp . fmap Flip . decodeDisk) cfgs)
     where
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -57,6 +57,8 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Teles
 import           Ouroboros.Consensus.HardFork.Combinator.State.Infra as X
 import           Ouroboros.Consensus.HardFork.Combinator.State.Instances as X ()
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types as X
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 {-------------------------------------------------------------------------------
   GetTip
@@ -111,7 +113,7 @@ recover =
 
 mostRecentTransitionInfo :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
-                         -> HardForkState LedgerState xs
+                         -> HardForkState (Flip LedgerState Canonical) xs
                          -> TransitionInfo
 mostRecentTransitionInfo HardForkLedgerConfig{..} st =
     hcollapse $
@@ -124,19 +126,19 @@ mostRecentTransitionInfo HardForkLedgerConfig{..} st =
   where
     cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
 
-    getTransition :: SingleEraBlock          blk
-                  => WrapPartialLedgerConfig blk
-                  -> K History.EraParams     blk
-                  -> Current LedgerState     blk
-                  -> K TransitionInfo        blk
-    getTransition cfg (K eraParams) Current{..} = K $
-        case singleEraTransition' cfg eraParams currentStart currentState of
-          Nothing -> TransitionUnknown (ledgerTipSlot currentState)
+    getTransition :: SingleEraBlock                       blk
+                  => WrapPartialLedgerConfig              blk
+                  -> K History.EraParams                  blk
+                  -> Current (Flip LedgerState Canonical) blk
+                  -> K TransitionInfo                     blk
+    getTransition cfg (K eraParams) Current{currentState = Flip curState, ..} = K $
+        case singleEraTransition' cfg eraParams currentStart curState of
+          Nothing -> TransitionUnknown (ledgerTipSlot curState)
           Just e  -> TransitionKnown e
 
 reconstructSummaryLedger :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
-                         -> HardForkState LedgerState xs
+                         -> HardForkState (Flip LedgerState Canonical) xs
                          -> History.Summary xs
 reconstructSummaryLedger cfg@HardForkLedgerConfig{..} st =
     reconstructSummary
@@ -150,7 +152,7 @@ reconstructSummaryLedger cfg@HardForkLedgerConfig{..} st =
 -- It should not be stored.
 epochInfoLedger :: All SingleEraBlock xs
                 => HardForkLedgerConfig xs
-                -> HardForkState LedgerState xs
+                -> HardForkState (Flip LedgerState Canonical) xs
                 -> EpochInfo (Except PastHorizonException)
 epochInfoLedger cfg st =
     History.summaryToEpochInfo $
@@ -177,7 +179,8 @@ epochInfoPrecomputedTransitionInfo shape transition st =
 extendToSlot :: forall xs. CanHardFork xs
              => HardForkLedgerConfig xs
              -> SlotNo
-             -> HardForkState LedgerState xs -> HardForkState LedgerState xs
+             -> HardForkState (Flip LedgerState Canonical) xs
+             -> HardForkState (Flip LedgerState Canonical) xs
 extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st) =
       HardForkState . unI
     . Telescope.extend
@@ -198,17 +201,17 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
     ei    = epochInfoLedger ledgerCfg ledgerSt
 
     -- Return the end of this era if we should transition to the next
-    whenExtend :: SingleEraBlock              blk
-               => WrapPartialLedgerConfig     blk
-               -> K History.EraParams         blk
-               -> Current LedgerState         blk
-               -> (Maybe :.: K History.Bound) blk
+    whenExtend :: SingleEraBlock                       blk
+               => WrapPartialLedgerConfig              blk
+               -> K History.EraParams                  blk
+               -> Current (Flip LedgerState Canonical) blk
+               -> (Maybe :.: K History.Bound)          blk
     whenExtend pcfg (K eraParams) cur = Comp $ K <$> do
         transition <- singleEraTransition'
                         pcfg
                         eraParams
                         (currentStart cur)
-                        (currentState cur)
+                        (unFlip $ currentState cur)
         let endBound = History.mkUpperBound
                          eraParams
                          (currentStart cur)
@@ -216,10 +219,10 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
         guard (slot >= History.boundSlot endBound)
         return endBound
 
-    howExtend :: Translate LedgerState blk blk'
+    howExtend :: TranslateLedgerState blk blk'
               -> History.Bound
-              -> Current LedgerState blk
-              -> (K Past blk, Current LedgerState blk')
+              -> Current (Flip LedgerState Canonical) blk
+              -> (K Past blk, Current (Flip LedgerState Canonical) blk')
     howExtend f currentEnd cur = (
           K Past {
               pastStart    = currentStart cur
@@ -227,12 +230,12 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
             }
         , Current {
               currentStart = currentEnd
-            , currentState = translateWith f
+            , currentState = Flip $ translateLedgerStateWith f
                                (History.boundEpoch currentEnd)
-                               (currentState cur)
+                               (unFlip (currentState cur))
             }
         )
 
-    translate :: InPairs (Translate LedgerState) xs
+    translate :: InPairs TranslateLedgerState xs
     translate = InPairs.requiringBoth cfgs $
                   translateLedgerState hardForkEraTranslation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -14,6 +14,7 @@ module Ouroboros.Consensus.HardFork.Combinator.State.Types (
   , TransitionInfo (..)
   , Translate (..)
   , TranslateForecast (..)
+  , TranslateLedgerState (..)
   ) where
 
 import           Prelude
@@ -26,6 +27,7 @@ import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.History (Bound)
+import           Ouroboros.Consensus.Ledger.Basics (Canonical, LedgerState)
 import           Ouroboros.Consensus.Ticked
 
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
@@ -93,8 +95,16 @@ newtype TranslateForecast f g x y = TranslateForecast {
       translateForecastWith ::
            Bound    -- 'Bound' of the transition (start of the new era)
         -> SlotNo   -- 'SlotNo' we're constructing a forecast for
-        -> f x
+        -> f x Canonical
         -> Except OutsideForecastRange (Ticked (g y))
+    }
+
+-- | Translate a LedgerState across an era transition.
+data TranslateLedgerState x y = TranslateLedgerState {
+        translateLedgerStateWith ::
+            EpochNo
+         -> LedgerState x Canonical
+         -> LedgerState y Canonical
     }
 
 -- | Knowledge in a particular era of the transition to the next era

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -21,8 +21,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
 -------------------------------------------------------------------------------}
 
 data EraTranslation xs = EraTranslation {
-      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (Translate LedgerState))       xs
-    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState)) xs
+      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    TranslateLedgerState)                           xs
+    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState))                  xs
     , translateLedgerView    :: InPairs (RequiringBoth WrapLedgerConfig    (TranslateForecast LedgerState WrapLedgerView)) xs
     }
   deriving NoThunks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Functors.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Functors.hs
@@ -1,8 +1,25 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Util.Functors (Product2 (..)) where
+module Ouroboros.Consensus.HardFork.Combinator.Util.Functors (
+    Flip (..)
+  , K1 (..)
+  , Product2 (..)
+  ) where
 
+import           Data.Kind (Type)
 import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
 
+type Product2 :: (x -> y -> Type) -> (x -> y -> Type) -> x -> y -> Type
 data Product2 f g x y = Pair2 (f x y) (g x y)
   deriving (Eq, Generic, Show)
+
+type Flip :: (x -> y -> Type) -> y -> x -> Type
+newtype Flip f x y = Flip {unFlip :: f y x}
+  deriving (Eq, Generic, NoThunks, Show)
+
+type K1 :: Type -> x -> y -> Type
+newtype K1 a b c = K1 a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE EmptyCase            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE EmptyCase                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneDeriving       #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 -- | Intended for qualified import
 --
@@ -100,7 +101,8 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 -- In addition to the standard SOP operators, the new operators that make
 -- a 'Telescope' a telescope are 'extend', 'retract' and 'align'; see their
 -- documentation for details.
-data Telescope (g :: k -> Type) (f :: k -> Type) (xs :: [k]) where
+type Telescope :: forall k. (k -> Type) -> (k -> Type) -> [k] -> Type
+data Telescope g f xs where
   TZ :: !(f x) ->                        Telescope g f (x ': xs)
   TS :: !(g x) -> !(Telescope g f xs) -> Telescope g f (x ': xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -155,7 +155,7 @@ validateHeader cfg ledgerView hdr history = do
 fromChain ::
      ApplyBlock (ExtLedgerState blk) blk
   => TopLevelConfig blk
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
      -- ^ Initial ledger state
   -> Chain blk
   -> HeaderStateHistory blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
@@ -9,8 +9,8 @@ class UpdateLedger blk => CommonProtocolParams blk where
 
   -- | The maximum header size in bytes according to the currently adopted
   -- protocol parameters of the ledger state.
-  maxHeaderSize :: LedgerState blk -> Word32
+  maxHeaderSize :: LedgerState blk Canonical -> Word32
 
   -- | The maximum transaction size in bytes according to the currently
   -- adopted protocol parameters of the ledger state.
-  maxTxSize :: LedgerState blk -> Word32
+  maxTxSize :: LedgerState blk Canonical -> Word32

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
@@ -66,8 +66,8 @@ class ( Show     (LedgerWarning blk)
   -- leaving it at this for now.
   inspectLedger ::
        TopLevelConfig blk
-    -> LedgerState    blk -- ^ Before
-    -> LedgerState    blk -- ^ After
+    -> LedgerState    blk Canonical -- ^ Before
+    -> LedgerState    blk Canonical -- ^ After
     -> [LedgerEvent   blk]
 
   -- Defaults
@@ -81,8 +81,8 @@ class ( Show     (LedgerWarning blk)
        , LedgerUpdate  blk ~ Void
        )
     => TopLevelConfig blk
-    -> LedgerState    blk -- ^ Before
-    -> LedgerState    blk -- ^ After
+    -> LedgerState    blk Canonical -- ^ Before
+    -> LedgerState    blk Canonical -- ^ After
     -> [LedgerEvent   blk]
   inspectLedger _ _ _ = []
     where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -47,6 +47,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip (..),
                      headerStateBlockNo, headerStatePoint)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query.Version
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -268,7 +269,7 @@ answerQuery ::
      (QueryLedger blk, ConfigSupportsNode blk, HasAnnTip blk)
   => ExtLedgerCfg blk
   -> Query blk result
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
   -> result
 answerQuery cfg query st = case query of
   BlockQuery blockQuery -> answerBlockQuery cfg blockQuery st
@@ -286,7 +287,7 @@ data family BlockQuery blk :: Type -> Type
 class (ShowQuery (BlockQuery blk), SameDepIndex (BlockQuery blk)) => QueryLedger blk where
 
   -- | Answer the given query about the extended ledger state.
-  answerBlockQuery :: ExtLedgerCfg blk -> BlockQuery blk result -> ExtLedgerState blk -> result
+  answerBlockQuery :: ExtLedgerCfg blk -> BlockQuery blk result -> ExtLedgerState blk Canonical -> result
 
 instance SameDepIndex (BlockQuery blk) => Eq (SomeSecond BlockQuery blk) where
   SomeSecond qry == SomeSecond qry' = isJust (sameDepIndex qry qry')

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -58,7 +58,7 @@ data WhetherToIntervene
 class ( UpdateLedger blk
       , NoThunks (GenTx blk)
       , NoThunks (Validated (GenTx blk))
-      , NoThunks (Ticked (LedgerState blk))
+      , NoThunks (Ticked1 (LedgerState blk) Canonical)
       , Show (GenTx blk)
       , Show (Validated (GenTx blk))
       , Show (ApplyTxErr blk)
@@ -73,8 +73,8 @@ class ( UpdateLedger blk
           -> WhetherToIntervene
           -> SlotNo -- ^ Slot number of the block containing the tx
           -> GenTx blk
-          -> TickedLedgerState blk
-          -> Except (ApplyTxErr blk) (TickedLedgerState blk, Validated (GenTx blk))
+          -> TickedLedgerState blk Canonical
+          -> Except (ApplyTxErr blk) (TickedLedgerState blk Canonical, Validated (GenTx blk))
 
   -- | Apply a previously validated transaction to a potentially different
   -- ledger state
@@ -86,8 +86,8 @@ class ( UpdateLedger blk
             => LedgerConfig blk
             -> SlotNo -- ^ Slot number of the block containing the tx
             -> Validated (GenTx blk)
-            -> TickedLedgerState blk
-            -> Except (ApplyTxErr blk) (TickedLedgerState blk)
+            -> TickedLedgerState blk Canonical
+            -> Except (ApplyTxErr blk) (TickedLedgerState blk Canonical)
 
   -- | The maximum number of bytes worth of transactions that can be put into
   -- a block according to the currently adopted protocol parameters of the
@@ -95,7 +95,7 @@ class ( UpdateLedger blk
   --
   -- This is (conservatively) computed by subtracting the header size and any
   -- other fixed overheads from the maximum block size.
-  txsMaxBytes :: TickedLedgerState blk -> Word32
+  txsMaxBytes :: TickedLedgerState blk Canonical -> Word32
 
   -- | Return the post-serialisation size in bytes of a 'GenTx' /when it is
   -- embedded in a block/. This size might differ from the size of the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
@@ -19,7 +19,7 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint
                      (DomainAccessPoint (..), IP (..), PortNumber,
                      RelayAccessPoint (..))
 
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerState)
 
 -- | A relay registered for a stake pool
 data StakePoolRelay =
@@ -48,4 +48,4 @@ class LedgerSupportsPeerSelection blk where
   --
   -- Note: if the ledger state is old, the registered relays can also be old and
   -- may no longer be online.
-  getPeers :: LedgerState blk -> [(PoolStake, NonEmpty StakePoolRelay)]
+  getPeers :: LedgerState blk Canonical -> [(PoolStake, NonEmpty StakePoolRelay)]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -11,6 +11,7 @@ import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Ticked (Ticked1)
 
 -- | Link protocol to ledger
 class ( BlockSupportsProtocol blk
@@ -22,7 +23,7 @@ class ( BlockSupportsProtocol blk
   -- See 'ledgerViewForecastAt' for a discussion and precise definition of the
   -- relation between this and forecasting.
   protocolLedgerView :: LedgerConfig blk
-                     -> Ticked (LedgerState blk)
+                     -> Ticked1 (LedgerState blk) Canonical
                      -> Ticked (LedgerView (BlockProtocol blk))
 
   -- | Get a forecast at the given ledger state.
@@ -63,7 +64,7 @@ class ( BlockSupportsProtocol blk
   ledgerViewForecastAt ::
        HasCallStack
     => LedgerConfig blk
-    -> LedgerState blk
+    -> LedgerState blk Canonical
     -> Forecast (LedgerView (BlockProtocol blk))
 
 -- | Relation between 'ledgerViewForecastAt' and 'applyChainTick'
@@ -73,7 +74,7 @@ _lemma_ledgerViewForecastAt_applyChainTick
      , Show (Ticked (LedgerView (BlockProtocol blk)))
      )
   => LedgerConfig blk
-  -> LedgerState blk
+  -> LedgerState blk Canonical
   -> Forecast (LedgerView (BlockProtocol blk))
   -> SlotNo
   -> Either String ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -302,7 +302,7 @@ data ForgeLedgerState blk =
     -- This will only be the case when we realized that we are the slot leader
     -- and we are actually producing a block. It is the caller's responsibility
     -- to call 'applyChainTick' and produce the ticked ledger state.
-    ForgeInKnownSlot SlotNo (TickedLedgerState blk)
+    ForgeInKnownSlot SlotNo (TickedLedgerState blk Canonical)
 
     -- | The slot number of the block is not yet known
     --
@@ -310,7 +310,7 @@ data ForgeLedgerState blk =
     -- will end up, we have to make an assumption about which slot number to use
     -- for 'applyChainTick' to prepare the ledger state; we will assume that
     -- they will end up in the slot after the slot at the tip of the ledger.
-  | ForgeInUnknownSlot (LedgerState blk)
+  | ForgeInUnknownSlot (LedgerState blk Canonical)
 
 {-------------------------------------------------------------------------------
   Mempool capacity in bytes
@@ -338,7 +338,7 @@ data MempoolCapacityBytesOverride
 -- the current ledger's maximum transaction capacity of a block.
 computeMempoolCapacity
   :: LedgerSupportsMempool blk
-  => TickedLedgerState blk
+  => TickedLedgerState blk Canonical
   -> MempoolCapacityBytesOverride
   -> MempoolCapacityBytes
 computeMempoolCapacity st = \case
@@ -390,7 +390,7 @@ data MempoolSnapshot blk idx = MempoolSnapshot {
   , snapshotSlotNo      :: SlotNo
 
     -- | The ledger state after all transactions in the snapshot
-  , snapshotLedgerState :: TickedLedgerState blk
+  , snapshotLedgerState :: TickedLedgerState blk Canonical
   }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -121,7 +121,7 @@ mkMempool mpEnv = Mempool
 
 -- | Abstract interface needed to run a Mempool.
 data LedgerInterface m blk = LedgerInterface
-    { getCurrentLedgerState :: STM m (LedgerState blk)
+    { getCurrentLedgerState :: STM m (LedgerState blk Canonical)
     }
 
 -- | Create a 'LedgerInterface' from a 'ChainDB'.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -189,7 +189,7 @@ pureRemoveTxs
   -> MempoolCapacityBytesOverride
   -> [GenTxId blk]
   -> InternalState blk
-  -> LedgerState blk
+  -> LedgerState blk Canonical
   -> RemoveTxs blk
 pureRemoveTxs cfg capacityOverride txIds IS { isTxs, isLastTicketNo } lstate =
     -- Filtering is O(n), but this function will rarely be used, as it is an
@@ -256,7 +256,7 @@ runSyncWithLedger stateVar (NewSyncedState is msp mTrace) = do
 pureSyncWithLedger
   :: (LedgerSupportsMempool blk, HasTxId (GenTx blk), ValidateEnvelope blk)
   => InternalState blk
-  -> LedgerState blk
+  -> LedgerState blk Canonical
   -> LedgerConfig blk
   -> MempoolCapacityBytesOverride
   -> SyncWithLedger blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs
@@ -30,9 +30,9 @@ import           Data.Measure (BoundedMeasure, Measure)
 import qualified Data.Measure as Measure
 
 import           Ouroboros.Consensus.Ledger.Abstract (Validated)
-import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerState, Canonical)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)
-import           Ouroboros.Consensus.Ticked (Ticked (..))
+import           Ouroboros.Consensus.Ticked (Ticked1)
 
 -- | Each block has its limits of how many transactions it can hold.
 -- That limit is compared against the sum of measurements
@@ -54,7 +54,7 @@ class BoundedMeasure (TxMeasure blk) => TxLimits blk where
   txMeasure        :: Validated (GenTx blk)    -> TxMeasure blk
 
   -- | What is the allowed capacity for txs in an individual block?
-  txsBlockCapacity :: Ticked (LedgerState blk) -> TxMeasure blk
+  txsBlockCapacity :: Ticked1 (LedgerState blk) Canonical -> TxMeasure blk
 
 -- | Is every component of the first value less-than-or-equal-to the
 -- corresponding component of the second value?

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -125,7 +125,7 @@ initSlotForgeTimeOracle cfg chainDB = do
     pure slotForgeTime
   where
     toSummary ::
-         ExtLedgerState blk
+         ExtLedgerState blk Canonical
       -> History.Summary (History.HardForkIndices blk)
     toSummary = History.hardForkSummary (configLedger cfg) . ledgerState
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -72,6 +72,7 @@ import           Ouroboros.Consensus.HeaderStateHistory
                      (HeaderStateHistory (..), validateHeader)
 import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
 import           Ouroboros.Consensus.HeaderValidation hiding (validateHeader)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -93,7 +94,7 @@ type Consensus (client :: Type -> Type -> Type -> (Type -> Type) -> Type -> Type
 data ChainDbView m blk = ChainDbView {
       getCurrentChain       :: STM m (AnchoredFragment (Header blk))
     , getHeaderStateHistory :: STM m (HeaderStateHistory blk)
-    , getPastLedger         :: Point blk -> STM m (Maybe (ExtLedgerState blk))
+    , getPastLedger         :: Point blk -> STM m (Maybe (ExtLedgerState blk Canonical))
     , getIsInvalidBlock     :: STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
     }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -9,6 +9,7 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip (..))
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Util.IOLike
@@ -18,7 +19,7 @@ localStateQueryServer ::
   => ExtLedgerCfg blk
   -> STM m (Point blk)
      -- ^ Get tip point
-  -> (Point blk -> STM m (Maybe (ExtLedgerState blk)))
+  -> (Point blk -> STM m (Maybe (ExtLedgerState blk Canonical)))
      -- ^ Get a past ledger
   -> STM m (Point blk)
      -- ^ Get the immutable point
@@ -48,7 +49,7 @@ localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
             | otherwise
             -> SendMsgFailure AcquireFailurePointNotOnChain idle
 
-    acquired :: ExtLedgerState blk
+    acquired :: ExtLedgerState blk Canonical
              -> ServerStAcquired blk (Point blk) (Query blk) m ()
     acquired ledgerState = ServerStAcquired {
           recvMsgQuery     = handleQuery ledgerState
@@ -57,7 +58,7 @@ localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
         }
 
     handleQuery ::
-         ExtLedgerState blk
+         ExtLedgerState blk Canonical
       -> Query blk result
       -> m (ServerStQuerying blk (Point blk) (Query blk) m () result)
     handleQuery ledgerState query = return $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -15,6 +15,7 @@ import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Basics (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.NodeId
 
@@ -37,7 +38,7 @@ enumCoreNodes (NumCoreNodes numNodes) =
 -- | Data required to run the specified protocol.
 data ProtocolInfo m b = ProtocolInfo {
         pInfoConfig       :: TopLevelConfig b
-      , pInfoInitLedger   :: ExtLedgerState b -- ^ At genesis
+      , pInfoInitLedger   :: ExtLedgerState b Canonical -- ^ At genesis
       , pInfoBlockForging :: m [BlockForging m b]
       }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -359,13 +359,13 @@ getTipBlockNo = fmap Network.getTipBlockNo . getCurrentTip
 -- | Get current ledger
 getCurrentLedger ::
      (Monad (STM m), IsLedger (LedgerState blk))
-  => ChainDB m blk -> STM m (ExtLedgerState blk)
+  => ChainDB m blk -> STM m (ExtLedgerState blk Canonical)
 getCurrentLedger = fmap LedgerDB.ledgerDbCurrent . getLedgerDB
 
 -- | Get the immutable ledger, i.e., typically @k@ blocks back.
 getImmutableLedger ::
      Monad (STM m)
-  => ChainDB m blk -> STM m (ExtLedgerState blk)
+  => ChainDB m blk -> STM m (ExtLedgerState blk Canonical)
 getImmutableLedger = fmap LedgerDB.ledgerDbAnchor . getLedgerDB
 
 -- | Get the ledger for the given point.
@@ -375,7 +375,7 @@ getImmutableLedger = fmap LedgerDB.ledgerDbAnchor . getLedgerDB
 -- returned.
 getPastLedger ::
      (Monad (STM m), LedgerSupportsProtocol blk)
-  => ChainDB m blk -> Point blk -> STM m (Maybe (ExtLedgerState blk))
+  => ChainDB m blk -> Point blk -> STM m (Maybe (ExtLedgerState blk Canonical))
 getPastLedger db pt = LedgerDB.ledgerDbPast pt <$> getLedgerDB db
 
 -- | Get a 'HeaderStateHistory' populated with the 'HeaderState's of the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -20,6 +20,7 @@ import           Control.Tracer (Tracer, contramap, nullTracer)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
@@ -64,7 +65,7 @@ data ChainDbArgs f m blk = ChainDbArgs {
     -- ^ Predicate to check for integrity of
     -- 'Ouroboros.Consensus.Storage.Common.GetVerifiedBlock' components when
     -- extracting them from both the VolatileDB and the ImmutableDB.
-    , cdbGenesis                :: HKD f (m (ExtLedgerState blk))
+    , cdbGenesis                :: HKD f (m (ExtLedgerState blk Canonical))
     , cdbCheckInFuture          :: HKD f (CheckInFuture m blk)
     , cdbImmutableDbCacheConfig :: ImmutableDB.CacheConfig
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -686,7 +686,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = do
         cfg :: TopLevelConfig blk
         cfg = cdbTopLevelConfig
 
-        ledger :: LedgerState blk
+        ledger :: LedgerState blk Canonical
         ledger = ledgerState (LgrDB.ledgerDbCurrent newLedgerDB)
 
         summary :: History.Summary (HardForkIndices blk)
@@ -1196,7 +1196,7 @@ futureCheckCandidate chainSelEnv validatedChainDiff =
 
     ValidatedChainDiff chainDiff@(ChainDiff _ suffix) _ = validatedChainDiff
 
-    validatedSuffix :: ValidatedFragment (Header blk) (LedgerState blk)
+    validatedSuffix :: ValidatedFragment (Header blk) (LedgerState blk Canonical)
     validatedSuffix =
       ledgerState . LgrDB.ledgerDbCurrent <$>
       ValidatedDiff.toValidatedFragment validatedChainDiff

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -128,8 +128,8 @@ deriving instance (IOLike m, LedgerSupportsProtocol blk)
 -- | 'EncodeDisk' and 'DecodeDisk' constraints needed for the LgrDB.
 type LgrDbSerialiseConstraints blk =
   ( Serialise      (HeaderHash  blk)
-  , EncodeDisk blk (LedgerState blk)
-  , DecodeDisk blk (LedgerState blk)
+  , EncodeDisk blk (LedgerState blk Canonical)
+  , DecodeDisk blk (LedgerState blk Canonical)
   , EncodeDisk blk (AnnTip      blk)
   , DecodeDisk blk (AnnTip      blk)
   , EncodeDisk blk (ChainDepState (BlockProtocol blk))
@@ -142,7 +142,7 @@ type LgrDbSerialiseConstraints blk =
 
 data LgrDbArgs f m blk = LgrDbArgs {
       lgrDiskPolicy     :: DiskPolicy
-    , lgrGenesis        :: HKD f (m (ExtLedgerState blk))
+    , lgrGenesis        :: HKD f (m (ExtLedgerState blk Canonical))
     , lgrHasFS          :: SomeHasFS m
     , lgrTopLevelConfig :: HKD f (TopLevelConfig blk)
     , lgrTraceLedger    :: Tracer m (LedgerDB' blk)
@@ -258,7 +258,7 @@ initFromDisk LgrDbArgs { lgrHasFS = hasFS, .. }
   where
     ccfg = configCodec lgrTopLevelConfig
 
-    decodeExtLedgerState' :: forall s. Decoder s (ExtLedgerState blk)
+    decodeExtLedgerState' :: forall s. Decoder s (ExtLedgerState blk Canonical)
     decodeExtLedgerState' = decodeExtLedgerState
                               (decodeDisk ccfg)
                               (decodeDisk ccfg)
@@ -316,7 +316,7 @@ takeSnapshot lgrDB@LgrDB{ cfg, tracer, hasFS } = wrapFailure (Proxy @blk) $ do
   where
     ccfg = configCodec cfg
 
-    encodeExtLedgerState' :: ExtLedgerState blk -> Encoding
+    encodeExtLedgerState' :: ExtLedgerState blk Canonical -> Encoding
     encodeExtLedgerState' = encodeExtLedgerState
                               (encodeDisk ccfg)
                               (encodeDisk ccfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
@@ -24,7 +24,7 @@ data InitChainDB m blk = InitChainDB {
       addBlock         :: blk -> m ()
 
       -- | Return the current ledger state
-    , getCurrentLedger :: m (LedgerState blk)
+    , getCurrentLedger :: m (LedgerState blk Canonical)
     }
 
 fromFull ::
@@ -40,7 +40,7 @@ fromFull db = InitChainDB {
 map ::
      Functor m
   => (blk' -> blk)
-  -> (LedgerState blk -> LedgerState blk')
+  -> (LedgerState blk Canonical -> LedgerState blk' Canonical)
   -> InitChainDB m blk -> InitChainDB m blk'
 map f g db = InitChainDB {
       addBlock         = addBlock db . f

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
@@ -2,11 +2,16 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Ouroboros.Consensus.Ticked (Ticked (..)) where
+module Ouroboros.Consensus.Ticked (
+    Ticked (..)
+  , Ticked1
+  ) where
 
 import           Data.Kind (Type)
 import           Data.SOP.BasicFunctors
@@ -28,6 +33,7 @@ import           NoThunks.Class (NoThunks)
 -- * New leader schedule computed for Shelley
 -- * Transition from Byron to Shelley activated in the hard fork combinator.
 -- * Nonces switched out at the start of a new epoch.
+type Ticked :: Type -> Type
 data family Ticked st :: Type
 
 -- Standard instance for use with trivial state
@@ -47,8 +53,16 @@ deriving instance
 
 deriving newtype instance {-# OVERLAPPING #-}
      Show (Ticked (f a))
-  => Show ((Ticked :.: f) a)
+  => Show ((Ticked :.: f) (a :: Type))
 
 deriving newtype instance
      NoThunks (Ticked (f a))
   => NoThunks ((Ticked :.: f) a)
+
+
+{-------------------------------------------------------------------------------
+  @'Ticked'@ for state with a poly-kinded type parameter
+-------------------------------------------------------------------------------}
+
+type Ticked1 :: (k -> Type) -> (k -> Type)
+data family Ticked1 st

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
@@ -34,7 +34,7 @@ import           NoThunks.Class (NoThunks)
 -- * Transition from Byron to Shelley activated in the hard fork combinator.
 -- * Nonces switched out at the start of a new epoch.
 type Ticked :: Type -> Type
-data family Ticked st :: Type
+data family Ticked st
 
 -- Standard instance for use with trivial state
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -1,11 +1,14 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE PolyKinds           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns             #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE KindSignatures           #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeOperators            #-}
 
 -- | Miscellaneous utilities
 module Ouroboros.Consensus.Util (
@@ -53,6 +56,8 @@ module Ouroboros.Consensus.Util (
   , checkThat
     -- * Sets
   , allDisjoint
+    -- * Maps
+  , dimap
     -- * Composition
   , (......:)
   , (.....:)
@@ -60,16 +65,23 @@ module Ouroboros.Consensus.Util (
   , (...:)
   , (..:)
   , (.:)
+    -- * Type-level composition
+  , (:..:) (..)
     -- * Product
   , pairFst
   , pairSnd
     -- * Miscellaneous
   , eitherToMaybe
   , fib
+    -- * Static Either
+  , StaticEither (..)
+  , fromStaticLeft
+  , fromStaticRight
   ) where
 
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashFromBytes,
                      hashFromBytesShort)
+import           Data.Bifunctor (Bifunctor (first, second))
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
@@ -80,6 +92,8 @@ import           Data.Functor.Product
 import           Data.Kind (Constraint, Type)
 import           Data.List (foldl', maximumBy)
 import           Data.List.NonEmpty (NonEmpty (..), (<|))
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -361,6 +375,15 @@ allDisjoint = go Set.empty
     go acc (xs:xss) = Set.disjoint acc xs && go (Set.union acc xs) xss
 
 {-------------------------------------------------------------------------------
+  Maps
+-------------------------------------------------------------------------------}
+
+-- | Map over keys and values
+dimap :: Ord k2 => (k1 -> k2) -> (v1 -> v2) -> Map k1 v1 -> Map k2 v2
+dimap keyFn valFn = Map.foldlWithKey update Map.empty
+  where update m k1 v1 =  Map.insert (keyFn k1) (valFn v1) m
+
+{-------------------------------------------------------------------------------
   Composition
 -------------------------------------------------------------------------------}
 
@@ -381,6 +404,19 @@ allDisjoint = go Set.empty
 
 (......:) :: (y -> z) -> (x0 -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> y) -> (x0 -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> z)
 (f ......: g) x0 x1 x2 x3 x4 x5 x6 = f (g x0 x1 x2 x3 x4 x5 x6)
+
+{-------------------------------------------------------------------------------
+  Type-level composition
+-------------------------------------------------------------------------------}
+
+-- | Compose two types where the second one expects two type variables
+--
+-- @@
+--   Comp2 (Just (Left "hi")) :: (Maybe :..: Either) String Int
+-- @@
+type (:..:) :: (y -> Type) -> (x0 -> x1 -> y) -> (x0 -> x1 -> Type)
+newtype (f :..: g) p r = Comp2 { unComp2 :: f (g p r) }
+
 {-------------------------------------------------------------------------------
   Product
 -------------------------------------------------------------------------------}
@@ -406,3 +442,24 @@ fib n = round $ phi ** fromIntegral n / sq5
 eitherToMaybe :: Either a b -> Maybe b
 eitherToMaybe (Left _)  = Nothing
 eitherToMaybe (Right x) = Just x
+
+{-------------------------------------------------------------------------------
+  Static Either
+-------------------------------------------------------------------------------}
+
+data StaticEither :: Bool -> Type -> Type -> Type where
+  StaticLeft  :: l -> StaticEither False l r
+  StaticRight :: r -> StaticEither True  l r
+
+instance Bifunctor (StaticEither b) where
+  first f (StaticLeft  l) = StaticLeft  (f l)
+  first _ (StaticRight r) = StaticRight    r
+
+  second _ (StaticLeft l)  = StaticLeft l
+  second f (StaticRight r) = StaticRight (f r)
+
+fromStaticLeft :: StaticEither 'False l r -> l
+fromStaticLeft (StaticLeft x) = x
+
+fromStaticRight :: StaticEither 'True l r -> r
+fromStaticRight (StaticRight x) = x

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
--- | A Read-Append-Write (RAW) lock
+-- | A writer-biased Readers-Appender-Writer (RAW) lock
 --
 -- Intended for qualified import
 module Ouroboros.Consensus.Util.MonadSTM.RAWLock (
@@ -31,7 +32,7 @@ import           Control.Monad.Except
 import           Data.Functor (($>))
 import           GHC.Generics (Generic)
 import           GHC.Stack (CallStack, HasCallStack, callStack)
-import           NoThunks.Class (AllowThunk (..))
+import           NoThunks.Class (AllowThunk (..), OnlyCheckWhnfNamed (..))
 
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -145,6 +146,7 @@ import           Ouroboros.Consensus.Util.IOLike
 -- * All public functions are exception-safe.
 --
 newtype RAWLock m st = RAWLock (StrictTVar m (RAWState st))
+  deriving NoThunks via OnlyCheckWhnfNamed "RAWLock" (RAWLock m st)
 
 -- | Create a new 'RAWLock'
 new :: (IOLike m, NoThunks st) => st -> m (RAWLock m st)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -1,18 +1,19 @@
-{-# LANGUAGE BangPatterns         #-}
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE EmptyCase            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE BangPatterns             #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE EmptyCase                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneDeriving       #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 module Ouroboros.Consensus.Util.SOP (
     -- * Minor variations on standard SOP operators
@@ -47,6 +48,16 @@ module Ouroboros.Consensus.Util.SOP (
   , hizipWith
   , hizipWith3
   , hizipWith4
+    -- * Tuples
+  , ApOnlySnd (..)
+  , ApOnlySnd2 (..)
+  , Fst
+  , MapSnd
+  , NsMapSnd (..)
+  , Snd
+  , Uncurry
+  , UncurryComp (..)
+  , castSndIdx
   ) where
 
 import           Data.Coerce
@@ -312,3 +323,54 @@ hizipWith4 ::
   -> h  f4 xs
   -> h  f5 xs
 hizipWith4 = hcizipWith4 (Proxy @Top)
+
+
+{-------------------------------------------------------------------------------
+  Tuples
+-------------------------------------------------------------------------------}
+
+type Fst :: (a, b) -> a
+type family Fst t where
+  Fst '(a,b) = a
+
+type Snd :: (a, b) -> b
+type family Snd t where
+    Snd '(a,b) = b
+
+type MapSnd :: [(Type, Type)] -> [Type]
+type family MapSnd xs where
+  MapSnd '[]       = '[]
+  MapSnd (x ': xs) = Snd x ': MapSnd xs
+
+type UncurryComp ::
+     (Type -> Type)
+  -> (Type -> Type -> Type)
+  -> (Type, Type)
+  -> Type
+newtype UncurryComp f g ab = UncurryComp (f (Uncurry g ab))
+
+type Uncurry :: (a -> b -> k) -> (a, b) -> k
+type family Uncurry f ab where
+  Uncurry f ab = (f (Fst ab) (Snd ab))
+
+type ApOnlySnd :: (a -> Type) -> (b, a) -> Type
+newtype ApOnlySnd f ba = ApOnlySnd { unApOnlySnd :: f (Snd ba) }
+
+type ApOnlySnd2 :: (a -> a -> Type) -> (b, a) -> (b, a) -> Type
+newtype ApOnlySnd2 f ab ab' = ApOnlySnd2 (f (Snd ab) (Snd ab'))
+
+class NsMapSnd xs where
+  nsMapSnd :: NS f (MapSnd xs) -> NS (ApOnlySnd f) xs
+
+instance NsMapSnd '[] where
+  nsMapSnd = \case {}
+
+instance NsMapSnd xs => NsMapSnd (x ': xs) where
+  nsMapSnd = \case
+    Z fx -> Z (ApOnlySnd fx)
+    S ns -> S (nsMapSnd ns)
+
+castSndIdx :: Index xs x -> Index (MapSnd xs) (Snd x)
+castSndIdx = \case
+  IZ   -> IZ
+  IS n -> IS (castSndIdx n)


### PR DESCRIPTION
# Description

In preparation for UTxO-HD, we need to lift an assumption that has been there in Consensus for a while already:

> When executing a Ledger rule on a Ledger State, the input and output states have the same type.

As we are still not making a distinction about the values this is yet true but it will not be once we start to disambiguate on the kind of values that the Ledger State contains, for now in the UTxO set, but in later versions in some other data structures.

This PR updates the `LedgerState` data family to have another type variable that is always instantiated to a phantom type `Canonical`, and all the codebase is updated accordingly.

Once the definitions are in place, most of the other changes are just mechanical changes to the types.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
