### PR TITLE
Implement `LedgerTables` and a trivial `BackingStore`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -141,3 +141,12 @@ constraints:
 
 allow-newer:
     Unique:hashable
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/anti-diffs
+  tag: 20fdb9839e208236f0f32c86555b16aa110e4f91
+  -- sha256: 0v7ifqgww1da0nsnq76dygcv88cwy9731l3q6cav51qwbbr7vm8a
+  subdir:
+    anti-diff
+    simple-semigroupoids

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -208,11 +208,11 @@ bridgeTransactionIds = Spec.Test.transactionIds
 forgeDualByronBlock
   :: HasCallStack
   => TopLevelConfig DualByronBlock
-  -> BlockNo                              -- ^ Current block number
-  -> SlotNo                               -- ^ Current slot number
-  -> TickedLedgerState DualByronBlock     -- ^ Ledger
-  -> [Validated (GenTx DualByronBlock)]   -- ^ Txs to add in the block
-  -> PBftIsLeader PBftByronCrypto         -- ^ Leader proof ('IsLeader')
+  -> BlockNo                                    -- ^ Current block number
+  -> SlotNo                                     -- ^ Current slot number
+  -> TickedLedgerState DualByronBlock Canonical -- ^ Ledger
+  -> [Validated (GenTx DualByronBlock)]         -- ^ Txs to add in the block
+  -> PBftIsLeader PBftByronCrypto               -- ^ Leader proof ('IsLeader')
   -> DualByronBlock
 forgeDualByronBlock cfg curBlockNo curSlotNo tickedLedger vtxs isLeader =
     -- NOTE: We do not /elaborate/ the real Byron block from the spec one, but

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -148,8 +148,8 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params credss =
         configGenesisData  = Impl.configGenesisData translated
         protocolParameters = Impl.gdProtocolParameters configGenesisData
 
-    initAbstractState :: LedgerState ByronSpecBlock
-    initConcreteState :: LedgerState ByronBlock
+    initAbstractState :: LedgerState ByronSpecBlock Canonical
+    initConcreteState :: LedgerState ByronBlock Canonical
 
     initAbstractState = initByronSpecLedgerState abstractGenesis
     initConcreteState = initByronLedgerState     concreteGenesis (Just initUtxo)

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -68,9 +68,9 @@ instance DecodeDiskDep (NestedCtxt Header) DualByronBlock where
                 (NestedCtxt (CtxtDual ctxt)) =
       decodeDiskDep ccfg (NestedCtxt ctxt)
 
-instance EncodeDisk DualByronBlock (LedgerState DualByronBlock) where
+instance EncodeDisk DualByronBlock (LedgerState DualByronBlock Canonical) where
   encodeDisk _ = encodeDualLedgerState encodeByronLedgerState
-instance DecodeDisk DualByronBlock (LedgerState DualByronBlock) where
+instance DecodeDisk DualByronBlock (LedgerState DualByronBlock Canonical) where
   decodeDisk _ = decodeDualLedgerState decodeByronLedgerState
 
 -- | @'ChainDepState' ('BlockProtocol' 'DualByronBlock')@

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -173,7 +173,7 @@ exampleChainDepState = S.fromList signers
   where
     signers = map (`S.PBftSigner` CC.exampleKeyHash) [1..4]
 
-emptyLedgerState :: LedgerState ByronBlock
+emptyLedgerState :: LedgerState ByronBlock Canonical
 emptyLedgerState = ByronLedgerState {
       byronLedgerTipBlockNo = Origin
     , byronLedgerState      = initState
@@ -184,13 +184,13 @@ emptyLedgerState = ByronLedgerState {
     Right initState = runExcept $
       CC.Block.initialChainValidationState ledgerConfig
 
-ledgerStateAfterEBB :: LedgerState ByronBlock
+ledgerStateAfterEBB :: LedgerState ByronBlock Canonical
 ledgerStateAfterEBB =
       reapplyLedgerBlock ledgerConfig exampleEBB
     . applyChainTick ledgerConfig (SlotNo 0)
     $ emptyLedgerState
 
-exampleLedgerState :: LedgerState ByronBlock
+exampleLedgerState :: LedgerState ByronBlock Canonical
 exampleLedgerState =
       reapplyLedgerBlock ledgerConfig exampleBlock
     . applyChainTick ledgerConfig (SlotNo 1)
@@ -199,7 +199,7 @@ exampleLedgerState =
 exampleHeaderState :: HeaderState ByronBlock
 exampleHeaderState = HeaderState (NotOrigin exampleAnnTip) exampleChainDepState
 
-exampleExtLedgerState :: ExtLedgerState ByronBlock
+exampleExtLedgerState :: ExtLedgerState ByronBlock Canonical
 exampleExtLedgerState = ExtLedgerState {
       ledgerState = exampleLedgerState
     , headerState = exampleHeaderState

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -41,6 +41,7 @@ import           Ouroboros.Network.SizeInBytes
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HeaderValidation (AnnTip (..))
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Protocol.PBFT.State (PBftState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as PBftState
@@ -268,7 +269,7 @@ instance Arbitrary CC.Del.Map where
 instance Arbitrary ByronTransition where
   arbitrary = ByronTransitionInfo . Map.fromList <$> arbitrary
 
-instance Arbitrary (LedgerState ByronBlock) where
+instance Arbitrary (LedgerState ByronBlock Canonical) where
   arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary (TipInfoIsEBB ByronBlock) where

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -40,6 +40,7 @@ import qualified Cardano.Crypto as Crypto
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      ProtocolInfo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
@@ -94,7 +95,7 @@ mkUpdateLabels
   -> NodeJoinPlan
   -> NodeTopology
   -> Ref.Result
-  -> Byron.LedgerState ByronBlock
+  -> Byron.LedgerState ByronBlock Canonical
      -- ^ from 'nodeOutputFinalLedger'
   -> (ProtocolVersionUpdateLabel, SoftwareVersionUpdateLabel)
 mkUpdateLabels params numSlots genesisConfig nodeJoinPlan topology result

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
@@ -39,6 +39,7 @@ import qualified Ouroboros.Network.Mock.Chain as Chain
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -974,7 +975,7 @@ prop_simple_real_pbft_convergence TestSetup
     finalChains :: [(NodeId, Chain ByronBlock)]
     finalChains = Map.toList $ nodeOutputFinalChain <$> testOutputNodes testOutput
 
-    finalLedgers :: [(NodeId, Byron.LedgerState ByronBlock)]
+    finalLedgers :: [(NodeId, Byron.LedgerState ByronBlock Canonical)]
     finalLedgers = Map.toList $ nodeOutputFinalLedger <$> testOutputNodes testOutput
 
     pvuLabels :: [(NodeId, ProtocolVersionUpdateLabel)]

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -268,7 +268,7 @@ instance TxGen DualByronBlock where
       -- Stops when the transaction generator cannot produce more txs
       go :: [GenTx DualByronBlock]     -- Accumulator
          -> Integer                    -- Number of txs to still produce
-         -> TickedLedgerState DualByronBlock
+         -> TickedLedgerState DualByronBlock Canonical
          -> Gen [GenTx DualByronBlock]
       go acc 0 _  = return (reverse acc)
       go acc n st = do
@@ -289,7 +289,7 @@ instance TxGen DualByronBlock where
 -- for now. Extending the scope will require integration with the restart/rekey
 -- infrastructure of the Byron tests.
 genTx :: TopLevelConfig DualByronBlock
-      -> Ticked (LedgerState DualByronBlock)
+      -> Ticked1 (LedgerState DualByronBlock) Canonical
       -> Gen (GenTx DualByronBlock)
 genTx cfg st = do
     aux <- sigGen (Rules.ctxtUTXOW cfg') st'

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -51,13 +51,13 @@ import           Ouroboros.Consensus.Byron.Protocol
 forgeByronBlock
   :: HasCallStack
   => TopLevelConfig ByronBlock
-  -> TxLimits.Overrides ByronBlock    -- ^ How to override max tx capacity
-                                      --   defined by ledger
-  -> BlockNo                          -- ^ Current block number
-  -> SlotNo                           -- ^ Current slot number
-  -> TickedLedgerState ByronBlock     -- ^ Current ledger
-  -> [Validated (GenTx ByronBlock)]   -- ^ Txs to consider adding in the block
-  -> PBftIsLeader PBftByronCrypto     -- ^ Leader proof ('IsLeader')
+  -> TxLimits.Overrides ByronBlock          -- ^ How to override max tx capacity
+                                            --   defined by ledger
+  -> BlockNo                                -- ^ Current block number
+  -> SlotNo                                 -- ^ Current slot number
+  -> TickedLedgerState ByronBlock Canonical -- ^ Current ledger
+  -> [Validated (GenTx ByronBlock)]         -- ^ Txs to consider adding in the block
+  -> PBftIsLeader PBftByronCrypto           -- ^ Leader proof ('IsLeader')
   -> ByronBlock
 forgeByronBlock cfg = forgeRegularBlock (configBlock cfg)
 
@@ -128,13 +128,13 @@ initBlockPayloads = BlockPayloads
 forgeRegularBlock
   :: HasCallStack
   => BlockConfig ByronBlock
-  -> TxLimits.Overrides ByronBlock     -- ^ How to override max tx capacity
-                                       --   defined by ledger
-  -> BlockNo                           -- ^ Current block number
-  -> SlotNo                            -- ^ Current slot number
-  -> TickedLedgerState ByronBlock      -- ^ Current ledger
-  -> [Validated (GenTx ByronBlock)]    -- ^ Txs to consider adding in the block
-  -> PBftIsLeader PBftByronCrypto      -- ^ Leader proof ('IsLeader')
+  -> TxLimits.Overrides ByronBlock          -- ^ How to override max tx capacity
+                                            --   defined by ledger
+  -> BlockNo                                -- ^ Current block number
+  -> SlotNo                                 -- ^ Current slot number
+  -> TickedLedgerState ByronBlock Canonical -- ^ Current ledger
+  -> [Validated (GenTx ByronBlock)]         -- ^ Txs to consider adding in the block
+  -> PBftIsLeader PBftByronCrypto           -- ^ Leader proof ('IsLeader')
   -> ByronBlock
 forgeRegularBlock cfg maxTxCapacityOverrides bno sno st txs isLeader =
     forge $

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Inspect.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Inspect.hs
@@ -107,7 +107,7 @@ data UpdateState =
 -- | All proposal updates, from new to old
 protocolUpdates ::
        LedgerConfig ByronBlock
-    -> LedgerState ByronBlock
+    -> LedgerState ByronBlock Canonical
     -> [ProtocolUpdate]
 protocolUpdates genesis st = concat [
       map fromCandidate candidates

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -36,7 +36,7 @@ module Ouroboros.Consensus.Byron.Ledger.Ledger (
     -- * Type family instances
   , BlockQuery (..)
   , LedgerState (..)
-  , Ticked (..)
+  , LedgerTables (..)
   , Ticked1 (..)
     -- * Auxiliary
   , validationErrorImpossible
@@ -78,8 +78,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
-import           Ouroboros.Consensus.Protocol.PBFT
-import           Ouroboros.Consensus.Ticked
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Util (ShowProxy (..), (..:))
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
@@ -504,3 +503,21 @@ decodeByronResult :: BlockQuery ByronBlock result
                   -> forall s. Decoder s result
 decodeByronResult query = case query of
     GetUpdateInterfaceState -> fromCBOR
+
+{-------------------------------------------------------------------------------
+  Ledger Tables
+-------------------------------------------------------------------------------}
+
+instance HasLedgerTables (LedgerState ByronBlock) where
+  data instance LedgerTables (LedgerState ByronBlock) mk = NoTables
+    deriving (Generic, Eq, Show, NoThunks)
+
+instance CanSerializeLedgerTables (LedgerState ByronBlock) where
+
+instance LedgerTablesAreTrivial (LedgerState ByronBlock) where
+  trivialLedgerTables = NoTables
+
+instance HasTickedLedgerTables (LedgerState ByronBlock) where
+  withLedgerTablesTicked TickedByronLedgerState{..} NoTables = TickedByronLedgerState{..}
+
+instance CanStowLedgerTables (LedgerState ByronBlock) where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -249,8 +249,8 @@ applyByronGenTx :: CC.ValidationMode
                 -> LedgerConfig ByronBlock
                 -> SlotNo
                 -> GenTx ByronBlock
-                -> TickedLedgerState ByronBlock
-                -> Except (ApplyTxErr ByronBlock) (TickedLedgerState ByronBlock)
+                -> TickedLedgerState ByronBlock Canonical
+                -> Except (ApplyTxErr ByronBlock) (TickedLedgerState ByronBlock Canonical)
 applyByronGenTx validationMode cfg slot genTx st =
     (\state -> st {tickedByronLedgerState = state}) <$>
       CC.applyMempoolPayload

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -28,6 +28,7 @@ import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
@@ -52,9 +53,9 @@ instance EncodeDisk ByronBlock ByronBlock where
 instance DecodeDisk ByronBlock (Lazy.ByteString -> ByronBlock) where
   decodeDisk ccfg = decodeByronBlock (getByronEpochSlots ccfg)
 
-instance EncodeDisk ByronBlock (LedgerState ByronBlock) where
+instance EncodeDisk ByronBlock (LedgerState ByronBlock Canonical) where
   encodeDisk _ = encodeByronLedgerState
-instance DecodeDisk ByronBlock (LedgerState ByronBlock) where
+instance DecodeDisk ByronBlock (LedgerState ByronBlock Canonical) where
   decodeDisk _ = decodeByronLedgerState
 
 -- | @'ChainDepState' ('BlockProtocol' 'ByronBlock')@

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
@@ -21,7 +21,7 @@ import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans ()
 
 forgeByronSpecBlock :: BlockNo
                     -> SlotNo
-                    -> Ticked (LedgerState ByronSpecBlock)
+                    -> Ticked1 (LedgerState ByronSpecBlock) Canonical
                     -> [Validated (GenTx ByronSpecBlock)]
                     -> Spec.VKey
                     -> ByronSpecBlock

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DerivingVia           #-}
@@ -13,7 +14,7 @@ module Ouroboros.Consensus.ByronSpec.Ledger.Ledger (
   , initByronSpecLedgerState
     -- * Type family instances
   , LedgerState (..)
-  , Ticked (..)
+  , LedgerTables (..)
   , Ticked1 (..)
   ) where
 
@@ -29,6 +30,7 @@ import qualified Control.State.Transition as Spec
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util ((..:))
 
@@ -157,3 +159,22 @@ getPParams =
       Spec.protocolParameters
     . getChainStateUPIState
     . byronSpecLedgerState
+
+{-------------------------------------------------------------------------------
+  Ledger Tables
+-------------------------------------------------------------------------------}
+
+instance HasLedgerTables (LedgerState ByronSpecBlock) where
+  data LedgerTables (LedgerState ByronSpecBlock) mk = NoTables
+    deriving (Generic, Eq, Show, NoThunks)
+
+instance CanSerializeLedgerTables (LedgerState ByronSpecBlock) where
+
+instance HasTickedLedgerTables (LedgerState ByronSpecBlock) where
+  withLedgerTablesTicked TickedByronSpecLedgerState{..} NoTables =
+    TickedByronSpecLedgerState{..}
+
+instance LedgerTablesAreTrivial (LedgerState ByronSpecBlock) where
+  trivialLedgerTables = NoTables
+
+instance CanStowLedgerTables (LedgerState ByronSpecBlock) where

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -34,6 +34,7 @@ library
                        Test.ThreadNet.TxGen.Mary
 
   build-depends:       base >=4.14 && <4.17
+                     , cardano-binary
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-slotting

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -40,6 +40,7 @@ import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
 import qualified Ouroboros.Consensus.HardFork.Combinator.State.Types as HFC
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 import qualified Ouroboros.Consensus.HardFork.History as History
@@ -159,17 +160,19 @@ instance ShelleyBasedHardForkConstraints proto1 era1 proto2 era2
       translateLedgerState ::
            InPairs.RequiringBoth
              WrapLedgerConfig
-             (HFC.Translate LedgerState)
+             HFC.TranslateLedgerState
              (ShelleyBlock proto1 era1)
              (ShelleyBlock proto2 era2)
       translateLedgerState =
           InPairs.RequireBoth
-        $ \_cfg1 cfg2 -> HFC.Translate
+        $ \_cfg1 cfg2 -> HFC.TranslateLedgerState
         $ \_epochNo ->
-              unComp
+              unFlip
+            . unComp
             . SL.translateEra'
                 (shelleyLedgerTranslationContext (unwrapLedgerConfig cfg2))
             . Comp
+            . Flip
 
       translateLedgerView ::
            InPairs.RequiringBoth

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -55,6 +55,7 @@ import           Ouroboros.Consensus.Shelley.Node
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.Cardano.Node
+import           Ouroboros.Consensus.Cardano.Tables ()
 
 import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
 import           Test.ThreadNet.General

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Api/Protocol/Types.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Api/Protocol/Types.hs
@@ -23,6 +23,7 @@ import           Ouroboros.Consensus.Cardano
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.ByronHFC (ByronBlockHFC)
 import           Ouroboros.Consensus.Cardano.Node
+import           Ouroboros.Consensus.Cardano.Tables ()
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
 import qualified Ouroboros.Consensus.Ledger.SupportsProtocol as Consensus
                      (LedgerSupportsProtocol)

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -55,7 +55,6 @@ import           Ouroboros.Consensus.Protocol.Abstract (LedgerView)
 import           Ouroboros.Consensus.Storage.Common (BlockComponent (..),
                      StreamFrom (..))
 import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (..))
-import           Ouroboros.Consensus.Ticked
 import qualified Ouroboros.Consensus.Util.IOLike as IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -52,6 +52,7 @@ import           Ouroboros.Consensus.Cardano.Block (CardanoEras,
                      CardanoShelleyEras)
 import           Ouroboros.Consensus.Cardano.Node (TriggerHardFork (..),
                      protocolInfoCardano)
+import           Ouroboros.Consensus.Cardano.Tables ()
 import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock (..),
                      OneEraBlock (..), OneEraHash (..), getHardForkState,
                      hardForkLedgerStatePerEra)

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -56,6 +56,7 @@ import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock (..),
                      OneEraBlock (..), OneEraHash (..), getHardForkState,
                      hardForkLedgerStatePerEra)
 import           Ouroboros.Consensus.HardFork.Combinator.State (currentState)
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -101,15 +102,15 @@ analyseWithLedgerState f (WithLedgerState cb sb sa) =
     p :: Proxy HasAnalysis
     p = Proxy
 
-    zipLS (Comp (Just sb')) (Comp (Just sa')) (I blk) =
+    zipLS (Comp (Just (Flip sb'))) (Comp (Just (Flip sa'))) (I blk) =
       Comp . Just $ WithLedgerState blk sb' sa'
     zipLS _ _ _ = Comp Nothing
 
     oeb = getOneEraBlock . getHardForkBlock $ cb
 
     goLS ::
-      LedgerState (CardanoBlock StandardCrypto) ->
-      NP (Maybe :.: LedgerState) (CardanoEras StandardCrypto)
+      LedgerState (CardanoBlock StandardCrypto) Canonical ->
+      NP (Maybe :.: (Flip LedgerState Canonical)) (CardanoEras StandardCrypto)
     goLS =
       hexpand (Comp Nothing)
         . hmap (Comp . Just . currentState)

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/HasAnalysis.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/HasAnalysis.hs
@@ -24,8 +24,8 @@ import           Ouroboros.Consensus.Util.Condense (Condense)
 
 data WithLedgerState blk = WithLedgerState
   { wlsBlk         :: blk
-  , wlsStateBefore :: LedgerState blk
-  , wlsStateAfter  :: LedgerState blk
+  , wlsStateBefore :: LedgerState blk Canonical
+  , wlsStateAfter  :: LedgerState blk Canonical
   }
 
 class (HasAnnTip blk, GetPrevHash blk, Condense (HeaderHash blk)) => HasAnalysis blk where

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Run.hs
@@ -16,6 +16,7 @@ import           Control.Tracer (Tracer (..), nullTracer)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as LedgerSupportsMempool
                      (HasTxs)
@@ -145,7 +146,7 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
       (OnlyValidation, _ )             -> VolatileDB.ValidateAll
       _                                -> VolatileDB.NoValidation
 
-    decodeExtLedgerState' :: forall s . TopLevelConfig blk -> Decoder s (ExtLedgerState blk)
+    decodeExtLedgerState' :: forall s . TopLevelConfig blk -> Decoder s (ExtLedgerState blk Canonical)
     decodeExtLedgerState' cfg =
       let ccfg = configCodec cfg
       in decodeExtLedgerState

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -35,7 +35,6 @@ import           Ouroboros.Consensus.Storage.ChainDB.API as ChainDB (ChainDB,
                      getPastLedger)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
                      (noPunishment)
-import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util.IOLike (atomically)
 import           Ouroboros.Network.AnchoredFragment as AF (Anchor (..),
                      AnchoredFragment, AnchoredSeq (..), headPoint)

--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -35,6 +35,7 @@ import           Ouroboros.Consensus.Storage.ChainDB.API as ChainDB (ChainDB,
                      getPastLedger)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
                      (noPunishment)
+import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util.IOLike (atomically)
 import           Ouroboros.Network.AnchoredFragment as AF (Anchor (..),
                      AnchoredFragment, AnchoredSeq (..), headPoint)
@@ -151,7 +152,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg = do
           _   -> exitEarly' "NoLeader"
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
-        let tickedLedgerState :: Ticked (LedgerState blk)
+        let tickedLedgerState :: Ticked1 (LedgerState blk) Canonical
             tickedLedgerState =
               applyChainTick
                 (configLedger cfg)

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -32,6 +32,7 @@ library
                        Ouroboros.Consensus.Cardano.CanHardFork
                        Ouroboros.Consensus.Cardano.Node
                        Ouroboros.Consensus.Cardano.ShelleyBased
+                       Ouroboros.Consensus.Cardano.Tables
 
   build-depends:       base              >=4.14  && <4.17
                      , bytestring        >=0.10  && <0.12
@@ -59,6 +60,7 @@ library
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-protocol
                      , ouroboros-consensus-shelley
+                     , sop-core
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -9,6 +9,7 @@ module Ouroboros.Consensus.Cardano.Block (
     CardanoEras
   , CardanoShelleyEras
   , module Ouroboros.Consensus.Shelley.Eras
+  , ShelleyBasedProtosAndEras
     -- * Block
   , CardanoBlock
     -- Note: by exporting the pattern synonyms as part of the matching data
@@ -106,6 +107,14 @@ type CardanoShelleyEras c =
    , ShelleyBlock (TPraos c) (MaryEra c)
    , ShelleyBlock (TPraos c) (AlonzoEra c)
    , ShelleyBlock (Praos c)  (BabbageEra c)
+   ]
+
+type ShelleyBasedProtosAndEras c =
+  '[ '(TPraos c, ShelleyEra c)
+   , '(TPraos c, AllegraEra c)
+   , '(TPraos c, MaryEra c)
+   , '(TPraos c, AlonzoEra c)
+   , '(Praos c,  BabbageEra c)
    ]
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -71,7 +71,7 @@ import           Data.SOP.Strict
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError,
                      TipInfo)
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerError)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr,
                      GenTxId)
 import           Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
@@ -80,6 +80,7 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 
@@ -938,55 +939,55 @@ pattern CardanoLedgerConfig cfgByron cfgShelley cfgAllegra cfgMary cfgAlonzo cfg
 -- 'LedgerState'. We don't give access to those internal details through the
 -- pattern synonyms. This is also the reason the pattern synonyms are not
 -- bidirectional.
-type CardanoLedgerState c = LedgerState (CardanoBlock c)
+type CardanoLedgerState c = LedgerState (CardanoBlock c) Canonical
 
 pattern LedgerStateByron
-  :: LedgerState ByronBlock
+  :: LedgerState ByronBlock Canonical
   -> CardanoLedgerState c
 pattern LedgerStateByron st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleByron (State.Current { currentState = st })))
+        (TeleByron (State.Current { currentState = Flip st })))
 
 pattern LedgerStateShelley
-  :: LedgerState (ShelleyBlock (TPraos c) (ShelleyEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (ShelleyEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateShelley st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleShelley _ (State.Current { currentState = st })))
+        (TeleShelley _ (State.Current { currentState = Flip st })))
 
 pattern LedgerStateAllegra
-  :: LedgerState (ShelleyBlock (TPraos c) (AllegraEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (AllegraEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateAllegra st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleAllegra _ _  (State.Current { currentState = st })))
+        (TeleAllegra _ _  (State.Current { currentState = Flip st })))
 
 pattern LedgerStateMary
