### PR TITLE
Introduces property checking the size of Header's VRF Certs for different Eras

### DIFF
--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -83,6 +83,7 @@ test-suite test
   main-is:             Main.hs
   other-modules:
                        Test.Consensus.Cardano.ByronCompatibility
+                       Test.Consensus.Cardano.Crypto
                        Test.Consensus.Cardano.Golden
                        Test.Consensus.Cardano.Serialisation
                        Test.ThreadNet.AllegraMary

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -94,6 +94,7 @@ test-suite test
   build-depends:       base              >=4.14 && <4.17
                      , bytestring
                      , cardano-crypto-class
+                     , cardano-crypto-praos
                      , cardano-slotting
                      , cborg
                      , containers

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
@@ -10,8 +10,8 @@ import           Cardano.Crypto.KES (MockKES)
 import           Cardano.Crypto.VRF (MockVRF)
 
 import           Cardano.Ledger.Crypto (Crypto (..))
+import qualified Cardano.Protocol.TPraos.API as Ledger
 
-import qualified Ouroboros.Consensus.Protocol.Praos as Praos
 import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 
 -- | A replacement for 'Test.Consensus.Shelley.MockCrypto' that is compatible
@@ -41,6 +41,6 @@ instance Crypto MockCryptoCompatByron where
   type KES      MockCryptoCompatByron = MockKES 10
   type VRF      MockCryptoCompatByron = MockVRF
 
-instance TPraos.PraosCrypto MockCryptoCompatByron
+instance Ledger.PraosCrypto MockCryptoCompatByron
 
-instance Praos.PraosCrypto MockCryptoCompatByron
+instance TPraos.PraosCrypto MockCryptoCompatByron

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
@@ -10,7 +10,7 @@ import           Cardano.Crypto.KES (MockKES)
 import           Cardano.Crypto.VRF (MockVRF)
 
 import           Cardano.Ledger.Crypto (Crypto (..))
-import qualified Cardano.Protocol.TPraos.API as Ledger
+import qualified Cardano.Protocol.TPraos.API as Protocol
 
 import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 
@@ -41,6 +41,6 @@ instance Crypto MockCryptoCompatByron where
   type KES      MockCryptoCompatByron = MockKES 10
   type VRF      MockCryptoCompatByron = MockVRF
 
-instance Ledger.PraosCrypto MockCryptoCompatByron
+instance Protocol.PraosCrypto MockCryptoCompatByron
 
 instance TPraos.PraosCrypto MockCryptoCompatByron

--- a/ouroboros-consensus-cardano-test/test/Main.hs
+++ b/ouroboros-consensus-cardano-test/test/Main.hs
@@ -8,6 +8,7 @@ import           Cardano.Crypto.Libsodium (sodiumInit)
 import           Test.Tasty
 
 import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
+import qualified Test.Consensus.Cardano.Crypto (tests)
 import qualified Test.Consensus.Cardano.Golden (tests)
 import qualified Test.Consensus.Cardano.Serialisation (tests)
 import qualified Test.ThreadNet.AllegraMary (tests)
@@ -30,6 +31,7 @@ tests =
   [ Test.Consensus.Cardano.ByronCompatibility.tests
   , Test.Consensus.Cardano.Golden.tests
   , Test.Consensus.Cardano.Serialisation.tests
+  , Test.Consensus.Cardano.Crypto.tests
   , Test.ThreadNet.AllegraMary.tests
   , Test.ThreadNet.Cardano.tests
   , Test.ThreadNet.MaryAlonzo.tests

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
@@ -41,16 +41,20 @@ tests =
 
 -- | Check that Babbage and Conway blocks use different VRF crypto.
 --
+-- This test is based on the following steps:
+--
 -- 1. generate (forge?) babbage or conway headers
---   - those should contain different VRF proofs (because they are supposed to use different algorithms)
+--   - those should contain different VRF proofs (because they are supposed to
+--     use different algorithms)
 --   - the VRF proof should be invalid for the other era
 -- 2. call some header validation functions that's calling VRF certificate check
 -- 3. assert that different VRF function is called for each era
 --    - the header should be valid
 --
--- * why not mock everything? because it does not check that we are implementing things correctly for Conway
---   we would like to test the dispatching induced by this type, to make it clear that Conway relies on different
---   crypto primitives
+-- * why not mock everything? because it does not check that we are
+--   implementing things correctly for Conway we would like to test
+--   the dispatchign induced by this type, to make clear Conway relies
+--   on different crypto primitives
 --
 -- What needs to change is this type:
 --

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
@@ -19,7 +19,8 @@
 module Test.Consensus.Cardano.Crypto (tests) where
 
 
-import           Cardano.Crypto.VRF (sizeOutputVRF, sizeCertVRF)
+import           Cardano.Crypto.VRF (sizeCertVRF)
+import           Cardano.Crypto.VRF.Praos (certSizeVRF)
 import           Ouroboros.Consensus.Cardano.Block (CardanoHeader,
                      StandardCrypto, pattern HeaderBabbage,
                      pattern HeaderConway)
@@ -28,7 +29,6 @@ import           Ouroboros.Consensus.Shelley.Protocol.Abstract
                      (pTieBreakVRFValue)
 import           Ouroboros.Consensus.Shelley.Protocol.Praos ()
 import           Test.Consensus.Cardano.Generators ()
-import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
 import           Test.QuickCheck (Property, property, (===))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
@@ -39,36 +39,46 @@ tests =
           testProperty "era-dependent VRF" prop_VRFCryptoDependsOnBlockEra
     ]
 
