### PR TITLE
Add links to the modules listed in docs/Onboarding

### DIFF
--- a/ouroboros-consensus/docs/Onboarding.md
+++ b/ouroboros-consensus/docs/Onboarding.md
@@ -204,26 +204,6 @@ The following artifacts influence and/or describe the Consensus implementation.
 
       * "The Cardano Consensus (and Storage Layer)" (aka "The Consensus Report")
 
-  * Large comments, for example in these modules. This list is a continual work
-    in progress -- if you find some comment to be particularly illuminating,
-    please open a PR adding it here.
-
-      * `Ouroboros.Consensus.Util.ResourceRegistry`
-      * `Ouroboros.Consensus.HeaderValidation`
-      * `Ouroboros.Consensus.Mempool.API`
-      * `Ouroboros.Consensus.Forecast`
-      * `Ouroboros.Consensus.HardFork.History.EraParams`
-      * `Ouroboros.Consensus.HardFork.History.Qry`
-      * `Ouroboros.Consensus.HardFork.History.Summary`
-      * `Ouroboros.Consensus.Protocol.Abstract`
-      * `Ouroboros.Consensus.Storage.ChainDB.API`
-      * `Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel`
-      * `Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator`
-      * `Ouroboros.Network.AnchoredFragment`
-      * `Ouroboros.Consensus.MiniProtocol.ChainSync.Client`
-      * `Ouroboros.Network.BlockFetch.Decision`
-      * `Network.TypedProtocol.Core`
-
   * CI-built Haddock, at https://input-output-hk.github.io/ouroboros-network/
 
   * IOHK media:

--- a/scripts/prolog
+++ b/scripts/prolog
@@ -82,6 +82,26 @@ This graph depicts the relationship between the various `xxx-consensus-yyy` pack
 
 * __db-analyser__: A command-line tool for offline analysis of the consensus database
 
+=== Consensus implementation
+
+The comments in modules listed below provide important information on the
+implementation of consensus.
+
+* "Ouroboros.Consensus.Util.ResourceRegistry"
+* "Ouroboros.Consensus.HeaderValidation"
+* "Ouroboros.Consensus.Mempool.API"
+* "Ouroboros.Consensus.Forecast"
+* "Ouroboros.Consensus.HardFork.History.EraParams"
+* "Ouroboros.Consensus.HardFork.History.Qry"
+* "Ouroboros.Consensus.HardFork.History.Summary"
+* "Ouroboros.Consensus.Protocol.Abstract"
+* "Ouroboros.Consensus.Storage.ChainDB.API"
+* "Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel"
+* "Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator"
+* "Ouroboros.Network.AnchoredFragment"
+* "Ouroboros.Consensus.MiniProtocol.ChainSync.Client"
+* "Ouroboros.Network.BlockFetch.Decision"
+
 === Consensus Components
 
 The following  [C4 Component Diagram](https://c4model.com/) provides a high-level overview of the main components involved in /Consensus/. Note that clicking on


### PR DESCRIPTION
As suggested by the gap analysis performed by Galois, the modules listed in `docs/Onboarding` are now listed and linked from our top-level haddocks.

Closes #4245 

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the
          appropriate `changelog.d` directory created using
          [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see
          the [Consensus release
          process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