-  :: LedgerState (ShelleyBlock (TPraos c) (MaryEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (MaryEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateMary st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleMary _ _ _ (State.Current { currentState = st })))
+        (TeleMary _ _ _ (State.Current { currentState = Flip st })))
 
 pattern LedgerStateAlonzo
-  :: LedgerState (ShelleyBlock (TPraos c) (AlonzoEra c))
+  :: LedgerState (ShelleyBlock (TPraos c) (AlonzoEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateAlonzo st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleAlonzo _ _ _ _ (State.Current { currentState = st })))
+        (TeleAlonzo _ _ _ _ (State.Current { currentState = Flip st })))
 
 pattern LedgerStateBabbage
-  :: LedgerState (ShelleyBlock (Praos c) (BabbageEra c))
+  :: LedgerState (ShelleyBlock (Praos c) (BabbageEra c)) Canonical
   -> CardanoLedgerState c
 pattern LedgerStateBabbage st <-
     HardForkLedgerState
       (State.HardForkState
-        (TeleBabbage _ _ _ _ _ (State.Current { currentState = st })))
+        (TeleBabbage _ _ _ _ _ (State.Current { currentState = Flip st })))
 
 {-# COMPLETE LedgerStateByron
            , LedgerStateShelley

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -30,7 +30,7 @@ import           Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (listToMaybe, mapMaybe)
 import           Data.Proxy
-import           Data.SOP.Strict (hpure, unComp, (:.:) (..))
+import           Data.SOP.Strict
 import           Data.Word
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
@@ -400,6 +400,8 @@ translateLedgerStateByronToShelleyWrapper =
             (byronLedgerState ledgerByron)
       , shelleyLedgerTransition =
           ShelleyTransitionInfo{shelleyAfterVoting = 0}
+      , shelleyLedgerTables =
+          ShelleyLedgerTables Canonical
       }
 
 translateChainDepStateByronToShelleyWrapper ::
@@ -625,13 +627,14 @@ translateLedgerStateAlonzoToBabbageWrapper =
         unFlip . unComp . SL.translateEra' (getBabbageTranslationContext cfgBabbage) . Comp . Flip . transPraosLS
   where
     transPraosLS ::
-      LedgerState (ShelleyBlock (TPraos c) (AlonzoEra c)) mk ->
-      LedgerState (ShelleyBlock (Praos c)  (AlonzoEra c)) mk
-    transPraosLS (ShelleyLedgerState wo nes st) =
+      LedgerState (ShelleyBlock (TPraos c) (AlonzoEra c)) Canonical ->
+      LedgerState (ShelleyBlock (Praos c)  (AlonzoEra c)) Canonical
+    transPraosLS (ShelleyLedgerState wo nes st (ShelleyLedgerTables Canonical)) =
       ShelleyLedgerState
         { shelleyLedgerTip        = fmap castShelleyTip wo
         , shelleyLedgerState      = nes
         , shelleyLedgerTransition = st
+        , shelleyLedgerTables     = ShelleyLedgerTables Canonical
         }
 
 getBabbageTranslationContext ::

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -63,6 +63,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import qualified Ouroboros.Consensus.Mempool.TxLimits as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -833,21 +834,21 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
     -- When the initial ledger state is not in the Byron era, register the
     -- initial staking and initial funds (if provided in the genesis config) in
     -- the ledger state.
-    initExtLedgerStateCardano :: ExtLedgerState (CardanoBlock c)
+    initExtLedgerStateCardano :: ExtLedgerState (CardanoBlock c) Canonical
     initExtLedgerStateCardano = ExtLedgerState {
           headerState = initHeaderState
         , ledgerState = overShelleyBasedLedgerState register initLedgerState
         }
       where
         initHeaderState :: HeaderState (CardanoBlock c)
-        initLedgerState :: LedgerState (CardanoBlock c)
+        initLedgerState :: LedgerState (CardanoBlock c) Canonical
         ExtLedgerState initLedgerState initHeaderState =
           injectInitialExtLedgerState cfg initExtLedgerStateByron
 
         register ::
              (EraCrypto era ~ c, ShelleyBasedEra era)
-          => LedgerState (ShelleyBlock proto era)
-          -> LedgerState (ShelleyBlock proto era)
+          => LedgerState (ShelleyBlock proto era) Canonical
+          -> LedgerState (ShelleyBlock proto era) Canonical
         register st = st {
               Shelley.shelleyLedgerState =
                 -- We must first register the initial funds, because the stake

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Tables.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Tables.hs
@@ -1,0 +1,561 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE EmptyCase                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeFamilyDependencies     #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE UndecidableSuperClasses    #-}
+{-# LANGUAGE ViewPatterns               #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+-- |
+
+module Ouroboros.Consensus.Cardano.Tables (
+    InjectLedgerTables (..)
+  , LedgerTablesCanHardFork (..)
+  , ShelleyTxOut (..)
+  , SndShelleyBasedEra
+  , TxOutWrapper (..)
+  , consolidateShelleyTele
+  , unconsolidateShelleyTele
+  ) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import           Data.Kind (Type)
+import           Data.Monoid (First (..))
+import           Data.Proxy
+import           Data.SOP.Strict
+import           Data.Typeable
+import           Data.Void
+import           GHC.Generics (Generic)
+import           GHC.Stack (HasCallStack)
+import           NoThunks.Class
+
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Tables
+import           Ouroboros.Consensus.Util.SOP
+
+import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
+
+import           Ouroboros.Consensus.Byron.Ledger
+import           Ouroboros.Consensus.Byron.Node ()
+
+import           Ouroboros.Consensus.Shelley.Ledger
+import           Ouroboros.Consensus.Shelley.Node ()
+
+import qualified Cardano.Ledger.Alonzo.Translation as Alonzo
+import qualified Cardano.Ledger.Babbage.Translation as Babbage
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Era as SL
+import           Cardano.Ledger.Hashes (EraIndependentTxBody)
+import           Cardano.Ledger.Keys (DSignable, Hash)
+import           Cardano.Ledger.Mary.Translation ()
+import qualified Cardano.Ledger.Shelley.API as SL
+
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Cardano.CanHardFork
+import qualified Ouroboros.Consensus.Protocol.Praos as Praos
+import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
+import           Ouroboros.Consensus.Shelley.Protocol.Praos ()
+
+{-------------------------------------------------------------------------------
+  Injecting Tables
+-------------------------------------------------------------------------------}
+
+-- | How to inject each era's ledger tables into their shared ledger tables
+class LedgerTablesCanHardFork xs where
+  hardForkInjectLedgerTablesKeysMK :: NP (InjectLedgerTables xs) xs
+
+newtype InjectLedgerTables xs x = InjectLedgerTables {
+      applyInjectLedgerTables :: forall mk. IsMapKind mk =>
+           LedgerTables (LedgerState                  x) mk
+        -> LedgerTables (LedgerState (HardForkBlock xs)) mk
+    }
+
+instance CardanoHardForkConstraints c => LedgerTablesCanHardFork (CardanoEras c) where
+  hardForkInjectLedgerTablesKeysMK =
+         byron
+      :* shelley IZ
+      :* shelley (IS IZ)
+      :* shelley (IS (IS IZ))
+      :* shelley (IS (IS (IS IZ)))
+      :* shelley (IS (IS (IS (IS IZ))))
+      :* Nil
+    where
+      byron :: InjectLedgerTables (CardanoEras c) ByronBlock
+      byron = InjectLedgerTables $ \NoTables -> pureLedgerTables emptyMK
+
+      shelley ::
+           forall era proto. (SL.Crypto era ~ c, Eq (Core.TxOut era))
+        => Index (ShelleyBasedEras c) era
+        -> InjectLedgerTables (CardanoEras c) (ShelleyBlock proto era)
+      shelley idx =
+          InjectLedgerTables
+        $ \(ShelleyLedgerTables lt) -> CardanoLedgerTables $ mapMK f lt
+        where
+          f :: Core.TxOut era -> CardanoTxOut c
+          f = ShelleyTxOut . injectNS idx . TxOutWrapper
+
+{-------------------------------------------------------------------------------
+  Partially applying 'Core.TxOut'
+-------------------------------------------------------------------------------}
+
+-- | Wrapper for partially applying the 'Core.TxOut' type family
+--
+-- For generality, Consensus uses that type family as eg the index of
+-- 'Core.TranslateEra'. We thus need to partially apply it.
+newtype TxOutWrapper era = TxOutWrapper {unTxOutWrapper :: Core.TxOut era}
+  deriving (Generic)
+
+deriving instance Eq       (Core.TxOut era) => Eq       (TxOutWrapper era)
+deriving instance NoThunks (Core.TxOut era) => NoThunks (TxOutWrapper era)
+deriving instance Show     (Core.TxOut era) => Show     (TxOutWrapper era)
+
+instance ShelleyBasedEra (AllegraEra c) => Core.TranslateEra (AllegraEra c) TxOutWrapper where
+  type TranslationError (AllegraEra c) TxOutWrapper = Void
+  translateEra ctxt = fmap TxOutWrapper . Core.translateEra ctxt . unTxOutWrapper
+
+instance ShelleyBasedEra (MaryEra c) => Core.TranslateEra (MaryEra c) TxOutWrapper where
+  type TranslationError (MaryEra c) TxOutWrapper = Void
+  translateEra ctxt = fmap TxOutWrapper . Core.translateEra ctxt . unTxOutWrapper
+
+instance ShelleyBasedEra (AlonzoEra c) => Core.TranslateEra (AlonzoEra c) TxOutWrapper where
+  type TranslationError (AlonzoEra c) TxOutWrapper = Void
+  translateEra _ctxt =
+        pure
+      . TxOutWrapper
+      . Alonzo.translateTxOut
+      . unTxOutWrapper
+
+instance ShelleyBasedEra (BabbageEra c) => Core.TranslateEra (BabbageEra c) TxOutWrapper where
+  type TranslationError (BabbageEra c) TxOutWrapper = Void
+  translateEra _ctxt =
+        pure
+      . TxOutWrapper
+      . Babbage.translateTxOut
+      . unTxOutWrapper
+
+{-------------------------------------------------------------------------------
+  The NS'ed tx out for Shelley eras
+-------------------------------------------------------------------------------}
+
+type ShelleyBasedEras c = MapSnd (ShelleyBasedProtosAndEras c)
+
+-- | We use this type for clarity, and because we don't want to declare
+-- 'FromCBOR' and 'ToCBOR' for 'NS'; serializations of sum involves design
+-- decisions that cannot be captured by an all-purpose 'NS' instance
+newtype ShelleyTxOut eras =
+    ShelleyTxOut { unShelleyTxOut :: NS TxOutWrapper eras }
+  deriving (Generic)
+
+instance All ShelleyBasedEra eras => Eq       (ShelleyTxOut eras) where
+  ShelleyTxOut (Z l) == ShelleyTxOut (Z r) = l == r
+  ShelleyTxOut (S l) == ShelleyTxOut (S r) = ShelleyTxOut l == ShelleyTxOut r
+  _                      == _              = False
+
+instance All ShelleyBasedEra eras => NoThunks (ShelleyTxOut eras) where
+  wNoThunks ctxt = (. unShelleyTxOut) $ \case
+      Z l -> noThunks ("Z" : ctxt) l
+      S r -> noThunks ("S" : ctxt) (ShelleyTxOut r)
+
+instance All ShelleyBasedEra eras => Show (ShelleyTxOut eras) where
+  showsPrec =
+      \p (ShelleyTxOut ns) -> showParen (p > 10) $ showString "ShelleyTxOut " . go ns
+    where
+      go :: All ShelleyBasedEra eras' => NS TxOutWrapper eras' -> ShowS
+      go = showParen True . \case
+        Z l -> showString "Z " . shows l
+        S r -> showString "S " . go r
+
+-- | Unlike nsToIndex, this is not restricted to the interval [0, 24)
+idxLength :: Index xs x -> Int
+idxLength = \case
+    IZ     -> 0
+    IS idx -> 1 + idxLength idx
+
+instance (All ShelleyBasedEra eras, Typeable eras) => ToCBOR (ShelleyTxOut eras) where
+  toCBOR (ShelleyTxOut x) =
+        hcollapse
+      $ hcimap (Proxy @ShelleyBasedEra) each x
+    where
+      each ::
+           ShelleyBasedEra era
+        => Index eras era
+        -> TxOutWrapper era
+        -> K CBOR.Encoding era
+      each idx (TxOutWrapper txout) = K $
+           CBOR.encodeListLen 2
+        <> CBOR.encodeWord (toEnum (idxLength idx))
+        <> toCBOR txout
+
+instance (All ShelleyBasedEra eras, Typeable eras) => FromCBOR (ShelleyTxOut eras) where
+  fromCBOR = do
+      CBOR.decodeListLenOf 2
+      tag <- CBOR.decodeWord
+      let aDecoder =
+              mconcat
+            $ hcollapse
+            $ hcmap
+                (Proxy @ShelleyBasedEra)
+                each
+                (indices @eras)
+      case getFirst $ aDecoder tag of
+        Nothing -> error $ "FromCBOR ShelleyTxOut, unknown tag: " <> show tag
+        Just x  -> unADecoder x
+    where
+      each ::
+           ShelleyBasedEra x
+        => Index eras x
+        -> K (Word -> First (ADecoder eras)) x
+      each idx = K $ \w -> First $
+        if w /= toEnum (idxLength idx) then Nothing else
+        Just
+          $ ADecoder
+          $ (ShelleyTxOut . injectNS idx . TxOutWrapper) <$> fromCBOR
+
+newtype ADecoder eras =
+  ADecoder {unADecoder :: forall s. CBOR.Decoder s (ShelleyTxOut eras)}
+
+{-------------------------------------------------------------------------------
+  Mapping lists of tuples
+-------------------------------------------------------------------------------}
+
+type MapShelleyBlock :: [(Type, Type)] -> [Type]
+type family MapShelleyBlock protosAndEras = blks | blks -> protosAndEras where
+  MapShelleyBlock '[]                              = '[]
+  MapShelleyBlock ('(proto, era) ': protosAndEras') = ShelleyBlock proto era ': MapShelleyBlock protosAndEras'
+
+class IsShelleyTele protosAndEras where
+  consolidateShelleyTele ::
+       Telescope              g                            f               (MapShelleyBlock protosAndEras)
+    -> Telescope (UncurryComp g ShelleyBlock) (UncurryComp f ShelleyBlock) protosAndEras
+  unconsolidateShelleyTele ::
+       Telescope (UncurryComp g ShelleyBlock) (UncurryComp f ShelleyBlock) protosAndEras
+    -> Telescope              g                            f               (MapShelleyBlock protosAndEras)
+
+instance IsShelleyTele '[] where
+  consolidateShelleyTele   = \case {}
+  unconsolidateShelleyTele = \case {}
+
+instance IsShelleyTele xs => IsShelleyTele ('(x, y) ': xs) where
+  consolidateShelleyTele = \case
+    TZ x       -> TZ (UncurryComp x)
+    TS p inner -> TS (UncurryComp p) (consolidateShelleyTele inner)
+  unconsolidateShelleyTele   = \case
+    TZ (UncurryComp x)       -> TZ x
+    TS (UncurryComp p) inner -> TS p (unconsolidateShelleyTele inner)
+
+class    (SL.Crypto (Snd a) ~ c, ShelleyBasedEra (Snd a)) => SndShelleyBasedEra c a
+instance (SL.Crypto (Snd a) ~ c, ShelleyBasedEra (Snd a)) => SndShelleyBasedEra c a
+
+{-------------------------------------------------------------------------------
+  HasLedgerTables helpers
+-------------------------------------------------------------------------------}
+
+-- We reuse this for both HasLedgerTables and HasTickedLedgerTables instances,
+-- so the @HasTickedLedgerTables x@ constraint here is excessive in the
+-- HasLedgerTables case. However, since x is always a Cardano era, we do know we
+-- have HasTickedLedgerTables for every x, so hardcoding the stronger constraint
+-- is easier than parameterizing this helper over the constraint.
+projectLedgerTablesHelper :: forall c mk fmk.
+     (CardanoHardForkConstraints c, IsMapKind mk)
+  => (forall blk.
+         HasTickedLedgerTables (LedgerState blk)
+      => fmk blk -> LedgerTables (LedgerState blk) mk
+     )
+  -> HardForkState fmk (CardanoEras c)
+  -> LedgerTables (LedgerState (CardanoBlock c)) mk
+projectLedgerTablesHelper prjLT (HardForkState st) =
+    case st of
+      -- the first era is Byron
+      TZ Current {
+          currentState = prjLT -> NoTables
+        } ->
+        pureLedgerTables emptyMK
+
+      -- all the remaining eras are Shelley
+      TS _past tele ->
+          hcollapse
+        $ hcimap
+            (Proxy @(SndShelleyBasedEra c))
+            projectOne
+            (Telescope.tip $ consolidateShelleyTele tele)
+  where
+    projectOne :: forall (a :: (Type, Type)).
+         (SL.Crypto (Snd a) ~ c, ShelleyBasedEra (Snd a))
+      => Index (ShelleyBasedProtosAndEras c)             a
+         -- ^ the current era of the ledger state we're projecting from
+      -> UncurryComp (Current fmk) ShelleyBlock a
+         -- ^ the ledger state we're projecting from
+      -> K (LedgerTables (LedgerState (CardanoBlock c)) mk) a
+    projectOne idx (UncurryComp current) =
+        K $ CardanoLedgerTables $ inj appliedMK
+      where
+        ShelleyLedgerTables appliedMK = prjLT $ currentState current
+
+        inj ::
+             mk (SL.TxIn c) (Core.TxOut (Snd a))
+          -> mk (SL.TxIn c) (CardanoTxOut c)
+        inj = mapMK (ShelleyTxOut . injectNS (castSndIdx idx) . TxOutWrapper)
+
+-- Same note regarding the @HasTickedLedgerTables x@ constraint as
+-- 'projectLedgerTablesHelper'
+withLedgerTablesHelper ::
+  forall c mk fany fmk.
+     (CardanoHardForkConstraints c, IsMapKind mk)
+  => (forall x.
+         HasTickedLedgerTables (LedgerState x)
+      => fany x -> LedgerTables (LedgerState x) mk -> fmk x
+     )
+  -> HardForkState fany (CardanoEras c)
+  -> LedgerTables (LedgerState (CardanoBlock c)) mk
+  -> HardForkState fmk (CardanoEras c)
+withLedgerTablesHelper withLT (HardForkState st) (CardanoLedgerTables appliedMK) =
+      HardForkState
+    $ case st of
+        -- the first era is Byron
+        TZ Current {
+            currentStart
+          , currentState = byronSt
+          } ->
+          TZ Current {
+                 currentStart
+               , currentState = withLT byronSt NoTables
+               }
+
+        -- all the remaining eras are Shelley
+        TS past tele ->
+            TS past
+          $ unconsolidateShelleyTele
+          $ hap
+              updateOne
+              (consolidateShelleyTele tele)
+  where
+    -- how to update the ledger table of each possible individual era
+    updateOne ::
+      NP
+        (     UncurryComp (Current fany) ShelleyBlock
+         -.-> UncurryComp (Current fmk ) ShelleyBlock
+        )
+        (ShelleyBasedProtosAndEras c)
+    updateOne =
+      hcmap
+        (Proxy @(SndShelleyBasedEra c))
+        (\(ApOnlySnd translate) -> fn $ \(UncurryComp current) ->
+            let Current{currentState = innerSt} = current
+                newInnerSt =
+                  withLT innerSt
+                  $ ShelleyLedgerTables
+                  $ mapMK
+                      (unTxOutWrapper . apFn translate . K)
+                      appliedMK
+            in UncurryComp $ current{currentState = newInnerSt})
+        translations
+
+    -- the composed translations for each possible era; see
+    -- 'composeTxOutTranslationPairs' to understand why this is partial but
+    -- is safe in the absence of Consensus bugs
+    translations ::
+      NP
+        (ApOnlySnd (K (CardanoTxOut c) -.-> TxOutWrapper))
+        (ShelleyBasedProtosAndEras c)
+    translations =
+        hmap
+          (\(ApOnlySnd f)
+             -> ApOnlySnd $ fn $ \(K (ShelleyTxOut x)) -> f `apFn` K (nsMapSnd x))
+          (composeTxOutTranslationPairs translateTxOut)
+
+{-------------------------------------------------------------------------------
+ Translating TxOuts through eras
+-------------------------------------------------------------------------------}
+
+-- | Auxiliary for convenience
+--
+-- We can't reuse 'Translate' because we don't have the 'EpochNo' it requires.
+newtype TranslateTxOutWrapper era1 era2 =
+    TranslateTxOutWrapper (Core.TxOut era1 -> Core.TxOut era2)
+
+-- | The 'Core.TxOut' translations between the adjacent Shelley-based eras in
+-- Cardano
+translateTxOut ::
+     CardanoHardForkConstraints c
+  => InPairs
+       (ApOnlySnd2 TranslateTxOutWrapper)
+       (ShelleyBasedProtosAndEras c)
+translateTxOut =
+      PCons (ApOnlySnd2 $ TranslateTxOutWrapper $ SL.translateEra' ())
+    $ PCons (ApOnlySnd2 $ TranslateTxOutWrapper $ SL.translateEra' ())
+    $ PCons (ApOnlySnd2 $ TranslateTxOutWrapper $ Alonzo.translateTxOut)
+    $ PCons (ApOnlySnd2 $ TranslateTxOutWrapper $ Babbage.translateTxOut)
+    $ PNil
+
+-- | Auxiliary @SOP@ combinator
+--
+-- WARNING: The functions in the result fail if the 'NS' argument's tag
+-- precedes the 'NP' index.
+--
+-- TODO use an accumulator instead of this quadratic traversal
+composeTxOutTranslationPairs ::
+     (SListI protosAndEras, HasCallStack)
+  => InPairs
+       (ApOnlySnd2 TranslateTxOutWrapper)
+       protosAndEras
+  -> NP
+       (ApOnlySnd (K (NS (ApOnlySnd TxOutWrapper) protosAndEras) -.-> TxOutWrapper))
+       protosAndEras
+composeTxOutTranslationPairs = \case
+    PNil                                  ->
+      (ApOnlySnd $ fn $ unApOnlySnd . unZ . unK) :* Nil
+    PCons (ApOnlySnd2 (TranslateTxOutWrapper f)) inner ->
+         (ApOnlySnd $ fn $
+            unApOnlySnd
+          . eitherNS
+              id
+              (error "composeTxOutTranslationPairs: anachrony")
+          . unK
+         )
+      :* hmap
+          (\(ApOnlySnd innerf) -> ApOnlySnd $ fn $
+              apFn innerf
+            . K
+            . eitherNS
+                (Z . ApOnlySnd . TxOutWrapper . f . unTxOutWrapper . unApOnlySnd)
+                id
+            . unK)
+          (composeTxOutTranslationPairs inner)
+  where
+    eitherNS :: (f x -> c) -> (NS f xs -> c) -> NS f (x ': xs) -> c
+    eitherNS l r = \case
+      Z x -> l x
+      S x -> r x
+
+{-------------------------------------------------------------------------------
+ HasLedgerTables instances
+-------------------------------------------------------------------------------}
+
+type CardanoTxOut c = ShelleyTxOut (ShelleyBasedEras c)
+
+-- Note that this is a HardForkBlock instance, but it's not compositional. This
+-- is because the LedgerTables relies on knowledge specific to Cardano and we
+-- have so far not found a pleasant way to express that compositionally.
+instance CardanoHardForkConstraints c => HasLedgerTables (LedgerState (CardanoBlock c)) where
+  newtype LedgerTables (LedgerState (CardanoBlock c)) mk = CardanoLedgerTables {
+        cardanoUTxOTable :: mk (SL.TxIn c) (CardanoTxOut c)
+      }
+    deriving (Generic)
+
+  projectLedgerTables (HardForkLedgerState hfstate) =
+      projectLedgerTablesHelper
+        (projectLedgerTables . unFlip)
+        hfstate
+
+  withLedgerTables (HardForkLedgerState hfstate) tables =
+        HardForkLedgerState
+      $ withLedgerTablesHelper
+          (\(Flip st) tables' -> Flip $ withLedgerTables st tables')
+          hfstate
+          tables
+
+  pureLedgerTables     f                                                                         = CardanoLedgerTables f
+  mapLedgerTables      f                                                 (CardanoLedgerTables x) = CardanoLedgerTables (f x)
+  traverseLedgerTables f                                                 (CardanoLedgerTables x) = CardanoLedgerTables <$> f x
+  zipLedgerTables      f                         (CardanoLedgerTables l) (CardanoLedgerTables r) = CardanoLedgerTables (f l r)
+  zipLedgerTables2     f (CardanoLedgerTables l) (CardanoLedgerTables c) (CardanoLedgerTables r) = CardanoLedgerTables (f l c r)
+  zipLedgerTablesA     f                         (CardanoLedgerTables l) (CardanoLedgerTables r) = CardanoLedgerTables <$> f l r
+  zipLedgerTables2A    f (CardanoLedgerTables l) (CardanoLedgerTables c) (CardanoLedgerTables r) = CardanoLedgerTables <$> f l c r
+  foldLedgerTables     f                                                 (CardanoLedgerTables x) = f x
+  foldLedgerTables2    f                         (CardanoLedgerTables l) (CardanoLedgerTables r) = f l r
+
+  namesLedgerTables = CardanoLedgerTables { cardanoUTxOTable = NameMK "cardanoUTxOTable" }
+
+deriving newtype instance ( IsMapKind mk
+                          , Praos.PraosCrypto c
+                          , TPraos.PraosCrypto c
+                          , DSignable c (Hash c EraIndependentTxBody)
+                          ) => Eq (LedgerTables (LedgerState (CardanoBlock c)) mk)
+deriving newtype instance ( IsMapKind mk
+                          , Praos.PraosCrypto c
+                          , TPraos.PraosCrypto c
+                          , DSignable c (Hash c EraIndependentTxBody)
+                          ) => NoThunks (LedgerTables (LedgerState (CardanoBlock c)) mk)
+deriving newtype instance ( IsMapKind mk
+                          , Praos.PraosCrypto c
+                          , TPraos.PraosCrypto c
+                          , DSignable c (Hash c EraIndependentTxBody)
+                          ) => Show (LedgerTables (LedgerState (CardanoBlock c)) mk)
+
+instance CardanoHardForkConstraints c => HasTickedLedgerTables (LedgerState (CardanoBlock c)) where
+  projectLedgerTablesTicked st = projectLedgerTablesHelper
+        (\(FlipTickedLedgerState st') -> projectLedgerTablesTicked st')
+        (tickedHardForkLedgerStatePerEra st)
+
+  withLedgerTablesTicked TickedHardForkLedgerState{..} tables =
+      TickedHardForkLedgerState {
+          tickedHardForkLedgerStateTransition = tickedHardForkLedgerStateTransition
+        , tickedHardForkLedgerStatePerEra     =
+            withLedgerTablesHelper
+              (\(FlipTickedLedgerState st) tables' ->
+                 FlipTickedLedgerState $ withLedgerTablesTicked st tables')
+              tickedHardForkLedgerStatePerEra
+              tables
+        }
+
+instance CardanoHardForkConstraints c
+      => CanSerializeLedgerTables (LedgerState (CardanoBlock c)) where
+    codecLedgerTables = CardanoLedgerTables (CodecMK toCBOR toCBOR fromCBOR fromCBOR)
+
+instance CardanoHardForkConstraints c
+      => CanStowLedgerTables (LedgerState (CardanoBlock c)) where
+  stowLedgerTables   hfstate =
+    let
+      innerState :: Telescope (K Past) (Current (Flip LedgerState ValuesMK)) (CardanoEras c)
+      innerState = getHardForkState $ hardForkLedgerStatePerEra hfstate
+
+      innerTable :: Telescope (K Past) (Current (Flip LedgerState EmptyMK)) (CardanoEras c)
+      innerTable =
+        hcmap
+          (Proxy @(Compose CanStowLedgerTables LedgerState))
+          (\(Current s (Flip st)) -> Current s $ Flip $ stowLedgerTables st)
+          innerState
+    in
+    HardForkLedgerState
+    $ HardForkState
+    $ innerTable
+
+  unstowLedgerTables hfstate =
+    let
+      innerState :: Telescope (K Past) (Current (Flip LedgerState EmptyMK)) (CardanoEras c)
+      innerState = getHardForkState $ hardForkLedgerStatePerEra hfstate
+
+      innerTable :: Telescope (K Past) (Current (Flip LedgerState ValuesMK)) (CardanoEras c)
+      innerTable =
+        hcmap
+          (Proxy @(Compose CanStowLedgerTables LedgerState))
+          (\(Current s (Flip st)) -> Current s $ Flip $ unstowLedgerTables st)
+          innerState
+    in
+    HardForkLedgerState
+    $ HardForkState
+    $ innerTable

--- a/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/Node.hs
@@ -90,6 +90,7 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -539,7 +540,7 @@ openChainDB
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
      -- ^ Initial ledger
   -> ChainDbArgs Defaults m blk
   -> (ChainDbArgs Identity m blk -> ChainDbArgs Identity m blk)
@@ -559,7 +560,7 @@ mkChainDbArgs
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
      -- ^ Initial ledger
   -> ChunkInfo
   -> ChainDbArgs Defaults m blk

--- a/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/NodeKernel.hs
@@ -337,7 +337,7 @@ forkBlockForging IS{..} blockForging =
         trace $ TraceNodeIsLeader currentSlot
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
-        let tickedLedgerState :: Ticked (LedgerState blk)
+        let tickedLedgerState :: Ticked1 (LedgerState blk) Canonical
             tickedLedgerState =
               applyChainTick
                 (configLedger cfg)
@@ -586,7 +586,7 @@ getMempoolWriter mempool = Inbound.TxSubmissionMempoolWriter
 getPeersFromCurrentLedger ::
      (IOLike m, LedgerSupportsPeerSelection blk)
   => NodeKernel m remotePeer localPeer blk
-  -> (LedgerState blk -> Bool)
+  -> (LedgerState blk Canonical -> Bool)
   -> STM m (Maybe [(PoolStake, NonEmpty RelayAccessPoint)])
 getPeersFromCurrentLedger kernel p = do
     immutableLedger <-
@@ -612,7 +612,7 @@ getPeersFromCurrentLedgerAfterSlot ::
 getPeersFromCurrentLedgerAfterSlot kernel slotNo =
     getPeersFromCurrentLedger kernel afterSlotNo
   where
-    afterSlotNo :: LedgerState blk -> Bool
+    afterSlotNo :: LedgerState blk Canonical -> Bool
     afterSlotNo st =
       case ledgerTipSlot st of
         Origin        -> False

--- a/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
@@ -27,6 +27,7 @@ import           Test.QuickCheck
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (hashFromBytesE)
@@ -114,7 +115,7 @@ instance Arbitrary (SomeSecond BlockQuery (SimpleBlock c ext)) where
 instance (SimpleCrypto c, Typeable ext) => Arbitrary (SomeResult (SimpleBlock c ext)) where
   arbitrary = SomeResult QueryLedgerTip <$> arbitrary
 
-instance Arbitrary (LedgerState (SimpleBlock c ext)) where
+instance Arbitrary (LedgerState (SimpleBlock c ext) Canonical) where
   arbitrary = SimpleLedgerState <$> arbitrary
 
 instance HashAlgorithm (SimpleHash c) => Arbitrary (AnnTip (SimpleBlock c ext)) where

--- a/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
@@ -116,7 +116,7 @@ instance (SimpleCrypto c, Typeable ext) => Arbitrary (SomeResult (SimpleBlock c 
   arbitrary = SomeResult QueryLedgerTip <$> arbitrary
 
 instance Arbitrary (LedgerState (SimpleBlock c ext) Canonical) where
-  arbitrary = SimpleLedgerState <$> arbitrary
+  arbitrary = flip SimpleLedgerState (SimpleLedgerTables Canonical) <$> arbitrary
 
 instance HashAlgorithm (SimpleHash c) => Arbitrary (AnnTip (SimpleBlock c ext)) where
   arbitrary = do

--- a/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -60,6 +60,7 @@ library
                      , mtl               >=2.2   && <2.3
                      , nothunks
                      , serialise         >=0.2   && <0.3
+                     , text
                      , time
 
                      , ouroboros-network-api

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Address.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Address.hs
@@ -11,7 +11,10 @@ import           Control.DeepSeq (NFData)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.String
+import           Data.Text (pack, unpack)
 import           NoThunks.Class (NoThunks)
+
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (NodeId (..))
@@ -28,6 +31,12 @@ newtype Addr = Addr String
     , NFData
     , NoThunks
     )
+
+instance ToCBOR Addr where
+  toCBOR (Addr a) = toCBOR $ pack a
+
+instance FromCBOR Addr where
+  fromCBOR = Addr . unpack <$> fromCBOR
 
 instance Condense Addr where
   condense (Addr addr) = addr

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -39,6 +39,7 @@ import           Ouroboros.Consensus.Mock.Ledger.Forge
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Signed
+import           Ouroboros.Consensus.Ticked (Ticked (TickedTrivial))
 import           Ouroboros.Consensus.Util.Condense
 
 import           Ouroboros.Consensus.Storage.Serialisation

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -43,10 +43,10 @@ forgeSimple :: forall c ext.
                )
             => ForgeExt c ext
             -> TopLevelConfig (SimpleBlock c ext)
-            -> BlockNo                                   -- ^ Current block number
-            -> SlotNo                                    -- ^ Current slot number
-            -> TickedLedgerState (SimpleBlock c ext)     -- ^ Current ledger
-            -> [GenTx (SimpleBlock c ext)]               -- ^ Txs to include
+            -> BlockNo                                         -- ^ Current block number
+            -> SlotNo                                          -- ^ Current slot number
+            -> TickedLedgerState (SimpleBlock c ext) Canonical -- ^ Current ledger
+            -> [GenTx (SimpleBlock c ext)]                     -- ^ Txs to include
             -> IsLeader (BlockProtocol (SimpleBlock c ext))
             -> SimpleBlock c ext
 forgeSimple ForgeExt { forgeExt } cfg curBlock curSlot tickedLedger txs proof =

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -55,8 +55,8 @@ instance Serialise ext => EncodeDisk (MockBlock ext) (Header (MockBlock ext))
 instance Serialise ext => DecodeDisk (MockBlock ext) (Lazy.ByteString -> Header (MockBlock ext)) where
   decodeDisk _ = const <$> decode
 
-instance EncodeDisk (MockBlock ext) (LedgerState (MockBlock ext))
-instance DecodeDisk (MockBlock ext) (LedgerState (MockBlock ext))
+instance EncodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical)
+instance DecodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical)
 
 instance EncodeDisk (MockBlock ext) (AnnTip (MockBlock ext)) where
   encodeDisk _ = defaultEncodeAnnTip encode

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -55,8 +55,10 @@ instance Serialise ext => EncodeDisk (MockBlock ext) (Header (MockBlock ext))
 instance Serialise ext => DecodeDisk (MockBlock ext) (Lazy.ByteString -> Header (MockBlock ext)) where
   decodeDisk _ = const <$> decode
 
-instance EncodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical)
-instance DecodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical)
+instance EncodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical) where
+  encodeDisk _ = encode . simpleLedgerState
+instance DecodeDisk (MockBlock ext) (LedgerState (MockBlock ext) Canonical) where
+  decodeDisk _ = flip SimpleLedgerState (SimpleLedgerTables Canonical) <$> decode
 
 instance EncodeDisk (MockBlock ext) (AnnTip (MockBlock ext)) where
   encodeDisk _ = defaultEncodeAnnTip encode

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -30,6 +30,7 @@ import qualified Cardano.Protocol.TPraos.BHeader as SL
 import           Data.Coerce (coerce)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Protocol.Praos (Praos)
@@ -135,6 +136,7 @@ fromShelleyLedgerExamples ShelleyLedgerExamples {
                                   }
     , shelleyLedgerState      = sleNewEpochState
     , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
+    , shelleyLedgerTables     = ShelleyLedgerTables Canonical
     }
     chainDepState = TPraosState (NotOrigin 1) sleChainDepState
     extLedgerState = ExtLedgerState
@@ -228,6 +230,7 @@ fromShelleyLedgerExamplesPraos ShelleyLedgerExamples {
                                   }
     , shelleyLedgerState      = sleNewEpochState
     , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
+    , shelleyLedgerTables     = ShelleyLedgerTables Canonical
     }
     chainDepState = translateChainDepState @(TPraos (EraCrypto era)) @(Praos (EraCrypto era))
       $ TPraosState (NotOrigin 1) sleChainDepState

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -182,7 +182,7 @@ instance CanMock proto era=> Arbitrary (ShelleyTip proto era) where
 instance Arbitrary ShelleyTransition where
   arbitrary = ShelleyTransitionInfo <$> arbitrary
 
-instance CanMock proto era => Arbitrary (LedgerState (ShelleyBlock proto era)) where
+instance CanMock proto era => Arbitrary (LedgerState (ShelleyBlock proto era) Canonical) where
   arbitrary = ShelleyLedgerState
     <$> arbitrary
     <*> arbitrary

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -183,7 +183,7 @@ instance Arbitrary ShelleyTransition where
   arbitrary = ShelleyTransitionInfo <$> arbitrary
 
 instance CanMock proto era => Arbitrary (LedgerState (ShelleyBlock proto era) Canonical) where
-  arbitrary = ShelleyLedgerState
+  arbitrary = (\a b c -> ShelleyLedgerState a b c (ShelleyLedgerTables Canonical))
     <$> arbitrary
     <*> arbitrary
     <*> arbitrary

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -80,7 +80,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (TPraos (MockCrypto h)) (MockShe
 
       go :: [GenTx (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))]  -- ^ Accumulator
          -> Integer  -- ^ Number of txs to still produce
-         -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))
+         -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h)) Canonical
          -> Gen [GenTx (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))]
       go acc 0 _  = return (reverse acc)
       go acc n st = do
