### PR TITLE
Fix PeerStateActions bugs and update testing

### DIFF
--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -282,9 +282,9 @@ miniProtocolJob tracer egressQueue
                         MiniProtocolNum a -> "prtcl-" ++ show a)
       w <- newTVarIO BL.empty
       let chan = muxChannel tracer egressQueue (Wanton w)
-                           miniProtocolNum miniProtocolDirEnum
-                           miniProtocolIngressQueue
-      (result, remainder)  <- protocolAction chan
+                            miniProtocolNum miniProtocolDirEnum
+                            miniProtocolIngressQueue
+      (result, remainder) <- protocolAction chan
       traceWith tracer (MuxTraceTerminating miniProtocolNum miniProtocolDirEnum)
       atomically $ do
         -- The Wanton w is the SDUs that are queued but not yet sent for this job.
@@ -685,7 +685,7 @@ runMiniProtocol Mux { muxMiniProtocols, muxControlCmdQueue , muxStatus}
       case st of
            MuxReady    -> readTMVar completionVar
            MuxStopping -> readTMVar completionVar
-                      <|> return (Left $ toException (MuxError (MuxShutdown Nothing) "Mux stoping"))
+                      <|> return (Left $ toException (MuxError (MuxShutdown Nothing) "Mux stopping"))
            MuxStopped  -> readTMVar completionVar
                       <|> return (Left $ toException (MuxError (MuxShutdown Nothing) "Mux stopped"))
            MuxFailed e -> readTMVar completionVar

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -153,7 +153,8 @@ data MuxTrace =
     | MuxTraceStartOnDemand MiniProtocolNum MiniProtocolDir
     | MuxTraceStartedOnDemand MiniProtocolNum MiniProtocolDir
     | MuxTraceTerminating MiniProtocolNum MiniProtocolDir
-    | MuxTraceShutdown
+    | MuxTraceStopping
+    | MuxTraceStopped
     | MuxTraceTCPInfo StructTCPInfo Word16
 
 instance Show MuxTrace where
@@ -191,7 +192,8 @@ instance Show MuxTrace where
     show (MuxTraceStartOnDemand mid dir) = printf "Preparing to start (%s) in %s" (show mid) (show dir)
     show (MuxTraceStartedOnDemand mid dir) = printf "Started on demand (%s) in %s" (show mid) (show dir)
     show (MuxTraceTerminating mid dir) = printf "Terminating (%s) in %s" (show mid) (show dir)
