### PR TITLE
Enforce version bounds per-bundle and inter-bundle

### DIFF
--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -51,11 +51,12 @@ library
                      , byron-spec-ledger
 
                      , ouroboros-network-api
-                     , ouroboros-consensus
-                     , ouroboros-consensus-test
-                     , ouroboros-consensus-byron
-                     , ouroboros-consensus-byronspec
 
+                     , ouroboros-consensus      ^>=0.3
+                     , ouroboros-consensus-test ^>=0.3
+
+                     , ouroboros-consensus-byron     ==0.3.0.0
+                     , ouroboros-consensus-byronspec ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -102,11 +103,14 @@ test-suite test
                      , small-steps-test
 
                      , ouroboros-network-mock
-                     , ouroboros-consensus
-                     , ouroboros-consensus-test
-                     , ouroboros-consensus-byron
+
+                     , ouroboros-consensus      ^>=0.3
+                     , ouroboros-consensus-test ^>=0.3
+
+                     , ouroboros-consensus-byron     ==0.3.0.0
+                     , ouroboros-consensus-byronspec ==0.3.0.0
+
                      , ouroboros-consensus-byron-test
-                     , ouroboros-consensus-byronspec
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -65,7 +65,8 @@ library
                      , text              >=1.2   && <1.3
 
                      , ouroboros-network-api
-                     , ouroboros-consensus
+
+                     , ouroboros-consensus ^>=0.3
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -96,9 +97,11 @@ executable db-converter
                      , text
 
                      , ouroboros-network-api
-                     , ouroboros-consensus
+
+                     , ouroboros-consensus           ^>=0.3
+                     , ouroboros-consensus-diffusion ^>=0.3
+
                      , ouroboros-consensus-byron
-                     , ouroboros-consensus-diffusion
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-byronspec/changelog.d
+++ b/ouroboros-consensus-byronspec/changelog.d
@@ -1,0 +1,1 @@
+../ouroboros-consensus-cardano/changelog.d

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -48,7 +48,7 @@ library
                      , small-steps
                      , transformers
 
-                     , ouroboros-consensus
+                     , ouroboros-consensus ^>=0.3
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -52,16 +52,18 @@ library
                      , cardano-protocol-tpraos
 
                      , ouroboros-network-api
-                     , ouroboros-consensus
-                     , ouroboros-consensus-test
-                     , ouroboros-consensus-byron
-                     , ouroboros-consensus-byron-test
-                     , ouroboros-consensus-shelley
-                     , ouroboros-consensus-shelley-test
-                     , ouroboros-consensus-cardano
-                     , ouroboros-consensus-protocol
-                     , ouroboros-consensus-protocol:ouroboros-consensus-protocol-test
-                     , ouroboros-consensus-diffusion
+
+                     , ouroboros-consensus                                            ^>=0.3
+                     , ouroboros-consensus-test                                       ^>=0.3
+                     , ouroboros-consensus-protocol                                   ^>=0.3
+                     , ouroboros-consensus-protocol:ouroboros-consensus-protocol-test ^>=0.3
+                     , ouroboros-consensus-diffusion                                  ^>=0.3
+
+                     , ouroboros-consensus-byron        ==0.3.0.0
+                     , ouroboros-consensus-byron-test   ==0.3.0.0
+                     , ouroboros-consensus-shelley      ==0.3.0.0
+                     , ouroboros-consensus-shelley-test ==0.3.0.0
+                     , ouroboros-consensus-cardano      ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -108,14 +110,17 @@ test-suite test
                      , cardano-protocol-tpraos
 
                      , ouroboros-network-api
-                     , ouroboros-consensus
-                     , ouroboros-consensus-test
-                     , ouroboros-consensus-byron
-                     , ouroboros-consensus-byron-test
-                     , ouroboros-consensus-protocol
-                     , ouroboros-consensus-shelley
-                     , ouroboros-consensus-shelley-test
-                     , ouroboros-consensus-cardano
+
+                     , ouroboros-consensus          ^>=0.3
+                     , ouroboros-consensus-test     ^>=0.3
+                     , ouroboros-consensus-protocol ^>=0.3
+
+                     , ouroboros-consensus-byron        ==0.3.0.0
+                     , ouroboros-consensus-byron-test   ==0.3.0.0
+                     , ouroboros-consensus-shelley      ==0.3.0.0
+                     , ouroboros-consensus-shelley-test ==0.3.0.0
+                     , ouroboros-consensus-cardano      ==0.3.0.0
+
                      , ouroboros-consensus-cardano-test
 
   default-language:    Haskell2010

--- a/ouroboros-consensus-cardano-tools/ouroboros-consensus-cardano-tools.cabal
+++ b/ouroboros-consensus-cardano-tools/ouroboros-consensus-cardano-tools.cabal
@@ -78,13 +78,15 @@ library
                      , cardano-prelude
                      , cardano-slotting
 
