### PR TITLE
Introduce the BackingStore and the TVar implementation

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -230,7 +230,10 @@ library
                        Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
                        Ouroboros.Consensus.Storage.LedgerDB
                        Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
-                       Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq
+                       Ouroboros.Consensus.Storage.LedgerDB.BackingStore
+                       Ouroboros.Consensus.Storage.LedgerDB.BackingStore.InMemory
+                       Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Trivial
+                       Ouroboros.Consensus.Storage.LedgerDB.DiffSeq
                        Ouroboros.Consensus.Storage.LedgerDB.Init
                        Ouroboros.Consensus.Storage.LedgerDB.InMemory
                        Ouroboros.Consensus.Storage.LedgerDB.LedgerDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Tables.hs
@@ -60,7 +60,7 @@ import           NoThunks.Class (NoThunks (..))
 
 import           Ouroboros.Consensus.Ticked
 
-import           Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (DiffSeq,
+import           Ouroboros.Consensus.Storage.LedgerDB.DiffSeq (DiffSeq,
                      empty, mapDiffSeq)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+
+-- | A store for key-value maps that can be extended with deltas.
+--
+-- When we talk about deltas we mean differences on key-value entries, for
+-- example a deletion of a key-value entry or an insertion.
+--
+-- Its intended use is for storing data structures from the 'LedgerState' and
+-- update them with differences produced by executing the Ledger rules.
+module Ouroboros.Consensus.Storage.LedgerDB.BackingStore (
+    -- * Backing store interface
+    BackingStore (..)
+  , BackingStoreInitialiser (..)
+  , BackingStorePath (..)
+  , BackingStoreValueHandle (..)
+  , InitFrom (..)
+  , RangeQuery (..)
+  , bsRead
+  , initFromCopy
+  , initFromValues
+  , withBsValueHandle
+    -- * Ledger DB wrappers
+  , LedgerBackingStore (..)
+  , LedgerBackingStoreInitialiser (..)
+  , LedgerBackingStoreValueHandle (..)
+  ) where
+
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
+
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
+
+import           Ouroboros.Consensus.Ledger.Tables
+import qualified Ouroboros.Consensus.Storage.FS.API as FS
+import qualified Ouroboros.Consensus.Storage.FS.API.Types as FS
+import           Ouroboros.Consensus.Util.IOLike (IOLike)
+import qualified Ouroboros.Consensus.Util.IOLike as IOLike
+
+{-------------------------------------------------------------------------------
+  Backing store interface
+-------------------------------------------------------------------------------}
+
+data InitFrom values =
+    InitFromValues !(WithOrigin SlotNo) !values
+  | InitFromCopy !BackingStorePath
+
+-- | Initialisation for a backing store
+newtype BackingStoreInitialiser m keys values diff = BackingStoreInitialiser {
+    bsiInit :: FS.SomeHasFS m -> InitFrom values -> m (BackingStore m keys values diff)
+  }
+  deriving newtype NoThunks
+
+initFromValues ::
+     BackingStoreInitialiser m keys values diff
+  -> FS.SomeHasFS m
+  -> WithOrigin SlotNo
+  -> values
+  -> m (BackingStore m keys values diff)
+initFromValues bsi shfs sl vs = bsiInit bsi shfs (InitFromValues sl vs)
+
+initFromCopy ::
+     BackingStoreInitialiser m keys values diff
+  -> FS.SomeHasFS m
+  -> BackingStorePath
+  -> m (BackingStore m keys values diff)
+initFromCopy bsi shfs bsp = bsiInit bsi shfs (InitFromCopy bsp)
+
+-- | A backing store for a map
+data BackingStore m keys values diff = BackingStore {
+    -- | Close the backing store
+    --
+    -- Other methods throw exceptions if called on a closed store.
+    bsClose       :: !(m ())
+    -- | Create a persistent copy
+    --
+    -- Each backing store implementation will offer a way to initialize itself
+    -- from such a path.
+    --
+    -- The destination path must not already exist. After this operation, it
+    -- will be a directory.
+  , bsCopy        :: !(FS.SomeHasFS m -> BackingStorePath -> m ())
+    -- | Open a 'BackingStoreValueHandle' capturing the current value of the
+    -- entire database
+  , bsValueHandle :: !(m (WithOrigin SlotNo, BackingStoreValueHandle m keys values))
+    -- | Apply a valid diff to the contents of the backing store
+  , bsWrite       :: !(SlotNo -> diff -> m ())
+  }
+
+deriving via OnlyCheckWhnfNamed "BackingStore" (BackingStore m keys values diff)
+  instance NoThunks (BackingStore m keys values diff)
+
+newtype BackingStorePath = BackingStorePath FS.FsPath
+  deriving stock (Show, Eq, Ord)
+  deriving newtype NoThunks
+
+-- | An ephemeral handle to an immutable value of the entire database
+--
+-- The performance cost is usually minimal unless this handle is held open too
+-- long. We expect clients of the BackingStore to not retain handles for a long
+-- time.
+data BackingStoreValueHandle m keys values = BackingStoreValueHandle {
+    -- | Close the handle
+    --
+    -- Other methods throw exceptions if called on a closed handle.
+    bsvhClose     :: !(m ())
+    -- | See 'RangeQuery'
+  , bsvhRangeRead :: !(RangeQuery keys -> m values)
+    -- | Read the given keys from the handle
+    --
+    -- Absent keys will merely not be present in the result instead of causing a
+    -- failure or an exception.
+  , bsvhRead      :: !(keys -> m values)
+  }
+
+data RangeQuery keys = RangeQuery {
+      -- | The result of this range query begin at first key that is strictly
+      -- greater than the greatest key in 'rqPrev'.
+      --
+      -- If the given set of keys is 'Just' but contains no keys, then the query
+      -- will return no results. (This is the steady-state once a looping range
+      -- query reaches the end of the table.)
+      rqPrev  :: Maybe keys
+      -- | Roughly how many values to read.
+      --
+      -- The query may return a different number of values than this even if it
+      -- has not reached the last key. The only crucial invariant is that the
+      -- query only returns an empty map if there are no more keys to read on
+      -- disk.
+      --
+      -- FIXME: #4398 can we satisfy this invariant if we read keys from disk
+      -- but all of them were deleted in the changelog?
+    , rqCount :: !Int
+    }
+    deriving stock (Show, Eq)
+
+deriving via OnlyCheckWhnfNamed "BackingStoreValueHandle" (BackingStoreValueHandle m keys values)
+  instance NoThunks (BackingStoreValueHandle m keys values)
+
+-- | A combination of 'bsValueHandle' and 'bsvhRead'
+bsRead ::
+     IOLike m
+  => BackingStore m keys values diff
+  -> keys
+  -> m (WithOrigin SlotNo, values)
+bsRead store keys = withBsValueHandle store $ \slot vh -> do
+    values <- bsvhRead vh keys
+    pure (slot, values)
+
+-- | A 'IOLike.bracket'ed 'bsValueHandle'
+withBsValueHandle ::
+     IOLike m
+  => BackingStore m keys values diff
+  -> (WithOrigin SlotNo -> BackingStoreValueHandle m keys values -> m a)
+  -> m a
+withBsValueHandle store kont =
+    IOLike.bracket
+      (bsValueHandle store)
+      (bsvhClose . snd)
+      (uncurry kont)
+
+{-------------------------------------------------------------------------------
+  Ledger DB wrappers
+-------------------------------------------------------------------------------}
+
+newtype LedgerBackingStoreInitialiser m l = LedgerBackingStoreInitialiser
+  (BackingStoreInitialiser m
+    (LedgerTables l KeysMK)
+    (LedgerTables l ValuesMK)
+    (LedgerTables l DiffMK)
+  )
+  deriving newtype (NoThunks)
+
+-- | A handle to the backing store for the ledger tables
+newtype LedgerBackingStore m l = LedgerBackingStore
+    (BackingStore m
+      (LedgerTables l KeysMK)
+      (LedgerTables l ValuesMK)
+      (LedgerTables l DiffMK)
+    )
+  deriving newtype (NoThunks)
+
+-- | A handle to the backing store for the ledger tables
+data LedgerBackingStoreValueHandle m l = LedgerBackingStoreValueHandle
+    !(WithOrigin SlotNo)
+    !(BackingStoreValueHandle m
+      (LedgerTables l KeysMK)
+      (LedgerTables l ValuesMK)
+    )
+  deriving stock    (Generic)
+  deriving anyclass (NoThunks)
+

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/InMemory.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE RankNTypes         #-}
+
+-- | An implementation of a 'BackingStore' using a TVar. This is the
+-- implementation known as "InMemory".
+module Ouroboros.Consensus.Storage.LedgerDB.BackingStore.InMemory (
+    -- * Constructor
+    newTVarBackingStoreInitialiser
+    -- * Errors
+  , StoreDirIsIncompatible (..)
+  ) where
+
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import           Control.Monad (join, unless, void, when)
+import qualified Data.ByteString.Lazy as BSL
+import           Data.String (fromString)
+import           GHC.Generics (Generic)
+
+import           Cardano.Binary as CBOR
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
+
+import           Ouroboros.Consensus.Storage.FS.API
+                     (HasFS (createDirectory, doesDirectoryExist, doesFileExist, mkFsErrorPath),
+                     SomeHasFS (SomeHasFS), hGetAll, hPutAll, withFile)
+import           Ouroboros.Consensus.Storage.FS.API.Types
+                     (AllowExisting (MustBeNew), FsErrorPath,
+                     FsPath (fsPathToList), OpenMode (ReadMode, WriteMode),
+                     fsPathFromList)
+import           Ouroboros.Consensus.Util.IOLike (Exception, IOLike,
+                     MonadSTM (STM, atomically), MonadThrow (throwIO), NoThunks,
+                     StrictTVar, newTVarIO, readTVar, throwSTM, writeTVar)
+
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore
+
+{-------------------------------------------------------------------------------
+  An in-memory backing store
+-------------------------------------------------------------------------------}
+
+data TVarBackingStoreContents m values =
+    TVarBackingStoreContentsClosed
+  | TVarBackingStoreContents
+      !(WithOrigin SlotNo)
+      !values
+  deriving (Generic, NoThunks)
+
+data TVarBackingStoreExn =
+    TVarBackingStoreClosedExn
+  | TVarBackingStoreValueHandleClosedExn
+  | TVarBackingStoreDirectoryExists
+  | TVarBackingStoreNonMonotonicSeq !(WithOrigin SlotNo) !(WithOrigin SlotNo)
+  | TVarBackingStoreDeserialiseExn CBOR.DeserialiseFailure
+  | TVarIncompleteDeserialiseExn
+  deriving anyclass (Exception)
+  deriving stock    (Show)
+
+-- | Use a 'TVar' as a trivial backing store
+newTVarBackingStoreInitialiser ::
+     (IOLike m, NoThunks values)
+  => (keys -> values -> values)
+  -> (RangeQuery keys -> values -> values)
+  -> (values -> diff -> values)
+  -> (values -> CBOR.Encoding)
+  -> (forall s. CBOR.Decoder s values)
+  -> BackingStoreInitialiser m keys values diff
+newTVarBackingStoreInitialiser lookup_ rangeRead_ forwardValues_ enc dec =
+  BackingStoreInitialiser $ \(SomeHasFS fs0) initialization -> do
+    ref <- do
+      (slot, values) <- case initialization of
+        InitFromCopy (BackingStorePath path) -> do
+          tvarFileExists <- doesFileExist fs0 (extendPath path)
+          unless tvarFileExists $
+            throwIO . StoreDirIsIncompatible $ mkFsErrorPath fs0 path
+          withFile fs0 (extendPath path) ReadMode $ \h -> do
+            bs <- hGetAll fs0 h
+            case CBOR.deserialiseFromBytes ((,) <$> CBOR.fromCBOR <*> dec) bs of
+              Left  err        -> throwIO $ TVarBackingStoreDeserialiseExn err
+              Right (extra, x) -> do
+                unless (BSL.null extra) $ throwIO TVarIncompleteDeserialiseExn
+                pure x
+        InitFromValues slot values -> pure (slot, values)
+      newTVarIO $ TVarBackingStoreContents slot values
+    pure BackingStore {
+        bsClose    = atomically $ do
+          guardClosed ref
+          writeTVar ref TVarBackingStoreContentsClosed
+      , bsCopy = \(SomeHasFS fs) (BackingStorePath path) ->
+          join $ atomically $ do
+            readTVar ref >>= \case
+              TVarBackingStoreContentsClosed                ->
+                throwSTM TVarBackingStoreClosedExn
+              TVarBackingStoreContents slot values -> pure $ do
+                exists <- doesDirectoryExist fs path
+                when exists $ throwIO TVarBackingStoreDirectoryExists
+                createDirectory fs path
+                withFile fs (extendPath path) (WriteMode MustBeNew) $ \h -> do
+                  void $ hPutAll fs h $ CBOR.toLazyByteString $ CBOR.toCBOR slot <> enc values
+      , bsValueHandle = join $ atomically $ do
+          readTVar ref >>= \case
+            TVarBackingStoreContentsClosed                ->
+              throwSTM TVarBackingStoreClosedExn
+            TVarBackingStoreContents slot values -> pure $ do
+              refHandleClosed <- newTVarIO False
+              pure $ (,) slot $ BackingStoreValueHandle {
+                  bsvhClose     = atomically $ do
+                    guardClosed ref
+                    guardHandleClosed refHandleClosed
+                    writeTVar refHandleClosed True
+                , bsvhRangeRead = \rq -> atomically $ do
+                    guardClosed ref
+                    guardHandleClosed refHandleClosed
+                    pure $ rangeRead_ rq values
+                , bsvhRead      = \keys -> atomically $ do
+                    guardClosed ref
+                    guardHandleClosed refHandleClosed
+                    pure $ lookup_ keys values
+                }
+      , bsWrite    = \slot2 diff -> atomically $ do
+          readTVar ref >>= \case
+            TVarBackingStoreContentsClosed        ->
+              throwSTM TVarBackingStoreClosedExn
+            TVarBackingStoreContents slot1 values -> do
+              unless (slot1 <= At slot2) $
+                throwSTM $ TVarBackingStoreNonMonotonicSeq (At slot2) slot1
+              writeTVar ref $
+                TVarBackingStoreContents
+                  (At slot2)
+                  (forwardValues_ values diff)
+      }
+  where
+    extendPath path =
+      fsPathFromList $ fsPathToList path <> [fromString "tvar"]
+
+guardClosed ::
+     IOLike m
+  => StrictTVar m (TVarBackingStoreContents ks vs)
+  -> STM m ()
+guardClosed ref = readTVar ref >>= \case
+  TVarBackingStoreContentsClosed -> throwSTM TVarBackingStoreClosedExn
+  TVarBackingStoreContents _ _   -> pure ()
+
+guardHandleClosed ::
+     IOLike m
+  => StrictTVar m Bool
+  -> STM m ()
+guardHandleClosed refHandleClosed = do
+  isClosed <- readTVar refHandleClosed
+  when isClosed $ throwSTM TVarBackingStoreValueHandleClosedExn
+
+{-------------------------------------------------------------------------------
+  Errors
+-------------------------------------------------------------------------------}
+
+newtype StoreDirIsIncompatible = StoreDirIsIncompatible FsErrorPath
+  deriving anyclass (Exception)
+
+instance Show StoreDirIsIncompatible where
+  show (StoreDirIsIncompatible p) =
+       "In-Memory database not found in the database directory: "
+    <> show p
+    <> ".\nPre-UTxO-HD and LMDB implementations are incompatible with the In-Memory \
+       \ implementation. Please delete your ledger database directory."

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Trivial.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/Trivial.hs
@@ -1,0 +1,35 @@
+-- | A Trivial backing store that just stores the slot number on a TVar. To be
+-- used by tests.
+module Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Trivial (trivialBackingStore) where
+
+import           Control.Monad (void)
+
+import           Cardano.Slotting.Slot (WithOrigin (..))
+
+import           Ouroboros.Consensus.Util.IOLike (IOLike)
+import qualified Ouroboros.Consensus.Util.IOLike as IOLike
+
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore
+
+{-------------------------------------------------------------------------------
+  A trivial backing store that holds only the slot number
+-------------------------------------------------------------------------------}
+
+trivialBackingStore :: IOLike m => values -> m (BackingStore m keys values diff)
+trivialBackingStore emptyValues = do
+  seqNo <- IOLike.newTVarIO Origin
+  pure $ BackingStore
+              (pure ())
+              (\_ _ -> pure ())
+              (IOLike.atomically $ do
+                  s <- IOLike.readTVar seqNo
+                  pure $ ( s
+                         , BackingStoreValueHandle
+                             (pure ())
+                             (\_ -> pure emptyValues)
+                             (\_ -> pure emptyValues)
+                         )
+              )
+              (\s _ -> void
+                     $ IOLike.atomically
+                     $ IOLike.modifyTVar seqNo (\_ -> At s))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/DiffSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/DiffSeq.hs
@@ -59,7 +59,7 @@
    operation to facilitate computing updated root measures.
 
 -}
-module Ouroboros.Consensus.Storage.LedgerDB.HD.DiffSeq (
+module Ouroboros.Consensus.Storage.LedgerDB.DiffSeq (
     -- * Sequences of diffs
     DiffSeq (..)
   , Element (..)


### PR DESCRIPTION
# Description

The Backing store is a store for key-value maps that can be implemented with a normal key-value database (in particular we will later implement it with [LMDB](http://www.lmdb.tech/doc/)).

This PR defines it and exposes the relevant interface to be used in UTxO-HD.

Part of #4212

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