-    show MuxTraceShutdown = "Mux shutdown"
+    show MuxTraceStopping = "Mux stopping"
+    show MuxTraceStopped  = "Mux stoppped"
 #ifdef os_HOST_linux
     show (MuxTraceTCPInfo StructTCPInfo
             { tcpi_snd_mss, tcpi_rcv_mss, tcpi_lost, tcpi_retrans

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -837,7 +837,6 @@ data ConnectionManagerTrace peerAddr handlerTrace
   | TrShutdown
   | TrConnectionExists             Provenance peerAddr    AbstractState
   | TrForbiddenConnection          (ConnectionId peerAddr)
-  | TrImpossibleConnection         (ConnectionId peerAddr)
   | TrConnectionFailure            (ConnectionId peerAddr)
   | TrConnectionNotFound           Provenance peerAddr
   | TrForbiddenOperation           peerAddr                AbstractState

--- a/ouroboros-network-framework/testlib/TestLib/ConnectionManager.hs
+++ b/ouroboros-network-framework/testlib/TestLib/ConnectionManager.hs
@@ -280,8 +280,6 @@ connectionManagerTraceMap (TrConnectionExists p _ as)      =
   "TrConnectionExists " ++ show p ++ " " ++ show as
 connectionManagerTraceMap (TrForbiddenConnection _)        =
   "TrForbiddenConnection"
-connectionManagerTraceMap (TrImpossibleConnection _)       =
-  "TrImpossibleConnection"
 connectionManagerTraceMap (TrConnectionFailure _)          =
   "TrConnectionFailure"
 connectionManagerTraceMap (TrConnectionNotFound p _)       =

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -124,7 +124,7 @@ testClient doneVar tip =
             atomically $ writeTVar doneVar True
             return $ Left ()
           else return $ Right (testClient doneVar tip),
-      ChainSyncExamples.points = \_ -> return (testClient doneVar tip)
+      ChainSyncExamples.points = \_ -> return (Right $ testClient doneVar tip)
     }
 
 -- | An experiment in which the client has a fork of the server chain.  The

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -138,7 +138,7 @@ data BlockFetchConfiguration =
          -- | Maximum requests in flight per each peer.
          bfcMaxRequestsInflight    :: !Word,
 
-         -- | Desired intervall between calls to fetchLogicIteration
+         -- | Desired interval between calls to fetchLogicIteration
          bfcDecisionLoopInterval   :: !DiffTime,
 
          -- | Salt used when comparing peers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -168,7 +168,12 @@ connections PeerSelectionActions{
                      Map.keysSet (EstablishedPeers.toMap establishedPeers'))
             Decision {
               decisionTrace = [ TraceDemoteLocalAsynchronous localDemotions
-                              , TraceDemoteAsynchronous nonLocalDemotions],
+                              | not $ null localDemotions
+                              ]
+                           <> [ TraceDemoteAsynchronous nonLocalDemotions
+                              | not $ null nonLocalDemotions
+                              ],
+
               decisionJobs  = [],
               decisionState = st {
                                 activePeers       = activePeers',

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -622,7 +622,7 @@ withPeerStateActions PeerStateActionsArguments {
           -- A /hot/ protocol terminated, we deactivate the connection and keep
           -- monitoring /warm/ and /established/ protocols.
           WithSomeProtocolTemperature (WithHot MiniProtocolSuccess {}) -> do
-            deactivatePeerConnection pch `catches` handlers
+            deactivatePeerConnection pch
             peerMonitoringLoop pch
 
           -- If an /established/ or /warm/ we demote the peer to 'PeerCold'.
@@ -632,20 +632,9 @@ withPeerStateActions PeerStateActionsArguments {
           -- supposed to terminate (unless the remote peer did something
           -- wrong).
           WithSomeProtocolTemperature (WithWarm MiniProtocolSuccess {}) ->
-            closePeerConnection pch `catches` handlers
+            closePeerConnection pch
           WithSomeProtocolTemperature (WithEstablished MiniProtocolSuccess {}) ->
-            closePeerConnection pch `catches` handlers
-
-      where
-        -- 'closePeerConnection' and 'deactivatePeerConnection' actions can
-        -- throw exceptions, but they maintain consistency of 'peerStateVar',
-        -- that's why these handlers are trivial.
-        handlers :: [Handler m ()]
-        handlers =
-          [ Handler (\(_ :: PeerSelectionActionException)               -> pure ()),
-            Handler (\(_ :: EstablishConnectionException versionNumber) -> pure ()),
-            Handler (\(_ :: PeerSelectionTimeoutException peerAddr)     -> pure ())
-          ]
+            closePeerConnection pch
 
 
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -243,12 +243,20 @@ import           Ouroboros.Network.ConnectionManager.Types
 data HasReturned a
     -- | A mini-protocol has returned value of type @a@.
   = Returned !a
+
     -- | A mini-protocol thrown some exception
   | Errored  !SomeException
+
    -- | A mini-protocol is not running.  This makes tracking state of hot
    -- protocols explicit, as they will not be running if a peer is in warm
    -- state.
-  | NotRunning
+   --
+   -- The argument is the return type of previous run.  We preserve it to not
+   -- miss updating the reactivate delay.
+  | NotRunning !(Either SomeException a)
+
+    -- | A mini-protocol has never been started yet.
+  | NotStarted
 
 hasReturnedFromEither :: Either SomeException a -> HasReturned a
 hasReturnedFromEither (Left e)  = Errored e
@@ -355,23 +363,32 @@ awaitFirstResult tok bundle = do
       -- For hot mini-protocols this will be the case when the peer is warm:
       -- we are interested when the first established or warm mini-protocol
       -- returned.
-      NotRunning -> retry
+      NotRunning _ -> retry
+      NotStarted   -> retry
 
 
--- | Data structure used in last-to-finish synchronisation 'awaitAll'.
+-- | Data structure used in last-to-finish synchronisation for all
+-- mini-protocols of a given temperature (see 'awaitAllResults').
 --
-data LastToFinishResult =
-    AllSucceeded
-  | SomeErrored ![MiniProtocolException]
+data LastToFinishResult a =
+    -- | All mini protocols returned successfully.
+    -- The map will contain results of all mini-protocols (of a given
+    -- temperature).
+    --
+    AllSucceeded !(Map MiniProtocolNum a)
 
-instance Semigroup LastToFinishResult where
-    AllSucceeded    <> AllSucceeded    = AllSucceeded
-    e@SomeErrored{} <> AllSucceeded    = e
-    AllSucceeded    <> e@SomeErrored{} = e
+    -- | Some mini-protocols (of a given temperature) errored.
+    --
+  | SomeErrored  ![MiniProtocolException]
+
+instance Semigroup (LastToFinishResult a) where
+    AllSucceeded a  <> AllSucceeded b  = AllSucceeded (a <> b)
+    e@SomeErrored{} <> AllSucceeded{}  = e
+    AllSucceeded{}  <> e@SomeErrored{} = e
     SomeErrored e   <> SomeErrored e'  = SomeErrored (e ++ e')
 
-instance Monoid LastToFinishResult where
-    mempty = AllSucceeded
+instance Monoid (LastToFinishResult a) where
+    mempty = AllSucceeded mempty
 
 
 -- | Last to finish synchronisation for mini-protocols of a given protocol
@@ -380,15 +397,17 @@ instance Monoid LastToFinishResult where
 awaitAllResults :: MonadSTM m
                 => SingProtocolTemperature pt
                 -> TemperatureBundle (ApplicationHandle muxMude bytes m a b)
-                -> STM m LastToFinishResult
+                -> STM m (LastToFinishResult a)
 awaitAllResults tok bundle = do
     results <-  readTVar (getMiniProtocolsVar tok bundle)
             >>= sequence
     return $ Map.foldMapWithKey
                (\num r -> case r of
-                          Errored  e -> SomeErrored [MiniProtocolException num e]
-                          Returned _ -> AllSucceeded
-                          NotRunning -> AllSucceeded)
+                          Errored  e           -> SomeErrored [MiniProtocolException num e]
+                          Returned a           -> AllSucceeded (Map.singleton num a)
+                          NotRunning (Right a) -> AllSucceeded (Map.singleton num a)
+                          NotRunning (Left e)  -> SomeErrored [MiniProtocolException num e]
+                          NotStarted           -> AllSucceeded mempty)
                results
 
 
@@ -738,7 +757,7 @@ withPeerStateActions PeerStateActionsArguments {
                       -- protocols, since 'establishPeerConnection' runs
                       -- 'startProtocols'; for hot protocols this will be
                       -- updated once the peer is promoted to hot.
-                      , pure NotRunning
+                      , pure NotStarted
                       ))
 
 
@@ -770,9 +789,12 @@ withPeerStateActions PeerStateActionsArguments {
         h (Just (Returned a)) = Just $ epReturnDelay spsExitPolicy a
         -- Note: we do 'RethrowPolicy' in 'ConnectionHandler' (see
         -- 'makeConnectionHandler').
-        h (Just Errored {})   = Just $ epErrorDelay spsExitPolicy
-        h (Just NotRunning)   = Nothing
-        h Nothing             = Nothing
+        h (Just Errored {})     = Just $ epErrorDelay spsExitPolicy
+        h (Just (NotRunning a)) = case a of
+                                    Left {} -> Just $ epErrorDelay spsExitPolicy
+                                    Right b -> Just $ epReturnDelay spsExitPolicy b
+        h (Just NotStarted)     = Nothing
+        h Nothing               = Nothing
 
 
     -- Take a warm peer and promote it to a hot one.
@@ -851,6 +873,7 @@ withPeerStateActions PeerStateActionsArguments {
                                 TimeoutError)
           throwIO (DeactivationTimeout pchConnectionId)
 
+        -- some of the hot mini-protocols errored
         Just (SomeErrored errs) -> do
           -- we don't need to notify the connection manager, we can instead
           -- relay on mux property: if any of the mini-protocols errors, mux
@@ -861,7 +884,8 @@ withPeerStateActions PeerStateActionsArguments {
                                 (ApplicationFailure errs))
           throwIO (MiniProtocolExceptions errs)
 
-        Just AllSucceeded -> do
+        -- all hot mini-protocols succeeded
+        Just (AllSucceeded results) -> do
           -- we don't notify the connection manager as this connection is still
           -- useful to the outbound governor (warm peer).
           wasWarm <- atomically $ do
@@ -870,9 +894,10 @@ withPeerStateActions PeerStateActionsArguments {
             notCold <- updateUnlessCold pchPeerStatus PeerWarm
             when notCold $ do
               -- We need to update hot protocols to indicate that they are not
-              -- running.
+              -- running. Preserve the results returned by their previous
+              -- execution.
               modifyTVar (getMiniProtocolsVar SingHot pchAppHandles)
-                         (\a -> Map.map (const (pure NotRunning)) a)
+                         (\_ -> Map.map (pure . NotRunning . Right) results)
             return notCold
 
           if wasWarm
@@ -930,7 +955,7 @@ withPeerStateActions PeerStateActionsArguments {
                                 (ApplicationFailure errs))
           throwIO (MiniProtocolExceptions errs)
 
-        Just AllSucceeded -> do
+        Just AllSucceeded {} -> do
           -- all mini-protocols terminated cleanly
           --
           -- 'unregisterOutboundConnection' could only fail to demote the peer if

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -321,7 +321,7 @@ data FirstToFinishResult
     -- | A mini-protocol failed with an exception.
     = MiniProtocolError   !MiniProtocolException
 
-    -- | A mini-protocols terminated sucessfuly.
+    -- | A mini-protocols terminated successfully.
     --
     -- TODO: we should record the return value of a protocol: it is meaningful
     -- (for tracing).  But it requires more plumbing to be done: consensus

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -883,10 +883,8 @@ withPeerStateActions PeerStateActionsArguments {
             when notCold $ do
               -- We need to update hot protocols to indicate that they are not
               -- running.
-              stateTVar (getMiniProtocolsVar SingHot pchAppHandles)
-                        (\a -> ( ()
-                               , Map.map (const (pure NotRunning)) a
-                               ))
+              modifyTVar (getMiniProtocolsVar SingHot pchAppHandles)
+                         (\a -> Map.map (const (pure NotRunning)) a)
             return notCold
 
           if wasWarm'

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -460,7 +460,6 @@ instance ( Show versionNumber
 
 data PeerSelectionTimeoutException peerAddr
     = DeactivationTimeout    !(ConnectionId peerAddr)
-    | CloseConnectionTimeout !(ConnectionId peerAddr)
   deriving Show
 
 instance ( Show peerAddr

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -215,7 +215,7 @@ demo chain0 updates delay = do
                     pure $ Left ()
                  else
                     pure $ Right $ consumerClient done target chain
-        , ChainSync.points = \_ -> pure $ consumerClient done target chain
+        , ChainSync.points = \_ -> pure $ Right $ consumerClient done target chain
         }
 
 prop_mux_demo_io :: TestBlockChainAndUpdates -> Property

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -171,8 +171,7 @@ run :: forall resolver m.
        , forall a. Semigroup a => Semigroup (m a)
        , Eq (Async m Void)
        )
-    => Tracer m String
-    -> Node.BlockGeneratorArgs Block StdGen
+    => Node.BlockGeneratorArgs Block StdGen
     -> Node.LimitsAndTimeouts Block
     -> Interfaces m
     -> Arguments m
@@ -180,7 +179,7 @@ run :: forall resolver m.
                              NtCAddr NtCVersion NtCVersionData
                              ResolverException m
     -> m Void
-run _debugTracer blockGeneratorArgs limits ni na tracersExtra =
+run blockGeneratorArgs limits ni na tracersExtra =
     Node.withNodeKernelThread blockGeneratorArgs
       $ \ nodeKernel nodeKernelThread -> do
         dnsTimeoutScriptVar <- LazySTM.newTVarIO (aDNSTimeoutScript na)

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -26,6 +26,8 @@ module Test.Ouroboros.Network.Diffusion.Node
   , PeerSelectionTargets (..)
   , RelayAccessPoint (..)
   , UseLedgerAfter (..)
+    -- * configuration constants
+  , config_RECONNECT_DELAY
   ) where
 
 import qualified Control.Concurrent.Class.MonadSTM as LazySTM
@@ -69,6 +71,7 @@ import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.ConnectionManager.Types (DataFlow (..))
 import qualified Ouroboros.Network.Diffusion as Diff
 import qualified Ouroboros.Network.Diffusion.P2P as Diff.P2P
+import           Ouroboros.Network.ExitPolicy (ReconnectDelay (..))
 import           Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.Governor
                      (PeerSelectionTargets (..))
@@ -242,7 +245,7 @@ run _debugTracer blockGeneratorArgs limits ni na tracersExtra =
               , Diff.P2P.daPeerMetrics            = peerMetrics
                 -- fetch mode is not used (no block-fetch mini-protocol)
               , Diff.P2P.daBlockFetchMode         = pure FetchModeDeadline
-              , Diff.P2P.daReturnPolicy           = \_ -> 0
+              , Diff.P2P.daReturnPolicy           = \_ -> config_RECONNECT_DELAY
               }
 
         apps <- Node.applications @_ @BlockHeader (aDebugTracer na) nodeKernel Node.cborCodecs limits appArgs
@@ -389,3 +392,10 @@ ntnToIPv6 :: NtNAddr -> Maybe NtNAddr
 ntnToIPv6 ntnAddr@(TestAddress (Node.EphemeralIPv6Addr _)) = Just ntnAddr
 ntnToIPv6 ntnAddr@(TestAddress (Node.IPAddr (IPv6 _) _))   = Just ntnAddr
 ntnToIPv6 (TestAddress _)                                  = Nothing
+
+--
+-- Constants
+--
+
+config_RECONNECT_DELAY :: ReconnectDelay
+config_RECONNECT_DELAY = 10

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -134,6 +134,7 @@ data Arguments m = Arguments
     , aKeepAliveInterval    :: DiffTime
     , aPingPongInterval     :: DiffTime
     , aShouldChainSyncExit  :: Block -> m Bool
+    , aChainSyncEarlyExit   :: Bool
 
     , aPeerSelectionTargets :: PeerSelectionTargets
     , aReadLocalRootPeers   :: STM m [(Int, Map RelayAccessPoint PeerAdvertise)]
@@ -379,6 +380,7 @@ run _debugTracer blockGeneratorArgs limits ni na tracersExtra =
       , Node.aaKeepAliveInterval        = aKeepAliveInterval na
       , Node.aaPingPongInterval         = aPingPongInterval na
       , Node.aaShouldChainSyncExit      = aShouldChainSyncExit na
+      , Node.aaChainSyncEarlyExit       = aChainSyncEarlyExit na
       }
 
 --- Utils

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -130,6 +130,7 @@ data Arguments m = Arguments
     , aDiffusionMode        :: DiffusionMode
     , aKeepAliveInterval    :: DiffTime
     , aPingPongInterval     :: DiffTime
+    , aShouldChainSyncExit  :: Block -> m Bool
 
     , aPeerSelectionTargets :: PeerSelectionTargets
     , aReadLocalRootPeers   :: STM m [(Int, Map RelayAccessPoint PeerAdvertise)]
@@ -369,7 +370,7 @@ run _debugTracer blockGeneratorArgs limits ni na tracersExtra =
       , Diff.P2P.daBulkChurnInterval     = 300
       }
 
-    appArgs :: Node.AppArgs m
+    appArgs :: Node.AppArgs Block m
     appArgs = Node.AppArgs
       { Node.aaLedgerPeersConsensusInterface
                                         = iLedgerPeersConsensusInterface ni
@@ -377,6 +378,7 @@ run _debugTracer blockGeneratorArgs limits ni na tracersExtra =
       , Node.aaDiffusionMode            = aDiffusionMode na
       , Node.aaKeepAliveInterval        = aKeepAliveInterval na
       , Node.aaPingPongInterval         = aPingPongInterval na
+      , Node.aaShouldChainSyncExit      = aShouldChainSyncExit na
       }
 
 --- Utils

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
@@ -344,7 +344,7 @@ applications debugTracer nodeKernel
                               Continue  -> pure (Right go)
                               Quiesce   -> error "Ouroboros.Network.Protocol.ChainSync.Examples.controlledClient: unexpected Quiesce"
                               Terminate -> pure (Left ())
-              , points = \_ -> pure go
+              , points = \_ -> pure (Right go)
               }
 
     chainSyncResponder

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
@@ -74,6 +74,7 @@ import           Ouroboros.Network.KeepAlive
 import qualified Ouroboros.Network.Mock.Chain as Chain
 import           Ouroboros.Network.Mock.ProducerState
 import           Ouroboros.Network.Mux
+import qualified Ouroboros.Network.NodeToNode as NodeToNode
 import           Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers
                      (LedgerPeersConsensusInterface)
@@ -258,7 +259,7 @@ applications debugTracer nodeKernel
     initiatorAndResponderApp = TemperatureBundle
       { withHot = WithHot $ \ connId controlMessageSTM ->
           [ MiniProtocol
-              { miniProtocolNum    = MiniProtocolNum 2
+              { miniProtocolNum    = NodeToNode.chainSyncMiniProtocolNum
               , miniProtocolLimits = chainSyncLimits limits
               , miniProtocolRun    =
                   InitiatorAndResponderProtocol
@@ -266,7 +267,7 @@ applications debugTracer nodeKernel
                     chainSyncResponder
               }
           , MiniProtocol
-              { miniProtocolNum    = MiniProtocolNum 3
+              { miniProtocolNum    = NodeToNode.blockFetchMiniProtocolNum
               , miniProtocolLimits = blockFetchLimits limits
               , miniProtocolRun    =
                   InitiatorAndResponderProtocol
@@ -286,7 +287,7 @@ applications debugTracer nodeKernel
           ]
       , withEstablished = WithEstablished $ \ connId controlMessageSTM ->
           [ MiniProtocol
-              { miniProtocolNum    = MiniProtocolNum 8
+              { miniProtocolNum    = NodeToNode.keepAliveMiniProtocolNum
               , miniProtocolLimits = keepAliveLimits limits
               , miniProtocolRun    =
                   InitiatorAndResponderProtocol
@@ -307,7 +308,6 @@ applications debugTracer nodeKernel
     chainSyncInitiator ConnectionId { remoteAddress }
                        controlMessageSTM =
         MuxPeerRaw $ \channel -> do
-          labelThisThread "ChainSyncClient"
           bracketSyncWithFetchClient (nkFetchClientRegistry nodeKernel)
                                      remoteAddress $
             bracket (registerClientChains nodeKernel remoteAddress)

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
@@ -446,6 +446,7 @@ unit_4177 = prop_inbound_governor_transitions_coverage absNoAttenuation script
               PeerSelectionTargets {targetNumberOfRootPeers = 0, targetNumberOfKnownPeers = 2, targetNumberOfEstablishedPeers = 2, targetNumberOfActivePeers = 1}
               (Script (DNSTimeout {getDNSTimeout = 0.239} :| [DNSTimeout {getDNSTimeout = 0.181},DNSTimeout {getDNSTimeout = 0.185},DNSTimeout {getDNSTimeout = 0.14},DNSTimeout {getDNSTimeout = 0.221}]))
               (Script (DNSLookupDelay {getDNSLookupDelay = 0.067} :| [DNSLookupDelay {getDNSLookupDelay = 0.097},DNSLookupDelay {getDNSLookupDelay = 0.101},DNSLookupDelay {getDNSLookupDelay = 0.096},DNSLookupDelay {getDNSLookupDelay = 0.051}]))
+              Nothing
           , [JoinNetwork 1.742857142857 Nothing
             ,Reconfigure 6.33333333333 [(1,Map.fromList [(RelayAccessDomain "test2" 65535,DoAdvertisePeer)])
                                         ,(1,Map.fromList [(RelayAccessAddress "0:6:0:3:0:6:0:5" 65530,DoAdvertisePeer)])]
@@ -461,6 +462,7 @@ unit_4177 = prop_inbound_governor_transitions_coverage absNoAttenuation script
              PeerSelectionTargets {targetNumberOfRootPeers = 2, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 1, targetNumberOfActivePeers = 1}
              (Script (DNSTimeout {getDNSTimeout = 0.28} :| [DNSTimeout {getDNSTimeout = 0.204},DNSTimeout {getDNSTimeout = 0.213}]))
              (Script (DNSLookupDelay {getDNSLookupDelay = 0.066} :| [DNSLookupDelay {getDNSLookupDelay = 0.102},DNSLookupDelay {getDNSLookupDelay = 0.031}]))
+             Nothing
           , [JoinNetwork 0.183783783783 Nothing
             ,Reconfigure 4.533333333333 [(1,Map.fromList [])]
             ]
@@ -904,6 +906,7 @@ unit_4191 = prop_diffusion_dns_can_recover absInfo script
                                                                    , DNSLookupDelay {getDNSLookupDelay = 0.05}
                                                                    , DNSLookupDelay {getDNSLookupDelay = 0.039}
                                                                    ]))
+            Nothing
             , [ JoinNetwork 6.710144927536 Nothing
               , Kill 7.454545454545
               , JoinNetwork 10.763157894736 (Just (TestAddress (IPAddr (read "4.138.119.62") 65527)))
@@ -1802,7 +1805,9 @@ async_demotion_network_script =
                            = Governor.PeerSelectionTargets 0 1 1 1,
         naDNSTimeoutScript = singletonScript (DNSTimeout 3),
         naDNSLookupDelayScript
-                           = singletonScript (DNSLookupDelay 0.2)
+                           = singletonScript (DNSLookupDelay 0.2),
+        naChainSyncExitOnBlockNo
+                           = Nothing
       }
 
 
@@ -2199,7 +2204,7 @@ prop_diffusion_cm_valid_transition_order defaultBearerInfo diffScript =
 prop_unit_4258 :: Property
 prop_unit_4258 =
   let bearerInfo = AbsBearerInfo {abiConnectionDelay = NormalDelay, abiInboundAttenuation = NoAttenuation FastSpeed, abiOutboundAttenuation = NoAttenuation FastSpeed, abiInboundWriteFailure = Nothing, abiOutboundWriteFailure = Nothing, abiAcceptFailure = Just (SmallDelay,AbsIOErrResourceExhausted), abiSDUSize = LargeSDU}
-      diffScript = DiffusionScript (SimArgs 1 10) [(NodeArgs (-3) InitiatorAndResponderDiffusionMode (Just 224) [] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.4") 9)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.8" 65531,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 2, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 4, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.397} :| [DNSTimeout {getDNSTimeout = 0.382},DNSTimeout {getDNSTimeout = 0.321},DNSTimeout {getDNSTimeout = 0.143},DNSTimeout {getDNSTimeout = 0.256},DNSTimeout {getDNSTimeout = 0.142},DNSTimeout {getDNSTimeout = 0.341},DNSTimeout {getDNSTimeout = 0.236}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.065} :| [])),[JoinNetwork 4.166666666666 Nothing,Kill 0.3,JoinNetwork 1.517857142857 Nothing,Reconfigure 0.245238095238 [],Reconfigure 4.190476190476 []]),(NodeArgs (-5) InitiatorAndResponderDiffusionMode (Just 269) [RelayAccessAddress "0.0.0.4" 9] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.8") 65531)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 4, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 3, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.281} :| [DNSTimeout {getDNSTimeout = 0.177},DNSTimeout {getDNSTimeout = 0.164},DNSTimeout {getDNSTimeout = 0.373}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.133} :| [DNSLookupDelay {getDNSLookupDelay = 0.128},DNSLookupDelay {getDNSLookupDelay = 0.049},DNSLookupDelay {getDNSLookupDelay = 0.058},DNSLookupDelay {getDNSLookupDelay = 0.042},DNSLookupDelay {getDNSLookupDelay = 0.117},DNSLookupDelay {getDNSLookupDelay = 0.064}])),[JoinNetwork 3.384615384615 Nothing,Reconfigure 3.583333333333 [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])],Kill 15.55555555555,JoinNetwork 30.53333333333 Nothing,Kill 71.11111111111])]
+      diffScript = DiffusionScript (SimArgs 1 10) [(NodeArgs (-3) InitiatorAndResponderDiffusionMode (Just 224) [] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.4") 9)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.8" 65531,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 2, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 4, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.397} :| [DNSTimeout {getDNSTimeout = 0.382},DNSTimeout {getDNSTimeout = 0.321},DNSTimeout {getDNSTimeout = 0.143},DNSTimeout {getDNSTimeout = 0.256},DNSTimeout {getDNSTimeout = 0.142},DNSTimeout {getDNSTimeout = 0.341},DNSTimeout {getDNSTimeout = 0.236}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.065} :| [])) Nothing,[JoinNetwork 4.166666666666 Nothing,Kill 0.3,JoinNetwork 1.517857142857 Nothing,Reconfigure 0.245238095238 [],Reconfigure 4.190476190476 []]),(NodeArgs (-5) InitiatorAndResponderDiffusionMode (Just 269) [RelayAccessAddress "0.0.0.4" 9] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.8") 65531)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 4, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 3, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.281} :| [DNSTimeout {getDNSTimeout = 0.177},DNSTimeout {getDNSTimeout = 0.164},DNSTimeout {getDNSTimeout = 0.373}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.133} :| [DNSLookupDelay {getDNSLookupDelay = 0.128},DNSLookupDelay {getDNSLookupDelay = 0.049},DNSLookupDelay {getDNSLookupDelay = 0.058},DNSLookupDelay {getDNSLookupDelay = 0.042},DNSLookupDelay {getDNSLookupDelay = 0.117},DNSLookupDelay {getDNSLookupDelay = 0.064}])) Nothing,[JoinNetwork 3.384615384615 Nothing,Reconfigure 3.583333333333 [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])],Kill 15.55555555555,JoinNetwork 30.53333333333 Nothing,Kill 71.11111111111])]
    in prop_diffusion_cm_valid_transition_order bearerInfo diffScript
 
 -- | A variant of ouroboros-network-framework

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
@@ -198,6 +198,7 @@ debugTracer = tracerWithTime
     tracer :: Tracer (IOSim s) (WithTime (WithName NtNAddr DiffusionTestTrace))
     tracer = Tracer traceM
 
+-- TODO: this should be part of the node setup if we use it for all the tests.
 tracersExtraWithTimeName
   :: NtNAddr
   -> Diff.P2P.TracersExtra NtNAddr NtNVersion NtNVersionData
@@ -205,7 +206,7 @@ tracersExtraWithTimeName
                            SomeException (IOSim s)
 tracersExtraWithTimeName ntnAddr =
   Diff.P2P.TracersExtra {
-    dtTraceLocalRootPeersTracer           = contramap
+      dtTraceLocalRootPeersTracer         = contramap
                                              DiffusionLocalRootPeerTrace
                                           . tracerWithName ntnAddr
                                           . tracerWithTime

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet.hs
@@ -448,6 +448,7 @@ unit_4177 = prop_inbound_governor_transitions_coverage absNoAttenuation script
               (Script (DNSTimeout {getDNSTimeout = 0.239} :| [DNSTimeout {getDNSTimeout = 0.181},DNSTimeout {getDNSTimeout = 0.185},DNSTimeout {getDNSTimeout = 0.14},DNSTimeout {getDNSTimeout = 0.221}]))
               (Script (DNSLookupDelay {getDNSLookupDelay = 0.067} :| [DNSLookupDelay {getDNSLookupDelay = 0.097},DNSLookupDelay {getDNSLookupDelay = 0.101},DNSLookupDelay {getDNSLookupDelay = 0.096},DNSLookupDelay {getDNSLookupDelay = 0.051}]))
               Nothing
+              False
           , [JoinNetwork 1.742857142857 Nothing
             ,Reconfigure 6.33333333333 [(1,Map.fromList [(RelayAccessDomain "test2" 65535,DoAdvertisePeer)])
                                         ,(1,Map.fromList [(RelayAccessAddress "0:6:0:3:0:6:0:5" 65530,DoAdvertisePeer)])]
@@ -464,6 +465,7 @@ unit_4177 = prop_inbound_governor_transitions_coverage absNoAttenuation script
              (Script (DNSTimeout {getDNSTimeout = 0.28} :| [DNSTimeout {getDNSTimeout = 0.204},DNSTimeout {getDNSTimeout = 0.213}]))
              (Script (DNSLookupDelay {getDNSLookupDelay = 0.066} :| [DNSLookupDelay {getDNSLookupDelay = 0.102},DNSLookupDelay {getDNSLookupDelay = 0.031}]))
              Nothing
+             False
           , [JoinNetwork 0.183783783783 Nothing
             ,Reconfigure 4.533333333333 [(1,Map.fromList [])]
             ]
@@ -908,6 +910,7 @@ unit_4191 = prop_diffusion_dns_can_recover absInfo script
                                                                    , DNSLookupDelay {getDNSLookupDelay = 0.039}
                                                                    ]))
             Nothing
+            False
             , [ JoinNetwork 6.710144927536 Nothing
               , Kill 7.454545454545
               , JoinNetwork 10.763157894736 (Just (TestAddress (IPAddr (read "4.138.119.62") 65527)))
@@ -1808,7 +1811,9 @@ async_demotion_network_script =
         naDNSLookupDelayScript
                            = singletonScript (DNSLookupDelay 0.2),
         naChainSyncExitOnBlockNo
-                           = Nothing
+                           = Nothing,
+        naChainSyncEarlyExit
+                           = False
       }
 
 
@@ -2202,10 +2207,13 @@ prop_diffusion_cm_valid_transition_order defaultBearerInfo diffScript =
 
 -- | Unit test that checks issue 4258
 -- https://github.com/input-output-hk/ouroboros-network/issues/4258
+--
+-- TODO: prettify the expression so it's easier to maintain it when things
+-- change.
 prop_unit_4258 :: Property
 prop_unit_4258 =
   let bearerInfo = AbsBearerInfo {abiConnectionDelay = NormalDelay, abiInboundAttenuation = NoAttenuation FastSpeed, abiOutboundAttenuation = NoAttenuation FastSpeed, abiInboundWriteFailure = Nothing, abiOutboundWriteFailure = Nothing, abiAcceptFailure = Just (SmallDelay,AbsIOErrResourceExhausted), abiSDUSize = LargeSDU}
-      diffScript = DiffusionScript (SimArgs 1 10) [(NodeArgs (-3) InitiatorAndResponderDiffusionMode (Just 224) [] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.4") 9)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.8" 65531,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 2, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 4, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.397} :| [DNSTimeout {getDNSTimeout = 0.382},DNSTimeout {getDNSTimeout = 0.321},DNSTimeout {getDNSTimeout = 0.143},DNSTimeout {getDNSTimeout = 0.256},DNSTimeout {getDNSTimeout = 0.142},DNSTimeout {getDNSTimeout = 0.341},DNSTimeout {getDNSTimeout = 0.236}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.065} :| [])) Nothing,[JoinNetwork 4.166666666666 Nothing,Kill 0.3,JoinNetwork 1.517857142857 Nothing,Reconfigure 0.245238095238 [],Reconfigure 4.190476190476 []]),(NodeArgs (-5) InitiatorAndResponderDiffusionMode (Just 269) [RelayAccessAddress "0.0.0.4" 9] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.8") 65531)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 4, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 3, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.281} :| [DNSTimeout {getDNSTimeout = 0.177},DNSTimeout {getDNSTimeout = 0.164},DNSTimeout {getDNSTimeout = 0.373}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.133} :| [DNSLookupDelay {getDNSLookupDelay = 0.128},DNSLookupDelay {getDNSLookupDelay = 0.049},DNSLookupDelay {getDNSLookupDelay = 0.058},DNSLookupDelay {getDNSLookupDelay = 0.042},DNSLookupDelay {getDNSLookupDelay = 0.117},DNSLookupDelay {getDNSLookupDelay = 0.064}])) Nothing,[JoinNetwork 3.384615384615 Nothing,Reconfigure 3.583333333333 [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])],Kill 15.55555555555,JoinNetwork 30.53333333333 Nothing,Kill 71.11111111111])]
+      diffScript = DiffusionScript (SimArgs 1 10) [(NodeArgs (-3) InitiatorAndResponderDiffusionMode (Just 224) [] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.4") 9)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.8" 65531,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 2, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 4, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.397} :| [DNSTimeout {getDNSTimeout = 0.382},DNSTimeout {getDNSTimeout = 0.321},DNSTimeout {getDNSTimeout = 0.143},DNSTimeout {getDNSTimeout = 0.256},DNSTimeout {getDNSTimeout = 0.142},DNSTimeout {getDNSTimeout = 0.341},DNSTimeout {getDNSTimeout = 0.236}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.065} :| [])) Nothing False,[JoinNetwork 4.166666666666 Nothing,Kill 0.3,JoinNetwork 1.517857142857 Nothing,Reconfigure 0.245238095238 [],Reconfigure 4.190476190476 []]),(NodeArgs (-5) InitiatorAndResponderDiffusionMode (Just 269) [RelayAccessAddress "0.0.0.4" 9] (Map.fromList []) (TestAddress (IPAddr (read "0.0.0.8") 65531)) [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])] PeerSelectionTargets {targetNumberOfRootPeers = 4, targetNumberOfKnownPeers = 5, targetNumberOfEstablishedPeers = 3, targetNumberOfActivePeers = 1} (Script (DNSTimeout {getDNSTimeout = 0.281} :| [DNSTimeout {getDNSTimeout = 0.177},DNSTimeout {getDNSTimeout = 0.164},DNSTimeout {getDNSTimeout = 0.373}])) (Script (DNSLookupDelay {getDNSLookupDelay = 0.133} :| [DNSLookupDelay {getDNSLookupDelay = 0.128},DNSLookupDelay {getDNSLookupDelay = 0.049},DNSLookupDelay {getDNSLookupDelay = 0.058},DNSLookupDelay {getDNSLookupDelay = 0.042},DNSLookupDelay {getDNSLookupDelay = 0.117},DNSLookupDelay {getDNSLookupDelay = 0.064}])) Nothing False,[JoinNetwork 3.384615384615 Nothing,Reconfigure 3.583333333333 [(1,Map.fromList [(RelayAccessAddress "0.0.0.4" 9,DoNotAdvertisePeer)])],Kill 15.55555555555,JoinNetwork 30.53333333333 Nothing,Kill 71.11111111111])]
    in prop_diffusion_cm_valid_transition_order bearerInfo diffScript
 
 -- | A variant of ouroboros-network-framework

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -155,6 +155,7 @@ data NodeArgs =
     , naDNSLookupDelayScript   :: Script DNSLookupDelay
       -- ^ 'Arguments' 'aDNSLookupDelayScript' value
     , naChainSyncExitOnBlockNo :: Maybe BlockNo