@@ -96,7 +96,7 @@ genTx
   :: forall h. HashAlgorithm h
   => TopLevelConfig (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))
   -> SlotNo
-  -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))
+  -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h)) Canonical
   -> Gen.GenEnv (MockShelley h)
   -> Gen (Maybe (GenTx (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))))
 genTx _cfg slotNo TickedShelleyLedgerState { tickedShelleyLedgerState } genEnv =

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
@@ -362,7 +362,7 @@ prop_simple_real_tpraos_convergence TestSetup
             DoGeneratePPUs    -> True
             DoNotGeneratePPUs -> False
 
-        finalLedgers :: [(NodeId, LedgerState (ShelleyBlock Proto Era))]
+        finalLedgers :: [(NodeId, LedgerState (ShelleyBlock Proto Era) Canonical)]
         finalLedgers =
             Map.toList $ nodeOutputFinalLedger <$> testOutputNodes testOutput
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -48,12 +48,12 @@ forgeShelleyBlock ::
   => HotKey (EraCrypto era) m
   -> CanBeLeader proto
   -> TopLevelConfig (ShelleyBlock proto era)
-  -> TxLimits.Overrides (ShelleyBlock proto era)  -- ^ How to override max tx
-                                                  --   capacity defined by ledger
-  -> BlockNo                                      -- ^ Current block number
-  -> SlotNo                                       -- ^ Current slot number
-  -> TickedLedgerState (ShelleyBlock proto era)   -- ^ Current ledger
-  -> [Validated (GenTx (ShelleyBlock proto era))] -- ^ Txs to add in the block
+  -> TxLimits.Overrides (ShelleyBlock proto era)          -- ^ How to override max tx
+                                                          --   capacity defined by ledger
+  -> BlockNo                                              -- ^ Current block number
+  -> SlotNo                                               -- ^ Current slot number
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical -- ^ Current ledger
+  -> [Validated (GenTx (ShelleyBlock proto era))]         -- ^ Txs to add in the block
   -> IsLeader proto
   -> m (ShelleyBlock proto era)
 forgeShelleyBlock

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -106,7 +106,7 @@ data UpdateState c = UpdateState {
 protocolUpdates ::
        forall era proto. ShelleyBasedEra era
     => SL.ShelleyGenesis era
-    -> LedgerState (ShelleyBlock proto era)
+    -> LedgerState (ShelleyBlock proto era) Canonical
     -> [ProtocolUpdate era]
 protocolUpdates genesis st = [
       ProtocolUpdate {

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -73,7 +73,7 @@ import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger
                      (ShelleyLedgerConfig (shelleyLedgerGlobals),
-                     Ticked (TickedShelleyLedgerState, tickedShelleyLedgerState),
+                     Ticked1 (TickedShelleyLedgerState, tickedShelleyLedgerState),
                      getPParams)
 
 data instance GenTx (ShelleyBlock proto era) = ShelleyTx !(SL.TxId (EraCrypto era)) !(Tx era)
@@ -224,9 +224,9 @@ applyShelleyTx :: forall era proto.
   -> WhetherToIntervene
   -> SlotNo
   -> GenTx (ShelleyBlock proto era)
-  -> TickedLedgerState (ShelleyBlock proto era)
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical
   -> Except (ApplyTxErr (ShelleyBlock proto era))
-       ( TickedLedgerState (ShelleyBlock proto era)
+       ( TickedLedgerState (ShelleyBlock proto era) Canonical
        , Validated (GenTx (ShelleyBlock proto era))
        )
 applyShelleyTx cfg wti slot (ShelleyTx _ tx) st = do
@@ -249,8 +249,8 @@ reapplyShelleyTx ::
   => LedgerConfig (ShelleyBlock proto era)
   -> SlotNo
   -> Validated (GenTx (ShelleyBlock proto era))
-  -> TickedLedgerState (ShelleyBlock proto era)
-  -> Except (ApplyTxErr (ShelleyBlock proto era)) (TickedLedgerState (ShelleyBlock proto era))
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical
+  -> Except (ApplyTxErr (ShelleyBlock proto era)) (TickedLedgerState (ShelleyBlock proto era) Canonical)
 reapplyShelleyTx cfg slot vgtx st = do
     mempoolState' <-
         SL.reapplyTx
@@ -275,8 +275,8 @@ set lens inner outer =
 theLedgerLens ::
      Functor f
   => (SL.LedgerState era -> f (SL.LedgerState era))
-  -> TickedLedgerState (ShelleyBlock proto era)
-  -> f (TickedLedgerState (ShelleyBlock proto era))
+  -> TickedLedgerState (ShelleyBlock proto era) Canonical
+  -> f (TickedLedgerState (ShelleyBlock proto era) Canonical)
 theLedgerLens f x =
         (\y -> x{tickedShelleyLedgerState = y})
     <$> SL.overNewEpochState f (tickedShelleyLedgerState x)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
@@ -113,7 +113,7 @@ instance
     mapForecast (translateTickedLedgerView @(TPraos crypto) @(Praos crypto)) $
       ledgerViewForecastAt @(ShelleyBlock (TPraos crypto) era) cfg st'
     where
-      st' :: LedgerState (ShelleyBlock (TPraos crypto) era)
+      st' :: LedgerState (ShelleyBlock (TPraos crypto) era) Canonical
       st' =
         ShelleyLedgerState
           { shelleyLedgerTip = coerceTip <$> shelleyLedgerTip st,

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/SupportsProtocol.hs
@@ -45,6 +45,7 @@ import           Ouroboros.Consensus.Shelley.Ledger.Protocol ()
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract ()
 import           Ouroboros.Consensus.Shelley.Protocol.Praos ()
 import           Ouroboros.Consensus.Shelley.Protocol.TPraos ()
+import           Ouroboros.Consensus.Ticked (Ticked)
 
 instance
   (ShelleyCompatible (TPraos crypto) era, crypto ~ EraCrypto era) =>
@@ -118,6 +119,7 @@ instance
         ShelleyLedgerState
           { shelleyLedgerTip = coerceTip <$> shelleyLedgerTip st,
             shelleyLedgerState = shelleyLedgerState st,
-            shelleyLedgerTransition = shelleyLedgerTransition st
+            shelleyLedgerTransition = shelleyLedgerTransition st,
+            shelleyLedgerTables = ShelleyLedgerTables Canonical
           }
       coerceTip (ShelleyTip slot block hash) = ShelleyTip slot block (coerce hash)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -17,6 +17,7 @@ import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
@@ -53,9 +54,9 @@ instance ShelleyCompatible proto era => EncodeDisk (ShelleyBlock proto era) (Hea
 instance ShelleyCompatible proto era => DecodeDisk (ShelleyBlock proto era) (Lazy.ByteString -> Header (ShelleyBlock proto era)) where
   decodeDisk _ = decodeShelleyHeader
 
-instance ShelleyCompatible proto era => EncodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era)) where
+instance ShelleyCompatible proto era => EncodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era) Canonical) where
   encodeDisk _ = encodeShelleyLedgerState
-instance ShelleyCompatible proto era => DecodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era)) where
+instance ShelleyCompatible proto era => DecodeDisk (ShelleyBlock proto era) (LedgerState (ShelleyBlock proto era) Canonical) where
   decodeDisk _ = decodeShelleyLedgerState
 
 -- | @'ChainDepState' ('BlockProtocol' ('ShelleyBlock' era))@

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -322,7 +322,7 @@ protocolInfoTPraosShelleyBased ProtocolParamsShelleyBased {
         , shelleyStorageConfigSecurityParam     = tpraosSecurityParam     tpraosParams
         }
 