-
+-- | Check Babbage and Conway blocks use different VRF crypto.
+--
+-- 1. generate (forge?) babbage or conway headers
+--   - those should contain different VRF proofs (because they are supposed to use different algorithms)
+--   - the VRF proof should be invalid for the other era
+-- 2. call some header validation functions that's calling VRF certificate check
+-- 3. assert that different VRF function is called for each era
+--    - the header should be valid
+--
+-- * why not mock everything? because it does not check that we are implementing things correctly for Conway
+--   we would like to test the dispatchign induced by this type, to make clear Conway relies on different
+--   crypto primitives
+--
+-- What needs to change is this type:
+--
+-- @@
+-- type CardanoShelleyEras c =
+--   '[ ShelleyBlock (TPraos c) (ShelleyEra c)
+--    , ShelleyBlock (TPraos c) (AllegraEra c)
+--    , ShelleyBlock (TPraos c) (MaryEra c)
+--    , ShelleyBlock (TPraos c) (AlonzoEra c)
+--    , ShelleyBlock (Praos c)  (BabbageEra c)
+--    , ShelleyBlock (Praos c)  (ConwayEra c)
+--    ]
+-- @@
+--
+-- is it enough to test a single specialised crypto function? yes,
+-- because that's a start, but also because using the high level
+-- HFBlock even with a single function would be evidence we are doing
+-- the dispatching right => we don't test the actual crypto functions,
+-- only the "dispatching" logic that requires different instances for
+-- different eras.
+--
 prop_VRFCryptoDependsOnBlockEra :: CardanoHeader StandardCrypto -> Property
 prop_VRFCryptoDependsOnBlockEra h =
   case h of
-    HeaderBabbage ShelleyHeader {shelleyHeaderRaw} -> sizeCertVRF (pTieBreakVRFValue shelleyHeaderRaw) === 8
-    HeaderConway ShelleyHeader {shelleyHeaderRaw} -> sizeCertVRF (pTieBreakVRFValue shelleyHeaderRaw) === 42
+    HeaderBabbage ShelleyHeader {shelleyHeaderRaw} ->
+      sizeCertVRF (pTieBreakVRFValue shelleyHeaderRaw) === fromIntegral certSizeVRF
+    HeaderConway ShelleyHeader {shelleyHeaderRaw} ->
+      -- TODO: this is were we need to change to check we use in the Conway case
+      -- Cardano.Crypto.VRF.PraosBatchCompat.certSizevrf
+      sizeCertVRF (pTieBreakVRFValue shelleyHeaderRaw) === fromIntegral certSizeVRF
     _ -> property True