+    , naChainSyncEarlyExit     :: Bool
     }
 
 instance Show NodeArgs where
@@ -347,6 +348,10 @@ genNodeArgs raps minConnected genLocalRootPeers (ntnAddr, rap) = do
                  , (4, pure Nothing)
                  ]
 
+  chainSyncEarlyExit <- frequency [ (1, pure True)
+                                  , (9, pure False)
+                                  ]
+
   return
    $ NodeArgs
       { naSeed                   = seed
@@ -360,6 +365,7 @@ genNodeArgs raps minConnected genLocalRootPeers (ntnAddr, rap) = do
       , naDNSTimeoutScript       = dnsTimeout
       , naDNSLookupDelayScript   = dnsLookupDelay
       , naChainSyncExitOnBlockNo = chainSyncExitOnBlockNo
+      , naChainSyncEarlyExit     = chainSyncEarlyExit
       }
   where
     hasActive :: Int -> PeerSelectionTargets -> Bool
@@ -739,6 +745,7 @@ diffusionSimulation
             , naDNSTimeoutScript       = dnsTimeout
             , naDNSLookupDelayScript   = dnsLookupDelay
             , naChainSyncExitOnBlockNo = chainSyncExitOnBlockNo
+            , naChainSyncEarlyExit     = chainSyncEarlyExit
             }
             ntnSnocket
             ntcSnocket
