### PR TITLE
Expose the `Pushing` newtype wrappers

### DIFF
--- a/ouroboros-consensus/changelog.d/20230223_095002_javier.sagredo_expose_ledgerdb_tracers.md
+++ b/ouroboros-consensus/changelog.d/20230223_095002_javier.sagredo_expose_ledgerdb_tracers.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Exposed the `Pushing` newtype wrappers for the tracing of the `LedgerDB`
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -46,6 +46,9 @@ module Ouroboros.Consensus.Storage.LedgerDB (
   , ledgerDbPushMany'
   , ledgerDbSwitch'
     -- ** Trace
+  , PushGoal (..)
+  , PushStart (..)
+  , Pushing (..)
   , UpdateLedgerDbTraceEvent (..)
     -- * Streaming
   , NextBlock (..)
@@ -99,7 +102,8 @@ import           Ouroboros.Consensus.Storage.LedgerDB.Stream (NextBlock (..),
                      StreamAPI (..), streamAll)
 import           Ouroboros.Consensus.Storage.LedgerDB.Update
                      (AnnLedgerError (..), AnnLedgerError', Ap (..),
-                     ExceededRollback (..), ResolveBlock, ResolvesBlocks (..),
+                     ExceededRollback (..), PushGoal (..), PushStart (..),
+                     Pushing (..), ResolveBlock, ResolvesBlocks (..),
                      ThrowsLedgerError (..), UpdateLedgerDbTraceEvent (..),
                      defaultResolveWithErrors, defaultThrowLedgerErrors,
                      ledgerDbBimap, ledgerDbPrune, ledgerDbPush, ledgerDbPush',

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
@@ -46,6 +46,9 @@ module Ouroboros.Consensus.Storage.LedgerDB.Update (
   , ledgerDbPushMany'
   , ledgerDbSwitch'
     -- * Trace
+  , PushGoal (..)
+  , PushStart (..)
+  , Pushing (..)
   , UpdateLedgerDbTraceEvent (..)
   ) where
 

--- a/scripts/ci/check-consensus-release.sh
+++ b/scripts/ci/check-consensus-release.sh
@@ -8,13 +8,13 @@
 # otherwise exits with exit code 1
 
 cardano_packages=$(find . -maxdepth 1 -type d -name "ouroboros-consensus-cardano*" -or -name "ouroboros-consensus-shelley*" -or -name "ouroboros-consensus-byron*")
-cardano_last_version=$(grep "<a id=" ouroboros-consensus-cardano/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2)
+cardano_last_version=$(grep "<a id=" ouroboros-consensus-cardano/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2 | head -n1)
 cardano_versions=$(for f in $cardano_packages; do
                        git show $(ls $f/*.cabal) | grep "+version" | rev | cut -d' ' -f1 | rev
                    done)
 
 consensus_packages=$(find . -maxdepth 1 -type d -name "ouroboros-consensus*" -not -name "*byron*" -not -name "*shelley*" -not -name "*cardano*")
-consensus_last_version=$(grep "<a id=" ouroboros-consensus/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2)
+consensus_last_version=$(grep "<a id=" ouroboros-consensus/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2 | head -n1)
 consensus_versions=$(for f in $consensus_packages; do
                          git show $(ls $f/*.cabal) | grep "+version" | rev | cut -d' ' -f1 | rev
                      done)


### PR DESCRIPTION
# Description

These types are needed by the node and we wrongly didn't expose them before.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [x] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