-
-  -- 1. generate (forge?) babbage or conway headers
-  --   - those should contain different VRF proofs (because they are supposed to use different algorithms)
-  --   - the VRF proof should be invalid for the other era
-  -- 2. call some header validation functions that's calling VRF certificate check
-  -- 3. assert that different VRF function is called for each era
-  --    - the header should be valid
-  --
-  -- why not mock everything? because it does not check that we are implementing things correctly for Conway
-  --
-  -- we would like to test the dispatchign induced by this type, to make clear Conway relies on different
-  -- crypto primitives
-  --
-  -- type CardanoShelleyEras c =
-  --   '[ ShelleyBlock (TPraos c) (ShelleyEra c)
-  --    , ShelleyBlock (TPraos c) (AllegraEra c)
-  --    , ShelleyBlock (TPraos c) (MaryEra c)
-  --    , ShelleyBlock (TPraos c) (AlonzoEra c)
-  --    , ShelleyBlock (Praos c)  (BabbageEra c)
-  --    , ShelleyBlock (Praos c)  (ConwayEra c)
-  --    ]
-  --
-  -- is it enough to test a single specialised crypto function?
-  -- - yes, becausae that's a start! but also because using the high levle HFBlock even with a single function
-  --   would be evidence we are doing the dispatching right => we don't test the actual crypto functions, only
-  --   the "dispatching" logic that requires different instances for different eras

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+-- | Tests consensus-specific crypto operations in relationship with blocks/headers.
+module Test.Consensus.Cardano.Crypto (tests) where
+
+
+import           Cardano.Crypto.VRF (sizeOutputVRF, sizeCertVRF)
+import           Ouroboros.Consensus.Cardano.Block (CardanoHeader,
+                     StandardCrypto, pattern HeaderBabbage,
+                     pattern HeaderConway)
+import           Ouroboros.Consensus.Shelley.Ledger.Block (Header (..))
+import           Ouroboros.Consensus.Shelley.Protocol.Abstract
+                     (pTieBreakVRFValue)
+import           Ouroboros.Consensus.Shelley.Protocol.Praos ()
+import           Test.Consensus.Cardano.Generators ()
+import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
+import           Test.QuickCheck (Property, property, (===))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+    testGroup "Cardano Crypto" [
+          testProperty "era-dependent VRF" prop_VRFCryptoDependsOnBlockEra
+    ]
+
+
+prop_VRFCryptoDependsOnBlockEra :: CardanoHeader StandardCrypto -> Property
+prop_VRFCryptoDependsOnBlockEra h =
+  case h of
+    HeaderBabbage ShelleyHeader {shelleyHeaderRaw} -> sizeCertVRF (pTieBreakVRFValue shelleyHeaderRaw) === 8
+    HeaderConway ShelleyHeader {shelleyHeaderRaw} -> sizeCertVRF (pTieBreakVRFValue shelleyHeaderRaw) === 42
+    _ -> property True
+
+  -- 1. generate (forge?) babbage or conway headers
+  --   - those should contain different VRF proofs (because they are supposed to use different algorithms)
+  --   - the VRF proof should be invalid for the other era
+  -- 2. call some header validation functions that's calling VRF certificate check
+  -- 3. assert that different VRF function is called for each era
+  --    - the header should be valid
+  --
+  -- why not mock everything? because it does not check that we are implementing things correctly for Conway
+  --
+  -- we would like to test the dispatchign induced by this type, to make clear Conway relies on different
+  -- crypto primitives
+  --
+  -- type CardanoShelleyEras c =
+  --   '[ ShelleyBlock (TPraos c) (ShelleyEra c)
+  --    , ShelleyBlock (TPraos c) (AllegraEra c)
+  --    , ShelleyBlock (TPraos c) (MaryEra c)
+  --    , ShelleyBlock (TPraos c) (AlonzoEra c)
+  --    , ShelleyBlock (Praos c)  (BabbageEra c)
+  --    , ShelleyBlock (Praos c)  (ConwayEra c)
+  --    ]
+  --
+  -- is it enough to test a single specialised crypto function?
+  -- - yes, becausae that's a start! but also because using the high levle HFBlock even with a single function
+  --   would be evidence we are doing the dispatching right => we don't test the actual crypto functions, only
+  --   the "dispatching" logic that requires different instances for different eras

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
@@ -39,7 +39,7 @@ tests =
           testProperty "era-dependent VRF" prop_VRFCryptoDependsOnBlockEra
     ]
 
--- | Check Babbage and Conway blocks use different VRF crypto.
+-- | Check that Babbage and Conway blocks use different VRF crypto.
 --
 -- 1. generate (forge?) babbage or conway headers
 --   - those should contain different VRF proofs (because they are supposed to use different algorithms)

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Crypto.hs
@@ -49,7 +49,7 @@ tests =
 --    - the header should be valid
 --
 -- * why not mock everything? because it does not check that we are implementing things correctly for Conway
---   we would like to test the dispatchign induced by this type, to make clear Conway relies on different
+--   we would like to test the dispatching induced by this type, to make it clear that Conway relies on different
 --   crypto primitives
 --
 -- What needs to change is this type:

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -47,6 +47,7 @@ library
                      , cardano-data
                      , cardano-ledger-byron
                      , cardano-ledger-core
+                     , cardano-ledger-mary
                      , cardano-ledger-shelley
                      , cardano-prelude
                      , cardano-protocol-tpraos

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -74,8 +74,7 @@ import           Ouroboros.Consensus.Shelley.ShelleyHFC
 
 import           Cardano.Ledger.Crypto (ADDRHASH, Crypto, DSIGN, HASH)
 import qualified Cardano.Ledger.Era as SL
-import           Cardano.Ledger.Hashes (EraIndependentTxBody)
-import           Cardano.Ledger.Keys (DSignable, Hash)
+import           Cardano.Ledger.Mary.Translation ()
 import qualified Cardano.Ledger.Shelley.API as SL
 import           Cardano.Ledger.Shelley.Translation
                      (toFromByronTranslationContext)
