### PR TITLE
db-analyser: correct protocol versions

### DIFF
--- a/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano-tools/src/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -247,7 +247,7 @@ instance Aeson.FromJSON CardanoConfig where
         f "TestMaryHardForkAtEpoch"    4 (\_ -> ()) :*
         f "TestAlonzoHardForkAtEpoch"  5 fst        :*
         f "TestBabbageHardForkAtEpoch" 7 fst        :*
-        f "TestConwayHardForkAtEpoch"  8 snd        :*
+        f "TestConwayHardForkAtEpoch"  9 snd        :*
         Nil
 
       let isBad :: NP ShelleyTransitionArguments xs -> Bool
@@ -310,6 +310,9 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         , shelleyBasedLeaderCredentials = []
         }
       ProtocolParamsShelley {
+          -- Note that this is /not/ the Shelley protocol version, see
+          -- https://github.com/input-output-hk/cardano-node/blob/daeae61a005776ee7b7514ce47de3933074234a8/cardano-node/src/Cardano/Node/Protocol/Cardano.hs#L167-L170
+          -- and the succeeding comments.
           shelleyProtVer                = ProtVer 3 0
         , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
         }
@@ -322,11 +325,11 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley genesisAlon
         , maryMaxTxCapacityOverrides    = Mempool.mkOverrides Mempool.noOverridesMeasure
         }
       ProtocolParamsAlonzo {
-          alonzoProtVer                 = ProtVer 6 0
+          alonzoProtVer                 = ProtVer 7 0
         , alonzoMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
         }
       ProtocolParamsBabbage {
-          babbageProtVer                 = ProtVer 7 0
+          babbageProtVer                 = ProtVer 9 0
         , babbageMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
         }
       ProtocolParamsConway {


### PR DESCRIPTION
# Description

Right now, db-analyser crashes when applying a block after the "Valentine HF" (also see https://github.com/cardano-foundation/CIPs/pull/463). This PR corrects this by bumping the respective protocol versions; and also adds a comment pointing to the (non-obvious) fact that these are the (anticipated) protocol versions of the *succeeding* era (this also came up [here](https://github.com/input-output-hk/ouroboros-network/pull/4349/files#r1108966245) recently).

Using `9` as the major protocol version for Conway assumes that there will be no further Babbage intra-era HFs.

Related issue: #3925

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