-    initLedgerState :: LedgerState (ShelleyBlock (TPraos c) era)
+    initLedgerState :: LedgerState (ShelleyBlock (TPraos c) era) Canonical
     initLedgerState = ShelleyLedgerState {
         shelleyLedgerTip        = Origin
       , shelleyLedgerState      =
@@ -335,7 +335,7 @@ protocolInfoTPraosShelleyBased ProtocolParamsShelleyBased {
     initChainDepState = TPraosState Origin $
       SL.initialChainDepState initialNonce (SL.sgGenDelegs genesis)
 
-    initExtLedgerState :: ExtLedgerState (ShelleyBlock (TPraos c) era)
+    initExtLedgerState :: ExtLedgerState (ShelleyBlock (TPraos c) era) Canonical
     initExtLedgerState = ExtLedgerState {
         ledgerState = initLedgerState
       , headerState = genesisHeaderState initChainDepState

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -329,6 +329,7 @@ protocolInfoTPraosShelleyBased ProtocolParamsShelleyBased {
           registerGenesisStaking (SL.sgStaking genesis) $
             SL.initialState genesis additionalGenesisConfig
       , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
+      , shelleyLedgerTables     = ShelleyLedgerTables Canonical
       }
 
     initChainDepState :: TPraosState c

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -236,7 +236,7 @@ data ThreadNetworkArgs m blk = ThreadNetworkArgs
 -- context.
 --
 data VertexStatus m blk
-  = VDown (Chain blk) (LedgerState blk)
+  = VDown (Chain blk) (LedgerState blk Canonical)
     -- ^ The vertex does not currently have a node instance; its previous
     -- instance stopped with this chain and ledger state (empty/initial before
     -- first instance)
@@ -588,7 +588,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       -> ResourceRegistry m
       -> (SlotNo -> STM m ())
       -> LedgerConfig blk
-      -> STM m (LedgerState blk)
+      -> STM m (LedgerState blk Canonical)
       -> Mempool m blk TicketNo
       -> [GenTx blk]
          -- ^ valid transactions the node should immediately propagate
@@ -667,7 +667,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                    -> OracularClock m
                    -> TopLevelConfig blk
                    -> Seed
-                   -> STM m (ExtLedgerState blk)
+                   -> STM m (ExtLedgerState blk Canonical)
                       -- ^ How to get the current ledger state
                    -> Mempool m blk TicketNo
                    -> m ()
@@ -685,7 +685,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
     mkArgs :: OracularClock m
            -> ResourceRegistry m
            -> TopLevelConfig blk
-           -> ExtLedgerState blk
+           -> ExtLedgerState blk Canonical
            -> Tracer m (RealPoint blk, ExtValidationError blk)
               -- ^ invalid block tracer
            -> Tracer m (RealPoint blk, BlockNo)
@@ -813,7 +813,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
             -> TopLevelConfig blk
             -> BlockNo
             -> SlotNo
-            -> TickedLedgerState blk
+            -> TickedLedgerState blk Canonical
             -> [Validated (GenTx blk)]
             -> IsLeader (BlockProtocol blk)
             -> m blk
@@ -1451,7 +1451,7 @@ data NodeOutput blk = NodeOutput
   { nodeOutputAdds         :: Map SlotNo (Set (RealPoint blk, BlockNo))
   , nodeOutputCannotForges :: Map SlotNo [CannotForge blk]
   , nodeOutputFinalChain   :: Chain blk
-  , nodeOutputFinalLedger  :: LedgerState blk
+  , nodeOutputFinalLedger  :: LedgerState blk Canonical
   , nodeOutputForges       :: Map SlotNo blk
   , nodeOutputHeaderAdds   :: Map SlotNo [(RealPoint blk, BlockNo)]
   , nodeOutputInvalids     :: Map (RealPoint blk) [ExtValidationError blk]
@@ -1472,7 +1472,7 @@ mkTestOutput ::
     => [( CoreNodeId
         , m (NodeInfo blk MockFS [])
         , Chain blk
-        , LedgerState blk
+        , LedgerState blk Canonical
         )]
     -> m (TestOutput blk)
 mkTestOutput vertexInfos = do

--- a/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
@@ -26,6 +26,8 @@ import           Ouroboros.Consensus.Util.SOP
 
 import           Ouroboros.Consensus.HardFork.Combinator
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 {-------------------------------------------------------------------------------
   TxGen class
@@ -49,7 +51,7 @@ class TxGen blk where
              -> SlotNo
              -> TopLevelConfig blk
              -> TxGenExtra blk
-             -> LedgerState blk
+             -> LedgerState blk Canonical
              -> Gen [GenTx blk]
 
 {-------------------------------------------------------------------------------
@@ -78,7 +80,7 @@ testGenTxsHfc ::
   -> SlotNo
   -> TopLevelConfig (HardForkBlock xs)
   -> NP WrapTxGenExtra xs
-  -> LedgerState (HardForkBlock xs)
+  -> LedgerState (HardForkBlock xs) Canonical
   -> Gen [GenTx (HardForkBlock xs)]
 testGenTxsHfc coreNodeId numCoreNodes curSlotNo cfg extras state =
     hcollapse $
@@ -99,8 +101,8 @@ testGenTxsHfc coreNodeId numCoreNodes curSlotNo cfg extras state =
       => Index xs blk
       -> TopLevelConfig blk
       -> WrapTxGenExtra blk
-      -> LedgerState blk
+      -> Flip LedgerState Canonical blk
       -> K (Gen [GenTx (HardForkBlock xs)]) blk
-    aux index cfg' (WrapTxGenExtra extra') state' = K $
+    aux index cfg' (WrapTxGenExtra extra') (Flip state') = K $
         fmap (injectNS' (Proxy @GenTx) index)
           <$> testGenTxs coreNodeId numCoreNodes curSlotNo cfg' extra' state'

--- a/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChainDB.hs
@@ -23,6 +23,7 @@ import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture (..))
 import qualified Ouroboros.Consensus.Fragment.Validated as VF
 import           Ouroboros.Consensus.HardFork.History.EraParams (EraParams,
                      eraEpochSize)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -65,7 +66,7 @@ data MinimalChainDbArgs m blk = MinimalChainDbArgs {
     mcdbTopLevelConfig :: TopLevelConfig blk
   , mcdbChunkInfo      :: ImmutableDB.ChunkInfo
   -- ^ Specifies the layout of the ImmutableDB on disk.
-  , mcdbInitLedger     :: ExtLedgerState blk
+  , mcdbInitLedger     :: ExtLedgerState blk Canonical
   -- ^ The initial ledger state.
   , mcdbRegistry       :: ResourceRegistry m
   -- ^ Keeps track of non-lexically scoped resources.

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/Arbitrary.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
 {-# LANGUAGE NumericUnderscores   #-}
+{-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TypeApplications     #-}

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
@@ -35,10 +35,10 @@ instance (ToExpr slot, ToExpr hash) => ToExpr (Block slot hash)
   ouroboros-consensus
 -------------------------------------------------------------------------------}
 
-instance ( ToExpr (LedgerState blk)
+instance ( ToExpr (LedgerState blk mk)
          , ToExpr (ChainDepState (BlockProtocol blk))
          , ToExpr (TipInfo blk)
-         ) => ToExpr (ExtLedgerState blk)
+         ) => ToExpr (ExtLedgerState blk mk)
 
 instance ( ToExpr (ChainDepState (BlockProtocol blk))
          , ToExpr (TipInfo blk)

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
@@ -56,7 +56,7 @@ import           Ouroboros.Network.Block (Serialised)
 import           Ouroboros.Consensus.Block (BlockProtocol, CodecConfig, Header,
                      HeaderHash, SlotNo, SomeSecond)
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerState)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState,
                      encodeExtLedgerState)
 import           Ouroboros.Consensus.Ledger.Query (BlockQuery, QueryVersion,
@@ -221,9 +221,9 @@ data Examples blk = Examples {
     , exampleQuery            :: Labelled (SomeSecond BlockQuery blk)
     , exampleResult           :: Labelled (SomeResult blk)
     , exampleAnnTip           :: Labelled (AnnTip blk)
-    , exampleLedgerState      :: Labelled (LedgerState blk)
+    , exampleLedgerState      :: Labelled (LedgerState blk Canonical)
     , exampleChainDepState    :: Labelled (ChainDepState (BlockProtocol blk))
-    , exampleExtLedgerState   :: Labelled (ExtLedgerState blk)
+    , exampleExtLedgerState   :: Labelled (ExtLedgerState blk Canonical)
     , exampleSlotNo           :: Labelled SlotNo
     }
 

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -48,7 +48,7 @@ import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerState)
 import           Ouroboros.Consensus.Ledger.Query (BlockQuery, Query (..),
                      QueryVersion)
 import qualified Ouroboros.Consensus.Ledger.Query as Query
@@ -130,7 +130,7 @@ roundtrip_all
      , Arbitrary' blk
      , Arbitrary' (Header blk)
      , Arbitrary' (HeaderHash blk)
-     , Arbitrary' (LedgerState blk)
+     , Arbitrary' (LedgerState blk Canonical)
      , Arbitrary' (AnnTip blk)
      , Arbitrary' (ChainDepState (BlockProtocol blk))
 
@@ -169,7 +169,7 @@ roundtrip_SerialiseDisk
      ( SerialiseDiskConstraints blk
      , Arbitrary' blk
      , Arbitrary' (Header blk)
-     , Arbitrary' (LedgerState blk)
+     , Arbitrary' (LedgerState blk Canonical)
      , Arbitrary' (AnnTip blk)
      , Arbitrary' (ChainDepState (BlockProtocol blk))
      )
@@ -190,7 +190,7 @@ roundtrip_SerialiseDisk ccfg dictNestedHdr =
       -- Since the 'LedgerState' is a large data structure, we lower the
       -- number of tests to avoid slowing down the testsuite too much
     , adjustOption (\(QuickCheckTests n) -> QuickCheckTests (1 `max` (div n 10))) $
-      rt (Proxy @(LedgerState blk)) "LedgerState"
+      rt (Proxy @(LedgerState blk Canonical)) "LedgerState"
     , rt (Proxy @(AnnTip blk)) "AnnTip"
     , rt (Proxy @(ChainDepState (BlockProtocol blk))) "ChainDepState"
     ]

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -76,6 +76,8 @@ import           Test.ThreadNet.Util.Seed
 import           Test.Util.HardFork.Future
 import           Test.Util.Slots (NumSlots (..))
 
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 import           Test.Consensus.HardFork.Combinator.A
 import           Test.Consensus.HardFork.Combinator.B
 
@@ -230,8 +232,8 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
             topLevelConfig nid
         , pInfoInitLedger = ExtLedgerState {
               ledgerState = HardForkLedgerState $
-                              initHardForkState
-                                initLedgerState
+                              initHardForkState $
+                              Flip initLedgerState
             , headerState = genesisHeaderState $
                               initHardForkState
                                 (WrapChainDepState initChainDepState)
@@ -244,7 +246,7 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
             ]
         }
 
-    initLedgerState :: LedgerState BlockA
+    initLedgerState :: LedgerState BlockA Canonical
     initLedgerState = LgrA {
           lgrA_tip        = GenesisPoint
         , lgrA_transition = Nothing
@@ -411,10 +413,10 @@ instance SerialiseHFC '[BlockA, BlockB]
 ledgerState_AtoB ::
      RequiringBoth
        WrapLedgerConfig
-       (Translate LedgerState)
+       (TranslateLedgerState)
        BlockA
        BlockB
-ledgerState_AtoB = InPairs.ignoringBoth $ Translate $ \_ LgrA{..} -> LgrB {
+ledgerState_AtoB = InPairs.ignoringBoth $ TranslateLedgerState $ \_ LgrA{..} -> LgrB {
       lgrB_tip = castPoint lgrA_tip
     }
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -33,6 +33,7 @@ module Test.Consensus.HardFork.Combinator.A (
   , GenTx (..)
   , Header (..)
   , LedgerState (..)
+  , LedgerTables (..)
   , NestedCtxt_ (..)
   , StorageConfig (..)
   , TxId (..)
@@ -80,6 +81,7 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
@@ -581,3 +583,24 @@ instance SerialiseNodeToClient BlockA (SomeSecond BlockQuery BlockA) where
 instance SerialiseResult BlockA (BlockQuery BlockA) where
   encodeResult _ _ = \case {}
   decodeResult _ _ = \case {}
+
+{-------------------------------------------------------------------------------
+  Ledger Tables
+-------------------------------------------------------------------------------}
+
+instance HasLedgerTables (LedgerState BlockA) where
+  data LedgerTables (LedgerState BlockA) mk = NoTables
+    deriving (Eq, Generic, NoThunks, Show)
+
+instance HasTickedLedgerTables (LedgerState BlockA) where
+  withLedgerTablesTicked st tbs =
+      TickedLedgerStateA
+    $ flip withLedgerTables tbs
+    $ getTickedLedgerStateA st
+
+instance LedgerTablesAreTrivial (LedgerState BlockA) where
+  trivialLedgerTables = NoTables
+
+instance CanSerializeLedgerTables (LedgerState BlockA) where
+
+instance CanStowLedgerTables (LedgerState BlockA) where

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -29,6 +29,7 @@ module Test.Consensus.HardFork.Combinator.B (
   , GenTx (..)
   , Header (..)
   , LedgerState (..)
+  , LedgerTables (..)
   , NestedCtxt_ (..)
   , StorageConfig (..)
   , TxId (..)
@@ -67,6 +68,7 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
@@ -439,3 +441,24 @@ instance SerialiseNodeToClient BlockB (SomeSecond BlockQuery BlockB) where
 instance SerialiseResult BlockB (BlockQuery BlockB) where
   encodeResult _ _ = \case {}
   decodeResult _ _ = \case {}
+
+{-------------------------------------------------------------------------------
+  Ledger Tables
+-------------------------------------------------------------------------------}
+
+instance HasLedgerTables (LedgerState BlockB) where
+  data LedgerTables (LedgerState BlockB) mk = NoTables
+    deriving (Eq, Generic, NoThunks, Show)
+
+instance HasTickedLedgerTables (LedgerState BlockB) where
+  withLedgerTablesTicked st tbs =
+      TickedLedgerStateB
+    $ flip withLedgerTables tbs
+    $ getTickedLedgerStateB st
+
+instance LedgerTablesAreTrivial (LedgerState BlockB) where
+  trivialLedgerTables = NoTables
+
+instance CanSerializeLedgerTables (LedgerState BlockB) where
+
+instance CanStowLedgerTables (LedgerState BlockB) where

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -162,24 +162,24 @@ instance BasicEnvelopeValidation BlockB where
 
 instance ValidateEnvelope BlockB where
 
-data instance LedgerState BlockB = LgrB {
+data instance LedgerState BlockB mk = LgrB {
       lgrB_tip :: Point BlockB
     }
   deriving (Show, Eq, Generic, Serialise)
-  deriving NoThunks via OnlyCheckWhnfNamed "LgrB" (LedgerState BlockB)
+  deriving NoThunks via OnlyCheckWhnfNamed "LgrB" (LedgerState BlockB mk)
 
 type instance LedgerCfg (LedgerState BlockB) = ()
 
 -- | Ticking has no state on the B ledger state
-newtype instance Ticked (LedgerState BlockB) = TickedLedgerStateB {
-      getTickedLedgerStateB :: LedgerState BlockB
+newtype instance Ticked1 (LedgerState BlockB) mk = TickedLedgerStateB {
+      getTickedLedgerStateB :: LedgerState BlockB mk
     }
-  deriving NoThunks via OnlyCheckWhnfNamed "TickedLgrB" (Ticked (LedgerState BlockB))
+  deriving NoThunks via OnlyCheckWhnfNamed "TickedLgrB" (Ticked1 (LedgerState BlockB) mk)
 
-instance GetTip (LedgerState BlockB) where
+instance GetTip (LedgerState BlockB Canonical) where
   getTip = castPoint . lgrB_tip
 
-instance GetTip (Ticked (LedgerState BlockB)) where
+instance GetTip (Ticked1 (LedgerState BlockB) Canonical) where
   getTip = castPoint . getTip . getTickedLedgerStateB
 
 instance IsLedger (LedgerState BlockB) where
@@ -219,7 +219,7 @@ forgeBlockB ::
      TopLevelConfig BlockB
   -> BlockNo
   -> SlotNo
-  -> TickedLedgerState BlockB
+  -> TickedLedgerState BlockB Canonical
   -> [GenTx BlockB]
   -> IsLeader (BlockProtocol BlockB)
   -> BlockB
@@ -382,8 +382,8 @@ instance SerialiseNodeToNodeConstraints   BlockB where
 
 deriving instance Serialise (AnnTip BlockB)
 
-instance EncodeDisk BlockB (LedgerState BlockB)
-instance DecodeDisk BlockB (LedgerState BlockB)
+instance EncodeDisk BlockB (LedgerState BlockB Canonical)
+instance DecodeDisk BlockB (LedgerState BlockB Canonical)
 
 instance EncodeDisk BlockB BlockB
 instance DecodeDisk BlockB (Lazy.ByteString -> BlockB) where

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
@@ -39,6 +39,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Ledger
                      (AnnForecast (..), mkHardForkForecast)
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
                      (InPairs (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
@@ -225,13 +226,13 @@ withinEraForecast maxLookAhead st = Forecast{
 -- | Translations between eras
 translations :: forall xs.
      TestSetup xs
-  -> InPairs (TranslateForecast (K LedgerState) (K LedgerView)) xs
+  -> InPairs (TranslateForecast (K1 LedgerState) (K LedgerView)) xs
 translations TestSetup{..} =
     case isNonEmpty (Proxy @xs) of
       ProofNonEmpty{} -> go testLookahead
   where
     go :: Exactly (x ': xs') MaxLookahead
-       -> InPairs (TranslateForecast (K LedgerState) (K LedgerView)) (x ': xs')
+       -> InPairs (TranslateForecast (K1 LedgerState) (K LedgerView)) (x ': xs')
     go (ExactlyCons _ ExactlyNil) =
         InPairs.PNil
     go (ExactlyCons this rest@(ExactlyCons next _)) =
@@ -239,9 +240,9 @@ translations TestSetup{..} =
 
     tr :: MaxLookahead -- ^ Look-ahead in the current era
        -> MaxLookahead -- ^ Look-ahead in the next era
-       -> TranslateForecast (K LedgerState) (K LedgerView) era era'
+       -> TranslateForecast (K1 LedgerState) (K LedgerView) era era'
     tr thisLookahead nextLookahead =
-        TranslateForecast $ \transition sno (K st) ->
+        TranslateForecast $ \transition sno (K1 st) ->
           assert (sno >= boundSlot transition) $ do
             let tip :: WithOrigin SlotNo
                 tip = ledgerTip st
@@ -283,7 +284,7 @@ acrossErasForecast setup@TestSetup{..} ledgerStates =
         . tickedHardForkLedgerViewPerEra
 
     go :: NonEmpty xs' TestEra
-       -> Telescope (K Past) (Current (AnnForecast (K LedgerState) (K LedgerView))) xs'
+       -> Telescope (K Past) (Current (AnnForecast (K1 LedgerState) (K LedgerView))) xs'
     go (NonEmptyOne era) =
         assert (testEraContains testForecastAt era) $
         TZ $ Current {
@@ -293,7 +294,7 @@ acrossErasForecast setup@TestSetup{..} ledgerStates =
                                      withinEraForecast
                                        (testEraMaxLookahead era)
                                        st
-              , annForecastState = K st
+              , annForecastState = K1 st
               , annForecastTip   = testForecastAt
               , annForecastEnd   = Nothing
               }
@@ -310,7 +311,7 @@ acrossErasForecast setup@TestSetup{..} ledgerStates =
                                        withinEraForecast
                                          (testEraMaxLookahead era)
                                          st
-                , annForecastState = K st
+                , annForecastState = K1 st
                 , annForecastTip   = testForecastAt
                 , annForecastEnd   = Just end
                 }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
@@ -43,6 +43,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Ledger
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
                      (Telescope (..))
@@ -837,14 +838,14 @@ mockHardForkLedgerView = \(HF.Shape pss) (HF.Transitions ts) (Chain ess) ->
               -> Exactly  (x ': xs) HF.EraParams
               -> AtMost         xs  EpochNo
               -> NonEmpty (x ': xs) [Event]
-              -> Telescope (K Past) (Current (AnnForecast (K ()) (K ()))) (x : xs)
+              -> Telescope (K Past) (Current (AnnForecast (K1 ()) (K ()))) (x : xs)
     mockState start (ExactlyCons ps _) ts (NonEmptyOne es) =
         TZ $ Current start $ AnnForecast {
             annForecast      = Forecast {
                 forecastAt  = tip es -- forecast at tip of ledger
               , forecastFor = \_for -> return $ TickedK TickedTrivial
               }
-          , annForecastState = K ()
+          , annForecastState = K1 ()
           , annForecastTip   = tip es
           , annForecastEnd   = HF.mkUpperBound ps start <$> atMostHead ts
           }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -517,7 +517,7 @@ genValidTxs = go []
           go (tx:txs) (n - 1) ledger'
 
 genValidTx :: LedgerState TestBlock Canonical -> Gen (TestTx, LedgerState TestBlock Canonical)
-genValidTx ledgerState@(SimpleLedgerState MockState { mockUtxo = utxo }) = do
+genValidTx ledgerState@(SimpleLedgerState MockState { mockUtxo = utxo } _) = do
     -- Never let someone go broke, otherwise we risk concentrating all the
     -- wealth in one person. That would be problematic (for the society) but
     -- also because we wouldn't be able to generate any valid transactions
@@ -553,7 +553,7 @@ genValidTx ledgerState@(SimpleLedgerState MockState { mockUtxo = utxo }) = do
       ]
 
 genInvalidTx :: LedgerState TestBlock Canonical -> Gen TestTx
-genInvalidTx ledgerState@(SimpleLedgerState MockState { mockUtxo = utxo }) = do
+genInvalidTx ledgerState@(SimpleLedgerState MockState { mockUtxo = utxo } _) = do
     let peopleWithFunds = nub $ map fst $ Map.elems utxo
     sender    <- elements peopleWithFunds
     recipient <- elements $ filter (/= sender) peopleWithFunds
@@ -575,7 +575,7 @@ genInvalidTx ledgerState@(SimpleLedgerState MockState { mockUtxo = utxo }) = do
 applyTxToLedger :: LedgerState TestBlock Canonical
                 -> TestTx
                 -> Except TestTxError (LedgerState TestBlock Canonical)
-applyTxToLedger (SimpleLedgerState mockState) tx =
+applyTxToLedger (SimpleLedgerState mockState _) tx =
     mkNewLedgerState <$> updateMockUTxO dummy tx mockState
   where
     -- All expiries in this test are 'DoNotExpire', so the current time is
@@ -584,7 +584,7 @@ applyTxToLedger (SimpleLedgerState mockState) tx =
     dummy = 0
 
     mkNewLedgerState mockState' =
-      SimpleLedgerState mockState' { mockTip = BlockPoint slot' hash' }
+      SimpleLedgerState mockState' { mockTip = BlockPoint slot' hash' } (SimpleLedgerTables Canonical)
 
     slot' = case pointSlot $ mockTip mockState of
       Origin      -> 0

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -446,7 +446,7 @@ computePastLedger ::
      TopLevelConfig TestBlock
   -> Point TestBlock
   -> Chain TestBlock
-  -> Maybe (ExtLedgerState TestBlock)
+  -> Maybe (ExtLedgerState TestBlock Canonical)
 computePastLedger cfg pt chain
     | pt `elem` validPoints
     = Just $ go testInitExtLedger (Chain.toOldestFirst chain)
@@ -469,7 +469,7 @@ computePastLedger cfg pt chain
     -- matching @pt@, after which we return the resulting ledger.
     --
     -- PRECONDITION: @pt@ is in the list of blocks or genesis.
-    go :: ExtLedgerState TestBlock -> [TestBlock] -> ExtLedgerState TestBlock
+    go :: ExtLedgerState TestBlock Canonical -> [TestBlock] -> ExtLedgerState TestBlock Canonical
     go !st blks
         | castPoint (getTip st) == pt
         = st

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -267,7 +267,7 @@ type TestConstraints blk =
   , LedgerSupportsProtocol            blk
   , InspectLedger                     blk
   , Eq (ChainDepState  (BlockProtocol blk))
-  , Eq (LedgerState                   blk)
+  , Eq (LedgerState                   blk Canonical)
   , Eq                                blk
   , Show                              blk
   , HasHeader                         blk
@@ -704,7 +704,7 @@ deriving instance (TestConstraints blk, Show1 r) => Show (Model blk m r)
 
 -- | Initial model
 initModel :: TopLevelConfig blk
-          -> ExtLedgerState blk
+          -> ExtLedgerState blk Canonical
           -> MaxClockSkew
           -> Model blk m r
 initModel cfg initLedger (MaxClockSkew maxClockSkew) = Model
@@ -1133,7 +1133,7 @@ sm :: TestConstraints blk
    => ChainDBEnv IO blk
    -> BlockGen                  blk IO
    -> TopLevelConfig            blk
-   -> ExtLedgerState            blk
+   -> ExtLedgerState            blk Canonical
    -> MaxClockSkew
    -> StateMachine (Model       blk IO)
                    (At Cmd      blk IO)
@@ -1188,7 +1188,7 @@ deriving instance ( ToExpr blk
                   , ToExpr (HeaderHash blk)
                   , ToExpr (ChainDepState (BlockProtocol blk))
                   , ToExpr (TipInfo blk)
-                  , ToExpr (LedgerState blk)
+                  , ToExpr (LedgerState blk Canonical)
                   , ToExpr (ExtValidationError blk)
                   )
                  => ToExpr (DBModel blk)
@@ -1196,7 +1196,7 @@ deriving instance ( ToExpr blk
                   , ToExpr (HeaderHash  blk)
                   , ToExpr (ChainDepState (BlockProtocol blk))
                   , ToExpr (TipInfo blk)
-                  , ToExpr (LedgerState blk)
+                  , ToExpr (LedgerState blk Canonical)
                   , ToExpr (ExtValidationError blk)
                   )
                  => ToExpr (Model blk IO Concrete)
@@ -1214,7 +1214,7 @@ deriving instance ToExpr TestBodyHash
 deriving instance ToExpr TestBlockError
 deriving instance ToExpr Blk
 deriving instance ToExpr (TipInfoIsEBB Blk)
-deriving instance ToExpr (LedgerState Blk)
+deriving instance ToExpr (LedgerState Blk Canonical)
 deriving instance ToExpr (HeaderError Blk)
 deriving instance ToExpr TestBlockOtherHeaderEnvelopeError
 deriving instance ToExpr (HeaderEnvelopeError Blk)
@@ -1624,7 +1624,7 @@ traceEventName = \case
 mkArgs :: IOLike m
        => TopLevelConfig Blk
        -> ImmutableDB.ChunkInfo
-       -> ExtLedgerState Blk
+       -> ExtLedgerState Blk Canonical
        -> ResourceRegistry m
        -> NodeDBs (StrictTVar m MockFS)
        -> Tracer m (TraceEvent Blk)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -63,6 +63,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -1190,3 +1191,22 @@ showLabelledExamples secParam mReplay relevant = do
   where
     run :: QSM.Commands (At Cmd) (At Resp) -> [Tag]
     run = filter relevant . tagEvents secParam . execCmds secParam
+
+{-------------------------------------------------------------------------------
+  Ledger Tables
+-------------------------------------------------------------------------------}
+
+instance HasLedgerTables (LedgerState TestBlock) where
+  data LedgerTables (LedgerState TestBlock) mk = NoTables
+    deriving (Generic, Eq, Show, NoThunks)
+
+instance CanSerializeLedgerTables (LedgerState TestBlock) where
+
+instance HasTickedLedgerTables (LedgerState TestBlock) where
+  withLedgerTablesTicked (TickedTestLedger st) tables =
+      TickedTestLedger $ withLedgerTables st tables
+
+instance LedgerTablesAreTrivial (LedgerState TestBlock) where
+  trivialLedgerTables = NoTables
+
+instance CanStowLedgerTables (LedgerState TestBlock) where

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -111,8 +111,8 @@ import           Ouroboros.Consensus.Storage.FS.API (HasFS (..), hGetExactly,
 import           Ouroboros.Consensus.Storage.FS.API.Types
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
 import           Ouroboros.Consensus.Storage.Serialisation
-import           Ouroboros.Consensus.Ticked (Ticked1)
 
+import           Ouroboros.Consensus.Ledger.Tables
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.SignableRepresentation ()
 
@@ -827,3 +827,23 @@ instance Hashable IsEBB
 
 instance (StandardHash b, Hashable (HeaderHash b)) => Hashable (ChainHash b)
   -- use generic instance
+
+
+{-------------------------------------------------------------------------------
+  Ledger Tables
+-------------------------------------------------------------------------------}
+
+instance HasLedgerTables (LedgerState TestBlock) where
+  data LedgerTables (LedgerState TestBlock) mk = NoTables
+    deriving (Generic, Eq, Show, NoThunks)
+
+instance CanSerializeLedgerTables (LedgerState TestBlock) where
+
+instance HasTickedLedgerTables (LedgerState TestBlock) where
+  withLedgerTablesTicked st tbs =
+    TickedTestLedger $ flip withLedgerTables tbs $ getTickedTestLedger st
+
+instance LedgerTablesAreTrivial (LedgerState TestBlock) where
+  trivialLedgerTables = NoTables
+
+instance CanStowLedgerTables (LedgerState TestBlock) where

--- a/ouroboros-consensus/docs/tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/docs/tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -43,11 +43,12 @@ As before, we require a few language extensions:
 > {-# LANGUAGE TypeFamilies               #-}
 > {-# LANGUAGE DerivingVia                #-}
 > {-# LANGUAGE DataKinds                  #-}
+> {-# LANGUAGE DeriveAnyClass             #-}
 > {-# LANGUAGE DeriveGeneric              #-}
 > {-# LANGUAGE FlexibleInstances          #-}
 > {-# LANGUAGE MultiParamTypeClasses      #-}
 > {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-> {-# LANGUAGE DeriveAnyClass #-}
+> {-# LANGUAGE RecordWildCards            #-}
 > {-# LANGUAGE StandaloneDeriving         #-}
 
 > module Ouroboros.Consensus.Tutorial.WithEpoch () where
@@ -78,6 +79,10 @@ And imports, of course:
 > import Ouroboros.Consensus.Ledger.Abstract
 >   (Canonical, LedgerState, LedgerCfg, GetTip, LedgerResult (..), ApplyBlock (..),
 >    UpdateLedger, IsLedger (..))
+> import Ouroboros.Consensus.Ledger.Tables
+>   (CanSerializeLedgerTables (..), HasLedgerTables(..),
+>    HasTickedLedgerTables(..), CanStowLedgerTables (..),
+>    LedgerTablesAreTrivial (..))
 >
 > import Ouroboros.Consensus.Ledger.SupportsMempool ()
 > import Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -676,3 +681,26 @@ involving `BlockC`:
 While this is a large ecosystem of interrelated typeclasses and families, the
 overall organization of things is such that Haskell's type checking can help
 guide the implementation.
+
+Appendix: UTxO-HD features
+==========================
+
+For reference on these instances and their meaning, please see the appendix in
+[the Simple tutorial](./Simple.lhs).
+
+> instance HasLedgerTables (LedgerState BlockD) where
+>   data instance LedgerTables (LedgerState BlockD) mk = NoTables
+>      deriving (Eq, Show, Generic, NoThunks)
+
+> instance HasTickedLedgerTables (LedgerState BlockD) where
+>   withLedgerTablesTicked st tbs =
+>       TickedLedgerStateD
+>     $ flip withLedgerTables tbs
+>     $ unTickedLedgerStateD st
+
+> instance CanStowLedgerTables (LedgerState BlockD) where
+
+> instance LedgerTablesAreTrivial (LedgerState BlockD) where
+>   trivialLedgerTables = NoTables
+
+> instance CanSerializeLedgerTables (LedgerState BlockD) where

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -336,6 +336,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wno-unticked-promoted-constructors
 
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -222,6 +222,7 @@ library
                        Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
                        Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
                        Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+                       Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore
                        Ouroboros.Consensus.Storage.LedgerDB.InMemory
                        Ouroboros.Consensus.Storage.LedgerDB.OnDisk
                        Ouroboros.Consensus.Storage.LedgerDB.Types

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -119,9 +119,11 @@ library
                        Ouroboros.Consensus.Ledger.Inspect
                        Ouroboros.Consensus.Ledger.Query
                        Ouroboros.Consensus.Ledger.Query.Version
+                       Ouroboros.Consensus.Ledger.SupportsHD
                        Ouroboros.Consensus.Ledger.SupportsMempool
                        Ouroboros.Consensus.Ledger.SupportsPeerSelection
                        Ouroboros.Consensus.Ledger.SupportsProtocol
+                       Ouroboros.Consensus.Ledger.Tables
                        Ouroboros.Consensus.Mempool
                        Ouroboros.Consensus.Mempool.API
                        Ouroboros.Consensus.Mempool.Impl
@@ -223,6 +225,7 @@ library
                        Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
                        Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
                        Ouroboros.Consensus.Storage.LedgerDB.HD.BackingStore
+                       Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq
                        Ouroboros.Consensus.Storage.LedgerDB.InMemory
                        Ouroboros.Consensus.Storage.LedgerDB.OnDisk
                        Ouroboros.Consensus.Storage.LedgerDB.Types
@@ -298,6 +301,7 @@ library
                      , directory         >=1.3   && <1.4
                      , filelock
                      , filepath          >=1.4   && <1.5
+                     , groups
                      , hashable
                      , measures
                      , mtl               >=2.2   && <2.3
@@ -315,6 +319,7 @@ library
                      , transformers
                      , vector            >=0.12  && <0.13
 
+                     , anti-diff
                      , io-classes       ^>=0.3
                      , typed-protocols
                      , ouroboros-network-api

--- a/ouroboros-consensus/src/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/Data/SOP/Strict.hs
@@ -1,19 +1,20 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE EmptyCase             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE BangPatterns             #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE EmptyCase                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneDeriving       #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 -- | Strict variant of SOP
 --
@@ -49,7 +50,8 @@ import           Data.SOP.Constraint
   NP
 -------------------------------------------------------------------------------}
 
-data NP :: (k -> Type) -> [k] -> Type where
+type NP :: (k -> Type) -> [k] -> Type
+data NP f xs where
   Nil  :: NP f '[]
   (:*) :: !(f x) -> !(NP f xs) -> NP f (x ': xs)
 
@@ -158,7 +160,8 @@ instance HTrans NP NP where
   NS
 -------------------------------------------------------------------------------}
 
-data NS :: (k -> Type) -> [k] -> Type where
+type NS :: (k -> Type) -> [k] -> Type
+data NS f xs where
   Z :: !(f x) -> NS f (x ': xs)
   S :: !(NS f xs) -> NS f (x ': xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
@@ -144,11 +144,11 @@ data BlockForging m blk = BlockForging {
       -- PRECONDITION: 'checkCanForge' returned @Right ()@.
     , forgeBlock ::
            TopLevelConfig blk
-        -> BlockNo                      -- Current block number
-        -> SlotNo                       -- Current slot number
-        -> TickedLedgerState blk        -- Current ledger state
-        -> [Validated (GenTx blk)]      -- Contents of the mempool
-        -> IsLeader (BlockProtocol blk) -- Proof we are leader
+        -> BlockNo                         -- Current block number
+        -> SlotNo                          -- Current slot number
+        -> TickedLedgerState blk Canonical -- Current ledger state
+        -> [Validated (GenTx blk)]         -- Contents of the mempool
+        -> IsLeader (BlockProtocol blk)    -- Proof we are leader
         -> m blk
     }
 
@@ -163,7 +163,7 @@ data BlockForging m blk = BlockForging {
 takeLargestPrefixThatFits ::
      TxLimits blk
   => TxLimits.Overrides blk
-  -> TickedLedgerState blk
+  -> TickedLedgerState blk Canonical
   -> [Validated (GenTx blk)]
   -> [Validated (GenTx blk)]
 takeLargestPrefixThatFits overrides ledger txs =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
@@ -49,7 +49,7 @@ newtype BackoffDelay = BackoffDelay NominalDiffTime
 data HardForkBlockchainTimeArgs m blk = HardForkBlockchainTimeArgs
   { hfbtBackoffDelay   :: m BackoffDelay
     -- ^ See 'BackoffDelay'
-  , hfbtGetLedgerState :: STM m (LedgerState blk)
+  , hfbtGetLedgerState :: STM m (LedgerState blk Canonical)
   , hfbtLedgerConfig   :: LedgerConfig blk
   , hfbtRegistry       :: ResourceRegistry m
   , hfbtSystemTime     :: SystemTime m
@@ -98,7 +98,7 @@ hardForkBlockchainTime args = do
       , hfbtMaxClockRewind = maxClockRewind
       } = args
 
-    summarize :: LedgerState blk -> HF.Summary (HardForkIndices blk)
+    summarize :: LedgerState blk Canonical -> HF.Summary (HardForkIndices blk)
     summarize st = hardForkSummary cfg st
 
     loop :: HF.RunWithCachedSummary xs m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -50,7 +50,7 @@ data CheckInFuture m blk = CheckInFuture {
        --
        -- > checkInFuture vf >>= \(af, fut) ->
        -- >   validatedFragment vf == af <=> null fut
-       checkInFuture :: ValidatedFragment (Header blk) (LedgerState blk)
+       checkInFuture :: ValidatedFragment (Header blk) (LedgerState blk Canonical)
                      -> m (AnchoredFragment (Header blk), [InFuture m blk])
     }
   deriving NoThunks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
@@ -43,7 +43,7 @@ data ValidatedFragment b l = UnsafeValidatedFragment {
 {-# COMPLETE ValidatedFragment #-}
 
 pattern ValidatedFragment ::
-     (IsLedger l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
+     (GetTip l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
   => AnchoredFragment b -> l -> ValidatedFragment b l
 pattern ValidatedFragment f l <- UnsafeValidatedFragment f l
   where
@@ -54,7 +54,7 @@ validatedTip = AF.headPoint . validatedFragment
 
 invariant ::
      forall l b.
-     (IsLedger l, HasHeader b, HeaderHash b ~ HeaderHash l)
+     (GetTip l, HasHeader b, HeaderHash b ~ HeaderHash l)
   => ValidatedFragment b l
   -> Either String ()
 invariant (ValidatedFragment fragment ledger)
@@ -75,7 +75,7 @@ invariant (ValidatedFragment fragment ledger)
 -- | Constructor for 'ValidatedFragment' that checks the invariant
 new ::
      forall l b.
-     (IsLedger l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
+     (GetTip l, HasHeader b, HeaderHash b ~ HeaderHash l, HasCallStack)
   => AnchoredFragment b
   -> l
   -> ValidatedFragment b l

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
@@ -49,7 +49,7 @@ pattern ValidatedChainDiff d l <- UnsafeValidatedChainDiff d l
 -- > getTip chainDiff == ledgerTipPoint ledger
 new ::
      forall b l.
-     (IsLedger l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
+     (GetTip l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
   => ChainDiff b
   -> l
   -> ValidatedChainDiff b l
@@ -69,7 +69,7 @@ new chainDiff ledger =
           show chainDiffTip <> " /= " <> show ledgerTip
 
 toValidatedFragment
-  :: (IsLedger l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
+  :: (GetTip l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
   => ValidatedChainDiff b l
   -> ValidatedFragment b l
 toValidatedFragment (UnsafeValidatedChainDiff cs l) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
@@ -50,7 +50,7 @@ class HasHardForkHistory blk where
   -- information, and so this function becomes little more than a projection
   -- (indeed, in this case the 'LedgerState' should be irrelevant).
   hardForkSummary :: LedgerConfig blk
-                  -> LedgerState blk
+                  -> LedgerState blk Canonical
                   -> HardFork.Summary (HardForkIndices blk)
 
 -- | Helper function that can be used to define 'hardForkSummary'
@@ -63,7 +63,7 @@ class HasHardForkHistory blk where
 -- hard fork combinator).
 neverForksHardForkSummary :: (LedgerConfig blk -> HardFork.EraParams)
                           -> LedgerConfig blk
-                          -> LedgerState blk
+                          -> LedgerState blk Canonical
                           -> HardFork.Summary '[blk]
 neverForksHardForkSummary getParams cfg _st =
     HardFork.neverForksSummary eraEpochSize eraSlotLength

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -88,7 +88,7 @@ class ( LedgerSupportsProtocol blk
   singleEraTransition :: PartialLedgerConfig blk
                       -> EraParams -- ^ Current era parameters
                       -> Bound     -- ^ Start of this era
-                      -> LedgerState blk
+                      -> LedgerState blk Canonical
                       -> Maybe EpochNo
 
   -- | Era information (for use in error messages)
@@ -101,7 +101,7 @@ singleEraTransition' :: SingleEraBlock blk
                      => WrapPartialLedgerConfig blk
                      -> EraParams
                      -> Bound
-                     -> LedgerState blk -> Maybe EpochNo
+                     -> LedgerState blk Canonical -> Maybe EpochNo
 singleEraTransition' = singleEraTransition . unwrapPartialLedgerConfig
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -59,6 +59,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.State.Instances ()
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors (Flip)
 
 {-------------------------------------------------------------------------------
   Hard fork protocol, block, and ledger state
@@ -76,13 +77,13 @@ instance Typeable xs => ShowProxy (HardForkBlock xs) where
 type instance BlockProtocol (HardForkBlock xs) = HardForkProtocol xs
 type instance HeaderHash    (HardForkBlock xs) = OneEraHash       xs
 
-newtype instance LedgerState (HardForkBlock xs) = HardForkLedgerState {
-      hardForkLedgerStatePerEra :: HardForkState LedgerState xs
+newtype instance LedgerState (HardForkBlock xs) mk = HardForkLedgerState {
+      hardForkLedgerStatePerEra :: HardForkState (Flip LedgerState mk) xs
     }
 
-deriving stock   instance CanHardFork xs => Show (LedgerState (HardForkBlock xs))
-deriving stock   instance CanHardFork xs => Eq   (LedgerState (HardForkBlock xs))
-deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs))
+deriving stock   instance CanHardFork xs => Show (LedgerState (HardForkBlock xs) Canonical)
+deriving stock   instance CanHardFork xs => Eq   (LedgerState (HardForkBlock xs) Canonical)
+deriving newtype instance CanHardFork xs => NoThunks (LedgerState (HardForkBlock xs) Canonical)
 
 {-------------------------------------------------------------------------------
   Protocol config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -52,6 +52,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode ()
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 {-------------------------------------------------------------------------------
   Simple patterns
@@ -169,11 +171,11 @@ pattern DegenBlockConfig x <- (project -> x)
 
 pattern DegenLedgerState ::
      NoHardForks b
-  => LedgerState b
-  -> LedgerState (HardForkBlock '[b])
-pattern DegenLedgerState x <- (project -> x)
+  => LedgerState b Canonical
+  -> LedgerState (HardForkBlock '[b]) Canonical
+pattern DegenLedgerState x <- (unFlip . project . Flip -> x)
   where
-    DegenLedgerState x = inject x
+    DegenLedgerState x = unFlip $ inject $ Flip x
 
 {-------------------------------------------------------------------------------
   Dealing with the config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
@@ -22,6 +22,8 @@ import           Ouroboros.Consensus.Util.Counting (exactlyTwo)
 import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
 
 import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 import qualified Ouroboros.Consensus.HardFork.History as History
 
 {-------------------------------------------------------------------------------
@@ -79,7 +81,7 @@ protocolInfoBinary protocolInfo1 eraParams1 toPartialConsensusConfig1 toPartialL
       , pInfoInitLedger = ExtLedgerState {
             ledgerState =
               HardForkLedgerState $
-                initHardForkState initLedgerState1
+                initHardForkState $ Flip initLedgerState1
           , headerState =
               genesisHeaderState $
                 initHardForkState $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.InjectTxs
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger (Ticked (..))
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
@@ -291,7 +291,7 @@ hardForkForgeBlock ::
   -> TopLevelConfig (HardForkBlock xs)
   -> BlockNo
   -> SlotNo
-  -> TickedLedgerState (HardForkBlock xs)
+  -> TickedLedgerState (HardForkBlock xs) Canonical
   -> [Validated (GenTx (HardForkBlock xs))]
   -> HardForkIsLeader xs
   -> m (HardForkBlock xs)
@@ -358,7 +358,7 @@ hardForkForgeBlock blockForging
       -> Product
            (Product
               WrapIsLeader
-              (Ticked :.: LedgerState))
+              (FlipTickedLedgerState Canonical))
            ([] :.: WrapValidatedGenTx)
            blk
       -> m blk
@@ -366,7 +366,7 @@ hardForkForgeBlock blockForging
                   cfg'
                   (Comp mBlockForging')
                   (Pair
-                    (Pair (WrapIsLeader isLeader') (Comp ledgerState'))
+                    (Pair (WrapIsLeader isLeader') (FlipTickedLedgerState ledgerState'))
                     (Comp txs')) =
         forgeBlock
           (fromMaybe

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -49,6 +49,7 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Inspect
+import           Ouroboros.Consensus.Ledger.SupportsHD
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense
@@ -183,7 +184,7 @@ tickOne ei slot index pcfg (Flip st) = Comp $ fmap FlipTickedLedgerState $
   ApplyBlock
 -------------------------------------------------------------------------------}
 
-instance CanHardFork xs
+instance (CanHardFork xs, LedgerSupportsHD (HardForkBlock xs))
       => ApplyBlock (LedgerState (HardForkBlock xs)) (HardForkBlock xs) where
 
   applyBlockLedgerResult cfg
@@ -257,7 +258,8 @@ reapply index (WrapLedgerConfig cfg) (Pair (I block) (FlipTickedLedgerState st))
   UpdateLedger
 -------------------------------------------------------------------------------}
 
-instance CanHardFork xs => UpdateLedger (HardForkBlock xs)
+instance (CanHardFork xs, LedgerSupportsHD (HardForkBlock xs))
+      => UpdateLedger (HardForkBlock xs)
 
 {-------------------------------------------------------------------------------
   HasHardForkHistory
@@ -326,7 +328,8 @@ instance CanHardFork xs => ValidateEnvelope (HardForkBlock xs) where
   LedgerSupportsProtocol
 -------------------------------------------------------------------------------}
 
-instance CanHardFork xs => LedgerSupportsProtocol (HardForkBlock xs) where
+instance (CanHardFork xs, LedgerSupportsHD (HardForkBlock xs))
+      => LedgerSupportsProtocol (HardForkBlock xs) where
   protocolLedgerView HardForkLedgerConfig{..}
                      (TickedHardForkLedgerState transition ticked) =
       TickedHardForkLedgerView {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams () where
 
@@ -6,6 +9,7 @@ import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
+import           Ouroboros.Consensus.Ledger.SupportsHD
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
@@ -14,7 +18,8 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
                      (Flip (..))
 
-instance CanHardFork xs => CommonProtocolParams (HardForkBlock xs) where
+instance (CanHardFork xs, LedgerSupportsHD (HardForkBlock xs))
+      => CommonProtocolParams (HardForkBlock xs) where
   maxHeaderSize = askCurrentLedger maxHeaderSize
   maxTxSize     = askCurrentLedger maxTxSize
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
@@ -4,12 +4,15 @@ module Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams () wh
 
 import           Data.SOP.Strict
 
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 instance CanHardFork xs => CommonProtocolParams (HardForkBlock xs) where
   maxHeaderSize = askCurrentLedger maxHeaderSize
@@ -17,10 +20,10 @@ instance CanHardFork xs => CommonProtocolParams (HardForkBlock xs) where
 
 askCurrentLedger
   :: CanHardFork xs
-  => (forall blk. CommonProtocolParams blk => LedgerState blk -> a)
-  -> LedgerState (HardForkBlock xs) -> a
+  => (forall blk. CommonProtocolParams blk => LedgerState blk Canonical -> a)
+  -> LedgerState (HardForkBlock xs) Canonical -> a
 askCurrentLedger f =
       hcollapse
-    . hcmap proxySingle (K . f)
+    . hcmap proxySingle (K . f . unFlip)
     . State.tip
     . hardForkLedgerStatePerEra

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/PeerSelection.hs
@@ -9,10 +9,12 @@ import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 instance CanHardFork xs => LedgerSupportsPeerSelection (HardForkBlock xs) where
   getPeers =
         hcollapse
-      . hcmap proxySingle (K . getPeers)
+      . hcmap proxySingle (K . getPeers . unFlip)
       . State.tip
       . hardForkLedgerStatePerEra

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -36,6 +36,7 @@ import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.SupportsHD
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (ShowProxy)
@@ -94,7 +95,8 @@ instance Typeable xs => ShowProxy (GenTx (HardForkBlock xs)) where
 
 type instance ApplyTxErr (HardForkBlock xs) = HardForkApplyTxErr xs
 
-instance CanHardFork xs => LedgerSupportsMempool (HardForkBlock xs) where
+instance (CanHardFork xs, LedgerSupportsHD (HardForkBlock xs))
+      => LedgerSupportsMempool (HardForkBlock xs) where
   applyTx   = applyHelper ModeApply
 
   reapplyTx = \cfg slot vtx tls ->

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -12,6 +12,7 @@ import           Data.SOP.Strict
 import           GHC.Stack
 
 import           Ouroboros.Consensus.Config.SupportsNode
+import           Ouroboros.Consensus.Ledger.SupportsHD
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
 
@@ -59,4 +60,5 @@ instance ( CanHardFork xs
            -- Instances that must be defined for specific values of @b@:
          , SupportedNetworkProtocolVersion (HardForkBlock xs)
          , SerialiseHFC xs
+         , LedgerSupportsHD (HardForkBlock xs)
          ) => RunNode (HardForkBlock xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
@@ -14,6 +14,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
 
 instance CanHardFork xs => NodeInitStorage (HardForkBlock xs) where
@@ -59,9 +62,9 @@ instance CanHardFork xs => NodeInitStorage (HardForkBlock xs) where
            SingleEraBlock blk
         => Index xs blk
         -> StorageConfig blk
-        -> LedgerState blk
+        -> Flip LedgerState Canonical blk
         -> K (m ()) blk
-      aux index cfg' currentLedger = K $
+      aux index cfg' (Flip currentLedger) = K $
           nodeInitChainDB cfg' InitChainDB {
               addBlock         = addBlock initChainDB
                                . injectNS' (Proxy @I) index

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -17,9 +17,12 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util ((.:))
 
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 import           Ouroboros.Consensus.Storage.ChainDB
 import           Ouroboros.Consensus.Storage.Serialisation
 
@@ -117,17 +120,17 @@ instance SerialiseHFC xs
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
 
 instance SerialiseHFC xs
-      => EncodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs) )where
+      => EncodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs) Canonical) where
   encodeDisk cfg =
-        encodeTelescope (hcmap pSHFC (fn . (K .: encodeDisk)) cfgs)
+        encodeTelescope (hcmap pSHFC (\cfg' -> fn (K . encodeDisk cfg' . unFlip)) cfgs)
       . hardForkLedgerStatePerEra
     where
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
 
 instance SerialiseHFC xs
-      => DecodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs)) where
+      => DecodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs) Canonical) where
   decodeDisk cfg =
         fmap HardForkLedgerState
-      $ decodeTelescope (hcmap pSHFC (Comp . decodeDisk) cfgs)
+      $ decodeTelescope (hcmap pSHFC (Comp . fmap Flip . decodeDisk) cfgs)
     where
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -57,6 +57,8 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Teles
 import           Ouroboros.Consensus.HardFork.Combinator.State.Infra as X
 import           Ouroboros.Consensus.HardFork.Combinator.State.Instances as X ()
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types as X
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Functors
+                     (Flip (..))
 
 {-------------------------------------------------------------------------------
   GetTip
@@ -111,7 +113,7 @@ recover =
 
 mostRecentTransitionInfo :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
-                         -> HardForkState LedgerState xs
+                         -> HardForkState (Flip LedgerState Canonical) xs
                          -> TransitionInfo
 mostRecentTransitionInfo HardForkLedgerConfig{..} st =
     hcollapse $
@@ -124,19 +126,19 @@ mostRecentTransitionInfo HardForkLedgerConfig{..} st =
   where
     cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
 
-    getTransition :: SingleEraBlock          blk
-                  => WrapPartialLedgerConfig blk
-                  -> K History.EraParams     blk
-                  -> Current LedgerState     blk
-                  -> K TransitionInfo        blk
-    getTransition cfg (K eraParams) Current{..} = K $
-        case singleEraTransition' cfg eraParams currentStart currentState of
-          Nothing -> TransitionUnknown (ledgerTipSlot currentState)
+    getTransition :: SingleEraBlock                       blk
+                  => WrapPartialLedgerConfig              blk
+                  -> K History.EraParams                  blk
+                  -> Current (Flip LedgerState Canonical) blk
+                  -> K TransitionInfo                     blk
+    getTransition cfg (K eraParams) Current{currentState = Flip curState, ..} = K $
+        case singleEraTransition' cfg eraParams currentStart curState of
+          Nothing -> TransitionUnknown (ledgerTipSlot curState)
           Just e  -> TransitionKnown e
 
 reconstructSummaryLedger :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
-                         -> HardForkState LedgerState xs
+                         -> HardForkState (Flip LedgerState Canonical) xs
                          -> History.Summary xs
 reconstructSummaryLedger cfg@HardForkLedgerConfig{..} st =
     reconstructSummary
@@ -150,7 +152,7 @@ reconstructSummaryLedger cfg@HardForkLedgerConfig{..} st =
 -- It should not be stored.
 epochInfoLedger :: All SingleEraBlock xs
                 => HardForkLedgerConfig xs
-                -> HardForkState LedgerState xs
+                -> HardForkState (Flip LedgerState Canonical) xs
                 -> EpochInfo (Except PastHorizonException)
 epochInfoLedger cfg st =
     History.summaryToEpochInfo $
@@ -177,7 +179,8 @@ epochInfoPrecomputedTransitionInfo shape transition st =
 extendToSlot :: forall xs. CanHardFork xs
              => HardForkLedgerConfig xs
              -> SlotNo
-             -> HardForkState LedgerState xs -> HardForkState LedgerState xs
+             -> HardForkState (Flip LedgerState Canonical) xs
+             -> HardForkState (Flip LedgerState Canonical) xs
 extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st) =
       HardForkState . unI
     . Telescope.extend
@@ -198,17 +201,17 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
     ei    = epochInfoLedger ledgerCfg ledgerSt
 
     -- Return the end of this era if we should transition to the next
-    whenExtend :: SingleEraBlock              blk
-               => WrapPartialLedgerConfig     blk
-               -> K History.EraParams         blk
-               -> Current LedgerState         blk
-               -> (Maybe :.: K History.Bound) blk
+    whenExtend :: SingleEraBlock                       blk
+               => WrapPartialLedgerConfig              blk
+               -> K History.EraParams                  blk
+               -> Current (Flip LedgerState Canonical) blk
+               -> (Maybe :.: K History.Bound)          blk
     whenExtend pcfg (K eraParams) cur = Comp $ K <$> do
         transition <- singleEraTransition'
                         pcfg
                         eraParams
                         (currentStart cur)
-                        (currentState cur)
+                        (unFlip $ currentState cur)
         let endBound = History.mkUpperBound
                          eraParams
                          (currentStart cur)
@@ -216,10 +219,10 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
         guard (slot >= History.boundSlot endBound)
         return endBound
 
-    howExtend :: Translate LedgerState blk blk'
+    howExtend :: TranslateLedgerState blk blk'
               -> History.Bound
-              -> Current LedgerState blk
-              -> (K Past blk, Current LedgerState blk')
+              -> Current (Flip LedgerState Canonical) blk
+              -> (K Past blk, Current (Flip LedgerState Canonical) blk')
     howExtend f currentEnd cur = (
           K Past {
               pastStart    = currentStart cur
@@ -227,12 +230,12 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
             }
         , Current {
               currentStart = currentEnd
-            , currentState = translateWith f
+            , currentState = Flip $ translateLedgerStateWith f
                                (History.boundEpoch currentEnd)
-                               (currentState cur)
+                               (unFlip (currentState cur))
             }
         )
 
-    translate :: InPairs (Translate LedgerState) xs
+    translate :: InPairs TranslateLedgerState xs
     translate = InPairs.requiringBoth cfgs $
                   translateLedgerState hardForkEraTranslation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -14,6 +14,7 @@ module Ouroboros.Consensus.HardFork.Combinator.State.Types (
   , TransitionInfo (..)
   , Translate (..)
   , TranslateForecast (..)
+  , TranslateLedgerState (..)
   ) where
 
 import           Prelude
@@ -26,6 +27,7 @@ import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.History (Bound)
+import           Ouroboros.Consensus.Ledger.Basics (Canonical, LedgerState)
 import           Ouroboros.Consensus.Ticked
 
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
@@ -93,8 +95,16 @@ newtype TranslateForecast f g x y = TranslateForecast {
       translateForecastWith ::
            Bound    -- 'Bound' of the transition (start of the new era)
         -> SlotNo   -- 'SlotNo' we're constructing a forecast for
-        -> f x
+        -> f x Canonical
         -> Except OutsideForecastRange (Ticked (g y))
+    }
+
+-- | Translate a LedgerState across an era transition.
+data TranslateLedgerState x y = TranslateLedgerState {
+        translateLedgerStateWith ::
+            EpochNo
+         -> LedgerState x Canonical
+         -> LedgerState y Canonical
     }
 
 -- | Knowledge in a particular era of the transition to the next era

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -21,8 +21,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
 -------------------------------------------------------------------------------}
 
 data EraTranslation xs = EraTranslation {
-      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (Translate LedgerState))       xs
-    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState)) xs
+      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    TranslateLedgerState)                           xs
+    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState))                  xs
     , translateLedgerView    :: InPairs (RequiringBoth WrapLedgerConfig    (TranslateForecast LedgerState WrapLedgerView)) xs
     }
   deriving NoThunks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Functors.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Functors.hs
@@ -1,8 +1,25 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Util.Functors (Product2 (..)) where
+module Ouroboros.Consensus.HardFork.Combinator.Util.Functors (
+    Flip (..)
+  , K1 (..)
+  , Product2 (..)
+  ) where
 
+import           Data.Kind (Type)
 import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
 
+type Product2 :: (x -> y -> Type) -> (x -> y -> Type) -> x -> y -> Type
 data Product2 f g x y = Pair2 (f x y) (g x y)
   deriving (Eq, Generic, Show)
+
+type Flip :: (x -> y -> Type) -> y -> x -> Type
+newtype Flip f x y = Flip {unFlip :: f y x}
+  deriving (Eq, Generic, NoThunks, Show)
+
+type K1 :: Type -> x -> y -> Type
+newtype K1 a b c = K1 a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE EmptyCase            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE EmptyCase                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneDeriving       #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 -- | Intended for qualified import
 --
@@ -100,7 +101,8 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 -- In addition to the standard SOP operators, the new operators that make
 -- a 'Telescope' a telescope are 'extend', 'retract' and 'align'; see their
 -- documentation for details.
-data Telescope (g :: k -> Type) (f :: k -> Type) (xs :: [k]) where
+type Telescope :: forall k. (k -> Type) -> (k -> Type) -> [k] -> Type
+data Telescope g f xs where
   TZ :: !(f x) ->                        Telescope g f (x ': xs)
   TS :: !(g x) -> !(Telescope g f xs) -> Telescope g f (x ': xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -155,7 +155,7 @@ validateHeader cfg ledgerView hdr history = do
 fromChain ::
      ApplyBlock (ExtLedgerState blk) blk
   => TopLevelConfig blk
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
      -- ^ Initial ledger state
   -> Chain blk
   -> HeaderStateHistory blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -40,6 +40,7 @@ import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.SupportsHD
 import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM, (..:))
 
@@ -77,6 +78,7 @@ class ( IsLedger l
       , HeaderHash l ~ HeaderHash blk
       , HasHeader blk
       , HasHeader (Header blk)
+      , LedgerSupportsHD blk
       ) => ApplyBlock l blk where
 
   -- | Apply a block to the ledger state.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
@@ -9,8 +9,8 @@ class UpdateLedger blk => CommonProtocolParams blk where
 
   -- | The maximum header size in bytes according to the currently adopted
   -- protocol parameters of the ledger state.
-  maxHeaderSize :: LedgerState blk -> Word32
+  maxHeaderSize :: LedgerState blk Canonical -> Word32
 
   -- | The maximum transaction size in bytes according to the currently
   -- adopted protocol parameters of the ledger state.
-  maxTxSize :: LedgerState blk -> Word32
+  maxTxSize :: LedgerState blk Canonical -> Word32

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
@@ -66,8 +66,8 @@ class ( Show     (LedgerWarning blk)
   -- leaving it at this for now.
   inspectLedger ::
        TopLevelConfig blk
-    -> LedgerState    blk -- ^ Before
-    -> LedgerState    blk -- ^ After
+    -> LedgerState    blk Canonical -- ^ Before
+    -> LedgerState    blk Canonical -- ^ After
     -> [LedgerEvent   blk]
 
   -- Defaults
@@ -81,8 +81,8 @@ class ( Show     (LedgerWarning blk)
        , LedgerUpdate  blk ~ Void
        )
     => TopLevelConfig blk
-    -> LedgerState    blk -- ^ Before
-    -> LedgerState    blk -- ^ After
+    -> LedgerState    blk Canonical -- ^ Before
+    -> LedgerState    blk Canonical -- ^ After
     -> [LedgerEvent   blk]
   inspectLedger _ _ _ = []
     where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -47,6 +47,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip (..),
                      headerStateBlockNo, headerStatePoint)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query.Version
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -268,7 +269,7 @@ answerQuery ::
      (QueryLedger blk, ConfigSupportsNode blk, HasAnnTip blk)
   => ExtLedgerCfg blk
   -> Query blk result
-  -> ExtLedgerState blk
+  -> ExtLedgerState blk Canonical
   -> result
 answerQuery cfg query st = case query of
   BlockQuery blockQuery -> answerBlockQuery cfg blockQuery st
@@ -286,7 +287,7 @@ data family BlockQuery blk :: Type -> Type
 class (ShowQuery (BlockQuery blk), SameDepIndex (BlockQuery blk)) => QueryLedger blk where
 
   -- | Answer the given query about the extended ledger state.
-  answerBlockQuery :: ExtLedgerCfg blk -> BlockQuery blk result -> ExtLedgerState blk -> result
+  answerBlockQuery :: ExtLedgerCfg blk -> BlockQuery blk result -> ExtLedgerState blk Canonical -> result
 
 instance SameDepIndex (BlockQuery blk) => Eq (SomeSecond BlockQuery blk) where
   SomeSecond qry == SomeSecond qry' = isJust (sameDepIndex qry qry')

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsHD.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsHD.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Ouroboros.Consensus.Ledger.SupportsHD (LedgerSupportsHD) where
+
+import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Tables
+
+-- | The constraints required for a ledger state to be able to manage ledger
+-- tables.
+--
+-- NOTE: The HardForkBlock doesn't satisfy this constraint because it doesn't
+-- have tables, as the tables for HardForkBlocks are not defined compositionally
+-- but rather as an mk of NS's. Because of this, we cannot say that a
+-- @'SingleEraBlock'@ supports HD and then get the HardForkBlock instance for
+-- free, as we do with the rest of the constraints in @'SingleEraBlock'@.
+type LedgerSupportsHD blk =
+      ( HasTickedLedgerTables (LedgerState blk)
+      , CanSerializeLedgerTables (LedgerState blk)
+      , CanStowLedgerTables (LedgerState blk)
+      )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -58,7 +58,7 @@ data WhetherToIntervene
 class ( UpdateLedger blk
       , NoThunks (GenTx blk)
       , NoThunks (Validated (GenTx blk))
-      , NoThunks (Ticked (LedgerState blk))
+      , NoThunks (Ticked1 (LedgerState blk) Canonical)
       , Show (GenTx blk)
       , Show (Validated (GenTx blk))
       , Show (ApplyTxErr blk)
@@ -73,8 +73,8 @@ class ( UpdateLedger blk
           -> WhetherToIntervene
           -> SlotNo -- ^ Slot number of the block containing the tx
           -> GenTx blk
-          -> TickedLedgerState blk
-          -> Except (ApplyTxErr blk) (TickedLedgerState blk, Validated (GenTx blk))
+          -> TickedLedgerState blk Canonical
+          -> Except (ApplyTxErr blk) (TickedLedgerState blk Canonical, Validated (GenTx blk))
 
   -- | Apply a previously validated transaction to a potentially different
   -- ledger state
@@ -86,8 +86,8 @@ class ( UpdateLedger blk
             => LedgerConfig blk
             -> SlotNo -- ^ Slot number of the block containing the tx
             -> Validated (GenTx blk)
-            -> TickedLedgerState blk
-            -> Except (ApplyTxErr blk) (TickedLedgerState blk)
+            -> TickedLedgerState blk Canonical
+            -> Except (ApplyTxErr blk) (TickedLedgerState blk Canonical)
 
   -- | The maximum number of bytes worth of transactions that can be put into
   -- a block according to the currently adopted protocol parameters of the
@@ -95,7 +95,7 @@ class ( UpdateLedger blk
   --
   -- This is (conservatively) computed by subtracting the header size and any
   -- other fixed overheads from the maximum block size.
-  txsMaxBytes :: TickedLedgerState blk -> Word32
+  txsMaxBytes :: TickedLedgerState blk Canonical -> Word32
 
   -- | Return the post-serialisation size in bytes of a 'GenTx' /when it is
   -- embedded in a block/. This size might differ from the size of the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
@@ -19,7 +19,7 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint
                      (DomainAccessPoint (..), IP (..), PortNumber,
                      RelayAccessPoint (..))
 
-import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical, LedgerState)
 
 -- | A relay registered for a stake pool
 data StakePoolRelay =
@@ -48,4 +48,4 @@ class LedgerSupportsPeerSelection blk where
   --
   -- Note: if the ledger state is old, the registered relays can also be old and
   -- may no longer be online.
-  getPeers :: LedgerState blk -> [(PoolStake, NonEmpty StakePoolRelay)]
+  getPeers :: LedgerState blk Canonical -> [(PoolStake, NonEmpty StakePoolRelay)]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -11,6 +11,7 @@ import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Ticked (Ticked1)
 
 -- | Link protocol to ledger
 class ( BlockSupportsProtocol blk
@@ -22,7 +23,7 @@ class ( BlockSupportsProtocol blk
   -- See 'ledgerViewForecastAt' for a discussion and precise definition of the
   -- relation between this and forecasting.
   protocolLedgerView :: LedgerConfig blk
-                     -> Ticked (LedgerState blk)
+                     -> Ticked1 (LedgerState blk) Canonical
                      -> Ticked (LedgerView (BlockProtocol blk))
 
   -- | Get a forecast at the given ledger state.
@@ -63,7 +64,7 @@ class ( BlockSupportsProtocol blk
   ledgerViewForecastAt ::
        HasCallStack
     => LedgerConfig blk
-    -> LedgerState blk
+    -> LedgerState blk Canonical
     -> Forecast (LedgerView (BlockProtocol blk))
 
 -- | Relation between 'ledgerViewForecastAt' and 'applyChainTick'
@@ -73,7 +74,7 @@ _lemma_ledgerViewForecastAt_applyChainTick
      , Show (Ticked (LedgerView (BlockProtocol blk)))
      )
   => LedgerConfig blk
-  -> LedgerState blk
+  -> LedgerState blk Canonical
   -> Forecast (LedgerView (BlockProtocol blk))
   -> SlotNo
   -> Either String ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
@@ -1,0 +1,598 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DefaultSignatures          #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE QuantifiedConstraints      #-}
+{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+-- | See @'LedgerTables'@
+module Ouroboros.Consensus.Ledger.Tables (
+    -- * Kinds
+    LedgerStateKind
+    -- * Basic LedgerState classes
+  , CanStowLedgerTables (..)
+  , HasLedgerTables (..)
+  , HasTickedLedgerTables (..)
+  , mapOverLedgerTables
+  , mapOverLedgerTablesTicked
+  , zipOverLedgerTables
+  , zipOverLedgerTablesTicked
+    -- * Concrete Ledger tables
+  , Canonical (..)
+  , CodecMK (..)
+  , DiffMK
+  , EmptyMK
+  , IsMapKind (..)
+  , KeysMK
+  , NameMK (..)
+  , SeqDiffMK
+  , TrackingMK
+  , ValuesMK (..)
+    -- * Serialization
+  , CanSerializeLedgerTables (..)
+  , valuesMKDecoder
+  , valuesMKEncoder
+    -- * Special classes
+  , LedgerTablesAreTrivial (..)
+  ) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Control.Exception as Exn
+import           Data.Kind (Constraint, Type)
+import qualified Data.Map as Map
+import           Data.Monoid (Sum (..))
+import           GHC.Generics
+import           NoThunks.Class (NoThunks (..))
+
+import           Ouroboros.Consensus.Ticked
+
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq
+
+{-------------------------------------------------------------------------------
+  Kinds
+-------------------------------------------------------------------------------}
+
+type MapKind         = {- key -} Type -> {- value -} Type -> Type
+type LedgerStateKind = MapKind -> Type
+
+{-------------------------------------------------------------------------------
+  Basic LedgerState classes
+-------------------------------------------------------------------------------}
+
+-- | Manipulating the @mk@ on the @'LedgerTables'@, extracting @'LedgerTables'@
+-- from a @'LedgerState'@ (which will share the same @mk@), or replacing the
+-- @'LedgerTables'@ associated to a particular in-memory @'LedgerState'@.
+type HasLedgerTables :: LedgerStateKind -> Constraint
+class ( forall mk. IsMapKind mk => Eq       (LedgerTables l mk)
+      , forall mk. IsMapKind mk => NoThunks (LedgerTables l mk)
+      , forall mk. IsMapKind mk => Show     (LedgerTables l mk)
+      ) => HasLedgerTables l where
+
+  -- | The Ledger Tables represent the portion of the data on disk that has been
+  -- pulled from disk and attached to the in-memory Ledger State or that will
+  -- eventually be written to disk.
+  --
+  -- With UTxO-HD and the split of the Ledger State into the in-memory part and
+  -- the on-disk part, this splitting was reflected in the new type parameter
+  -- added to the Ledger State, to which we refer as "the MapKind" or @mk@.
+  --
+  -- Every @'LedgerState'@ is associated with a @'LedgerTables'@ and they both
+  -- share the @mk@. They both are of kind @'LedgerStateKind'@. @'LedgerTables'@
+  -- is just a way to refer /only/ to a partial view of the on-disk data without
+  -- having the rest of the in-memory Ledger State in scope.
+  --
+  -- The @mk@ can be instantiated to anything that is map-like, i.e. that expects
+  -- two type parameters, the key and the value.
+  data family LedgerTables l :: LedgerStateKind
+
+  -- | Extract the ledger tables from a ledger state
+  --
+  -- NOTE: This 'IsMapKind' constraint is necessary because the 'CardanoBlock'
+  -- instance uses 'mapMK'.
+  projectLedgerTables :: forall mk. IsMapKind mk => l mk -> LedgerTables l mk
+  default projectLedgerTables ::
+        LedgerTablesAreTrivial l
+      => l mk
+      -> LedgerTables l mk
+  projectLedgerTables _ = trivialLedgerTables
+
+  -- | Overwrite the tables in some ledger state.
+  --
+  -- The contents of the tables should not be /younger/ than the content of the
+  -- ledger state. In particular, for a
+  -- 'Ouroboros.Consensus.HardFork.Combinator.Basics.HardForkBlock' ledger, the
+  -- tables argument should not contain any data from eras that succeed the
+  -- current era of the ledger state argument.
+  --
+  -- NOTE: This 'IsMapKind' constraint is necessary because the
+  -- 'CardanoBlock' instance uses 'mapMK'.
+  withLedgerTables :: IsMapKind mk => l any -> LedgerTables l mk -> l mk
+  default withLedgerTables ::
+       (IsMapKind mk, LedgerTablesAreTrivial l)
+    => l any
+    -> LedgerTables l mk
+    -> l mk
+  withLedgerTables st _ = convertMapKind st
+
+  pureLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+       )
+    -> LedgerTables l mk
+  default pureLedgerTables ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+       )
+    -> LedgerTables l mk
+  pureLedgerTables _ = trivialLedgerTables
+
+  mapLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+  default mapLedgerTables ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+  mapLedgerTables _ _ = trivialLedgerTables
+
+  traverseLedgerTables ::
+       Applicative f
+    => (forall k v .
+           (Ord k, Eq v)
+        =>    mk1 k v
+        -> f (mk2 k v)
+       )
+    ->    LedgerTables l mk1
+    -> f (LedgerTables l mk2)
+  default traverseLedgerTables ::
+       (Applicative f, LedgerTablesAreTrivial l)
+    => (forall k v .
+           (Ord k, Eq v)
+        =>    mk1 k v
+        -> f (mk2 k v)
+       )
+    ->    LedgerTables l mk1
+    -> f (LedgerTables l mk2)
+  traverseLedgerTables _ _ = pure trivialLedgerTables
+
+  zipLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+  default zipLedgerTables ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+  zipLedgerTables _ _ _ = trivialLedgerTables
+
+  zipLedgerTables2 ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> mk4 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> LedgerTables l mk4
+  default zipLedgerTables2 ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> mk4 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> LedgerTables l mk4
+  zipLedgerTables2 _ _ _ _ = trivialLedgerTables
+
+  zipLedgerTablesA ::
+       Applicative f
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> f (mk3 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> f (LedgerTables l mk3)
+  default zipLedgerTablesA ::
+       (Applicative f, LedgerTablesAreTrivial l)
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> f (mk3 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> f (LedgerTables l mk3)
+  zipLedgerTablesA _ _ _ = pure trivialLedgerTables
+
+  zipLedgerTables2A ::
+       Applicative f
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> f (mk4 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> f (LedgerTables l mk4)
+  default zipLedgerTables2A ::
+       (Applicative f, LedgerTablesAreTrivial l)
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> f (mk4 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> f (LedgerTables l mk4)
+  zipLedgerTables2A _ _ _ _ = pure trivialLedgerTables
+
+  foldLedgerTables ::
+       Monoid m
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+         -> m
+       )
+    -> LedgerTables l mk
+    -> m
+  foldLedgerTables _ _ = mempty
+
+  foldLedgerTables2 ::
+       Monoid m
+    => (forall k v.
+           (Ord k, Eq v)
+        => mk1 k v
+        -> mk2 k v
+        -> m
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> m
+  foldLedgerTables2 _ _ _ = mempty
+
+  -- | The ledger tables will eventually be stored in some BackingStore under a
+  -- db-like table named after this value
+  namesLedgerTables :: LedgerTables l NameMK
+  namesLedgerTables = pureLedgerTables (NameMK "NoTables")
+
+overLedgerTables ::
+     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (LedgerTables l mk1 -> LedgerTables l mk2)
+  -> l mk1
+  -> l mk2
+overLedgerTables f l = withLedgerTables l $ f $ projectLedgerTables l
+
+mapOverLedgerTables ::
+     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (forall k v.
+          (Ord k, Eq v)
+       => mk1 k v
+       -> mk2 k v
+     )
+  -> l mk1
+  -> l mk2
+mapOverLedgerTables f = overLedgerTables $ mapLedgerTables f
+
+zipOverLedgerTables ::
+     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk3)
+  => (forall k v.
+          (Ord k, Eq v)
+       => mk1 k v
+       -> mk2 k v
+       -> mk3 k v
+     )
+  ->              l mk1
+  -> LedgerTables l mk2
+  ->              l mk3
+zipOverLedgerTables f l tables2 =
+    overLedgerTables
+      (\tables1 -> zipLedgerTables f tables1 tables2)
+      l
+
+type HasTickedLedgerTables :: LedgerStateKind -> Constraint
+class HasLedgerTables l => HasTickedLedgerTables l where
+  -- | NOTE: The 'IsMapKind' constraint is here for the same reason
+  -- it's on 'projectLedgerTables'
+  projectLedgerTablesTicked :: IsMapKind mk => Ticked1 l mk  -> LedgerTables l mk
+  default projectLedgerTablesTicked ::
+       LedgerTablesAreTrivial l
+    => Ticked1 l mk
+    -> LedgerTables l mk
+  projectLedgerTablesTicked _ = trivialLedgerTables
+
+  -- | NOTE: The 'IsMapKind' constraint is here for the same reason
+  -- it's on 'withLedgerTables'
+  withLedgerTablesTicked :: IsMapKind mk => Ticked1 l any -> LedgerTables l mk -> Ticked1 l mk
+
+overLedgerTablesTicked ::
+     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (LedgerTables l mk1 -> LedgerTables l mk2)
+  -> Ticked1 l mk1
+  -> Ticked1 l mk2
+overLedgerTablesTicked f l =
+    withLedgerTablesTicked l $ f $ projectLedgerTablesTicked l
+
+mapOverLedgerTablesTicked ::
+     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (forall k v.
+         (Ord k, Eq v)
+      => mk1 k v
+      -> mk2 k v
+     )
+  -> Ticked1 l mk1
+  -> Ticked1 l mk2
+mapOverLedgerTablesTicked f = overLedgerTablesTicked $ mapLedgerTables f
+
+zipOverLedgerTablesTicked ::
+     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk3)
+  => (forall k v.
+         (Ord k, Eq v)
+      => mk1 k v
+      -> mk2 k v
+      -> mk3 k v
+     )
+  -> Ticked1      l mk1
+  -> LedgerTables l mk2
+  -> Ticked1      l mk3
+zipOverLedgerTablesTicked f l tables2 =
+    overLedgerTablesTicked
+      (\tables1 -> zipLedgerTables f tables1 tables2)
+      l
+
+-- | LedgerTables are projections of data from a LedgerState and as such they
+-- can be injected back into a LedgerState. This is necessary because the Ledger
+-- rules are ignorant to UTxO-HD changes so by stowing the ledger tables, we are
+-- able to provide a Ledger State with a restricted UTxO set that is enough to
+-- execute the Ledger rules.
+type CanStowLedgerTables :: LedgerStateKind -> Constraint
+class CanStowLedgerTables l where
+
+  stowLedgerTables     :: l ValuesMK -> l EmptyMK
+  default stowLedgerTables :: LedgerTablesAreTrivial l => l ValuesMK -> l EmptyMK
+  stowLedgerTables = convertMapKind
+
+  unstowLedgerTables   :: l EmptyMK  -> l ValuesMK
+  default unstowLedgerTables :: LedgerTablesAreTrivial l => l EmptyMK -> l ValuesMK
+  unstowLedgerTables = convertMapKind
+
+{-------------------------------------------------------------------------------
+  Concrete ledger tables
+
+We provide here  the usual structures that we expect to deal with, namely:
+- @'ValuesMK'@: a map of keys to values
+- @'KeysMK'@: a set of keys
+- @'DiffMK'@: a map of keys to value differences
+- @'TrackingMK'@: the product of both @'ValuesMK'@ and @'DiffMK'@
+- @'SeqDiffMK'@: an efficient sequence of differences
+- @'CodecMK'@: @CBOR@ encoder and decoder for the key and value
+-------------------------------------------------------------------------------}
+
+-- | The Canonical MapKind, which has no constructor, and therefore a
+-- @LedgerState blk Canonical@ will have all the contents in memory. This is
+-- just a phantom type used to sketch later development and shall not land on
+-- the release version.
+data Canonical k v = Canonical
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+newtype DiffMK     k v = DiffMK      (Diff k v)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+data    EmptyMK    k v = EmptyMK
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+newtype KeysMK     k v = KeysMK      (Keys k v)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+newtype SeqDiffMK  k v = SeqDiffMK   (DiffSeq k v)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+data    TrackingMK k v = TrackingMK !(Values k v) !(Diff k v)
+  deriving (Generic, Eq, Show, NoThunks)
+
+newtype ValuesMK   k v = ValuesMK    (Values k v)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+-- | A codec 'MapKind' that will be used to refer to @'LedgerTables' l CodecMK@
+-- as the codecs that can encode every key and value in the @'LedgerTables' l
+-- mk@.
+data CodecMK k v = CodecMK
+                     (k -> CBOR.Encoding)
+                     (v -> CBOR.Encoding)
+                     (forall s . CBOR.Decoder s k)
+                     (forall s . CBOR.Decoder s v)
+
+newtype NameMK k v = NameMK String
+
+-- | A general interface to mapkinds.
+--
+-- In some cases where @mk@ is not specialised to a concrete mapkind like
+-- @'ValuesMK'@, there are often still a number of operations that we can
+-- perform for this @mk@ that make sense regardless of the concrete mapkind. For
+-- example, we should always be able to map over a mapkind to change the type of
+-- values that it contains. This class is an interface to mapkinds that provides
+-- such common functions.
+type IsMapKind :: MapKind -> Constraint
+class ( forall k v. (Eq       k, Eq       v) => Eq       (mk k v)
+      , forall k v. (NoThunks k, NoThunks v) => NoThunks (mk k v)
+      , forall k v. (Show     k, Show     v) => Show     (mk k v)
+      ) => IsMapKind mk where
+  emptyMK :: forall k v. (Ord k, Eq v) => mk k v
+  default emptyMK :: forall k v. Monoid (mk k v) => mk k v
+  emptyMK = mempty
+
+  mapMK :: forall k v v'. (Ord k, Eq v, Eq v') => (v -> v') -> mk k v -> mk k v'
+  default mapMK :: forall k v v'. (Functor (mk k)) => (v -> v') -> mk k v -> mk k v'
+  mapMK = fmap
+
+instance IsMapKind Canonical where
+  emptyMK = Canonical
+  mapMK _ Canonical = Canonical
+
+instance IsMapKind EmptyMK where
+  emptyMK = EmptyMK
+  mapMK _ EmptyMK = EmptyMK
+
+instance IsMapKind KeysMK where
+  emptyMK = KeysMK mempty
+  mapMK f (KeysMK ks) = KeysMK $ fmap f ks
+
+instance IsMapKind ValuesMK where
+  emptyMK = ValuesMK mempty
+  mapMK f (ValuesMK vs) = ValuesMK $ fmap f vs
+
+instance IsMapKind TrackingMK where
+  emptyMK = TrackingMK mempty mempty
+  mapMK f (TrackingMK vs d) = TrackingMK (fmap f vs) (fmap f d)
+
+instance IsMapKind DiffMK where
+  emptyMK = DiffMK mempty
+  mapMK f (DiffMK d) = DiffMK $ fmap f d
+
+instance IsMapKind SeqDiffMK where
+  emptyMK = SeqDiffMK empty
+  mapMK f (SeqDiffMK ds) = SeqDiffMK $ mapDiffSeq f ds
+
+instance Ord k => Semigroup (KeysMK k v) where
+  KeysMK l <> KeysMK r = KeysMK (l <> r)
+
+instance Ord k => Monoid (KeysMK k v) where
+  mempty = KeysMK mempty
+
+instance Functor (DiffMK k) where
+  fmap f (DiffMK d) = DiffMK $ fmap f d
+
+{-------------------------------------------------------------------------------
+  Serialization Codecs
+-------------------------------------------------------------------------------}
+
+-- | This class provides a 'CodecMK' that can be used to encode/decode keys and
+-- values on @'LedgerTables' l mk@
+type CanSerializeLedgerTables :: LedgerStateKind -> Constraint
+class CanSerializeLedgerTables l where
+  codecLedgerTables :: LedgerTables l CodecMK
+  default codecLedgerTables :: LedgerTablesAreTrivial l => LedgerTables l CodecMK
+  codecLedgerTables = trivialLedgerTables
+
+-- | Default encoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
+-- in-memory backing store.
+valuesMKEncoder ::
+     ( HasLedgerTables l
+     , CanSerializeLedgerTables l
+     )
+  => LedgerTables l ValuesMK
+  -> CBOR.Encoding
+valuesMKEncoder tables =
+       CBOR.encodeListLen (getSum (foldLedgerTables (\_ -> Sum 1) tables))
+    <> foldLedgerTables2 go codecLedgerTables tables
+  where
+    go :: CodecMK k v -> ValuesMK k v -> CBOR.Encoding
+    go (CodecMK encK encV _decK _decV) (ValuesMK (Values m)) =
+         CBOR.encodeMapLen (fromIntegral $ Map.size m)
+      <> Map.foldMapWithKey (\k v -> encK k <> encV v) m
+
+-- | Default decoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
+-- in-memory backing store.
+valuesMKDecoder ::
+     ( HasLedgerTables l
+     , CanSerializeLedgerTables l
+     )
+  => CBOR.Decoder s (LedgerTables l ValuesMK)
+valuesMKDecoder = do
+    numTables <- CBOR.decodeListLen
+    if numTables == 0
+      then
+        return $ pureLedgerTables emptyMK
+      else do
+        mapLen <- CBOR.decodeMapLen
+        ret    <- traverseLedgerTables (go mapLen) codecLedgerTables
+        Exn.assert ((getSum (foldLedgerTables (\_ -> Sum 1) ret)) == numTables)
+          $ return ret
+ where
+  go :: Ord k
+     => Int
+     -> CodecMK k v
+     -> CBOR.Decoder s (ValuesMK k v)
+  go len (CodecMK _encK _encV decK decV) =
+        ValuesMK . Values . Map.fromList
+    <$> sequence (replicate len ((,) <$> decK <*> decV))
+
+{-------------------------------------------------------------------------------
+  Special classes of ledger states
+-------------------------------------------------------------------------------}
+
+type LedgerTablesAreTrivial :: LedgerStateKind -> Constraint
+class LedgerTablesAreTrivial l where
+  -- | If the ledger state is always in memory, then @l mk@ will be isomorphic
+  -- to @l mk'@ for all @mk@, @mk'@. As a result, we can convert between ledgers
+  -- states indexed by different map kinds.
+  --
+  -- This function is useful to combine functions that operate on functions that
+  -- transform the map kind on a ledger state (eg @applyChainTickLedgerResult@).
+  convertMapKind :: IsMapKind mk' => l mk -> l mk'
+  default convertMapKind :: (IsMapKind mk', HasLedgerTables l) => l mk -> l mk'
+  convertMapKind st = st `withLedgerTables` trivialLedgerTables
+
+  trivialLedgerTables :: LedgerTables l mk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -302,7 +302,7 @@ data ForgeLedgerState blk =
     -- This will only be the case when we realized that we are the slot leader
     -- and we are actually producing a block. It is the caller's responsibility
     -- to call 'applyChainTick' and produce the ticked ledger state.
-    ForgeInKnownSlot SlotNo (TickedLedgerState blk)
+    ForgeInKnownSlot SlotNo (TickedLedgerState blk Canonical)
 
     -- | The slot number of the block is not yet known
     --
@@ -310,7 +310,7 @@ data ForgeLedgerState blk =
     -- will end up, we have to make an assumption about which slot number to use
     -- for 'applyChainTick' to prepare the ledger state; we will assume that
     -- they will end up in the slot after the slot at the tip of the ledger.
-  | ForgeInUnknownSlot (LedgerState blk)
+  | ForgeInUnknownSlot (LedgerState blk Canonical)
 
 {-------------------------------------------------------------------------------
   Mempool capacity in bytes
@@ -338,7 +338,7 @@ data MempoolCapacityBytesOverride
 -- the current ledger's maximum transaction capacity of a block.
 computeMempoolCapacity
   :: LedgerSupportsMempool blk
-  => TickedLedgerState blk
+  => TickedLedgerState blk Canonical
   -> MempoolCapacityBytesOverride
   -> MempoolCapacityBytes
 computeMempoolCapacity st = \case
@@ -390,7 +390,7 @@ data MempoolSnapshot blk idx = MempoolSnapshot {
   , snapshotSlotNo      :: SlotNo
 
     -- | The ledger state after all transactions in the snapshot
-  , snapshotLedgerState :: TickedLedgerState blk
+  , snapshotLedgerState :: TickedLedgerState blk Canonical
   }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -121,7 +121,7 @@ mkMempool mpEnv = Mempool
 
 -- | Abstract interface needed to run a Mempool.
 data LedgerInterface m blk = LedgerInterface
-    { getCurrentLedgerState :: STM m (LedgerState blk)
+    { getCurrentLedgerState :: STM m (LedgerState blk Canonical)
     }
 
 -- | Create a 'LedgerInterface' from a 'ChainDB'.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -189,7 +189,7 @@ pureRemoveTxs
   -> MempoolCapacityBytesOverride
   -> [GenTxId blk]
   -> InternalState blk
-  -> LedgerState blk
+  -> LedgerState blk Canonical
   -> RemoveTxs blk
 pureRemoveTxs cfg capacityOverride txIds IS { isTxs, isLastTicketNo } lstate =
     -- Filtering is O(n), but this function will rarely be used, as it is an
@@ -256,7 +256,7 @@ runSyncWithLedger stateVar (NewSyncedState is msp mTrace) = do
 pureSyncWithLedger
   :: (LedgerSupportsMempool blk, HasTxId (GenTx blk), ValidateEnvelope blk)
   => InternalState blk
-  -> LedgerState blk
+  -> LedgerState blk Canonical
   -> LedgerConfig blk
   -> MempoolCapacityBytesOverride
   -> SyncWithLedger blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs
@@ -30,9 +30,9 @@ import           Data.Measure (BoundedMeasure, Measure)
 import qualified Data.Measure as Measure
 
 import           Ouroboros.Consensus.Ledger.Abstract (Validated)
-import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import           Ouroboros.Consensus.Ledger.Basics (LedgerState, Canonical)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)
-import           Ouroboros.Consensus.Ticked (Ticked (..))
+import           Ouroboros.Consensus.Ticked (Ticked1)
 
 -- | Each block has its limits of how many transactions it can hold.
 -- That limit is compared against the sum of measurements
@@ -54,7 +54,7 @@ class BoundedMeasure (TxMeasure blk) => TxLimits blk where
   txMeasure        :: Validated (GenTx blk)    -> TxMeasure blk
 
   -- | What is the allowed capacity for txs in an individual block?
-  txsBlockCapacity :: Ticked (LedgerState blk) -> TxMeasure blk
+  txsBlockCapacity :: Ticked1 (LedgerState blk) Canonical -> TxMeasure blk
 
 -- | Is every component of the first value less-than-or-equal-to the
 -- corresponding component of the second value?

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -125,7 +125,7 @@ initSlotForgeTimeOracle cfg chainDB = do
     pure slotForgeTime
   where
     toSummary ::
-         ExtLedgerState blk
+         ExtLedgerState blk Canonical
       -> History.Summary (History.HardForkIndices blk)
     toSummary = History.hardForkSummary (configLedger cfg) . ledgerState
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -72,6 +72,7 @@ import           Ouroboros.Consensus.HeaderStateHistory
                      (HeaderStateHistory (..), validateHeader)
 import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
 import           Ouroboros.Consensus.HeaderValidation hiding (validateHeader)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -93,7 +94,7 @@ type Consensus (client :: Type -> Type -> Type -> (Type -> Type) -> Type -> Type
 data ChainDbView m blk = ChainDbView {
       getCurrentChain       :: STM m (AnchoredFragment (Header blk))
     , getHeaderStateHistory :: STM m (HeaderStateHistory blk)
-    , getPastLedger         :: Point blk -> STM m (Maybe (ExtLedgerState blk))
+    , getPastLedger         :: Point blk -> STM m (Maybe (ExtLedgerState blk Canonical))
     , getIsInvalidBlock     :: STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
     }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -9,6 +9,7 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip (..))
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Util.IOLike
@@ -18,7 +19,7 @@ localStateQueryServer ::
   => ExtLedgerCfg blk
   -> STM m (Point blk)
      -- ^ Get tip point
-  -> (Point blk -> STM m (Maybe (ExtLedgerState blk)))
+  -> (Point blk -> STM m (Maybe (ExtLedgerState blk Canonical)))
      -- ^ Get a past ledger
   -> STM m (Point blk)
      -- ^ Get the immutable point
@@ -48,7 +49,7 @@ localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
             | otherwise
             -> SendMsgFailure AcquireFailurePointNotOnChain idle
 
-    acquired :: ExtLedgerState blk
+    acquired :: ExtLedgerState blk Canonical
              -> ServerStAcquired blk (Point blk) (Query blk) m ()
     acquired ledgerState = ServerStAcquired {
           recvMsgQuery     = handleQuery ledgerState
@@ -57,7 +58,7 @@ localStateQueryServer cfg getTipPoint getPastLedger getImmutablePoint =
         }
 
     handleQuery ::
-         ExtLedgerState blk
+         ExtLedgerState blk Canonical
       -> Query blk result
       -> m (ServerStQuerying blk (Point blk) (Query blk) m () result)
     handleQuery ledgerState query = return $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -15,6 +15,7 @@ import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Basics (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.NodeId
 
@@ -37,7 +38,7 @@ enumCoreNodes (NumCoreNodes numNodes) =
 -- | Data required to run the specified protocol.
 data ProtocolInfo m b = ProtocolInfo {
         pInfoConfig       :: TopLevelConfig b
-      , pInfoInitLedger   :: ExtLedgerState b -- ^ At genesis
+      , pInfoInitLedger   :: ExtLedgerState b Canonical -- ^ At genesis
       , pInfoBlockForging :: m [BlockForging m b]
       }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -359,13 +359,13 @@ getTipBlockNo = fmap Network.getTipBlockNo . getCurrentTip
 -- | Get current ledger
 getCurrentLedger ::
      (Monad (STM m), IsLedger (LedgerState blk))
-  => ChainDB m blk -> STM m (ExtLedgerState blk)
+  => ChainDB m blk -> STM m (ExtLedgerState blk Canonical)
 getCurrentLedger = fmap LedgerDB.ledgerDbCurrent . getLedgerDB
 
 -- | Get the immutable ledger, i.e., typically @k@ blocks back.
 getImmutableLedger ::
      Monad (STM m)
-  => ChainDB m blk -> STM m (ExtLedgerState blk)
+  => ChainDB m blk -> STM m (ExtLedgerState blk Canonical)
 getImmutableLedger = fmap LedgerDB.ledgerDbAnchor . getLedgerDB
 
 -- | Get the ledger for the given point.
@@ -375,7 +375,7 @@ getImmutableLedger = fmap LedgerDB.ledgerDbAnchor . getLedgerDB
 -- returned.
 getPastLedger ::
      (Monad (STM m), LedgerSupportsProtocol blk)
-  => ChainDB m blk -> Point blk -> STM m (Maybe (ExtLedgerState blk))
+  => ChainDB m blk -> Point blk -> STM m (Maybe (ExtLedgerState blk Canonical))
 getPastLedger db pt = LedgerDB.ledgerDbPast pt <$> getLedgerDB db
 
 -- | Get a 'HeaderStateHistory' populated with the 'HeaderState's of the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -20,6 +20,7 @@ import           Control.Tracer (Tracer, contramap, nullTracer)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture)
+import           Ouroboros.Consensus.Ledger.Abstract (Canonical)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
@@ -64,7 +65,7 @@ data ChainDbArgs f m blk = ChainDbArgs {
     -- ^ Predicate to check for integrity of
     -- 'Ouroboros.Consensus.Storage.Common.GetVerifiedBlock' components when
     -- extracting them from both the VolatileDB and the ImmutableDB.
-    , cdbGenesis                :: HKD f (m (ExtLedgerState blk))
+    , cdbGenesis                :: HKD f (m (ExtLedgerState blk Canonical))
     , cdbCheckInFuture          :: HKD f (CheckInFuture m blk)
     , cdbImmutableDbCacheConfig :: ImmutableDB.CacheConfig
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -686,7 +686,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = do
         cfg :: TopLevelConfig blk
         cfg = cdbTopLevelConfig
 
-        ledger :: LedgerState blk
+        ledger :: LedgerState blk Canonical
         ledger = ledgerState (LgrDB.ledgerDbCurrent newLedgerDB)
 
         summary :: History.Summary (HardForkIndices blk)
@@ -1196,7 +1196,7 @@ futureCheckCandidate chainSelEnv validatedChainDiff =
 
     ValidatedChainDiff chainDiff@(ChainDiff _ suffix) _ = validatedChainDiff
 
-    validatedSuffix :: ValidatedFragment (Header blk) (LedgerState blk)
+    validatedSuffix :: ValidatedFragment (Header blk) (LedgerState blk Canonical)
     validatedSuffix =
       ledgerState . LgrDB.ledgerDbCurrent <$>
       ValidatedDiff.toValidatedFragment validatedChainDiff

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -128,8 +128,8 @@ deriving instance (IOLike m, LedgerSupportsProtocol blk)
 -- | 'EncodeDisk' and 'DecodeDisk' constraints needed for the LgrDB.
 type LgrDbSerialiseConstraints blk =
   ( Serialise      (HeaderHash  blk)
-  , EncodeDisk blk (LedgerState blk)
-  , DecodeDisk blk (LedgerState blk)
+  , EncodeDisk blk (LedgerState blk Canonical)
+  , DecodeDisk blk (LedgerState blk Canonical)
   , EncodeDisk blk (AnnTip      blk)
   , DecodeDisk blk (AnnTip      blk)
   , EncodeDisk blk (ChainDepState (BlockProtocol blk))
@@ -142,7 +142,7 @@ type LgrDbSerialiseConstraints blk =
 
 data LgrDbArgs f m blk = LgrDbArgs {
       lgrDiskPolicy     :: DiskPolicy
-    , lgrGenesis        :: HKD f (m (ExtLedgerState blk))
+    , lgrGenesis        :: HKD f (m (ExtLedgerState blk Canonical))
     , lgrHasFS          :: SomeHasFS m
     , lgrTopLevelConfig :: HKD f (TopLevelConfig blk)
     , lgrTraceLedger    :: Tracer m (LedgerDB' blk)
@@ -258,7 +258,7 @@ initFromDisk LgrDbArgs { lgrHasFS = hasFS, .. }
   where
     ccfg = configCodec lgrTopLevelConfig
 
-    decodeExtLedgerState' :: forall s. Decoder s (ExtLedgerState blk)
+    decodeExtLedgerState' :: forall s. Decoder s (ExtLedgerState blk Canonical)
     decodeExtLedgerState' = decodeExtLedgerState
                               (decodeDisk ccfg)
                               (decodeDisk ccfg)
@@ -316,7 +316,7 @@ takeSnapshot lgrDB@LgrDB{ cfg, tracer, hasFS } = wrapFailure (Proxy @blk) $ do
   where
     ccfg = configCodec cfg
 
-    encodeExtLedgerState' :: ExtLedgerState blk -> Encoding
+    encodeExtLedgerState' :: ExtLedgerState blk Canonical -> Encoding
     encodeExtLedgerState' = encodeExtLedgerState
                               (encodeDisk ccfg)
                               (encodeDisk ccfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
@@ -24,7 +24,7 @@ data InitChainDB m blk = InitChainDB {
       addBlock         :: blk -> m ()
 
       -- | Return the current ledger state
-    , getCurrentLedger :: m (LedgerState blk)
+    , getCurrentLedger :: m (LedgerState blk Canonical)
     }
 
 fromFull ::
@@ -40,7 +40,7 @@ fromFull db = InitChainDB {
 map ::
      Functor m
   => (blk' -> blk)
-  -> (LedgerState blk -> LedgerState blk')
+  -> (LedgerState blk Canonical -> LedgerState blk' Canonical)
   -> InitChainDB m blk -> InitChainDB m blk'
 map f g db = InitChainDB {
       addBlock         = addBlock db . f

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
@@ -1,0 +1,353 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MonoLocalBinds             #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+
+{- | Sequences of diffs for ledger tables.
+
+   These diff sequences are an instantiation of a strict finger tree with root
+   measures. The tree/sequence itself contains diffs and slot information, while
+   the root measure is the total sum of all diffs in the sequence. The internal
+   measure is used to keep track of sequence length and maximum slot numbers.
+
+   The diff datatype that we use forms a @'Group'@, which allows for relatively
+   efficient splitting of finger trees with respect to recomputing measures by
+   means of the @'invert'@ operation that the @'Group'@ type class requires.
+   Namely, if either the left or right part of the split is small in comparison
+   with the input sequence, then we can subtract the diffs in the smaller part
+   from the root measure of the input to (quickly) compute the root measure of
+   the /other/ part of the split. This is much faster than computing the root
+   measures from scratch by doing a linear-time pass over the elements of the
+   split parts, or a logarithmic-time pass over intermediate sums of diffs in
+   case we store cumulative diffs in the nodes of the finger tree.
+
+   === Example of fast splits
+
+   As an analogy, consider this example: we have a sequence of consecutive
+   integer numbers @xs = [1..n]@ where @n@ is large, and we define the root
+   measure of the sequence to be the total sum of these numbers, @rmxs = sum
+   [1..n]@ (we assume @rmxs@ is fully evaluated). Say we split this sequence of
+   integer numbers at the index @2@, then we get /left/ and /right/ parts of the
+   split @ys@ and @zs respectively.
+
+   > splitAt 2 xs = (ys, zs) = ([1..2], [3..n])
+
+   How should we compute we the root measure @rmys@ of @ys@? Since @ys@ is
+   small, we can just compute @rmys = sum [1..2]@. How should we compute the
+   root measure @rmzs@ of @zs@? We should not compute @rmzs = sum [3..n]@ in
+   this case, since @n@ is large. Instead, we compute @rmzs = rmxs - rmys@,
+   which evaluates to its result in time that is linear in the length of @ys@,
+   in this case @O(1)@.
+
+   === Why not store sums of diffs in the internal measure instead of the root
+   measure?
+
+   We could also have used the interal measure of the strict finger tree to
+   store intermediate sums of diffs for all subtrees of the node. The subtree
+   rooted at the root of the tree would then store the total sum of diffs.
+   However, we would have now to recompute a possibly logarithmic number of sums
+   of diffs when we split or extend the sequence. Given that in @consensus@ we
+   use the total sum of diffs nearly as often as we split or extend the diff
+   sequence, this proved to be too costly. The single-instance root measure
+   reduces the overhead of this "caching" of intermediate sums of diffs by only
+   using a single total sum of diffs, though augmented with an @'invert'@
+   operation to facilitate computing updated root measures.
+
+   === Note on the use of @l@ and @r@ infixes in function names
+
+   Functions like @'splitl'@, @'splitlAt'@ and @'splitrAtFromEnd'@ use infix @l@
+   and @r@ characters to indicate that its time complexity is determined by
+   either the length of the left part or right part of the split respectively.
+   This means that if we expect the left part of a split to be small relative to
+   the length of the input, then we should use an @l@-variant. If the reverse is
+   true, then we should use an @r@-variant.
+-}
+module Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (
+    -- * Sequences of diffs
+    DiffSeq (..)
+  , Element (..)
+  , InternalMeasure (..)
+  , Length (..)
+  , RootMeasure (..)
+  , SlotNoLB (..)
+  , SlotNoUB (..)
+    -- * Diff re-export
+  , module MapDiff
+    -- * Short-hands for type-class constraints
+  , SM
+    -- * API: derived functions
+  , append
+  , cumulativeDiff
+  , empty
+  , extend
+  , length
+    -- * Slots
+  , maxSlot
+  , minSlot
+    -- * Splitting
+  , split
+  , splitAt
+  , splitAtFromEnd
+    -- * Maps
+  , mapDiffSeq
+  ) where
+
+import           Prelude hiding (length, splitAt)
+
+import qualified Control.Exception as Exn
+import           Data.Bifunctor (Bifunctor (bimap))
+import           Data.Group
+import           Data.Maybe (fromMaybe)
+import           Data.Monoid (Sum (..))
+import           Data.Semigroup (Max (..), Min (..))
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+
+import           Data.FingerTree.RootMeasured.Strict hiding (split, splitSized,
+                     splitl, splitr)
+import qualified Data.FingerTree.RootMeasured.Strict as RMFT (splitSized)
+import           Data.Map.Diff.Strict as MapDiff
+
+import qualified Cardano.Slotting.Slot as Slot
+
+{-------------------------------------------------------------------------------
+  Sequences of diffs
+-------------------------------------------------------------------------------}
+
+-- | A sequence key-value store differences.
+--
+-- INVARIANT: The slot numbers of consecutive elements should be strictly
+-- increasing. Manipulating the underlying @'StrictFingerTree'@ directly may
+-- break this invariant.
+newtype DiffSeq k v =
+  UnsafeDiffSeq
+    (StrictFingerTree
+      (RootMeasure k v)
+      (InternalMeasure k v)
+      (Element k v)
+    )
+  deriving stock (Generic, Show, Eq)
+  deriving anyclass (NoThunks)
+
+-- The @'SlotNo'@ is not included in the root measure, since it is
+-- not a @'Group'@ instance.
+data RootMeasure k v = RootMeasure {
+    -- | Cumulative length
+    rmLength :: {-# UNPACK #-} !Length
+    -- | Cumulative diff
+  , rmDiff   :: !(Diff k v)
+  }
+  deriving stock (Generic, Show, Eq, Functor)
+  deriving anyclass (NoThunks)
+
+data InternalMeasure k v = InternalMeasure {
+    -- | Cumulative length
+    imLength  :: {-# UNPACK #-} !Length
+    -- | Leftmost slot number (or lower bound)
+    --
+    -- Empty diff sequences have no rightmost slot number, so in that case
+    -- @imSlotNo == Nothing@.
+  , imSlotNoL ::                !(Maybe SlotNoLB)
+    -- | Rightmost slot number (or upper bound)
+    --
+    -- Empty diff sequences have no leftmost slot number, so in that case
+    -- @imSlotNo == Nothing@.
+  , imSlotNoR ::                !(Maybe SlotNoUB)
+  }
+  deriving stock (Generic, Show, Eq, Functor)
+  deriving anyclass (NoThunks)
+
+data Element k v = Element {
+    elSlotNo :: {-# UNPACK #-} !Slot.SlotNo
+  , elDiff   ::                !(Diff k v)
+  }
+  deriving stock (Generic, Show, Eq, Functor)
+  deriving anyclass (NoThunks)
+
+-- | Length of a sequence of differences.
+newtype Length = Length { unLength :: Int }
+  deriving stock (Generic, Show, Eq, Ord)
+  deriving newtype (Num)
+  deriving anyclass (NoThunks)
+  deriving Semigroup via Sum Int
+  deriving Monoid via Sum Int
+  deriving Group via Sum Int
+
+-- | An upper bound on slot numbers.
+newtype SlotNoUB = SlotNoUB {unSlotNoUB :: Slot.SlotNo}
+  deriving stock (Generic, Show, Eq, Ord)
+  deriving newtype (Num)
+  deriving anyclass (NoThunks)
+  deriving Semigroup via Max Slot.SlotNo
+  deriving Monoid via Max Slot.SlotNo
+
+-- | A lower bound on slot numbers.
+newtype SlotNoLB = SlotNoLB {unSlotNoLB :: Slot.SlotNo}
+  deriving stock (Generic, Show, Eq, Ord)
+  deriving newtype (Num)
+  deriving anyclass (NoThunks)
+  deriving Semigroup via Min Slot.SlotNo
+  deriving Monoid via Min Slot.SlotNo
+
+-- FIXME(jdral): It should be the case that there is a strict inequality, but
+-- EBBs violate this. Should we use something else instead of slots? Points?
+noSlotBoundsIntersect :: SlotNoUB -> SlotNoLB -> Bool
+noSlotBoundsIntersect (SlotNoUB sl1) (SlotNoLB sl2) = sl1 <= sl2
+
+{-------------------------------------------------------------------------------
+  Root measuring
+-------------------------------------------------------------------------------}
+
+instance (Ord k, Eq v) => RootMeasured (RootMeasure k v) (Element k v) where
+  measureRoot (Element _ d) = RootMeasure 1 d
+
+instance (Ord k, Eq v) => Semigroup (RootMeasure k v) where
+  RootMeasure len1 d1 <> RootMeasure len2 d2 =
+      RootMeasure (len1 <> len2) (d1 <> d2)
+
+instance (Ord k, Eq v) => Monoid (RootMeasure k v) where
+  mempty = RootMeasure mempty mempty
+
+instance (Ord k, Eq v) => Group (RootMeasure k v) where
+  invert (RootMeasure len d) =
+    RootMeasure (invert len) (invert d)
+
+{-------------------------------------------------------------------------------
+  Internal measuring
+-------------------------------------------------------------------------------}
+
+-- FIXME(jdral): It is probably preferable to not use bang patterns here, but
+-- instead to rely use bang patterns in types to enforce strictness of the slot
+-- fields.
+instance Measured (InternalMeasure k v) (Element k v) where
+  measure (Element !sl _d) = InternalMeasure {
+      imLength  = 1
+    , imSlotNoL = Just $ SlotNoLB sl
+    , imSlotNoR = Just $ SlotNoUB sl
+    }
+
+instance Semigroup (InternalMeasure k v) where
+  InternalMeasure len1 sl1L sl1R <> InternalMeasure len2 sl2L sl2R =
+    InternalMeasure (len1 <> len2) (sl1L <> sl2L) (sl1R <> sl2R)
+
+instance Monoid (InternalMeasure k v) where
+  mempty = InternalMeasure mempty mempty mempty
+
+{-------------------------------------------------------------------------------
+  Short-hands types and constraints
+-------------------------------------------------------------------------------}
+
+-- | Short-hand for @'SuperMeasured'@.
+type SM k v =
+  SuperMeasured (RootMeasure k v) (InternalMeasure k v) (Element k v)
+
+{-------------------------------------------------------------------------------
+  API: derived functions
+-------------------------------------------------------------------------------}
+
+cumulativeDiff ::
+     SM k v
+  => DiffSeq k v
+  -> Diff k v
+cumulativeDiff (UnsafeDiffSeq ft) = rmDiff $ measureRoot ft
+
+length ::
+     SM k v
+  => DiffSeq k v -> Int
+length (UnsafeDiffSeq ft) = unLength . rmLength $ measureRoot ft
+
+extend ::
+     SM k v
+  => DiffSeq k v
+  -> Slot.SlotNo
+  -> Diff k v
+  -> DiffSeq k v
+extend (UnsafeDiffSeq ft) sl d =
+    Exn.assert invariant $ UnsafeDiffSeq $ ft |> Element sl d
+  where
+    invariant = case imSlotNoR $ measure ft of
+      Nothing  -> True
+      Just slR -> noSlotBoundsIntersect slR (SlotNoLB sl)
+
+append ::
+     (Ord k, Eq v)
+  => DiffSeq k v
+  -> DiffSeq k v
+  -> DiffSeq k v
+append (UnsafeDiffSeq ft1) (UnsafeDiffSeq ft2) =
+    Exn.assert invariant $ UnsafeDiffSeq (ft1 <> ft2)
+  where
+    sl1R      = imSlotNoR $ measure ft1
+    sl2L      = imSlotNoL $ measure ft2
+    invariant = fromMaybe True (noSlotBoundsIntersect <$> sl1R <*> sl2L)
+
+empty ::
+     (Ord k, Eq v)
+  => DiffSeq k v
+empty = UnsafeDiffSeq mempty
+
+{-------------------------------------------------------------------------------
+  Slots
+-------------------------------------------------------------------------------}
+
+maxSlot ::
+     SM k v
+  => DiffSeq k v
+  -> Maybe Slot.SlotNo
+maxSlot (UnsafeDiffSeq ft) = unSlotNoUB <$> imSlotNoR (measure ft)
+
+minSlot ::
+     SM k v
+  => DiffSeq k v
+  -> Maybe Slot.SlotNo
+minSlot (UnsafeDiffSeq ft) = unSlotNoLB <$> imSlotNoL (measure ft)
+
+{-------------------------------------------------------------------------------
+  Splitting
+-------------------------------------------------------------------------------}
+
+instance Sized (InternalMeasure k v) where
+  size = unLength . imLength
+
+split ::
+     SM k v
+  => (InternalMeasure k v -> Bool)
+  -> DiffSeq k v
+  -> (DiffSeq k v, DiffSeq k v)
+split p (UnsafeDiffSeq ft) = bimap UnsafeDiffSeq UnsafeDiffSeq $ RMFT.splitSized p ft
+
+splitAt ::
+     SM k v
+  => Int
+  -> DiffSeq k v
+  -> (DiffSeq k v, DiffSeq k v)
+splitAt n = split ((Length n<) . imLength)
+
+splitAtFromEnd ::
+     SM k v
+  => Int
+  -> DiffSeq k v
+  -> (DiffSeq k v, DiffSeq k v)
+splitAtFromEnd n dseq =
+    Exn.assert (n <= len) $ splitAt (len - n) dseq
+  where
+    len = length dseq
+
+{-------------------------------------------------------------------------------
+  Maps
+-------------------------------------------------------------------------------}
+
+mapDiffSeq ::
+       ( SM k v
+       , SM k v'
+       )
+    => (v -> v')
+    -> DiffSeq k v
+    -> DiffSeq k v'
+mapDiffSeq f (UnsafeDiffSeq ft) = UnsafeDiffSeq $ fmap' (fmap f) ft

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ConstraintKinds          #-}
 {-# LANGUAGE DeriveAnyClass           #-}
 {-# LANGUAGE DeriveGeneric            #-}
@@ -247,7 +248,7 @@ instance Monad m => ThrowsLedgerError (ExceptT (AnnLedgerError l blk) m) l blk w
 -- * Compute the constraint @c@ on the monad @m@ in order to run the query:
 --   a. If we are passing a block by reference, we must be able to resolve it.
 --   b. If we are applying rather than reapplying, we might have ledger errors.
-type Ap :: (Type -> Type) -> (Type -> Type) -> Type -> Constraint -> Type
+type Ap :: (Type -> Type) -> LedgerStateKind -> Type -> Constraint -> Type
 data Ap m l blk c where
   ReapplyVal ::           blk -> Ap m l blk ()
   ApplyVal   ::           blk -> Ap m l blk (                      ThrowsLedgerError m l blk)
@@ -342,7 +343,7 @@ ledgerDbIsSaturated (SecurityParam k) db =
 -- When no ledger state (or anchor) has the given 'Point', 'Nothing' is
 -- returned.
 ledgerDbPast ::
-     (HeaderHash (l Canonical) ~ HeaderHash l, HasHeader blk, IsLedger l, HeaderHash l ~ HeaderHash blk)
+     (HasHeader blk, IsLedger l, HeaderHash l ~ HeaderHash blk)
   => Point blk
   -> LedgerDB l
   -> Maybe (l Canonical)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
@@ -580,19 +581,19 @@ data TraceReplayEvent blk
   Backing store specializations
 -------------------------------------------------------------------------------}
 
-type LedgerBackingStoreInitialiser :: (Type -> Type) -> (Type -> Type) -> Type
+type LedgerBackingStoreInitialiser :: (Type -> Type) -> LedgerStateKind -> Type
 newtype LedgerBackingStoreInitialiser m l = LedgerBackingStoreInitialiser
   (BackingStoreInitialiser m () () ())
   deriving newtype (NoThunks)
 
 -- | A handle to the backing store for the ledger tables
-type LedgerBackingStore :: (Type -> Type) -> (Type -> Type) -> Type
+type LedgerBackingStore :: (Type -> Type) -> LedgerStateKind -> Type
 newtype LedgerBackingStore m l = LedgerBackingStore
     (BackingStore m  () () ())
   deriving newtype (NoThunks)
 
 -- | A handle to the backing store for the ledger tables
-type LedgerBackingStoreValueHandle :: (Type -> Type) -> (Type -> Type) -> Type
+type LedgerBackingStoreValueHandle :: (Type -> Type) -> LedgerStateKind -> Type
 data LedgerBackingStoreValueHandle m l = LedgerBackingStoreValueHandle
     !(WithOrigin SlotNo)
     !(BackingStoreValueHandle m () ())

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
@@ -2,11 +2,16 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Ouroboros.Consensus.Ticked (Ticked (..)) where
+module Ouroboros.Consensus.Ticked (
+    Ticked (..)
+  , Ticked1
+  ) where
 
 import           Data.Kind (Type)
 import           Data.SOP.BasicFunctors
@@ -28,6 +33,7 @@ import           NoThunks.Class (NoThunks)
 -- * New leader schedule computed for Shelley
 -- * Transition from Byron to Shelley activated in the hard fork combinator.
 -- * Nonces switched out at the start of a new epoch.
+type Ticked :: Type -> Type
 data family Ticked st :: Type
 
 -- Standard instance for use with trivial state
@@ -47,8 +53,16 @@ deriving instance
 
 deriving newtype instance {-# OVERLAPPING #-}
      Show (Ticked (f a))
-  => Show ((Ticked :.: f) a)
+  => Show ((Ticked :.: f) (a :: Type))
 
 deriving newtype instance
      NoThunks (Ticked (f a))
   => NoThunks ((Ticked :.: f) a)
+
+
+{-------------------------------------------------------------------------------
+  @'Ticked'@ for state with a poly-kinded type parameter
+-------------------------------------------------------------------------------}
+
+type Ticked1 :: (k -> Type) -> (k -> Type)
+data family Ticked1 st

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
@@ -34,7 +34,7 @@ import           NoThunks.Class (NoThunks)
 -- * Transition from Byron to Shelley activated in the hard fork combinator.
 -- * Nonces switched out at the start of a new epoch.
 type Ticked :: Type -> Type
-data family Ticked st :: Type
+data family Ticked st
 
 -- Standard instance for use with trivial state
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -1,11 +1,14 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE PolyKinds           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns             #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE KindSignatures           #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeOperators            #-}
 
 -- | Miscellaneous utilities
 module Ouroboros.Consensus.Util (
@@ -53,6 +56,8 @@ module Ouroboros.Consensus.Util (
   , checkThat
     -- * Sets
   , allDisjoint
+    -- * Maps
+  , dimap
     -- * Composition
   , (......:)
   , (.....:)
@@ -60,16 +65,23 @@ module Ouroboros.Consensus.Util (
   , (...:)
   , (..:)
   , (.:)
+    -- * Type-level composition
+  , (:..:) (..)
     -- * Product
   , pairFst
   , pairSnd
     -- * Miscellaneous
   , eitherToMaybe
   , fib
+    -- * Static Either
+  , StaticEither (..)
+  , fromStaticLeft
+  , fromStaticRight
   ) where
 
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashFromBytes,
                      hashFromBytesShort)
+import           Data.Bifunctor (Bifunctor (first, second))
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
@@ -80,6 +92,8 @@ import           Data.Functor.Product
 import           Data.Kind (Constraint, Type)
 import           Data.List (foldl', maximumBy)
 import           Data.List.NonEmpty (NonEmpty (..), (<|))
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -361,6 +375,15 @@ allDisjoint = go Set.empty
     go acc (xs:xss) = Set.disjoint acc xs && go (Set.union acc xs) xss
 
 {-------------------------------------------------------------------------------
+  Maps
+-------------------------------------------------------------------------------}
+
+-- | Map over keys and values
+dimap :: Ord k2 => (k1 -> k2) -> (v1 -> v2) -> Map k1 v1 -> Map k2 v2
+dimap keyFn valFn = Map.foldlWithKey update Map.empty
+  where update m k1 v1 =  Map.insert (keyFn k1) (valFn v1) m
+
+{-------------------------------------------------------------------------------
   Composition
 -------------------------------------------------------------------------------}
 
@@ -381,6 +404,19 @@ allDisjoint = go Set.empty
 
 (......:) :: (y -> z) -> (x0 -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> y) -> (x0 -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> z)
 (f ......: g) x0 x1 x2 x3 x4 x5 x6 = f (g x0 x1 x2 x3 x4 x5 x6)
+
+{-------------------------------------------------------------------------------
+  Type-level composition
+-------------------------------------------------------------------------------}
+
+-- | Compose two types where the second one expects two type variables
+--
+-- @@
+--   Comp2 (Just (Left "hi")) :: (Maybe :..: Either) String Int
+-- @@
+type (:..:) :: (y -> Type) -> (x0 -> x1 -> y) -> (x0 -> x1 -> Type)
+newtype (f :..: g) p r = Comp2 { unComp2 :: f (g p r) }
+
 {-------------------------------------------------------------------------------
   Product
 -------------------------------------------------------------------------------}
@@ -406,3 +442,24 @@ fib n = round $ phi ** fromIntegral n / sq5
 eitherToMaybe :: Either a b -> Maybe b
 eitherToMaybe (Left _)  = Nothing
 eitherToMaybe (Right x) = Just x
+
+{-------------------------------------------------------------------------------
+  Static Either
+-------------------------------------------------------------------------------}
+
+data StaticEither :: Bool -> Type -> Type -> Type where
+  StaticLeft  :: l -> StaticEither False l r
+  StaticRight :: r -> StaticEither True  l r
+
+instance Bifunctor (StaticEither b) where
+  first f (StaticLeft  l) = StaticLeft  (f l)
+  first _ (StaticRight r) = StaticRight    r
+
+  second _ (StaticLeft l)  = StaticLeft l
+  second f (StaticRight r) = StaticRight (f r)
+
+fromStaticLeft :: StaticEither 'False l r -> l
+fromStaticLeft (StaticLeft x) = x
+
+fromStaticRight :: StaticEither 'True l r -> r
+fromStaticRight (StaticRight x) = x

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
--- | A Read-Append-Write (RAW) lock
+-- | A writer-biased Readers-Appender-Writer (RAW) lock
 --
 -- Intended for qualified import
 module Ouroboros.Consensus.Util.MonadSTM.RAWLock (
@@ -31,7 +32,7 @@ import           Control.Monad.Except
 import           Data.Functor (($>))
 import           GHC.Generics (Generic)
 import           GHC.Stack (CallStack, HasCallStack, callStack)
-import           NoThunks.Class (AllowThunk (..))
+import           NoThunks.Class (AllowThunk (..), OnlyCheckWhnfNamed (..))
 
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -145,6 +146,7 @@ import           Ouroboros.Consensus.Util.IOLike
 -- * All public functions are exception-safe.
 --
 newtype RAWLock m st = RAWLock (StrictTVar m (RAWState st))
+  deriving NoThunks via OnlyCheckWhnfNamed "RAWLock" (RAWLock m st)
 
 -- | Create a new 'RAWLock'
 new :: (IOLike m, NoThunks st) => st -> m (RAWLock m st)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -1,18 +1,19 @@
-{-# LANGUAGE BangPatterns         #-}
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE EmptyCase            #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE BangPatterns             #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE EmptyCase                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneDeriving       #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 module Ouroboros.Consensus.Util.SOP (
     -- * Minor variations on standard SOP operators
@@ -47,6 +48,16 @@ module Ouroboros.Consensus.Util.SOP (
   , hizipWith
   , hizipWith3
   , hizipWith4
+    -- * Tuples
+  , ApOnlySnd (..)
+  , ApOnlySnd2 (..)
+  , Fst
+  , MapSnd
+  , NsMapSnd (..)
+  , Snd
+  , Uncurry
+  , UncurryComp (..)
+  , castSndIdx
   ) where
 
 import           Data.Coerce
@@ -312,3 +323,54 @@ hizipWith4 ::
   -> h  f4 xs
   -> h  f5 xs
 hizipWith4 = hcizipWith4 (Proxy @Top)
+
+
+{-------------------------------------------------------------------------------
+  Tuples
+-------------------------------------------------------------------------------}
+
+type Fst :: (a, b) -> a
+type family Fst t where
+  Fst '(a,b) = a
+
+type Snd :: (a, b) -> b
+type family Snd t where
+    Snd '(a,b) = b
+
+type MapSnd :: [(Type, Type)] -> [Type]
+type family MapSnd xs where
+  MapSnd '[]       = '[]
+  MapSnd (x ': xs) = Snd x ': MapSnd xs
+
+type UncurryComp ::
+     (Type -> Type)
+  -> (Type -> Type -> Type)
+  -> (Type, Type)
+  -> Type
+newtype UncurryComp f g ab = UncurryComp (f (Uncurry g ab))
+
+type Uncurry :: (a -> b -> k) -> (a, b) -> k
+type family Uncurry f ab where
+  Uncurry f ab = (f (Fst ab) (Snd ab))
+
+type ApOnlySnd :: (a -> Type) -> (b, a) -> Type
+newtype ApOnlySnd f ba = ApOnlySnd { unApOnlySnd :: f (Snd ba) }
+
+type ApOnlySnd2 :: (a -> a -> Type) -> (b, a) -> (b, a) -> Type
+newtype ApOnlySnd2 f ab ab' = ApOnlySnd2 (f (Snd ab) (Snd ab'))
+
+class NsMapSnd xs where
+  nsMapSnd :: NS f (MapSnd xs) -> NS (ApOnlySnd f) xs
+
+instance NsMapSnd '[] where
+  nsMapSnd = \case {}
+
+instance NsMapSnd xs => NsMapSnd (x ': xs) where
+  nsMapSnd = \case
+    Z fx -> Z (ApOnlySnd fx)
+    S ns -> S (nsMapSnd ns)
+
+castSndIdx :: Index xs x -> Index (MapSnd xs) (Snd x)
+castSndIdx = \case
+  IZ   -> IZ
+  IS n -> IS (castSndIdx n)

--- a/ouroboros-network-api/src/Ouroboros/Network/AnchoredSeq.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/AnchoredSeq.hs
@@ -45,6 +45,7 @@ module Ouroboros.Network.AnchoredSeq
   , splitAfterMeasure
   , splitBeforeMeasure
   , join
+  , unsafeJoin
   , anchorNewest
   , selectOffsets
   , filter
@@ -632,6 +633,14 @@ join f s1@(AnchoredSeq a1 ft1) (AnchoredSeq a2 ft2)
     = Just $ AnchoredSeq a1 (ft1 FT.>< ft2)
     | otherwise
     = Nothing
+
+unsafeJoin ::
+     forall v a b. Anchorable v a b
+  => AnchoredSeq v a b
+  -> AnchoredSeq v a b
+  -> AnchoredSeq v a b
+unsafeJoin (AnchoredSeq a1 ft1) (AnchoredSeq _a2 ft2) =
+    AnchoredSeq a1 (ft1 FT.>< ft2)
 
 -- | \( O(o \log(\min(i,n-i))) \). Select the elements and optionally the anchor
 -- based on the given offsets, starting from the head of the 'AnchoredSeq'.


### PR DESCRIPTION
# Description

This PR defines the typeclasses used in the UTxO-HD implementation. Instances are provided for all the blocks in the repository, but for now some of them are just trivial instances.

It also defines the `BackingStore` interface used to access the backend for UTxO-HD values.

An important note to make is that *every* block is required to define all the UTxO-HD interface albeit trivial. This makes sense as all blocks are supposed to work the same way, even if we then don't ever use some of the instances.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the
          appropriate `changelog.d` directory created using
          [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see
          the [Consensus release
          process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