@@ -514,7 +513,7 @@ translateLedgerViewByronToShelleyWrapper =
 -------------------------------------------------------------------------------}
 
 translateLedgerStateShelleyToAllegraWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -526,7 +525,7 @@ translateLedgerStateShelleyToAllegraWrapper =
         unComp . SL.translateEra' () . Comp
 
 translateTxShelleyToAllegraWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => InjectTx
        (ShelleyBlock (TPraos c) (ShelleyEra c))
        (ShelleyBlock (TPraos c) (AllegraEra c))
@@ -534,7 +533,7 @@ translateTxShelleyToAllegraWrapper = InjectTx $
     fmap unComp . eitherToMaybe . runExcept . SL.translateEra () . Comp
 
 translateValidatedTxShelleyToAllegraWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => InjectValidatedTx
        (ShelleyBlock (TPraos c) (ShelleyEra c))
        (ShelleyBlock (TPraos c) (AllegraEra c))
@@ -546,7 +545,7 @@ translateValidatedTxShelleyToAllegraWrapper = InjectValidatedTx $
 -------------------------------------------------------------------------------}
 
 translateLedgerStateAllegraToMaryWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -562,7 +561,7 @@ translateLedgerStateAllegraToMaryWrapper =
 -------------------------------------------------------------------------------}
 
 translateTxAllegraToMaryWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => InjectTx
        (ShelleyBlock (TPraos c) (AllegraEra c))
        (ShelleyBlock (TPraos c) (MaryEra c))
@@ -570,7 +569,7 @@ translateTxAllegraToMaryWrapper = InjectTx $
     fmap unComp . eitherToMaybe . runExcept . SL.translateEra () . Comp
 
 translateValidatedTxAllegraToMaryWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => InjectValidatedTx
        (ShelleyBlock (TPraos c) (AllegraEra c))
        (ShelleyBlock (TPraos c) (MaryEra c))
@@ -582,7 +581,7 @@ translateValidatedTxAllegraToMaryWrapper = InjectValidatedTx $
 -------------------------------------------------------------------------------}
 
 translateLedgerStateMaryToAlonzoWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -600,7 +599,7 @@ getAlonzoTranslationContext =
     shelleyLedgerTranslationContext . unwrapLedgerConfig
 
 translateTxMaryToAlonzoWrapper ::
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => SL.TranslationContext (AlonzoEra c)
   -> InjectTx
        (ShelleyBlock (TPraos c) (MaryEra c))
@@ -610,7 +609,7 @@ translateTxMaryToAlonzoWrapper ctxt = InjectTx $
 
 translateValidatedTxMaryToAlonzoWrapper ::
      forall c.
-     (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+     (PraosCrypto c)
   => SL.TranslationContext (AlonzoEra c)
   -> InjectValidatedTx
        (ShelleyBlock (TPraos c) (MaryEra c))
@@ -623,7 +622,7 @@ translateValidatedTxMaryToAlonzoWrapper ctxt = InjectValidatedTx $
 -------------------------------------------------------------------------------}
 
 translateLedgerStateAlonzoToBabbageWrapper ::
-     (Praos.PraosCrypto c, TPraos.PraosCrypto c)
+     (Praos.PraosCrypto c)
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -513,7 +513,7 @@ translateLedgerViewByronToShelleyWrapper =
 -------------------------------------------------------------------------------}
 
 translateLedgerStateShelleyToAllegraWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -525,7 +525,7 @@ translateLedgerStateShelleyToAllegraWrapper =
         unComp . SL.translateEra' () . Comp
 
 translateTxShelleyToAllegraWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => InjectTx
        (ShelleyBlock (TPraos c) (ShelleyEra c))
        (ShelleyBlock (TPraos c) (AllegraEra c))
@@ -533,7 +533,7 @@ translateTxShelleyToAllegraWrapper = InjectTx $
     fmap unComp . eitherToMaybe . runExcept . SL.translateEra () . Comp
 
 translateValidatedTxShelleyToAllegraWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => InjectValidatedTx
        (ShelleyBlock (TPraos c) (ShelleyEra c))
        (ShelleyBlock (TPraos c) (AllegraEra c))
@@ -545,7 +545,7 @@ translateValidatedTxShelleyToAllegraWrapper = InjectValidatedTx $
 -------------------------------------------------------------------------------}
 
 translateLedgerStateAllegraToMaryWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -561,7 +561,7 @@ translateLedgerStateAllegraToMaryWrapper =
 -------------------------------------------------------------------------------}
 
 translateTxAllegraToMaryWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => InjectTx
        (ShelleyBlock (TPraos c) (AllegraEra c))
        (ShelleyBlock (TPraos c) (MaryEra c))
@@ -569,7 +569,7 @@ translateTxAllegraToMaryWrapper = InjectTx $
     fmap unComp . eitherToMaybe . runExcept . SL.translateEra () . Comp
 
 translateValidatedTxAllegraToMaryWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => InjectValidatedTx
        (ShelleyBlock (TPraos c) (AllegraEra c))
        (ShelleyBlock (TPraos c) (MaryEra c))