@@ -838,6 +845,7 @@ diffusionSimulation
               , NodeKernel.aPingPongInterval     = 10
               , NodeKernel.aPeerSelectionTargets = peerSelectionTargets
               , NodeKernel.aShouldChainSyncExit  = shouldChainSyncExit chainSyncExitVar
+              , NodeKernel.aChainSyncEarlyExit   = chainSyncEarlyExit
               , NodeKernel.aReadLocalRootPeers   = readLocalRootPeers
               , NodeKernel.aReadPublicRootPeers  = readPublicRootPeers
               , NodeKernel.aReadUseLedgerAfter   = readUseLedgerAfter

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -88,7 +88,8 @@ import           Ouroboros.Network.Server.RateLimiting
 import           Ouroboros.Network.Snocket (Snocket, TestAddress (..))
 
 import           Ouroboros.Network.Block (BlockNo)
-import           Ouroboros.Network.Mock.ConcreteBlock (Block (..), BlockHeader (..))
+import           Ouroboros.Network.Mock.ConcreteBlock (Block (..),
+                     BlockHeader (..))
 import           Ouroboros.Network.Testing.Data.Script (Script (..))
 import           Ouroboros.Network.Testing.Utils (WithName (..),
                      genDelayWithPrecision, tracerWithName)

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -33,15 +33,13 @@ module Test.Ouroboros.Network.Testnet.Simulation.Node
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad (forM, replicateM, (>=>))
 import           Control.Monad.Class.MonadAsync
