### PR TITLE
Fix upper bound for cardano-crypto-xxx packages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -96,9 +96,9 @@ constraints:
   , base-deriving-via >= 0.1.0.0
   , cardano-binary >= 1.5.0
   , cardano-binary-test >= 1.3.0
-  , cardano-crypto-class >= 2.0.0.1
-  , cardano-crypto-praos >= 2.0.0.0.1
-  , cardano-crypto-tests >= 2.0.0.0.1
+  , cardano-crypto-class >= 2.0.0.1 && < 2.2.0.0
+  , cardano-crypto-praos >= 2.0.0.0.1 && < 2.2.0.0
+  , cardano-crypto-tests >= 2.0.0.0.1 && < 2.2.0.0
   , cardano-slotting >= 0.1.0.0
   , measures >= 0.1.0.0
   , orphans-deriving-via >= 0.1.0.0


### PR DESCRIPTION
# Description

Due to https://github.com/input-output-hk/cardano-base/pull/255 we must set tighter upper bounds to unsure we don't run into 'cabal update' issues as the interfaces have changed heavily.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