@@ -581,7 +581,7 @@ translateValidatedTxAllegraToMaryWrapper = InjectValidatedTx $
 -------------------------------------------------------------------------------}
 
 translateLedgerStateMaryToAlonzoWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -599,7 +599,7 @@ getAlonzoTranslationContext =
     shelleyLedgerTranslationContext . unwrapLedgerConfig
 
 translateTxMaryToAlonzoWrapper ::
-     (PraosCrypto c)
+     PraosCrypto c
   => SL.TranslationContext (AlonzoEra c)
   -> InjectTx
        (ShelleyBlock (TPraos c) (MaryEra c))
@@ -622,7 +622,7 @@ translateValidatedTxMaryToAlonzoWrapper ctxt = InjectValidatedTx $
 -------------------------------------------------------------------------------}
 
 translateLedgerStateAlonzoToBabbageWrapper ::
-     (Praos.PraosCrypto c)
+     PraosCrypto c
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -644,7 +644,7 @@ translateLedgerStateAlonzoToBabbageWrapper =
         }
 
 translateTxAlonzoToBabbageWrapper ::
-     (Praos.PraosCrypto c)
+     Praos.PraosCrypto c
   => SL.TranslationContext (BabbageEra c)
   -> InjectTx
        (ShelleyBlock (TPraos c) (AlonzoEra c))
@@ -659,7 +659,7 @@ translateTxAlonzoToBabbageWrapper ctxt = InjectTx $
 
 translateValidatedTxAlonzoToBabbageWrapper ::
      forall c.
-     (Praos.PraosCrypto c)
+     Praos.PraosCrypto c
   => SL.TranslationContext (BabbageEra c)
   -> InjectValidatedTx
        (ShelleyBlock (TPraos c) (AlonzoEra c))
@@ -684,7 +684,7 @@ translateValidatedTxAlonzoToBabbageWrapper ctxt = InjectValidatedTx $
 -------------------------------------------------------------------------------}
 
 translateLedgerStateBabbageToConwayWrapper ::
-     (Praos.PraosCrypto c)
+     PraosCrypto c
   => RequiringBoth
        WrapLedgerConfig
        (Translate LedgerState)
@@ -702,7 +702,7 @@ getConwayTranslationContext =
     shelleyLedgerTranslationContext . unwrapLedgerConfig
 
 translateTxBabbageToConwayWrapper ::
-     (Praos.PraosCrypto c)
+     Praos.PraosCrypto c
   => SL.TranslationContext (ConwayEra c)
   -> InjectTx
        (ShelleyBlock (Praos c) (BabbageEra c))
@@ -711,8 +711,7 @@ translateTxBabbageToConwayWrapper ctxt = InjectTx $
     fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp
 
 translateValidatedTxBabbageToConwayWrapper ::
-     forall c.
-     (Praos.PraosCrypto c)
+     PraosCrypto c
   => SL.TranslationContext (ConwayEra c)
   -> InjectValidatedTx
        (ShelleyBlock (Praos c) (BabbageEra c))

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyBased.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyBased.hs
@@ -16,7 +16,6 @@ import           Data.SOP.Strict hiding (All2)
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.HardFork.Combinator
 import qualified Ouroboros.Consensus.Protocol.Praos as Praos
-import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 import           Ouroboros.Consensus.Shelley.HFEras ()
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
                      ShelleyCompatible)
@@ -25,7 +24,7 @@ import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
 -- given function to it.
 overShelleyBasedLedgerState ::
      forall c.