-                     (MonadAsync (Async, cancel, waitAny, withAsync))
-import           Control.Monad.Class.MonadFork (MonadFork)
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSay
-import           Control.Monad.Class.MonadST (MonadST)
-import           Control.Monad.Class.MonadThrow (MonadCatch, MonadEvaluate,
-                     MonadMask, MonadThrow, SomeException)
-import           Control.Monad.Class.MonadTime (DiffTime, MonadTime)
-import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
-import           Control.Monad.Fix (MonadFix)
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Fix
 import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 
 import           Control.Monad.IOSim (IOSim, traceM)
@@ -729,22 +727,22 @@ diffusionSimulation
                          dMapVarMap'' sArgs nArgs' cs
     runCommand _ _ _ _ _ _ (JoinNetwork _ _:_) =
       error "runCommand: Impossible happened"
-    runCommand (Just (async, _)) ntnSnocket ntcSnocket dMapVarMap sArgs nArgs
+    runCommand (Just (async_, _)) ntnSnocket ntcSnocket dMapVarMap sArgs nArgs
                (Kill delay:cs) = do
       threadDelay delay
       traceWith tracer (WithName (naAddr nArgs) TrKillingNode)
-      cancel async
+      cancel async_
       runCommand Nothing ntnSnocket ntcSnocket dMapVarMap sArgs nArgs cs
     runCommand _ _ _ _ _ _ (Kill _:_) = do
       error "runCommand: Impossible happened"
     runCommand Nothing _ _ _ _ _ (Reconfigure _ _:_) =
       error "runCommand: Impossible happened"