-                     , ouroboros-consensus
-                     , ouroboros-consensus-byron
-                     , ouroboros-consensus-cardano
-                     , ouroboros-consensus-protocol
-                     , ouroboros-consensus-shelley
                      , ouroboros-network-api
-                     , ouroboros-consensus-diffusion
+
+                     , ouroboros-consensus           ^>=0.3
+                     , ouroboros-consensus-diffusion ^>=0.3
+                     , ouroboros-consensus-protocol  ^>=0.3
+
+                     , ouroboros-consensus-byron   ==0.3.0.0
+                     , ouroboros-consensus-shelley ==0.3.0.0
+                     , ouroboros-consensus-cardano ==0.3.0.0
 
   other-modules:       Cardano.Api.Key
                      , Cardano.Api.KeysByron
@@ -120,10 +122,12 @@ executable db-analyser
   build-depends:       base              >=4.14 && <4.17
                      , cardano-crypto-wrapper
                      , optparse-applicative
-                     , ouroboros-consensus
-                     , ouroboros-consensus-byron
+
+                     , ouroboros-consensus ^>=0.3
+
+                     , ouroboros-consensus-byron         ==0.3.0.0
+                     , ouroboros-consensus-shelley       ==0.3.0.0
                      , ouroboros-consensus-cardano-tools
-                     , ouroboros-consensus-shelley
 
   other-modules:     DBAnalyser.Parsers
 
@@ -149,7 +153,9 @@ executable db-synthesizer
 
   build-depends:       base              >=4.14 && <4.17
                      , optparse-applicative
-                     , ouroboros-consensus
+
+                     , ouroboros-consensus ==0.3.0.0
+
                      , ouroboros-consensus-cardano-tools
 
   other-modules:     DBSynthesizer.Parsers
@@ -176,9 +182,10 @@ test-suite test
   default-language:  Haskell2010
 
   build-depends:       base              >=4.14 && <4.17
-                     , ouroboros-consensus-cardano-tools
                      , tasty
                      , tasty-hunit
+
+                     , ouroboros-consensus-cardano-tools
 
   ghc-options:       -Wall
                      -Wcompat

--- a/ouroboros-consensus-cardano/changelog.d/20230228_130310_jasataco_enforce_bundle_constraints.md
+++ b/ouroboros-consensus-cardano/changelog.d/20230228_130310_jasataco_enforce_bundle_constraints.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Version bounds for the bundle have been fixed and version bounds for
+  `ouroboros-consensus` bundle have been set to `^>=0.3`
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -52,10 +52,11 @@ library
                      , cardano-protocol-tpraos
                      , cardano-slotting
 
-                     , ouroboros-consensus
-                     , ouroboros-consensus-byron
-                     , ouroboros-consensus-protocol
-                     , ouroboros-consensus-shelley
+                     , ouroboros-consensus          ^>=0.3
+                     , ouroboros-consensus-protocol ^>=0.3
+
+                     , ouroboros-consensus-byron   ==0.3.0.0
+                     , ouroboros-consensus-shelley ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -93,7 +93,8 @@ library
                      , ouroboros-network-framework ^>=0.3
                      , ouroboros-network-protocols ^>=0.3
                      , ouroboros-network ^>=0.4.0.1
-                     , ouroboros-consensus ^>=0.3
+
+                     , ouroboros-consensus ==0.3.0.0
 
   ghc-options:         -Wall
                        -Wcompat

--- a/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
+++ b/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
@@ -34,9 +34,10 @@ library
                      , containers        >=0.5   && <0.7
                      , serialise         >=0.2   && <0.3
                      , QuickCheck
-                     , ouroboros-consensus
-                     , ouroboros-consensus-mock
-                     , ouroboros-consensus-test
+
+                     , ouroboros-consensus      ==0.3.0.0
+                     , ouroboros-consensus-mock ==0.3.0.0
+                     , ouroboros-consensus-test ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -73,10 +74,11 @@ test-suite test
                      , tasty-quickcheck
 
                      , ouroboros-network-mock
-                     , ouroboros-consensus
-                     , ouroboros-consensus-mock
+
+                     , ouroboros-consensus           ==0.3.0.0
+                     , ouroboros-consensus-mock      ==0.3.0.0
                      , ouroboros-consensus-mock-test
-                     , ouroboros-consensus-test
+                     , ouroboros-consensus-test      ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -65,7 +65,8 @@ library
 
                      , ouroboros-network-api
                      , ouroboros-network-mock
-                     , ouroboros-consensus
+
+                     , ouroboros-consensus ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -51,7 +51,7 @@ library
     containers,
     mtl,
     nothunks,
-    ouroboros-consensus,
+    ouroboros-consensus ==0.3.0.0,
     serialise,
     text
   ghc-options:

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -58,11 +58,13 @@ library
                      , small-steps
 
                      , ouroboros-network-api
