### PR TITLE
Release `ouroboros-consensus-cardano` 0.3.0.0

### DIFF
--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   ouroboros-consensus-byron-test
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               Test infrastructure for Byron
 description:            Test infrastructure for Byron.
 license:                Apache-2.0

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   ouroboros-consensus-byron
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               Byron ledger integration in the Ouroboros consensus layer
 description:            Byron ledger integration in the Ouroboros consensus layer.
 license:                Apache-2.0

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   ouroboros-consensus-byronspec
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               ByronSpec ledger integration in the Ouroboros consensus layer
 description:            ByronSpec ledger integration in the Ouroboros consensus layer.
 license:                Apache-2.0

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -1,7 +1,7 @@
 cabal-version:         3.0
 
 name:                   ouroboros-consensus-cardano-test
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               Test of the instantation of the Ouroboros consensus layer used by Cardano
 description:            Test of the instantation of the Ouroboros consensus layer used by Cardano.
 license:                Apache-2.0

--- a/ouroboros-consensus-cardano-tools/ouroboros-consensus-cardano-tools.cabal
+++ b/ouroboros-consensus-cardano-tools/ouroboros-consensus-cardano-tools.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   ouroboros-consensus-cardano-tools
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               Programmatically synthesize and analyse a ChainDB
 description:            Programmatically synthesize and analyse a ChainDB.
 license:                Apache-2.0

--- a/ouroboros-consensus-cardano/CHANGELOG.md
+++ b/ouroboros-consensus-cardano/CHANGELOG.md
@@ -18,8 +18,8 @@ process](../ouroboros-consensus/docs/ReleaseProcess.md).
 
 # Changelog entries
 
-<a id='changelog-0.2.0.0'></a>
-## 0.2.0.0 — 2023-02-09
+<a id='changelog-0.3.0.0'></a>
+## 0.3.0.0 — 2023-02-09
 
 ### Patch
 

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -1,7 +1,7 @@
 cabal-version:         3.0
 
 name:                   ouroboros-consensus-cardano
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               The instantation of the Ouroboros consensus layer used by Cardano
 description:            The instantation of the Ouroboros consensus layer used by Cardano.
 license:                Apache-2.0

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -1,7 +1,7 @@
 cabal-version:         3.0
 
 name:                   ouroboros-consensus-shelley-test
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               Test infrastructure for Shelley
 description:            Test infrastructure for Shelley.
 license:                Apache-2.0

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   ouroboros-consensus-shelley
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               Shelley ledger integration in the Ouroboros consensus layer
 description:            Shelley ledger integration in the Ouroboros consensus layer.
 license:                Apache-2.0


### PR DESCRIPTION
# Description

There was a conflict with a version `0.2.0.0` what was already released in CHaP. Therefore we are bumping the release to 0.3.0.0 instead.
