### PR TITLE
Introduce `HasLedgerTables` and related operations

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,12 +13,12 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for some Nix commands you will need to run if you
 -- update either of these.
 -- repeat the index-state for hackage to work around haskell.nix parsing limitation
-index-state: 2023-01-19T00:00:00Z
+index-state: 2023-02-18T00:00:00Z
 index-state: 
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-01-19T00:00:00Z
+  , hackage.haskell.org 2023-02-18T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2022-11-15T00:00:00Z
+  , cardano-haskell-packages 2023-02-18T00:00:00Z
 
 packages: ./cardano-ping
           ./ouroboros-network-testing

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -123,6 +123,8 @@ library
                        Ouroboros.Consensus.Ledger.SupportsMempool
                        Ouroboros.Consensus.Ledger.SupportsPeerSelection
                        Ouroboros.Consensus.Ledger.SupportsProtocol
+                       Ouroboros.Consensus.Ledger.Tables
+                       Ouroboros.Consensus.Ledger.Tables.Utils
                        Ouroboros.Consensus.Mempool
                        Ouroboros.Consensus.Mempool.API
                        Ouroboros.Consensus.Mempool.Capacity
@@ -228,6 +230,7 @@ library
                        Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
                        Ouroboros.Consensus.Storage.LedgerDB
                        Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+                       Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq
                        Ouroboros.Consensus.Storage.LedgerDB.Init
                        Ouroboros.Consensus.Storage.LedgerDB.InMemory
                        Ouroboros.Consensus.Storage.LedgerDB.LedgerDB
@@ -308,6 +311,7 @@ library
                      , directory         >=1.3   && <1.4
                      , filelock
                      , filepath          >=1.4   && <1.5
+                     , groups
                      , hashable
                      , measures
                      , mtl               >=2.2   && <2.3
@@ -325,6 +329,8 @@ library
                      , transformers
                      , vector            >=0.12  && <0.13
 
