### PR TITLE
Add deprecation warnings to old exposed entities

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -20,6 +20,10 @@
 {-# LANGUAGE UndecidableInstances       #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+
+-- Remove this when @TraceLedgerEvent@ is gone
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- | Main tests for the chain DB.
 --
 -- These are the main tests for the chain DB. Commands include
@@ -1667,6 +1671,10 @@ traceEventName = \case
     TraceGCEvent                ev    -> "GC."                <> constrName ev
     TraceIteratorEvent          ev    -> "Iterator."          <> constrName ev
     TraceSnapshotEvent          ev    -> "Ledger."            <> constrName ev
+    -- This one is deprecated but unless we match it we get non-exhaustiveness
+    -- warnings. When this constructor is deleted we must remove this match as
+    -- well as re-enable the deprecation warnings at the top of this file.
+    TraceLedgerEvent            ev    -> "Ledger."            <> constrName ev
     TraceLedgerReplayEvent      ev    -> "LedgerReplay."      <> constrName ev
     TraceImmutableDBEvent       ev    -> "ImmutableDB."       <> constrName ev
     TraceVolatileDBEvent        ev    -> "VolatileDB."        <> constrName ev

--- a/ouroboros-consensus/changelog.d/20230227_125617_jasataco_add_deprecations.md
+++ b/ouroboros-consensus/changelog.d/20230227_125617_jasataco_add_deprecations.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- `Ouroboros.Consensus.Storage.LedgerDB.*` and `Ouroboros.Consensus.Mempool.*`
+  modules now have deprecation warnings for the previously exposed API to ease
+  updates downstream. Old modules have deprecation headers and also every
+  function and type exposed is now an alias to the right entity coupled together
+  with a deprecation warning.
+
+

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -130,6 +130,7 @@ library
                        Ouroboros.Consensus.Mempool.Impl.Pure
                        Ouroboros.Consensus.Mempool.Impl.Types
                        Ouroboros.Consensus.Mempool.TxLimits
+                       Ouroboros.Consensus.Mempool.Impl
                        Ouroboros.Consensus.Mempool.Init
                        Ouroboros.Consensus.Mempool.Query
                        Ouroboros.Consensus.Mempool.TxSeq
@@ -235,6 +236,7 @@ library
                        Ouroboros.Consensus.Storage.LedgerDB.Query
                        Ouroboros.Consensus.Storage.LedgerDB.Snapshots
                        Ouroboros.Consensus.Storage.LedgerDB.Stream
+                       Ouroboros.Consensus.Storage.LedgerDB.Types
                        Ouroboros.Consensus.Storage.LedgerDB.Update
                        Ouroboros.Consensus.Storage.Serialisation
                        Ouroboros.Consensus.Storage.VolatileDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -1,0 +1,8 @@
+module Ouroboros.Consensus.Mempool.Impl {-# DEPRECATED "Use Ouroboros.Consensus.Mempool" #-}(
+    Mempool.openMempool
+  , Mempool.LedgerInterface (..)
+  , Mempool.chainDBLedgerInterface
+  , Mempool.openMempoolWithoutSyncThread
+  ) where
+
+import qualified Ouroboros.Consensus.Mempool as Mempool

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -58,7 +58,9 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Util (repeatedly)
 import           Ouroboros.Consensus.Util.IOLike
 
-import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Mempool.API hiding (MempoolCapacityBytes,
+                     MempoolCapacityBytesOverride, MempoolSize,
+                     TraceEventMempool, computeMempoolCapacity)
 import           Ouroboros.Consensus.Mempool.Capacity
 import           Ouroboros.Consensus.Mempool.TxSeq (TxSeq (..), TxTicket (..))
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -1,17 +1,28 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- | Pure side of the Mempool implementation.
 --
 -- Operations are performed in a pure style returning data types that model
 -- the control flow through the operation and can then be interpreted to perform
 -- the actual STM/IO operations.
-module Ouroboros.Consensus.Mempool.Impl.Pure {-# DEPRECATED "User Ouroboros.Consensus.Mempool instead!" #-} (
+module Ouroboros.Consensus.Mempool.Impl.Pure {-# DEPRECATED "User Ouroboros.Consensus.Mempool instead" #-} (
     -- * Mempool
     pureGetSnapshotFor
   , pureRemoveTxs
   , pureSyncWithLedger
     -- * MempoolSnapshot
-  , snapshotFromIS
+  , implSnapshotFromIS
   ) where
+
+import           Ouroboros.Consensus.Ledger.SupportsMempool
 
 import           Ouroboros.Consensus.Mempool.Update
 import           Ouroboros.Consensus.Mempool.Query
 import           Ouroboros.Consensus.Mempool.Impl.Common
+import           Ouroboros.Consensus.Mempool.API
+
+{-# DEPRECATED implSnapshotFromIS "Use Ouroboros.Consensus.Mempool.Impl.Common (snapshotFromIS)" #-}
+implSnapshotFromIS
+  :: HasTxId (GenTx blk)
+  => InternalState blk
+  -> MempoolSnapshot blk
+implSnapshotFromIS = snapshotFromIS

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Ouroboros.Consensus.Mempool.Impl.Types {-# DEPRECATED "Use Ouroboros.Consensus.Mempool instead" #-} (
     -- * Internal State
     InternalState (..)
@@ -8,6 +9,7 @@ module Ouroboros.Consensus.Mempool.Impl.Types {-# DEPRECATED "Use Ouroboros.Cons
   , extendVRNew
   , extendVRPrevApplied
   , revalidateTxsFor
+  , validateIS
   , validateStateFor
     -- * Tick ledger state
   , tickLedgerState
@@ -16,4 +18,17 @@ module Ouroboros.Consensus.Mempool.Impl.Types {-# DEPRECATED "Use Ouroboros.Cons
   , validationResultFromIS
   ) where
 
+import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.SupportsMempool
+
+import           Ouroboros.Consensus.Mempool.Capacity
 import           Ouroboros.Consensus.Mempool.Impl.Common
+
+{-# DEPRECATED validateIS "This function should not be used (it will throw an error), it was internal no longer exists" #-}
+validateIS
+  :: InternalState blk
+  -> LedgerState blk
+  -> LedgerConfig blk
+  -> MempoolCapacityBytesOverride
+  -> ValidationResult (Validated (GenTx blk)) blk
+validateIS = error "Deprecated"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
@@ -20,7 +20,9 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Watcher (..), forkLinkedWatcher)
 
-import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Mempool.API hiding (MempoolCapacityBytes,
+                     MempoolCapacityBytesOverride, MempoolSize,
+                     TraceEventMempool, computeMempoolCapacity)
 import           Ouroboros.Consensus.Mempool.Capacity
 import           Ouroboros.Consensus.Mempool.Impl.Common
 import           Ouroboros.Consensus.Mempool.Query

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Query.hs
@@ -7,7 +7,9 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 
-import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Mempool.API hiding (MempoolCapacityBytes,
+                     MempoolCapacityBytesOverride, MempoolSize,
+                     TraceEventMempool, computeMempoolCapacity)
 import           Ouroboros.Consensus.Mempool.Capacity
 import           Ouroboros.Consensus.Mempool.Impl.Common
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Update.hs
@@ -24,7 +24,9 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.IOLike
 
-import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Mempool.API hiding (MempoolCapacityBytes,
+                     MempoolCapacityBytesOverride, MempoolSize,
+                     TraceEventMempool, computeMempoolCapacity)
 import           Ouroboros.Consensus.Mempool.Capacity
 import           Ouroboros.Consensus.Mempool.Impl.Common
 import           Ouroboros.Consensus.Mempool.TxSeq (TxTicket (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -495,6 +495,7 @@ getBlockToAdd (BlocksToAdd queue) = atomically $ readTBQueue queue
   Trace types
 -------------------------------------------------------------------------------}
 
+{-# DEPRECATED TraceLedgerEvent "Use TraceSnapshotEvent"#-}
 -- | Trace type for the various events of the ChainDB.
 data TraceEvent blk
   = TraceAddBlockEvent          (TraceAddBlockEvent           blk)
@@ -505,10 +506,12 @@ data TraceEvent blk
   | TraceOpenEvent              (TraceOpenEvent               blk)
   | TraceIteratorEvent          (TraceIteratorEvent           blk)
   | TraceSnapshotEvent          (LgrDB.TraceSnapshotEvent     blk)
+  | TraceLedgerEvent            (LgrDB.TraceSnapshotEvent     blk)
   | TraceLedgerReplayEvent      (LgrDB.TraceReplayEvent       blk)
   | TraceImmutableDBEvent       (ImmutableDB.TraceEvent       blk)
   | TraceVolatileDBEvent        (VolatileDB.TraceEvent        blk)
   deriving (Generic)
+
 
 deriving instance
   ( Eq (Header blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -35,6 +35,7 @@ module Ouroboros.Consensus.Storage.LedgerDB (
     -- ** Block resolution
   , ResolveBlock
   , ResolvesBlocks (..)
+  , defaultResolveBlocks
     -- ** Operations
   , defaultResolveWithErrors
   , ledgerDbBimap
@@ -105,7 +106,7 @@ import           Ouroboros.Consensus.Storage.LedgerDB.Update
                      ExceededRollback (..), PushGoal (..), PushStart (..),
                      Pushing (..), ResolveBlock, ResolvesBlocks (..),
                      ThrowsLedgerError (..), UpdateLedgerDbTraceEvent (..),
-                     defaultResolveWithErrors, defaultThrowLedgerErrors,
-                     ledgerDbBimap, ledgerDbPrune, ledgerDbPush, ledgerDbPush',
-                     ledgerDbPushMany', ledgerDbSwitch, ledgerDbSwitch',
-                     ledgerDbWithAnchor)
+                     defaultResolveBlocks, defaultResolveWithErrors,
+                     defaultThrowLedgerErrors, ledgerDbBimap, ledgerDbPrune,
+                     ledgerDbPush, ledgerDbPush', ledgerDbPushMany',
+                     ledgerDbSwitch, ledgerDbSwitch', ledgerDbWithAnchor)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -1,5 +1,189 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE QuantifiedConstraints  #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE UndecidableInstances   #-}
 module Ouroboros.Consensus.Storage.LedgerDB.InMemory {-# DEPRECATED "Use Ouroboros.Consensus.Storage.LedgerDB instead" #-}
-  ( module Ouroboros.Consensus.Storage.LedgerDB
+  ( -- * LedgerDB proper
+    LDB.LedgerDbCfg (..)
+  , ledgerDbWithAnchor
+    -- ** opaque
+  , LDB.LedgerDB
+    -- ** Serialisation
+  , decodeSnapshotBackwardsCompatible
+  , encodeSnapshot
+    -- ** Queries
+  , ledgerDbAnchor
+  , ledgerDbBimap
+  , ledgerDbCurrent
+  , ledgerDbPast
+  , ledgerDbPrune
+  , ledgerDbSnapshots
+  , ledgerDbTip
+    -- ** Running updates
+  , LDB.AnnLedgerError (..)
+  , LDB.Ap (..)
+  , LDB.ResolveBlock
+  , LDB.ResolvesBlocks (..)
+  , LDB.ThrowsLedgerError (..)
+  , defaultResolveBlocks
+  , defaultResolveWithErrors
+  , defaultThrowLedgerErrors
+    -- ** Updates
+  , LDB.ExceededRollback (..)
+  , ledgerDbPush
+  , ledgerDbSwitch
+    -- * Exports for the benefit of tests
+    -- ** Additional queries
+  , ledgerDbIsSaturated
+  , ledgerDbMaxRollback
+    -- ** Pure API
+  , ledgerDbPush'
+  , ledgerDbPushMany'
+  , ledgerDbSwitch'
   ) where
 
-import Ouroboros.Consensus.Storage.LedgerDB
+import           Codec.Serialise.Decoding (Decoder)
+import           Codec.Serialise.Encoding (Encoding)
+import           Control.Monad.Except hiding (ap)
+import           Control.Monad.Reader hiding (ap)
+import           Data.Word
+
+import           Ouroboros.Network.AnchoredSeq (AnchoredSeq (..), Anchorable)
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract
+
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LDB
+
+{-------------------------------------------------------------------------------
+  Local non-exported aliases
+-------------------------------------------------------------------------------}
+type LedgerDB l           = LDB.LedgerDB l
+type ResolveBlock m blk   = LDB.ResolveBlock m blk
+type AnnLedgerError l blk = LDB.AnnLedgerError l blk
+type Ap m l blk c         = LDB.Ap m l blk c
+type ExceededRollback     = LDB.ExceededRollback
+type LedgerDbCfg l        = LDB.LedgerDbCfg l
+
+{-------------------------------------------------------------------------------
+  Deprecated functions
+-------------------------------------------------------------------------------}
+
+{-# DEPRECATED ledgerDbWithAnchor "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbWithAnchor)" #-}
+ledgerDbWithAnchor :: GetTip l => l -> LedgerDB l
+ledgerDbWithAnchor = LDB.ledgerDbWithAnchor
+
+{-# DEPRECATED defaultResolveBlocks "Use Ouroboros.Consensus.Storage.LedgerDB (defaultResolveBlocks)" #-}
+defaultResolveBlocks :: ResolveBlock m blk
+                     -> ReaderT (ResolveBlock m blk) m a
+                     -> m a
+defaultResolveBlocks = LDB.defaultResolveBlocks
+
+{-# DEPRECATED defaultThrowLedgerErrors "Use Ouroboros.Consensus.Storage.LedgerDB (defaultThrowLedgerErrors)" #-}
+defaultThrowLedgerErrors :: ExceptT (AnnLedgerError l blk) m a
+                         -> m (Either (AnnLedgerError l blk) a)
+defaultThrowLedgerErrors = LDB.defaultThrowLedgerErrors
+
+{-# DEPRECATED defaultResolveWithErrors "Use Ouroboros.Consensus.Storage.LedgerDB (defaultResolveWithErrors)" #-}
+defaultResolveWithErrors :: ResolveBlock m blk
+                         -> ExceptT (AnnLedgerError l blk)
+                                    (ReaderT (ResolveBlock m blk) m)
+                                    a
+                         -> m (Either (AnnLedgerError l blk) a)
+defaultResolveWithErrors = LDB.defaultResolveWithErrors
+
+{-# DEPRECATED ledgerDbCurrent "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbCurrent)" #-}
+ledgerDbCurrent :: GetTip l => LedgerDB l -> l
+ledgerDbCurrent = LDB.ledgerDbCurrent
+
+{-# DEPRECATED ledgerDbAnchor "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbAnchor)" #-}
+ledgerDbAnchor :: LedgerDB l -> l
+ledgerDbAnchor = LDB.ledgerDbAnchor
+
+{-# DEPRECATED ledgerDbSnapshots "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbSnapshots)" #-}
+ledgerDbSnapshots :: LedgerDB l -> [(Word64, l)]
+ledgerDbSnapshots = LDB.ledgerDbSnapshots
+
+{-# DEPRECATED ledgerDbMaxRollback "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbMaxRollback)" #-}
+ledgerDbMaxRollback :: GetTip l => LedgerDB l -> Word64
+ledgerDbMaxRollback = LDB.ledgerDbMaxRollback
+
+{-# DEPRECATED ledgerDbTip "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbTip)" #-}
+ledgerDbTip :: GetTip l => LedgerDB l -> Point l
+ledgerDbTip = LDB.ledgerDbTip
+
+{-# DEPRECATED ledgerDbIsSaturated "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbIsSaturated)" #-}
+ledgerDbIsSaturated :: GetTip l => SecurityParam -> LedgerDB l -> Bool
+ledgerDbIsSaturated = LDB.ledgerDbIsSaturated
+
+{-# DEPRECATED ledgerDbPast "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbPast)" #-}
+ledgerDbPast ::
+     (HeaderHash blk ~ HeaderHash l, HasHeader blk, IsLedger l)
+  => Point blk
+  -> LedgerDB l
+  -> Maybe l
+ledgerDbPast = LDB.ledgerDbPast
+
+{-# DEPRECATED ledgerDbBimap "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbBimap)" #-}
+ledgerDbBimap ::
+     (Anchorable (WithOrigin SlotNo) a b)
+  => (l -> a)
+  -> (l -> b)
+  -> LedgerDB l
+  -> AnchoredSeq (WithOrigin SlotNo) a b
+ledgerDbBimap = LDB.ledgerDbBimap
+
+{-# DEPRECATED ledgerDbPrune "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbPrune)" #-}
+ledgerDbPrune :: GetTip l => SecurityParam -> LedgerDB l -> LedgerDB l
+ledgerDbPrune = LDB.ledgerDbPrune
+
+
+
+{-# DEPRECATED ledgerDbPush "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbPush)" #-}
+ledgerDbPush :: (ApplyBlock l blk, Monad m, c) => LedgerDbCfg l
+             -> Ap m l blk c -> LedgerDB l -> m (LedgerDB l)
+ledgerDbPush = LDB.ledgerDbPush
+
+{-# DEPRECATED ledgerDbSwitch "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbSwitch)" #-}
+ledgerDbSwitch :: (ApplyBlock l blk, Monad m, c)
+               => LedgerDbCfg l
+               -> Word64          -- ^ How many blocks to roll back
+               -> (LDB.UpdateLedgerDbTraceEvent blk -> m ())
+               -> [Ap m l blk c]  -- ^ New blocks to apply
+               -> LedgerDB l
+               -> m (Either ExceededRollback (LedgerDB l))
+ledgerDbSwitch = LDB.ledgerDbSwitch
+
+{-# DEPRECATED ledgerDbPush' "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbPush')" #-}
+ledgerDbPush' :: ApplyBlock l blk
+              => LedgerDbCfg l -> blk -> LedgerDB l -> LedgerDB l
+ledgerDbPush' = LDB.ledgerDbPush'
+
+{-# DEPRECATED ledgerDbPushMany' "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbPushMany')" #-}
+ledgerDbPushMany' :: ApplyBlock l blk
+                  => LedgerDbCfg l -> [blk] -> LedgerDB l -> LedgerDB l
+ledgerDbPushMany' = LDB.ledgerDbPushMany'
+
+{-# DEPRECATED ledgerDbSwitch' "Use Ouroboros.Consensus.Storage.LedgerDB (ledgerDbSwitch')" #-}
+ledgerDbSwitch' :: ApplyBlock l blk
+                => LedgerDbCfg l
+                -> Word64 -> [blk] -> LedgerDB l -> Maybe (LedgerDB l)
+ledgerDbSwitch' = LDB.ledgerDbSwitch'
+
+{-# DEPRECATED encodeSnapshot "Use Ouroboros.Consensus.Storage.LedgerDB (encodeSnapshot)" #-}
+encodeSnapshot :: (l -> Encoding) -> l -> Encoding
+encodeSnapshot = LDB.encodeSnapshot
+
+{-# DEPRECATED decodeSnapshotBackwardsCompatible "Use Ouroboros.Consensus.Storage.LedgerDB (decodeSnapshotBackwardsCompatible)" #-}
+decodeSnapshotBackwardsCompatible ::
+     Proxy blk
+  -> (forall s. Decoder s l)
+  -> (forall s. Decoder s (HeaderHash blk))
+  -> forall s. Decoder s l
+decodeSnapshotBackwardsCompatible = LDB.decodeSnapshotBackwardsCompatible

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -1,5 +1,152 @@
-module Ouroboros.Consensus.Storage.LedgerDB.OnDisk {-# DEPRECATED "Use Ouroboros.Consensus.Storage.LedgerDB instead" #-}
-  ( module Ouroboros.Consensus.Storage.LedgerDB
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RankNTypes          #-}
+module Ouroboros.Consensus.Storage.LedgerDB.OnDisk {-# DEPRECATED "Use Ouroboros.Consensus.Storage.LedgerDB instead" #-} (
+    -- * Opening the database
+    InitFailure
+  , LDB.SnapshotFailure (..)
+  , LDB.InitLog (..)
+  , initLedgerDB
+    -- ** Instantiate in-memory to @blk@
+  , LDB.AnnLedgerError'
+  , LDB.LedgerDB'
+    -- ** Abstraction over the stream API
+  , LDB.NextBlock (..)
+  , LDB.StreamAPI (..)
+    -- * Read from disk
+  , readSnapshot
+    -- * Write to disk
+  , takeSnapshot
+  , trimSnapshots
+  , writeSnapshot
+    -- * Low-level API (primarily exposed for testing)
+  , deleteSnapshot
+  , snapshotToFileName
+  , snapshotToPath
+    -- ** opaque
+  , LDB.DiskSnapshot (..)
+    -- * Trace events
+  , LDB.ReplayGoal (..)
+  , LDB.ReplayStart (..)
+  , TraceEvent
+  , LDB.TraceSnapshotEvent (..)
+  , LDB.TraceReplayEvent (..)
+  , decorateReplayTracerWithGoal
   ) where
 
-import Ouroboros.Consensus.Storage.LedgerDB
+import           Codec.Serialise.Decoding (Decoder)
+import           Codec.Serialise.Encoding (Encoding)
+import           Control.Monad.Except
+import           Control.Tracer
+import           Data.Word
+import           GHC.Stack
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Inspect
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr)
+import           Ouroboros.Consensus.Util.IOLike
+
+import           Ouroboros.Consensus.Storage.FS.API
+import           Ouroboros.Consensus.Storage.FS.API.Types
+
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LDB
+
+{-------------------------------------------------------------------------------
+  Non-exported local aliases
+-------------------------------------------------------------------------------}
+type LedgerDB'        blk = LDB.LedgerDB' blk
+type StreamAPI m      blk = LDB.StreamAPI m blk
+type InitLog          blk = LDB.InitLog blk
+type DiskSnapshot         = LDB.DiskSnapshot
+type ReplayGoal       blk = LDB.ReplayGoal blk
+type TraceReplayEvent blk = LDB.TraceReplayEvent blk
+
+{-------------------------------------------------------------------------------
+  Renamed types
+-------------------------------------------------------------------------------}
+
+{-# DEPRECATED InitFailure "Use Ouroboros.Consensus.Storage.LedgerDB (SnapshotFailure)" #-}
+type InitFailure blk = LDB.SnapshotFailure blk
+
+{-# DEPRECATED TraceEvent "Use Ouroboros.Consensus.Storage.LedgerDB (TraceSnapshotEvent)" #-}
+type TraceEvent blk = LDB.TraceSnapshotEvent blk
+
+{-------------------------------------------------------------------------------
+  Deprecated functions
+-------------------------------------------------------------------------------}
+
+{-# DEPRECATED initLedgerDB "Use Ouroboros.Consensus.Storage.LedgerDB (initLedgerDB)" #-}
+initLedgerDB ::
+     forall m blk. (
+         IOLike m
+       , LedgerSupportsProtocol blk
+       , InspectLedger blk
+       , HasCallStack
+       )
+  => Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
+  -> Tracer m (TraceEvent blk)
+  -> SomeHasFS m
+  -> (forall s. Decoder s (ExtLedgerState blk))
+  -> (forall s. Decoder s (HeaderHash blk))
+  -> LDB.LedgerDbCfg (ExtLedgerState blk)
+  -> m (ExtLedgerState blk) -- ^ Genesis ledger state
+  -> StreamAPI m blk
+  -> m (InitLog blk, LedgerDB' blk, Word64)
+initLedgerDB = LDB.initLedgerDB
+
+{-# DEPRECATED takeSnapshot "Use Ouroboros.Consensus.Storage.LedgerDB (takeSnapshot)" #-}
+takeSnapshot ::
+     (MonadThrow m, IsLedger (LedgerState blk))
+  => Tracer m (TraceEvent blk)
+  -> SomeHasFS m
+  -> (ExtLedgerState blk -> Encoding)
+  -> LedgerDB' blk -> m (Maybe (DiskSnapshot, RealPoint blk))
+takeSnapshot t fs e = LDB.takeSnapshot t fs e . LDB.ledgerDbAnchor
+
+{-# DEPRECATED trimSnapshots "Use Ouroboros.Consensus.Storage.LedgerDB (trimSnapshots)" #-}
+trimSnapshots ::
+     Monad m
+  => Tracer m (TraceEvent r)
+  -> SomeHasFS m
+  -> DiskPolicy
+  -> m [DiskSnapshot]
+trimSnapshots = LDB.trimSnapshots
+
+{-# DEPRECATED readSnapshot "Use Ouroboros.Consensus.Storage.LedgerDB (readSnapshot)" #-}
+readSnapshot ::
+     IOLike m => SomeHasFS m
+  -> (forall s. Decoder s (ExtLedgerState blk))
+  -> (forall s. Decoder s (HeaderHash blk))
+  -> DiskSnapshot
+  -> ExceptT ReadIncrementalErr m (ExtLedgerState blk)
+readSnapshot = LDB.readSnapshot
+
+{-# DEPRECATED writeSnapshot "Use Ouroboros.Consensus.Storage.LedgerDB (writeSnapshot)" #-}
+writeSnapshot ::
+     MonadThrow m => SomeHasFS m
+  -> (ExtLedgerState blk -> Encoding)
+  -> DiskSnapshot
+  -> ExtLedgerState blk -> m ()
+writeSnapshot = LDB.writeSnapshot
+
+{-# DEPRECATED deleteSnapshot "Use Ouroboros.Consensus.Storage.LedgerDB (deleteSnapshot)" #-}
+deleteSnapshot :: SomeHasFS m -> DiskSnapshot -> m ()
+deleteSnapshot = LDB.deleteSnapshot
+
+{-# DEPRECATED snapshotToFileName "Use Ouroboros.Consensus.Storage.LedgerDB (snapshotToFileName)" #-}
+snapshotToFileName :: DiskSnapshot -> String
+snapshotToFileName = LDB.snapshotToFileName
+
+{-# DEPRECATED snapshotToPath "Use Ouroboros.Consensus.Storage.LedgerDB (snapshotToPath)" #-}
+snapshotToPath :: DiskSnapshot -> FsPath
+snapshotToPath = LDB.snapshotToPath
+
+{-# DEPRECATED decorateReplayTracerWithGoal "Use Ouroboros.Consensus.Storage.LedgerDB (decorateReplayTracerWithGoal)" #-}
+decorateReplayTracerWithGoal
+  :: Point blk -- ^ Tip of the ImmutableDB
+  -> Tracer m (TraceReplayEvent blk)
+  -> Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
+decorateReplayTracerWithGoal = LDB.decorateReplayTracerWithGoal

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Types.hs
@@ -1,0 +1,8 @@
+module Ouroboros.Consensus.Storage.LedgerDB.Types {-# DEPRECATED "Use Ouroboros.Consensus.Storage.LedgerDB instead" #-} (
+    LDB.PushGoal (..)
+  , LDB.PushStart (..)
+  , LDB.Pushing (..)
+  , LDB.UpdateLedgerDbTraceEvent (..)
+  ) where
+
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Update.hs
@@ -35,6 +35,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.Update (
     -- * Block resolution
   , ResolveBlock
   , ResolvesBlocks (..)
+  , defaultResolveBlocks
     -- * Updates
   , defaultResolveWithErrors
   , ledgerDbBimap

--- a/scripts/ci/check-stylish.sh
+++ b/scripts/ci/check-stylish.sh
@@ -8,8 +8,10 @@ fd -p ouroboros-consensus \
     -E Setup.hs \
     -E ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs \
     -E ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs \
+    -E ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Types.hs \
     -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs \
-    -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs \
+    -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs\
+    -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs \
     -E ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs \
     -X stylish-haskell \
     -c .stylish-haskell.yaml -i
@@ -17,6 +19,8 @@ fd -p ouroboros-consensus \
 # We don't want these deprecation warnings to be removed accidentally
 grep "DEPRECATED" ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs >/dev/null 2>&1
 grep "DEPRECATED" ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs   >/dev/null 2>&1
+grep "DEPRECATED" ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/Types.hs    >/dev/null 2>&1
 grep "DEPRECATED" ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs         >/dev/null 2>&1
 grep "DEPRECATED" ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Types.hs        >/dev/null 2>&1
+grep "DEPRECATED" ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs              >/dev/null 2>&1
 grep "DEPRECATED" ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxLimits.hs          >/dev/null 2>&1


### PR DESCRIPTION
# Description

Some entities that were previously exposed have changed their name or moved locations. This PR adds deprecation warnings in all the entities that were present previously, pointing to the right entity to import and are still aliases so code should continue running even if the warnings are dismissed.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [x] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