-     (TPraos.PraosCrypto c, Praos.PraosCrypto c)
+     (Praos.PraosCrypto c)
   => (   forall era proto. (EraCrypto era ~ c, ShelleyCompatible proto era)
       => LedgerState (ShelleyBlock proto era)
       -> LedgerState (ShelleyBlock proto era)

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -31,6 +31,7 @@ library
     Ouroboros.Consensus.Protocol.Ledger.Util
     Ouroboros.Consensus.Protocol.Praos
     Ouroboros.Consensus.Protocol.Praos.Common
+    Ouroboros.Consensus.Protocol.Praos.Crypto
     Ouroboros.Consensus.Protocol.Praos.Header
     Ouroboros.Consensus.Protocol.Praos.Translate
     Ouroboros.Consensus.Protocol.Praos.Views
@@ -41,6 +42,7 @@ library
     base >=4.14 && <4.17,
     bytestring,
     cardano-binary,
+    cardano-crypto-praos  ^>= 2.0.0.0.1,
     cardano-crypto-class,
     cardano-ledger-binary,
     cardano-ledger-core,

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -42,7 +42,7 @@ library
     base >=4.14 && <4.17,
     bytestring,
     cardano-binary,
-    cardano-crypto-praos  ^>= 2.0.0.0.1,
+    cardano-crypto-praos  >= 2.0.0.0.1,
     cardano-crypto-class,
     cardano-ledger-binary,
     cardano-ledger-core,

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -42,7 +42,6 @@ library
     base >=4.14 && <4.17,
     bytestring,
     cardano-binary,
-    cardano-crypto-praos  >= 2.0.0.0.1,
     cardano-crypto-class,
     cardano-ledger-binary,
     cardano-ledger-core,

--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -80,9 +80,9 @@ import           Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
 import           Ouroboros.Consensus.Protocol.Praos.Common
 import           Ouroboros.Consensus.Protocol.Praos.Crypto (HASH, PraosCrypto,
                      VRF)
+import qualified Ouroboros.Consensus.Protocol.Praos.Views as Views
 import           Ouroboros.Consensus.Protocol.Praos.VRF (InputVRF, mkInputVRF,
                      vrfLeaderValue, vrfNonceValue)
-import qualified Ouroboros.Consensus.Protocol.Praos.Views as Views
 import           Ouroboros.Consensus.Protocol.TPraos
                      (ConsensusConfig (TPraosConfig, tpraosEpochInfo, tpraosParams))
 import           Ouroboros.Consensus.Ticked (Ticked)

--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/Crypto.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/Crypto.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE UndecidableInstances    #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Ouroboros.Consensus.Protocol.Praos.Crypto (
+    HASH
+  , KES
+  , PraosCrypto
+  , VRF
+  ) where
+
+import qualified Cardano.Crypto.DSIGN as DSIGN
+import qualified Cardano.Crypto.Hash as Hash
+import qualified Cardano.Crypto.KES as KES
+import qualified Cardano.Crypto.VRF as VRF
+import           Cardano.Ledger.Core (EraIndependentTxBody)
+import           Cardano.Ledger.Crypto (Crypto, DSIGN, HASH, KES,
+                     StandardCrypto, VRF)
+import qualified Cardano.Protocol.TPraos.API as Ledger
+import           Cardano.Protocol.TPraos.OCert (OCertSignable)
+import           Ouroboros.Consensus.Protocol.Praos.Header (HeaderBody)
+import           Ouroboros.Consensus.Protocol.Praos.VRF (InputVRF)
+
+class
+    ( KES.KESAlgorithm (KES c)
+    , KES.ContextKES (KES c) ~ ()
+    , KES.Signable (KES c) (HeaderBody c)
+    , VRF.VRFAlgorithm (VRF c)
+    , VRF.Signable (VRF c) InputVRF
+    , DSIGN.Signable (DSIGN c) (OCertSignable c)
+    , DSIGN.Signable (DSIGN c) (Hash.Hash (HASH c) EraIndependentTxBody)
+    , VRF.ContextVRF (VRF c) ~ ()
+    , Crypto c
+    , Ledger.PraosCrypto c
+    ) =>
+    PraosCrypto c
+
+instance PraosCrypto StandardCrypto

--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/VRF.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/Praos/VRF.hs
@@ -30,7 +30,7 @@ import           Cardano.Crypto.Util
 import           Cardano.Crypto.VRF (CertifiedVRF (certifiedOutput),
                      OutputVRF (..), getOutputVRFBytes)
 import           Cardano.Ledger.BaseTypes (Nonce (NeutralNonce, Nonce))
-import           Cardano.Ledger.Serialization (runByteBuilder)
+import           Cardano.Ledger.Binary (runByteBuilder)
 import           Cardano.Ledger.Slot (SlotNo (SlotNo))
 import           Cardano.Protocol.TPraos.BHeader (BoundedNatural,
                      assertBoundedNatural)