+                     , diff-containers
+                     , fingertree-rm
                      , io-classes       ^>=0.3
                      , typed-protocols
                      , ouroboros-network-api

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
@@ -1,0 +1,618 @@
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DefaultSignatures        #-}
+{-# LANGUAGE DeriveAnyClass           #-}
+{-# LANGUAGE DeriveGeneric            #-}
+{-# LANGUAGE DerivingStrategies       #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE QuantifiedConstraints    #-}
+{-# LANGUAGE Rank2Types               #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeFamilies             #-}
+
+-- | See @'LedgerTables'@
+module Ouroboros.Consensus.Ledger.Tables (
+    -- * Kinds
+    LedgerStateKind
+  , MapKind
+    -- * Basic LedgerState classes
+  , CanStowLedgerTables (..)
+  , HasLedgerTables (..)
+  , HasTickedLedgerTables (..)
+  , mapOverLedgerTables
+  , mapOverLedgerTablesTicked
+  , zipOverLedgerTables
+  , zipOverLedgerTablesTicked
+    -- * @MapKind@s
+    -- $concrete-tables
+
+    -- ** Interface
+  , IsMapKind (..)
+    -- ** Concrete definitions
+  , Canonical (..)
+  , CodecMK (..)
+  , DiffMK (..)
+  , EmptyMK (..)
+  , KeysMK (..)
+  , NameMK (..)
+  , SeqDiffMK (..)
+  , TrackingMK (..)
+  , ValuesMK (..)
+    -- * Serialization
+  , CanSerializeLedgerTables (..)
+  , valuesMKDecoder
+  , valuesMKEncoder
+    -- * Special classes
+  , LedgerTablesAreTrivial (..)
+  ) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Control.Exception as Exn
+import           Data.Kind (Constraint, Type)
+import           Data.Map.Diff.Strict (Diff)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Monoid (Sum (..))
+import           Data.Set (Set)
+import           GHC.Generics
+import           NoThunks.Class (NoThunks (..))
+
+import           Ouroboros.Consensus.Ticked
+
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (DiffSeq,
+                     empty, mapDiffSeq)
+
+{-------------------------------------------------------------------------------
+  Kinds
+-------------------------------------------------------------------------------}
+
+type MapKind         = {- key -} Type -> {- value -} Type -> Type
+type LedgerStateKind = MapKind -> Type
+
+{-------------------------------------------------------------------------------
+  Basic LedgerState classes
+-------------------------------------------------------------------------------}
+
+-- | Manipulating the @mk@ on the @'LedgerTables'@, extracting @'LedgerTables'@
+-- from a @'LedgerState'@ (which will share the same @mk@), or replacing the
+-- @'LedgerTables'@ associated to a particular in-memory @'LedgerState'@.
+type HasLedgerTables :: LedgerStateKind -> Constraint
+class ( forall mk. IsMapKind mk => Eq       (LedgerTables l mk)
+      , forall mk. IsMapKind mk => NoThunks (LedgerTables l mk)
+      , forall mk. IsMapKind mk => Show     (LedgerTables l mk)
+      ) => HasLedgerTables l where
+
+  -- | The Ledger Tables represent the portion of the data on disk that has been
+  -- pulled from disk and attached to the in-memory Ledger State or that will
+  -- eventually be written to disk.
+  --
+  -- With UTxO-HD and the split of the Ledger State into the in-memory part and
+  -- the on-disk part, this splitting was reflected in the new type parameter
+  -- added to the Ledger State, to which we refer as "the MapKind" or @mk@.
+  --
+  -- Every @'LedgerState'@ is associated with a @'LedgerTables'@ and they both
+  -- share the @mk@. They both are of kind @'LedgerStateKind'@. @'LedgerTables'@
+  -- is just a way to refer /only/ to a partial view of the on-disk data without
+  -- having the rest of the in-memory Ledger State in scope.
+  --
+  -- The @mk@ can be instantiated to anything that is map-like, i.e. that expects
+  -- two type parameters, the key and the value.
+  data family LedgerTables l :: LedgerStateKind
+
+  -- | Extract the ledger tables from a ledger state
+  --
+  -- This 'IsMapKind' constraint is necessary because the 'CardanoBlock'
+  -- instance uses 'mapMK'.
+  projectLedgerTables :: forall mk. IsMapKind mk => l mk -> LedgerTables l mk
+  default projectLedgerTables ::
+        LedgerTablesAreTrivial l
+      => l mk
+      -> LedgerTables l mk
+  projectLedgerTables _ = trivialLedgerTables
+
+  -- | Overwrite the tables in the given ledger state.
+  --
+  -- The contents of the tables should not be /younger/ than the content of the
+  -- ledger state. In particular, for a
+  -- 'Ouroboros.Consensus.HardFork.Combinator.Basics.HardForkBlock' ledger, the
+  -- tables argument should not contain any data from eras that succeed the
+  -- current era of the ledger state argument.
+  --
+  -- This 'IsMapKind' constraint is necessary because the 'CardanoBlock'
+  -- instance uses 'mapMK'.
+  withLedgerTables :: IsMapKind mk => l any -> LedgerTables l mk -> l mk
+  default withLedgerTables ::
+       (IsMapKind mk, LedgerTablesAreTrivial l)
+    => l any
+    -> LedgerTables l mk
+    -> l mk
+  withLedgerTables st _ = convertMapKind st
+
+  pureLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+       )
+    -> LedgerTables l mk
+  default pureLedgerTables ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+       )
+    -> LedgerTables l mk
+  pureLedgerTables _ = trivialLedgerTables
+
+  mapLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+  default mapLedgerTables ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+  mapLedgerTables _ _ = trivialLedgerTables
+
+  traverseLedgerTables ::
+       Applicative f
+    => (forall k v .
+           (Ord k, Eq v)
+        =>    mk1 k v
+        -> f (mk2 k v)
+       )
+    ->    LedgerTables l mk1
+    -> f (LedgerTables l mk2)
+  default traverseLedgerTables ::
+       (Applicative f, LedgerTablesAreTrivial l)
+    => (forall k v .
+           (Ord k, Eq v)
+        =>    mk1 k v
+        -> f (mk2 k v)
+       )
+    ->    LedgerTables l mk1
+    -> f (LedgerTables l mk2)
+  traverseLedgerTables _ _ = pure trivialLedgerTables
+
+  zipLedgerTables ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+  default zipLedgerTables ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+  zipLedgerTables _ _ _ = trivialLedgerTables
+
+  zipLedgerTables2 ::
+       (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> mk4 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> LedgerTables l mk4
+  default zipLedgerTables2 ::
+       LedgerTablesAreTrivial l
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> mk4 k v
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> LedgerTables l mk4
+  zipLedgerTables2 _ _ _ _ = trivialLedgerTables
+
+  zipLedgerTablesA ::
+       Applicative f
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> f (mk3 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> f (LedgerTables l mk3)
+  default zipLedgerTablesA ::
+       (Applicative f, LedgerTablesAreTrivial l)
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> f (mk3 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> f (LedgerTables l mk3)
+  zipLedgerTablesA _ _ _ = pure trivialLedgerTables
+
+  zipLedgerTables2A ::
+       Applicative f
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> f (mk4 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> f (LedgerTables l mk4)
+  default zipLedgerTables2A ::
+       (Applicative f, LedgerTablesAreTrivial l)
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk1 k v
+         -> mk2 k v
+         -> mk3 k v
+         -> f (mk4 k v)
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> LedgerTables l mk3
+    -> f (LedgerTables l mk4)
+  zipLedgerTables2A _ _ _ _ = pure trivialLedgerTables
+
+  foldLedgerTables ::
+       Monoid m
+    => (forall k v.
+            (Ord k, Eq v)
+         => mk k v
+         -> m
+       )
+    -> LedgerTables l mk
+    -> m
+  foldLedgerTables _ _ = mempty
+
+  foldLedgerTables2 ::
+       Monoid m
+    => (forall k v.
+           (Ord k, Eq v)
+        => mk1 k v
+        -> mk2 k v
+        -> m
+       )
+    -> LedgerTables l mk1
+    -> LedgerTables l mk2
+    -> m
+  foldLedgerTables2 _ _ _ = mempty
+
+  -- | The ledger tables will eventually be stored in some BackingStore under a
+  -- db-like table named after this value
+  namesLedgerTables :: LedgerTables l NameMK
+  default namesLedgerTables :: LedgerTablesAreTrivial l => LedgerTables l NameMK
+  namesLedgerTables = trivialLedgerTables
+
+overLedgerTables ::
+     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (LedgerTables l mk1 -> LedgerTables l mk2)
+  -> l mk1
+  -> l mk2
+overLedgerTables f l = withLedgerTables l $ f $ projectLedgerTables l
+
+mapOverLedgerTables ::
+     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (forall k v.
+          (Ord k, Eq v)
+       => mk1 k v
+       -> mk2 k v
+     )
+  -> l mk1
+  -> l mk2
+mapOverLedgerTables f = overLedgerTables $ mapLedgerTables f
+
+zipOverLedgerTables ::
+     (HasLedgerTables l, IsMapKind mk1, IsMapKind mk3)
+  => (forall k v.
+          (Ord k, Eq v)
+       => mk1 k v
+       -> mk2 k v
+       -> mk3 k v
+     )
+  ->              l mk1
+  -> LedgerTables l mk2
+  ->              l mk3
+zipOverLedgerTables f l tables2 =
+    overLedgerTables
+      (\tables1 -> zipLedgerTables f tables1 tables2)
+      l
+
+type HasTickedLedgerTables :: LedgerStateKind -> Constraint
+class HasLedgerTables l => HasTickedLedgerTables l where
+  -- The 'IsMapKind' constraint is here for the same reason it's on
+  -- 'projectLedgerTables'
+  projectLedgerTablesTicked :: IsMapKind mk => Ticked1 l mk  -> LedgerTables l mk
+  default projectLedgerTablesTicked ::
+       LedgerTablesAreTrivial l
+    => Ticked1 l mk
+    -> LedgerTables l mk
+  projectLedgerTablesTicked _ = trivialLedgerTables
+
+  -- The 'IsMapKind' constraint is here for the same reason it's on
+  -- 'withLedgerTables'
+  withLedgerTablesTicked :: IsMapKind mk => Ticked1 l any -> LedgerTables l mk -> Ticked1 l mk
+
+overLedgerTablesTicked ::
+     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (LedgerTables l mk1 -> LedgerTables l mk2)
+  -> Ticked1 l mk1
+  -> Ticked1 l mk2
+overLedgerTablesTicked f l =
+    withLedgerTablesTicked l $ f $ projectLedgerTablesTicked l
+
+mapOverLedgerTablesTicked ::
+     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk2)
+  => (forall k v.
+         (Ord k, Eq v)
+      => mk1 k v
+      -> mk2 k v
+     )
+  -> Ticked1 l mk1
+  -> Ticked1 l mk2
+mapOverLedgerTablesTicked f = overLedgerTablesTicked $ mapLedgerTables f
+
+zipOverLedgerTablesTicked ::
+     (HasTickedLedgerTables l, IsMapKind mk1, IsMapKind mk3)
+  => (forall k v.
+         (Ord k, Eq v)
+      => mk1 k v
+      -> mk2 k v
+      -> mk3 k v
+     )
+  -> Ticked1      l mk1
+  -> LedgerTables l mk2
+  -> Ticked1      l mk3
+zipOverLedgerTablesTicked f l tables2 =
+    overLedgerTablesTicked
+      (\tables1 -> zipLedgerTables f tables1 tables2)
+      l
+
+-- | LedgerTables are projections of data from a LedgerState and as such they
+-- can be injected back into a LedgerState. This is necessary because the Ledger
+-- rules are unaware of UTxO-HD changes. Thus, by stowing the ledger tables, we are
+-- able to provide a Ledger State with a restricted UTxO set that is enough to
+-- execute the Ledger rules.
+type CanStowLedgerTables :: LedgerStateKind -> Constraint
+class CanStowLedgerTables l where
+
+  stowLedgerTables     :: l ValuesMK -> l EmptyMK
+  default stowLedgerTables :: LedgerTablesAreTrivial l => l ValuesMK -> l EmptyMK
+  stowLedgerTables = convertMapKind
+
+  unstowLedgerTables   :: l EmptyMK  -> l ValuesMK
+  default unstowLedgerTables :: LedgerTablesAreTrivial l => l EmptyMK -> l ValuesMK
+  unstowLedgerTables = convertMapKind
+
+{-------------------------------------------------------------------------------
+  @MapKind@s
+-------------------------------------------------------------------------------}
+
+{- $concrete-tables
+
+We provide here  the usual structures that we expect to deal with, namely:
+
+- 'ValuesMK': a map of keys to values
+
+- 'KeysMK': a set of keys
+
+- 'DiffMK': a map of keys to value differences
+
+- 'TrackingMK': the product of both 'ValuesMK' and 'DiffMK'
+
+- 'SeqDiffMK': an efficient sequence of differences
+
+- 'CodecMK': @CBOR@ encoder and decoder for the key and value
+
+-}
+
+-- | A general interface to mapkinds.
+--
+-- In some cases where @mk@ is not specialised to a concrete mapkind like
+-- @'ValuesMK'@, there are often still a number of operations that we can
+-- perform for this @mk@ that make sense regardless of the concrete mapkind. For
+-- example, we should always be able to map over a mapkind to change the type of
+-- values that it contains. This class is an interface to mapkinds that provides
+-- such common functions.
+type IsMapKind :: MapKind -> Constraint
+class ( forall k v. (Eq       k, Eq       v) => Eq       (mk k v)
+      , forall k v. (NoThunks k, NoThunks v) => NoThunks (mk k v)
+      , forall k v. (Show     k, Show     v) => Show     (mk k v)
+      ) => IsMapKind mk where
+  emptyMK :: forall k v. (Ord k, Eq v) => mk k v
+  default emptyMK :: forall k v. Monoid (mk k v) => mk k v
+  emptyMK = mempty
+
+  mapMK :: forall k v v'. (Ord k, Eq v, Eq v') => (v -> v') -> mk k v -> mk k v'
+  default mapMK :: forall k v v'. (Functor (mk k)) => (v -> v') -> mk k v -> mk k v'
+  mapMK = fmap
+
+-- | The Canonical MapKind, which has no constructor, and therefore a
+-- @LedgerState blk Canonical@ will have all the contents in memory. This is
+-- just a phantom type used to sketch later development and shall not land on
+-- the release version.
+data Canonical k v = Canonical
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+newtype DiffMK     k v = DiffMK      (Diff k v)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+data    EmptyMK    k v = EmptyMK
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+newtype KeysMK     k v = KeysMK      (Set k)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+newtype SeqDiffMK  k v = SeqDiffMK   (DiffSeq k v)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+data    TrackingMK k v = TrackingMK !(Map k v) !(Diff k v)
+  deriving (Generic, Eq, Show, NoThunks)
+
+newtype ValuesMK   k v = ValuesMK    (Map k v)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass NoThunks
+
+-- | A codec 'MapKind' that will be used to refer to @'LedgerTables' l CodecMK@
+-- as the codecs that can encode every key and value in the @'LedgerTables' l
+-- mk@.
+data CodecMK k v = CodecMK
+                     (k -> CBOR.Encoding)
+                     (v -> CBOR.Encoding)
+                     (forall s . CBOR.Decoder s k)
+                     (forall s . CBOR.Decoder s v)
+
+newtype NameMK k v = NameMK String
+
+instance IsMapKind Canonical where
+  emptyMK = Canonical
+  mapMK _ Canonical = Canonical
+
+instance IsMapKind EmptyMK where
+  emptyMK = EmptyMK
+  mapMK _ EmptyMK = EmptyMK
+
+instance IsMapKind KeysMK where
+  emptyMK = KeysMK mempty
+  mapMK _ (KeysMK ks) = KeysMK ks
+
+instance IsMapKind ValuesMK where
+  emptyMK = ValuesMK mempty
+  mapMK f (ValuesMK vs) = ValuesMK $ fmap f vs
+
+instance IsMapKind TrackingMK where
+  emptyMK = TrackingMK mempty mempty
+  mapMK f (TrackingMK vs d) = TrackingMK (fmap f vs) (fmap f d)
+
+instance IsMapKind DiffMK where
+  emptyMK = DiffMK mempty
+  mapMK f (DiffMK d) = DiffMK $ fmap f d
+
+instance IsMapKind SeqDiffMK where
+  emptyMK = SeqDiffMK empty
+  mapMK f (SeqDiffMK ds) = SeqDiffMK $ mapDiffSeq f ds
+
+instance Ord k => Semigroup (KeysMK k v) where
+  KeysMK l <> KeysMK r = KeysMK (l <> r)
+
+instance Ord k => Monoid (KeysMK k v) where
+  mempty = KeysMK mempty
+
+instance Functor (DiffMK k) where
+  fmap f (DiffMK d) = DiffMK $ fmap f d
+
+{-------------------------------------------------------------------------------
+  Serialization Codecs
+-------------------------------------------------------------------------------}
+
+-- | This class provides a 'CodecMK' that can be used to encode/decode keys and
+-- values on @'LedgerTables' l mk@
+type CanSerializeLedgerTables :: LedgerStateKind -> Constraint
+class CanSerializeLedgerTables l where
+  codecLedgerTables :: LedgerTables l CodecMK
+  default codecLedgerTables :: LedgerTablesAreTrivial l => LedgerTables l CodecMK
+  codecLedgerTables = trivialLedgerTables
+
+-- | Default encoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
+-- in-memory backing store.
+valuesMKEncoder ::
+     ( HasLedgerTables l
+     , CanSerializeLedgerTables l
+     )
+  => LedgerTables l ValuesMK
+  -> CBOR.Encoding
+valuesMKEncoder tables =
+       CBOR.encodeListLen (getSum (foldLedgerTables (\_ -> Sum 1) tables))
+    <> foldLedgerTables2 go codecLedgerTables tables
+  where
+    go :: CodecMK k v -> ValuesMK k v -> CBOR.Encoding
+    go (CodecMK encK encV _decK _decV) (ValuesMK m) =
+         CBOR.encodeMapLen (fromIntegral $ Map.size m)
+      <> Map.foldMapWithKey (\k v -> encK k <> encV v) m
+
+-- | Default decoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
+-- in-memory backing store.
+valuesMKDecoder ::
+     ( HasLedgerTables l
+     , CanSerializeLedgerTables l
+     )
+  => CBOR.Decoder s (LedgerTables l ValuesMK)
+valuesMKDecoder = do
+    numTables <- CBOR.decodeListLen
+    if numTables == 0
+      then
+        return $ pureLedgerTables emptyMK
+      else do
+        mapLen <- CBOR.decodeMapLen
+        ret    <- traverseLedgerTables (go mapLen) codecLedgerTables
+        Exn.assert ((getSum (foldLedgerTables (\_ -> Sum 1) ret)) == numTables)
+          $ return ret
+ where
+  go :: Ord k
+     => Int
+     -> CodecMK k v
+     -> CBOR.Decoder s (ValuesMK k v)
+  go len (CodecMK _encK _encV decK decV) =
+        ValuesMK . Map.fromList
+    <$> sequence (replicate len ((,) <$> decK <*> decV))
+
+{-------------------------------------------------------------------------------
+  Special classes of ledger states
+-------------------------------------------------------------------------------}
+
+type LedgerTablesAreTrivial :: LedgerStateKind -> Constraint
+-- | For some ledger states we won't be defining 'LedgerTables' and instead the
+-- ledger state will be fully stored in memory, as before UTxO-HD. The ledger
+-- states that are defined this way can be made instances of this class which
+-- allows for easy manipulation of the types of @mk@ required at any step of the
+-- program.
+class LedgerTablesAreTrivial l where
+  -- | If the ledger state is always in memory, then @l mk@ will be isomorphic
+  -- to @l mk'@ for all @mk@, @mk'@. As a result, we can convert between ledgers
+  -- states indexed by different map kinds.
+  --
+  -- This function is useful to combine functions that operate on functions that
+  -- transform the map kind on a ledger state (eg @applyChainTickLedgerResult@).
+  convertMapKind :: IsMapKind mk' => l mk -> l mk'
+  default convertMapKind :: (IsMapKind mk', HasLedgerTables l) => l mk -> l mk'
+  convertMapKind st = st `withLedgerTables` trivialLedgerTables
+
+  -- | As the ledger tables are trivial, this functions provides the only data
+  -- constructor that is defined for them.
+  trivialLedgerTables :: LedgerTables l mk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+-- | A collection of useful combinators to shorten the code in other places.
+--
+-- TODO: #4394 provide better ergonomics. This whole module provides ways to
+-- combine tables of two ledger states to produce another one. It is written
+-- very much ad-hoc and we should probably think of some way to make this more
+-- ergonomic. In particular for functions that take two ledger states, it is
+-- unclear if it will keep the in-memory part of the first or the second one.
+module Ouroboros.Consensus.Ledger.Tables.Utils (
+    applyLedgerTablesDiffs
+  , applyLedgerTablesDiffsTicked
+  , attachAndApplyDiffsTicked
+  , calculateAdditions
+  , calculateDifference
+  , calculateDifferenceTicked
+  , emptyLedgerTables
+  , forgetLedgerTables
+  , forgetLedgerTablesDiffs
+  , forgetLedgerTablesDiffsTicked
+  , forgetLedgerTablesValues
+  , forgetLedgerTablesValuesTicked
+  , noNewTickingDiffs
+  , prependLedgerTablesDiffs
+  , prependLedgerTablesDiffsFromTicked
+  , prependLedgerTablesDiffsRaw
+  , prependLedgerTablesDiffsTicked
+  , prependLedgerTablesTrackingDiffs
+  , rawReapplyTracking
+  , reapplyTrackingTicked
+    -- * Testing
+  , rawApplyDiffs
+  , rawCalculateDifference
+  , rawForgetValues
+  , rawPrependTrackingDiffs
+  ) where
+
+import           Data.Map.Diff.Strict
+import           Data.Map.Diff.Strict.Internal
+
+import           Ouroboros.Consensus.Ticked
+
+import           Ouroboros.Consensus.Ledger.Tables
+
+-- | When applying a block that is not on an era transition, ticking won't
+-- generate new values, so this function can be used to wrap the call to the
+-- ledger rules that perform the tick.
+noNewTickingDiffs :: HasTickedLedgerTables l
+                   => l any
+                   -> l DiffMK
+noNewTickingDiffs l = withLedgerTables l emptyLedgerTables
+
+{-------------------------------------------------------------------------------
+  Utils aliases
+-------------------------------------------------------------------------------}
+
+-- | Empty values for every table
+emptyLedgerTables :: forall mk l. (HasLedgerTables l, IsMapKind mk) => LedgerTables l mk
+emptyLedgerTables = pureLedgerTables emptyMK
+
+-- Forget all
+
+forgetLedgerTables :: HasLedgerTables l => l mk -> l EmptyMK
+forgetLedgerTables l = withLedgerTables l emptyLedgerTables
+
+-- Forget values
+
+rawForgetValues :: TrackingMK k v -> DiffMK k v
+rawForgetValues (TrackingMK _vs d) = DiffMK d
+
+forgetLedgerTablesValues :: HasLedgerTables l => l TrackingMK -> l DiffMK
+forgetLedgerTablesValues = mapOverLedgerTables rawForgetValues
+
+forgetLedgerTablesValuesTicked :: HasTickedLedgerTables l => Ticked1 l TrackingMK -> Ticked1 l DiffMK
+forgetLedgerTablesValuesTicked = mapOverLedgerTablesTicked rawForgetValues
+
+-- Forget diffs
+
+rawForgetDiffs :: TrackingMK k v -> ValuesMK k v
+rawForgetDiffs (TrackingMK vs _ds) = ValuesMK vs
+
+forgetLedgerTablesDiffs       ::       HasLedgerTables l =>         l TrackingMK ->         l ValuesMK
+forgetLedgerTablesDiffsTicked :: HasTickedLedgerTables l => Ticked1 l TrackingMK -> Ticked1 l ValuesMK
+forgetLedgerTablesDiffs       = mapOverLedgerTables rawForgetDiffs
+forgetLedgerTablesDiffsTicked = mapOverLedgerTablesTicked rawForgetDiffs
+
+-- Prepend diffs
+
+rawPrependDiffs ::
+     (Ord k, Eq v)
+  => DiffMK k v -- ^ Earlier differences
+  -> DiffMK k v -- ^ Later differences
+  -> DiffMK k v
+rawPrependDiffs (DiffMK d1) (DiffMK d2) = DiffMK (d1 <> d2)
+
+prependLedgerTablesDiffsRaw        ::       HasLedgerTables l => LedgerTables l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffs           ::       HasLedgerTables l =>              l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffsFromTicked :: HasTickedLedgerTables l => Ticked1      l DiffMK ->         l DiffMK ->         l DiffMK
+prependLedgerTablesDiffsTicked     :: HasTickedLedgerTables l =>              l DiffMK -> Ticked1 l DiffMK -> Ticked1 l DiffMK
+prependLedgerTablesDiffsRaw        = flip (zipOverLedgerTables rawPrependDiffs)
+prependLedgerTablesDiffs           = prependLedgerTablesDiffsRaw . projectLedgerTables
+prependLedgerTablesDiffsFromTicked = prependLedgerTablesDiffsRaw . projectLedgerTablesTicked
+prependLedgerTablesDiffsTicked     = flip (zipOverLedgerTablesTicked rawPrependDiffs) . projectLedgerTables
+
+-- Apply diffs
+
+rawApplyDiffs ::
+     Ord k
+  => ValuesMK k v -- ^ Values to which differences are applied
+  -> DiffMK   k v -- ^ Differences to apply
+  -> ValuesMK k v
+rawApplyDiffs (ValuesMK vals) (DiffMK diffs) = ValuesMK (unsafeApplyDiff vals diffs)
+
+applyLedgerTablesDiffs       ::       HasLedgerTables l => l ValuesMK ->         l DiffMK ->         l ValuesMK
+applyLedgerTablesDiffsTicked :: HasTickedLedgerTables l => l ValuesMK -> Ticked1 l DiffMK -> Ticked1 l ValuesMK
+applyLedgerTablesDiffs       = flip (zipOverLedgerTables       $ flip rawApplyDiffs) . projectLedgerTables
+applyLedgerTablesDiffsTicked = flip (zipOverLedgerTablesTicked $ flip rawApplyDiffs) . projectLedgerTables
+
+-- Calculate differences
+
+rawCalculateDifference ::
+     (Ord k, Eq v)
+  => ValuesMK   k v
+  -> ValuesMK   k v
+  -> TrackingMK k v
+rawCalculateDifference (ValuesMK before) (ValuesMK after) = TrackingMK after (diff before after)
+
+calculateAdditions        ::       HasLedgerTables l =>         l ValuesMK ->                               l TrackingMK
+calculateDifference       :: HasTickedLedgerTables l => Ticked1 l ValuesMK ->         l ValuesMK ->         l TrackingMK
+calculateDifferenceTicked :: HasTickedLedgerTables l => Ticked1 l ValuesMK -> Ticked1 l ValuesMK -> Ticked1 l TrackingMK
+calculateAdditions               after = zipOverLedgerTables       (flip rawCalculateDifference) after emptyLedgerTables
+calculateDifference       before after = zipOverLedgerTables       (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
+calculateDifferenceTicked before after = zipOverLedgerTablesTicked (flip rawCalculateDifference) after (projectLedgerTablesTicked before)
+
+rawAttachAndApplyDiffs ::
+     Ord k
+  => DiffMK     k v
+  -> ValuesMK   k v
+  -> TrackingMK k v
+rawAttachAndApplyDiffs (DiffMK d) (ValuesMK v) = TrackingMK (unsafeApplyDiff v d) d
+
+-- | Replace the tables in the first parameter with the tables of the second
+-- parameter after applying the differences in the first parameter to them
+attachAndApplyDiffsTicked ::
+     HasTickedLedgerTables l
+  => Ticked1 l DiffMK
+  ->         l ValuesMK
+  -> Ticked1 l TrackingMK
+attachAndApplyDiffsTicked after before =
+    zipOverLedgerTablesTicked rawAttachAndApplyDiffs after
+  $ projectLedgerTables before
+
+rawPrependTrackingDiffs ::
+      (Ord k, Eq v)
+   => TrackingMK k v
+   -> TrackingMK k v
+   -> TrackingMK k v
+rawPrependTrackingDiffs (TrackingMK v d2) (TrackingMK _v d1) =
+  TrackingMK v (d1 <> d2)
+
+-- | Mappend the differences in the ledger tables. Keep the ledger state of the
+-- first one.
+prependLedgerTablesTrackingDiffs ::
+     HasTickedLedgerTables l
+  => Ticked1 l TrackingMK
+  -> Ticked1 l TrackingMK
+  -> Ticked1 l TrackingMK
+prependLedgerTablesTrackingDiffs after before =
+    zipOverLedgerTablesTicked rawPrependTrackingDiffs after
+  $ projectLedgerTablesTicked before
+
+rawReapplyTracking ::
+     Ord k
+  => TrackingMK k v
+  -> ValuesMK   k v
+  -> TrackingMK k v
+rawReapplyTracking (TrackingMK _v d) (ValuesMK v) = TrackingMK (unsafeApplyDiff v d) d
+
+-- | Replace the tables in the first parameter with the tables of the second
+-- parameter after applying the differences in the first parameter to them
+reapplyTrackingTicked ::
+     HasTickedLedgerTables l
+  => Ticked1 l TrackingMK
+  ->         l ValuesMK
+  -> Ticked1 l TrackingMK
+reapplyTrackingTicked after before =
+    zipOverLedgerTablesTicked rawReapplyTracking after
+  $ projectLedgerTables before

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/HD/DiffSeq.hs
@@ -1,0 +1,342 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MonoLocalBinds             #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+
+{- | Sequences of diffs for ledger tables.
+
+   These diff sequences are an instantiation of a strict finger tree with root
+   measures. The tree/sequence itself contains diffs and slot information, while
+   the root measure is the total sum of all diffs in the sequence. The internal
+   measure is used to keep track of sequence length and maximum slot numbers.
+
+   The diff datatype that we use forms a @'Group'@, which allows for relatively
+   efficient splitting of finger trees with respect to recomputing measures by
+   means of the @'invert'@ operation that the @'Group'@ type class requires.
+   Namely, if either the left or right part of the split is small in comparison
+   with the input sequence, then we can subtract the diffs in the smaller part
+   from the root measure of the input to (quickly) compute the root measure of
+   the /other/ part of the split. This is much faster than computing the root
+   measures from scratch by doing a linear-time pass over the elements of the
+   split parts, or a logarithmic-time pass over intermediate sums of diffs in
+   case we store cumulative diffs in the nodes of the finger tree.
+
+   === Example of fast splits
+
+   As an analogy, consider this example: we have a sequence of consecutive
+   integer numbers @xs = [1..n]@ where @n@ is large, and we define the root
+   measure of the sequence to be the total sum of these numbers, @rmxs = sum
+   [1..n]@ (we assume @rmxs@ is fully evaluated). Say we split this sequence of
+   integer numbers at the index @2@, then we get /left/ and /right/ parts of the
+   split @ys@ and @zs respectively.
+
+   > splitAt 2 xs = (ys, zs) = ([1..2], [3..n])
+
+   How should we compute we the root measure @rmys@ of @ys@? Since @ys@ is
+   small, we can just compute @rmys = sum [1..2]@. How should we compute the
+   root measure @rmzs@ of @zs@? We should not compute @rmzs = sum [3..n]@ in
+   this case, since @n@ is large. Instead, we compute @rmzs = rmxs - rmys@,
+   which evaluates to its result in time that is linear in the length of @ys@,
+   in this case @O(1)@.
+
+   === Why not store sums of diffs in the internal measure instead of the root
+   measure?
+
+   We could also have used the interal measure of the strict finger tree to
+   store intermediate sums of diffs for all subtrees of the node. The subtree
+   rooted at the root of the tree would then store the total sum of diffs.
+   However, we would have now to recompute a possibly logarithmic number of sums
+   of diffs when we split or extend the sequence. Given that in @consensus@ we
+   use the total sum of diffs nearly as often as we split or extend the diff
+   sequence, this proved to be too costly. The single-instance root measure
+   reduces the overhead of this "caching" of intermediate sums of diffs by only
+   using a single total sum of diffs, though augmented with an @'invert'@
+   operation to facilitate computing updated root measures.
+
+-}
+module Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (
+    -- * Sequences of diffs
+    DiffSeq (..)
+  , Element (..)
+  , InternalMeasure (..)
+  , Length (..)
+  , RootMeasure (..)
+  , SlotNoLB (..)
+  , SlotNoUB (..)
+    -- * Short-hands for type-class constraints
+  , SM
+    -- * API: derived functions
+  , append
+  , cumulativeDiff
+  , empty
+  , extend
+  , length
+    -- * Slots
+  , maxSlot
+  , minSlot
+    -- * Splitting
+  , split
+  , splitAt
+  , splitAtFromEnd
+    -- * Maps
+  , mapDiffSeq
+  ) where
+
+import           Prelude hiding (length, splitAt)
+
+import qualified Control.Exception as Exn
+import           Data.Bifunctor (Bifunctor (bimap))
+import           Data.Group
+import           Data.Maybe.Strict
+import           Data.Monoid (Sum (..))
+import           Data.Semigroup (Max (..), Min (..))
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+
+import           Data.FingerTree.RootMeasured.Strict hiding (split)
+import qualified Data.FingerTree.RootMeasured.Strict as RMFT (splitSized)
+import           Data.Map.Diff.Strict as MapDiff
+
+import qualified Cardano.Slotting.Slot as Slot
+
+{-------------------------------------------------------------------------------
+  Sequences of diffs
+-------------------------------------------------------------------------------}
+
+-- | A sequence of key-value store differences.
+--
+-- INVARIANT: The slot numbers of consecutive elements should be strictly
+-- increasing. Manipulating the underlying @'StrictFingerTree'@ directly may
+-- break this invariant.
+newtype DiffSeq k v =
+  UnsafeDiffSeq
+    (StrictFingerTree
+      (RootMeasure k v)
+      (InternalMeasure k v)
+      (Element k v)
+    )
+  deriving stock (Generic, Show, Eq)
+  deriving anyclass (NoThunks)
+
+-- The @'SlotNo'@ is not included in the root measure, since it is
+-- not a @'Group'@ instance.
+data RootMeasure k v = RootMeasure {
+    -- | Cumulative length
+    rmLength :: {-# UNPACK #-} !Length
+    -- | Cumulative diff
+  , rmDiff   :: !(Diff k v)
+  }
+  deriving stock (Generic, Show, Eq, Functor)
+  deriving anyclass (NoThunks)
+
+data InternalMeasure k v = InternalMeasure {
+    -- | Cumulative length
+    imLength  :: {-# UNPACK #-} !Length
+    -- | Leftmost slot number (or lower bound)
+    --
+    -- Empty diff sequences have no rightmost slot number, so in that case
+    -- @imSlotNo == Nothing@.
+  , imSlotNoL ::                !(StrictMaybe SlotNoLB)
+    -- | Rightmost slot number (or upper bound)
+    --
+    -- Empty diff sequences have no leftmost slot number, so in that case
+    -- @imSlotNo == Nothing@.
+  , imSlotNoR ::                !(StrictMaybe SlotNoUB)
+  }
+  deriving stock (Generic, Show, Eq, Functor)
+  deriving anyclass (NoThunks)
+
+data Element k v = Element {
+    elSlotNo :: {-# UNPACK #-} !Slot.SlotNo
+  , elDiff   ::                !(Diff k v)
+  }
+  deriving stock (Generic, Show, Eq, Functor)
+  deriving anyclass (NoThunks)
+
+-- | Length of a sequence of differences.
+newtype Length = Length { unLength :: Int }
+  deriving stock (Generic, Show, Eq, Ord)
+  deriving newtype (Num)
+  deriving anyclass (NoThunks)
+  deriving Semigroup via Sum Int
+  deriving Monoid via Sum Int
+  deriving Group via Sum Int
+
+-- | An upper bound on slot numbers.
+newtype SlotNoUB = SlotNoUB {unSlotNoUB :: Slot.SlotNo}
+  deriving stock (Generic, Show, Eq, Ord)
+  deriving newtype (Num)
+  deriving anyclass (NoThunks)
+  deriving Semigroup via Max Slot.SlotNo
+  deriving Monoid via Max Slot.SlotNo
+
+-- | A lower bound on slot numbers.
+newtype SlotNoLB = SlotNoLB {unSlotNoLB :: Slot.SlotNo}
+  deriving stock (Generic, Show, Eq, Ord)
+  deriving newtype (Num)
+  deriving anyclass (NoThunks)
+  deriving Semigroup via Min Slot.SlotNo
+  deriving Monoid via Min Slot.SlotNo
+
+noSlotBoundsIntersect :: SlotNoUB -> SlotNoLB -> Bool
+noSlotBoundsIntersect (SlotNoUB sl1) (SlotNoLB sl2) = sl1 <= sl2
+
+{-------------------------------------------------------------------------------
+  Root measuring
+-------------------------------------------------------------------------------}
+
+instance (Ord k, Eq v) => RootMeasured (RootMeasure k v) (Element k v) where
+  measureRoot (Element _ d) = RootMeasure 1 d
+
+instance (Ord k, Eq v) => Semigroup (RootMeasure k v) where
+  RootMeasure len1 d1 <> RootMeasure len2 d2 =
+      RootMeasure (len1 <> len2) (d1 <> d2)
+
+instance (Ord k, Eq v) => Monoid (RootMeasure k v) where
+  mempty = RootMeasure mempty mempty
+
+instance (Ord k, Eq v) => Group (RootMeasure k v) where
+  invert (RootMeasure len d) =
+    RootMeasure (invert len) (invert d)
+
+{-------------------------------------------------------------------------------
+  Internal measuring
+-------------------------------------------------------------------------------}
+
+instance Measured (InternalMeasure k v) (Element k v) where
+  measure (Element sl _d) = InternalMeasure {
+      imLength  = 1
+    , imSlotNoL = SJust $ SlotNoLB sl
+    , imSlotNoR = SJust $ SlotNoUB sl
+    }
+
+instance Semigroup (InternalMeasure k v) where
+  InternalMeasure len1 sl1L sl1R <> InternalMeasure len2 sl2L sl2R =
+    InternalMeasure (len1 <> len2) (sl1L <> sl2L) (sl1R <> sl2R)
+
+instance Monoid (InternalMeasure k v) where
+  mempty = InternalMeasure mempty mempty mempty
+
+{-------------------------------------------------------------------------------
+  Short-hands types and constraints
+-------------------------------------------------------------------------------}
+
+-- | Short-hand for @'SuperMeasured'@.
+type SM k v =
+  SuperMeasured (RootMeasure k v) (InternalMeasure k v) (Element k v)
+
+{-------------------------------------------------------------------------------
+  Queries
+-------------------------------------------------------------------------------}
+
+cumulativeDiff ::
+     SM k v
+  => DiffSeq k v
+  -> Diff k v
+cumulativeDiff (UnsafeDiffSeq ft) = rmDiff $ measureRoot ft
+
+length ::
+     SM k v
+  => DiffSeq k v -> Int
+length (UnsafeDiffSeq ft) = unLength . rmLength $ measureRoot ft
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+extend ::
+     SM k v
+  => DiffSeq k v
+  -> Slot.SlotNo
+  -> Diff k v
+  -> DiffSeq k v
+extend (UnsafeDiffSeq ft) sl d =
+    Exn.assert invariant $ UnsafeDiffSeq $ ft |> Element sl d
+  where
+    invariant = case imSlotNoR $ measure ft of
+      SNothing  -> True
+      SJust slR -> noSlotBoundsIntersect slR (SlotNoLB sl)
+
+append ::
+     (Ord k, Eq v)
+  => DiffSeq k v
+  -> DiffSeq k v
+  -> DiffSeq k v
+append (UnsafeDiffSeq ft1) (UnsafeDiffSeq ft2) =
+    Exn.assert invariant $ UnsafeDiffSeq (ft1 <> ft2)
+  where
+    sl1R      = imSlotNoR $ measure ft1
+    sl2L      = imSlotNoL $ measure ft2
+    invariant = case (noSlotBoundsIntersect <$> sl1R <*> sl2L) of
+      SNothing -> True
+      SJust v  -> v
+
+empty ::
+     (Ord k, Eq v)
+  => DiffSeq k v
+empty = UnsafeDiffSeq mempty
+
+{-------------------------------------------------------------------------------
+  Slots
+-------------------------------------------------------------------------------}
+
+maxSlot ::
+     SM k v
+  => DiffSeq k v
+  -> StrictMaybe Slot.SlotNo
+maxSlot (UnsafeDiffSeq ft) = unSlotNoUB <$> imSlotNoR (measure ft)
+
+minSlot ::
+     SM k v
+  => DiffSeq k v
+  -> StrictMaybe Slot.SlotNo
+minSlot (UnsafeDiffSeq ft) = unSlotNoLB <$> imSlotNoL (measure ft)
+
+{-------------------------------------------------------------------------------
+  Splitting
+-------------------------------------------------------------------------------}
+
+instance Sized (InternalMeasure k v) where
+  size = unLength . imLength
+
+split ::
+     SM k v
+  => (InternalMeasure k v -> Bool)
+  -> DiffSeq k v
+  -> (DiffSeq k v, DiffSeq k v)
+split p (UnsafeDiffSeq ft) = bimap UnsafeDiffSeq UnsafeDiffSeq $ RMFT.splitSized p ft
+
+splitAt ::
+     SM k v
+  => Int
+  -> DiffSeq k v
+  -> (DiffSeq k v, DiffSeq k v)
+splitAt n = split ((Length n<) . imLength)
+
+splitAtFromEnd ::
+     SM k v
+  => Int
+  -> DiffSeq k v
+  -> (DiffSeq k v, DiffSeq k v)
+splitAtFromEnd n dseq =
+    Exn.assert (n <= len) $ splitAt (len - n) dseq
+  where
+    len = length dseq
+
+{-------------------------------------------------------------------------------
+  Maps
+-------------------------------------------------------------------------------}
+
+mapDiffSeq ::
+       ( SM k v
+       , SM k v'
+       )
+    => (v -> v')
+    -> DiffSeq k v
+    -> DiffSeq k v'
+mapDiffSeq f (UnsafeDiffSeq ft) = UnsafeDiffSeq $ fmap' (fmap f) ft


### PR DESCRIPTION
# Description

As a first step in the UTxO-HD feature, this PR introduces the concept of Ledger tables and all the operations related to them.

Ledger tables are projections of data structures in the ledger that will eventually be moved to disk. A more thorough description can be found in the haddocks.

Part of #4212 

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated 
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
