### PR TITLE
Improve Consensus changelog check

### DIFF
--- a/.github/workflows/consensus-changelog-consistency.yml
+++ b/.github/workflows/consensus-changelog-consistency.yml
@@ -17,4 +17,4 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: "Check changelog consistency"
-      run: ./scripts/ci/check-consensus-release.sh
+      run: CI=1 ./scripts/ci/check-consensus-release.sh

--- a/scripts/ci/check-consensus-release.sh
+++ b/scripts/ci/check-consensus-release.sh
@@ -1,64 +1,67 @@
 #!/usr/bin/env bash
 
 # For each one of the two bundles, check that:
-# (1) if the version in the cabal file was changed in any of the packages wrt the latest version described in the changelog
-# (2) then it was changed on all of them
-# (3) and to the same value
-# (4) and also there are no remaining changelog entries
+# (1) they all have the same version
+# (2) if the version was changed from the last one on the changelog then there
+#     must be no remaining changelog files
 # otherwise exits with exit code 1
+
+# If $CI is set, then use `git show` as GHA does a sparse checkout. Otherwise,
+# do a normal cat of the cabal file
 
 cardano_packages=$(find . -maxdepth 1 -type d -name "ouroboros-consensus-cardano*" -or -name "ouroboros-consensus-shelley*" -or -name "ouroboros-consensus-byron*")
 cardano_last_version=$(grep "<a id=" ouroboros-consensus-cardano/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2 | head -n1)
-cardano_versions=$(for f in $cardano_packages; do
-                       git show $(ls $f/*.cabal) | grep "+version" | rev | cut -d' ' -f1 | rev
-                   done)
+cardano_new_versions=$(if [[ -n "${CI}" ]]; then
+                           for f in $cardano_packages; do
+                               git show $(ls $f/*.cabal) | grep "+version" | rev | cut -d' ' -f1 | rev
+                           done
+                       else for f in $cardano_packages; do
+                               cat $f/*.cabal | grep "^version" | rev | cut -d' ' -f1 | rev
+                            done
+                       fi)
 
 consensus_packages=$(find . -maxdepth 1 -type d -name "ouroboros-consensus*" -not -name "*byron*" -not -name "*shelley*" -not -name "*cardano*")
 consensus_last_version=$(grep "<a id=" ouroboros-consensus/CHANGELOG.md  | cut -d\' -f2 | cut -d- -f2 | head -n1)
-consensus_versions=$(for f in $consensus_packages; do
-                         git show $(ls $f/*.cabal) | grep "+version" | rev | cut -d' ' -f1 | rev
-                     done)
+consensus_new_versions=$(if [[ -n "${CI}" ]]; then
+                           for f in $consensus_packages; do
+                               git show $(ls $f/*.cabal) | grep "+version" | rev | cut -d' ' -f1 | rev
+                           done
+                       else for f in $consensus_packages; do
+                               cat $f/*.cabal | grep "^version" | rev | cut -d' ' -f1 | rev
+                            done
+                       fi)
 
-if [ $(echo "$consensus_versions" | tr ' ' '\n' | sort | uniq) == "$consensus_last_version" ]; then # See (1) above
-    echo "ouroboros-consensus version not updated"
+
+if [ $(echo "$consensus_new_versions" | sort | uniq | wc -l) != 1 ]; then  # See (1) above
+    echo "Inconsistent versioning of the ouroboros-consensus bundle, more than one version number: $consensus_new_versions"
+    exit 1
 else
-    if [ $(echo "$consensus_versions" | wc -l) != $(echo "$consensus_packages" | wc -l) ]; then  # See (2) above
-        echo "Some packages in ouroboros-consensus bundle are being updated and others not."
-        exit 1
+    if [ $(echo "$consensus_new_versions" | sort | uniq) == "$consensus_last_version" ]; then
+        echo "ouroboros-consensus version not updated, currently at $consensus_last_version"
     else
-        if [ $(echo "$consensus_versions" | sort | uniq | wc -l) != 1 ]; then  # See (3) above
-            echo "Inconsistent versioning of the ouroboros-consensus bundle."
+        if [ $(ls -l ouroboros-consensus/changelog.d | wc -l) != 2 ]; then # See (2) above
+            echo "Tried to release for ouroboros-consensus but there are remaining changelog files:"
+            ls -l ouroboros-consensus/changelog.d
             exit 1
         else
-            if [ $(ls -l ouroboros-consensus/changelog.d | wc -l) != 2 ]; then # See (4) above
-                echo "Tried to release for ouroboros-consensus but there are remaining changelog files."
-                exit 1
-            else
-                echo "ouroboros-consensus version succesfully updated"
-            fi
+            echo "ouroboros-consensus version succesfully updated"
         fi
     fi
 fi
 
-
-# Cardano didn't have a first version when this was released, that's why there is that default value
-if [ $(echo "$cardano_versions" | tr ' ' '\n' | sort | uniq) == "${cardano_last_version:-0.1.0.0}" ]; then # See (1) above
-    echo "ouroboros-consensus-cardano version not updated"
+if [ $(echo "$cardano_new_versions" | sort | uniq | wc -l) != 1 ]; then  # See (1) above
+    echo "Inconsistent versioning of the ouroboros-cardano bundle, more than one version number: $cardano_new_versions"
+    exit 1
 else
-    if [ $(echo "$cardano_versions" | wc -l) != $(echo "$cardano_packages" | wc -l) ]; then # See (2) above
-        echo "Some packages in ouroboros-consensus-cardano bundle are being updated and others not."
-        exit 1
+    if [ $(echo "$cardano_new_versions" | sort | uniq) == "${cardano_last_version:-0.1.0.0}" ]; then
+        echo "ouroboros-cardano version not updated, currently at $cardano_last_version"
     else
-        if [ $(echo "$cardano_versions" | sort | uniq | wc -l) != 1 ]; then # See (3) above
-            echo "Inconsistent versioning of the ouroboros-consensus-cardano bundle."
+        if [ $(ls -l ouroboros-consensus-cardano/changelog.d | wc -l) != 2 ]; then # See (2) above
+            echo "Tried to release for ouroboros-cardano but there are remaining changelog files."
+            ls -l ouroboros-consensus-cardano/changelog.d
             exit 1
         else
-            if [ $(ls -l ouroboros-consensus-cardano/changelog.d | wc -l) != 2 ]; then # See (4) above
-                echo "Tried to release for ouroboros-consensus-cardano but there are remaining changelog files."
-                exit 1
-            else
-                echo "ouroboros-consensus-cardano version succesfully updated"
-            fi
+            echo "ouroboros-cardano version succesfully updated"
         fi
     fi
 fi


### PR DESCRIPTION
# Description

The check is now a bit less flaky :pray:

```
$ ./scripts/ci/check-consensus-release.sh 
ouroboros-consensus version not updated, currently at 0.2.1.0
ouroboros-cardano version not updated, currently at 0.3.0.0
```