-    runCommand (Just (async, lrpVar)) ntnSnocket ntcSnocket dMapVarMap sArgs nArgs
+    runCommand (Just (async_, lrpVar)) ntnSnocket ntcSnocket dMapVarMap sArgs nArgs
                (Reconfigure delay newLrp:cs) = do
       threadDelay delay
       traceWith tracer (WithName (naAddr nArgs) TrReconfiguringNode)
       _ <- atomically $ writeTVar lrpVar newLrp
-      runCommand (Just (async, lrpVar)) ntnSnocket ntcSnocket dMapVarMap sArgs nArgs
+      runCommand (Just (async_, lrpVar)) ntnSnocket ntcSnocket dMapVarMap sArgs nArgs
                  cs
 
     updateDomainMap :: DiffTime

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -344,7 +344,8 @@ genNodeArgs raps minConnected genLocalRootPeers (ntnAddr, rap) = do
   dnsLookupDelay <- arbitrary
   chainSyncExitOnBlockNo
     <- frequency [ (1,      Just . fromIntegral . getPositive
-                       <$> (arbitrary :: Gen (Positive Int)))
+                        <$> (arbitrary :: Gen (Positive Int))
+                            `suchThat` (\(Positive a) -> a < 5))
                  , (4, pure Nothing)
                  ]
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -281,7 +281,9 @@ genSimArgs raps = do
   -- chance that someone gets to make a block
   let bgaSlotDuration = secondsToDiffTime 1
       numberOfNodes   = length [ r | r@(RelayAccessAddress _ _) <- raps ]
