### PR TITLE
Fix hashtag in `network-spec` docs

### DIFF
--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -241,7 +241,7 @@ Note that there's also the hard fork combinator (HFC) which allows us to
 combine multiple eras into a single blockchain.  It affects how things are
 encoded across different eras.  Currently this is not properly documented (see
 \href{https://github.com/input-output-hk/ouroboros-consensus/issues/7}{issue
-#7}). In the mean time we can only offer informal advise: things are encoded as
+\#7}). In the mean time we can only offer informal advise: things are encoded as
 tuples (length 2 lists), where the first element is a zero based index of an
 era while the second item represents the data from that era (e.g. block,
 transaction, etc).


### PR DESCRIPTION
# Description

A hashtag was breaking CI, see [this](https://ci.zw3rk.com/log/j6g3ykj0pzfbdmxakvibijmgjqnh390r-ouroboros-network-docs.drv)

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
