### PR TITLE
Fix a bug in peer-state-actions

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -168,7 +168,12 @@ connections PeerSelectionActions{
                      Map.keysSet (EstablishedPeers.toMap establishedPeers'))
             Decision {
               decisionTrace = [ TraceDemoteLocalAsynchronous localDemotions
-                              , TraceDemoteAsynchronous nonLocalDemotions],
+                              | not $ null localDemotions
+                              ]
+                           <> [ TraceDemoteAsynchronous nonLocalDemotions
+                              | not $ null nonLocalDemotions
+                              ],
+
               decisionJobs  = [],
               decisionState = st {
                                 activePeers       = activePeers',

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -622,7 +622,7 @@ withPeerStateActions PeerStateActionsArguments {
           -- A /hot/ protocol terminated, we deactivate the connection and keep
           -- monitoring /warm/ and /established/ protocols.
           WithSomeProtocolTemperature (WithHot MiniProtocolSuccess {}) -> do
-            deactivatePeerConnection pch `catches` handlers
+            deactivatePeerConnection pch
             peerMonitoringLoop pch
 
           -- If an /established/ or /warm/ we demote the peer to 'PeerCold'.
@@ -632,20 +632,9 @@ withPeerStateActions PeerStateActionsArguments {
           -- supposed to terminate (unless the remote peer did something
           -- wrong).
           WithSomeProtocolTemperature (WithWarm MiniProtocolSuccess {}) ->
-            closePeerConnection pch `catches` handlers
+            closePeerConnection pch
           WithSomeProtocolTemperature (WithEstablished MiniProtocolSuccess {}) ->
-            closePeerConnection pch `catches` handlers
-
-      where
-        -- 'closePeerConnection' and 'deactivatePeerConnection' actions can
-        -- throw exceptions, but they maintain consistency of 'peerStateVar',
-        -- that's why these handlers are trivial.
-        handlers :: [Handler m ()]
-        handlers =
-          [ Handler (\(_ :: PeerSelectionActionException)               -> pure ()),
-            Handler (\(_ :: EstablishConnectionException versionNumber) -> pure ()),
-            Handler (\(_ :: PeerSelectionTimeoutException peerAddr)     -> pure ())
-          ]
+            closePeerConnection pch
 
 
 


### PR DESCRIPTION

# Description

Fixed a bug in peer state actions: when demoting a peer from hot to warm the
monitoring loop might busy loop.

- peer-state-actions: do not catch exceptions in the monitoring loop
- peer-selection: filter out empty traces

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