--- a/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/TPraos.hs
+++ b/ouroboros-consensus-protocol/src/Ouroboros/Consensus/Protocol/TPraos.hs
@@ -28,7 +28,7 @@ module Ouroboros.Consensus.Protocol.TPraos (
   , mkShelleyGlobals
   , mkTPraosParams
     -- * Crypto
-  , SL.PraosCrypto
+  , PraosCrypto
   , StandardCrypto
     -- * CannotForge
   , TPraosCannotForge (..)
@@ -78,6 +78,7 @@ import           Ouroboros.Consensus.Protocol.Ledger.HotKey (HotKey)
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Protocol.Ledger.Util
 import           Ouroboros.Consensus.Protocol.Praos.Common
+import           Ouroboros.Consensus.Protocol.Praos.Crypto (PraosCrypto)
 
 {-------------------------------------------------------------------------------
   Fields required by TPraos in the header

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -24,6 +24,7 @@ import           Ouroboros.Consensus.Protocol.TPraos (PraosCrypto, TPraos,
                      TPraosState (..))
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger
+import           Ouroboros.Consensus.Shelley.Protocol.Abstract (pHeaderHash)
 import           Ouroboros.Consensus.Shelley.Protocol.TPraos ()
 
 import           Generic.Random (genericArbitraryU)
@@ -109,7 +110,9 @@ instance (CanMock (Praos crypto) era, crypto ~ EraCrypto era)
 
 instance (CanMock (TPraos crypto) era, crypto ~ EraCrypto era)
   => Arbitrary (Header (ShelleyBlock (TPraos crypto) era)) where
-  arbitrary = getHeader <$> arbitrary
+  arbitrary = do
+    hdr <- arbitrary
+    pure $ ShelleyHeader hdr (pHeaderHash hdr)
 
 instance (CanMock (Praos crypto) era, crypto ~ EraCrypto era)
   => Arbitrary (Header (ShelleyBlock (Praos crypto) era)) where

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
@@ -73,7 +73,7 @@ import           Control.State.Transition (PredicateFailure)
 import           Data.Data (Proxy (Proxy))
 import           Ouroboros.Consensus.Ledger.SupportsMempool
                      (WhetherToIntervene (..))
-import qualified Ouroboros.Consensus.Protocol.Praos as Praos
+import           Ouroboros.Consensus.Protocol.Praos (PraosCrypto)
 
 {-------------------------------------------------------------------------------
   Eras instantiated with standard crypto
@@ -183,35 +183,35 @@ defaultApplyShelleyBasedTx globals ledgerEnv mempoolState _wti tx =
       mempoolState
       tx
 
-instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+instance (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (ShelleyEra c) where
   shelleyBasedEraName _ = "Shelley"
 
   applyShelleyBasedTx = defaultApplyShelleyBasedTx
 
-instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+instance (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (AllegraEra c) where
   shelleyBasedEraName _ = "Allegra"
 
   applyShelleyBasedTx = defaultApplyShelleyBasedTx
 
-instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+instance (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (MaryEra c) where
   shelleyBasedEraName _ = "Mary"
 
   applyShelleyBasedTx = defaultApplyShelleyBasedTx
 
-instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
+instance (PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (AlonzoEra c) where
   shelleyBasedEraName _ = "Alonzo"
 
   applyShelleyBasedTx = applyAlonzoBasedTx
 
-instance (Praos.PraosCrypto c) => ShelleyBasedEra (BabbageEra c) where
+instance (PraosCrypto c) => ShelleyBasedEra (BabbageEra c) where
   shelleyBasedEraName _ = "Babbage"
   applyShelleyBasedTx = applyAlonzoBasedTx
 
-instance (Praos.PraosCrypto c) => ShelleyBasedEra (ConwayEra c) where
+instance (PraosCrypto c) => ShelleyBasedEra (ConwayEra c) where
   shelleyBasedEraName _ = "Conway"
   applyShelleyBasedTx = applyAlonzoBasedTx
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -27,9 +27,7 @@ import           Ouroboros.Consensus.Storage.Serialisation
 
 import qualified Cardano.Ledger.Shelley.API as SL
 
-import qualified Cardano.Protocol.TPraos.API as SL
 import           Ouroboros.Consensus.Protocol.Praos (PraosState)
-import qualified Ouroboros.Consensus.Protocol.Praos as Praos
 import           Ouroboros.Consensus.Protocol.TPraos
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger
@@ -62,16 +60,17 @@ instance ShelleyCompatible proto era => DecodeDisk (ShelleyBlock proto era) (Led
   decodeDisk _ = decodeShelleyLedgerState
 
 -- | @'ChainDepState' ('BlockProtocol' ('ShelleyBlock' era))@
-instance (ShelleyCompatible proto era, EraCrypto era ~ c, SL.PraosCrypto c) => EncodeDisk (ShelleyBlock proto era) (TPraosState c) where
+instance (ShelleyCompatible proto era, EraCrypto era ~ c, PraosCrypto c) => EncodeDisk (ShelleyBlock proto era) (TPraosState c) where
   encodeDisk _ = encode
+
 -- | @'ChainDepState' ('BlockProtocol' ('ShelleyBlock' era))@
-instance (ShelleyCompatible proto era, EraCrypto era ~ c, SL.PraosCrypto c) => DecodeDisk (ShelleyBlock proto era) (TPraosState c) where
+instance (ShelleyCompatible proto era, EraCrypto era ~ c, PraosCrypto c) => DecodeDisk (ShelleyBlock proto era) (TPraosState c) where
   decodeDisk _ = decode
 
-instance (ShelleyCompatible proto era, EraCrypto era ~ c, Praos.PraosCrypto c) => EncodeDisk (ShelleyBlock proto era) (PraosState c) where
+instance (ShelleyCompatible proto era, EraCrypto era ~ c, PraosCrypto c) => EncodeDisk (ShelleyBlock proto era) (PraosState c) where
   encodeDisk _ = encode
 -- | @'ChainDepState' ('BlockProtocol' ('ShelleyBlock' era))@
-instance (ShelleyCompatible proto era, EraCrypto era ~ c, Praos.PraosCrypto c) => DecodeDisk (ShelleyBlock proto era) (PraosState c) where
+instance (ShelleyCompatible proto era, EraCrypto era ~ c, PraosCrypto c) => DecodeDisk (ShelleyBlock proto era) (PraosState c) where
   decodeDisk _ = decode
 instance ShelleyCompatible proto era
   => EncodeDisk (ShelleyBlock proto era) (AnnTip (ShelleyBlock proto era)) where

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -10,7 +10,6 @@ import qualified Cardano.Crypto.KES as SL
 import           Cardano.Crypto.VRF (certifiedOutput)
 import           Cardano.Ledger.Chain (ChainPredicateFailure)
 import qualified Cardano.Ledger.Shelley.API as SL
-import           Cardano.Protocol.TPraos.API (PraosCrypto)
 import qualified Cardano.Protocol.TPraos.API as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import           Cardano.Protocol.TPraos.OCert (ocertKESPeriod, ocertVkHot)
@@ -20,7 +19,7 @@ import           Data.Either (isRight)
 import           Ouroboros.Consensus.Protocol.Signed (Signed,
                      SignedHeader (headerSigned))
 import           Ouroboros.Consensus.Protocol.TPraos
-                     (MaxMajorProtVer (MaxMajorProtVer), TPraos,
+                     (MaxMajorProtVer (MaxMajorProtVer), PraosCrypto, TPraos,
                      TPraosCannotForge, TPraosFields (..), TPraosToSign (..),
                      Ticked (TickedPraosLedgerView), forgeTPraosFields,
                      tpraosMaxMajorPV, tpraosParams, tpraosSlotsPerKESPeriod)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -54,12 +54,11 @@ import qualified Cardano.Ledger.BaseTypes as SL (mkVersion)
 import qualified Cardano.Ledger.Core as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 
-import qualified Cardano.Protocol.TPraos.API as SL
 import qualified Ouroboros.Consensus.Forecast as Forecast
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol, ledgerViewForecastAt)
 import           Ouroboros.Consensus.Protocol.Praos
-import           Ouroboros.Consensus.Protocol.TPraos hiding (PraosCrypto)
+import           Ouroboros.Consensus.Protocol.TPraos
 import           Ouroboros.Consensus.Protocol.Translate (TranslateProto)
 import qualified Ouroboros.Consensus.Protocol.Translate as Proto
 import           Ouroboros.Consensus.Shelley.Eras
@@ -207,7 +206,7 @@ instance PraosCrypto c => HasPartialConsensusConfig (Praos c) where
 
   toPartialConsensusConfig _ = praosParams
 
-instance SL.PraosCrypto c => HasPartialConsensusConfig (TPraos c) where
+instance PraosCrypto c => HasPartialConsensusConfig (TPraos c) where
   type PartialConsensusConfig (TPraos c) = TPraosParams
 
   completeConsensusConfig _ tpraosEpochInfo tpraosParams = TPraosConfig {..}


### PR DESCRIPTION
# Description

This PR does 2 things:
* An attempt at minimising the "attack surface" of consensus' dependencies on cardano-ledger crypto stuff related to Praos/TPraos, 
* Introduction of Property to check dispatching of crypto depending on era actually produces the right results.

## Hide Ledger's `PraosCrypto`

The idea is to remove direct dependencies from consensus package to cardano-ledger's `TPraos.API` module. There is a duplication of the `PraosCrypto` typeclass between the two components which does seem unnecessary as ultimately, these crypto primitives should end up in the consensus where they are used and relevant. 

I would have loved to be able to remove the ledger's `PraosCrypto` altogether but of course this is not possible as we use quite a few functions from the ledger that depend on it. So the tiny first step consists in hiding the dependency on `Ledger.PraosCrypto` behind the `Ouroboros.Consensus.Praos.Crypto.PraosCrypto` typeclass (reexported by `Praos` and `TPraos` modules). This simplifies some constraints down the road.

The hypothesis this work is based on is that if we manage to locate all dependencies from consensus to ledger for KES and VRF stuff, then introducing a new `Crypto` typeclass and primitives will have a minimal impact over the codebase and could be done independently of the refactoring in the cardano-ledger.

## Add Property to check "dispatching" of VRF per Era

The goal of #4150 is to ensure different eras can have different crypto implementations for things such as VRF proofs generation and verification, and KES signing. While #4151 provided solutions to this problem, this PR tries to make the problem manifest through a property that, given an arbitrary header from different eras, verifies the correct crypto is used. This is done simply by verifying the sizes of the VRF certificates which are different between plain Praos and Batch compatible VRF. 
 
# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