-                     , ouroboros-consensus
-                     , ouroboros-consensus-protocol
-                     , ouroboros-consensus-protocol:ouroboros-consensus-protocol-test
-                     , ouroboros-consensus-test
-                     , ouroboros-consensus-shelley
+
+                     , ouroboros-consensus                                            ^>=0.3
+                     , ouroboros-consensus-protocol                                   ^>=0.3
+                     , ouroboros-consensus-protocol:ouroboros-consensus-protocol-test ^>=0.3
+                     , ouroboros-consensus-test                                       ^>=0.3
+
+                     , ouroboros-consensus-shelley ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -105,10 +107,11 @@ test-suite test
                      , cardano-ledger-shelley
                      , cardano-protocol-tpraos
 
-                     , ouroboros-consensus
-                     , ouroboros-consensus-protocol
-                     , ouroboros-consensus-test
-                     , ouroboros-consensus-shelley
+                     , ouroboros-consensus          ^>=0.3
+                     , ouroboros-consensus-protocol ^>=0.3
+                     , ouroboros-consensus-test     ^>=0.3
+
+                     , ouroboros-consensus-shelley ==0.3.0.0
                      , ouroboros-consensus-shelley-test
 
   default-language:    Haskell2010

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -85,8 +85,9 @@ library
                      , small-steps
 
                      , ouroboros-network-api
-                     , ouroboros-consensus
-                     , ouroboros-consensus-protocol
+
+                     , ouroboros-consensus           ^>=0.3
+                     , ouroboros-consensus-protocol  ^>=0.3
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -122,8 +122,9 @@ library
                      , ouroboros-network-framework
                      , ouroboros-network-mock
                      , ouroboros-network-protocols
-                     , ouroboros-consensus
-                     , ouroboros-consensus-diffusion
+
+                     , ouroboros-consensus           ==0.3.0.0
+                     , ouroboros-consensus-diffusion ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -193,10 +194,11 @@ test-suite test-consensus
                      , ouroboros-network-mock
                      , ouroboros-network-protocols
                      , ouroboros-network-protocols:testlib
-                     , ouroboros-consensus
-                     , ouroboros-consensus-mock
+
+                     , ouroboros-consensus           ==0.3.0.0
+                     , ouroboros-consensus-mock      ==0.3.0.0
                      , ouroboros-consensus-test
-                     , ouroboros-consensus-diffusion
+                     , ouroboros-consensus-diffusion ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -278,7 +280,8 @@ test-suite test-storage
                      , io-sim
                      , ouroboros-network-api
                      , ouroboros-network-mock
-                     , ouroboros-consensus
+
+                     , ouroboros-consensus      ==0.3.0.0
                      , ouroboros-consensus-test
 
   default-language:    Haskell2010
@@ -309,7 +312,7 @@ test-suite test-infra
                      , tasty
                      , tasty-quickcheck
 
-                     , ouroboros-consensus
+                     , ouroboros-consensus      ==0.3.0.0
                      , ouroboros-consensus-test
 
   default-language:    Haskell2010

--- a/ouroboros-consensus-tutorials/changelog.d
+++ b/ouroboros-consensus-tutorials/changelog.d
@@ -1,0 +1,1 @@
+../ouroboros-consensus/changelog.d

--- a/ouroboros-consensus-tutorials/ouroboros-consensus-tutorials.cabal
+++ b/ouroboros-consensus-tutorials/ouroboros-consensus-tutorials.cabal
@@ -33,8 +33,9 @@ library
                      , mtl
                      , nothunks
                      , serialise
-                     , ouroboros-consensus
                      , ouroboros-network-api
+
+                     , ouroboros-consensus ==0.3.0.0
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus/CHANGELOG.md
+++ b/ouroboros-consensus/CHANGELOG.md
@@ -7,6 +7,7 @@ This Changelog describes changes on the ledger agnostic Consensus packages:
 - `ouroboros-consensus-mock`
 - `ouroboros-consensus-mock-test`
 - `ouroboros-consensus-protocol`
+- `ouroboros-consensus-tutorials`
 
 If you don't see here the package you're interested in, see the top-level
 [Consensus-CHANGELOG.md](../Consensus-CHANGELOG.md).

--- a/ouroboros-consensus/changelog.d/20230228_130303_jasataco_enforce_bundle_constraints.md
+++ b/ouroboros-consensus/changelog.d/20230228_130303_jasataco_enforce_bundle_constraints.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Version bounds for the bundle have been fixed
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->


### PR DESCRIPTION
# Description

- Intra-bundle dependencies are fixed to the exact same version.
- Inter-bundle dependencies are set to the current version up to the next minor (see treatment on `^>=` [here](https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-build-depends))

Motivated by [this FAQ](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api) I think this would only be a minor bump.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [x] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