-      quota = 20 `div` numberOfNodes
+      quota = if numberOfNodes > 0
+                then 20 `div` numberOfNodes
+                else 100
 
   return
    $ SimArgs

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -244,5 +244,5 @@ demo chain0 updates = do
                     pure $ Left ()
                  else
                     pure $ Right $ consumerClient done target chain
-        , ChainSync.points = \_ -> pure $ consumerClient done target chain
+        , ChainSync.points = \_ -> pure $ Right $ consumerClient done target chain
         }

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -227,7 +227,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
                     pure $ Left ()
                  else
                     pure $ Right $ consumerClient done target chain
-        , ChainSync.points = \_ -> pure $ consumerClient done target chain
+        , ChainSync.points = \_ -> pure $ Right $ consumerClient done target chain
         }
 
 data WithThreadAndTime a = WithThreadAndTime {


### PR DESCRIPTION

# Description

This PR fixes three bugs (two in production code, one in testing)

* fixed a `hot -> warm -> hot` cycle; we used to forget the reason for `hot -> warm` demotion and then use `0` promtion delay.
* fixed exception handling in `deactivatePeerConnection` (part of
  `PeerStateActions`), which can result in a tight loop (eventually broken by mux shutdown)

* fixed a deadlock of chain-sync & block-fetch in `sim-net`: we used two
  different `FetchClientRegistry` which blocked `chain-sync` to start.

This PR also includes a test which can reproduce the first bug and various
smaller code changes.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
