### PR TITLE
Add `Wunused-packages` to default `ghc-options` for consensus packages.

### DIFF
--- a/.github/workflows/cabal.project.local.Linux
+++ b/.github/workflows/cabal.project.local.Linux
@@ -90,3 +90,6 @@ package ouroboros-consensus-cardano-tools
 
 package ouroboros-consensus-diffusion
   ghc-options: -Werror
+
+package ouroboros-consensus-tutorials
+  ghc-options: -Werror

--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -51,8 +51,6 @@ library
                      , byron-spec-ledger
 
                      , ouroboros-network-api
-                     , ouroboros-network-mock
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
                      , ouroboros-consensus-test
                      , ouroboros-consensus-byron
@@ -68,6 +66,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
 
 test-suite test
@@ -88,7 +87,6 @@ test-suite test
                      , cardano-ledger-binary
                      , cardano-ledger-byron
                      , cardano-ledger-byron-test
-                     , cardano-slotting
                      , cborg
                      , containers
                      , filepath
@@ -119,6 +117,7 @@ test-suite test
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -55,7 +55,6 @@ library
                      , cardano-ledger-binary
                      , cardano-ledger-byron
                      , cardano-prelude
-                     , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
                      , cryptonite        >=0.25  && <0.31
@@ -66,7 +65,6 @@ library
                      , text              >=1.2   && <1.3
 
                      , ouroboros-network-api
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
 
   default-language:    Haskell2010
@@ -78,6 +76,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
 
@@ -96,7 +95,7 @@ executable db-converter
                      , streaming
                      , text
 
-                     , ouroboros-network
+                     , ouroboros-network-api
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-diffusion
@@ -110,3 +109,4 @@ executable db-converter
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -38,7 +38,6 @@ library
                      , bimap             >=0.4   && <0.5
                      , cardano-ledger-binary
                      , cardano-ledger-byron-test
-                     , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
                      , byron-spec-chain
@@ -49,7 +48,6 @@ library
                      , small-steps
                      , transformers
 
-                     , ouroboros-network
                      , ouroboros-consensus
 
   default-language:    Haskell2010
@@ -61,3 +59,4 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -42,22 +42,16 @@ library
                      , mtl
                      , microlens
                      , QuickCheck
-                     , sop-core
                      , cardano-strict-containers
 
-                     , cardano-ledger-alonzo
                      , cardano-ledger-alonzo-test
-                     , cardano-ledger-babbage
-                     , cardano-ledger-babbage-test
                      , cardano-ledger-conway-test
                      , cardano-ledger-byron
                      , cardano-ledger-core:{cardano-ledger-core, testlib}
                      , cardano-ledger-shelley
-                     , cardano-ledger-shelley-test
                      , cardano-protocol-tpraos
 
                      , ouroboros-network-api
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
                      , ouroboros-consensus-test
                      , ouroboros-consensus-byron
@@ -78,6 +72,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
 
 test-suite test
@@ -108,13 +103,11 @@ test-suite test
 
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron
-                     , cardano-ledger-conway
                      , cardano-ledger-core
                      , cardano-ledger-shelley
                      , cardano-protocol-tpraos
 
                      , ouroboros-network-api
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
                      , ouroboros-consensus-test
                      , ouroboros-consensus-byron
@@ -134,6 +127,7 @@ test-suite test
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts

--- a/ouroboros-consensus-cardano-tools/ouroboros-consensus-cardano-tools.cabal
+++ b/ouroboros-consensus-cardano-tools/ouroboros-consensus-cardano-tools.cabal
@@ -50,7 +50,6 @@ library
                      , cborg
                      , containers
                      , contra-tracer
-                     , deepseq
                      , directory
                      , filepath
                      , microlens
@@ -85,7 +84,6 @@ library
                      , ouroboros-consensus-protocol
                      , ouroboros-consensus-shelley
                      , ouroboros-network-api
-                     , ouroboros-network-protocols
                      , ouroboros-consensus-diffusion
 
   other-modules:       Cardano.Api.Key
@@ -112,6 +110,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
 
@@ -137,6 +136,7 @@ executable db-analyser
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -threaded
                        -rtsopts
                        "-with-rtsopts=-T -I0 -N2 -A16m"
@@ -148,19 +148,13 @@ executable db-synthesizer
   default-language:    Haskell2010
 
   build-depends:       base              >=4.14 && <4.17
-                     , aeson
-                     , bytestring
-                     , directory
-                     , filepath
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-consensus-cardano-tools
-                     , transformers
-                     , transformers-except
 
   other-modules:     DBSynthesizer.Parsers
 
-  ghc-options:       -Wall
+  ghc-options:        -Wall
                      -Wcompat
                      -Wincomplete-uni-patterns
                      -Wincomplete-record-updates
@@ -168,6 +162,7 @@ executable db-synthesizer
                      -Widentities
                      -Wredundant-constraints
                      -Wmissing-export-lists
+                     -Wunused-packages
                      -O2
                      -threaded
                      -rtsopts
@@ -184,7 +179,7 @@ test-suite test
                      , ouroboros-consensus-cardano-tools
                      , tasty
                      , tasty-hunit
-                     
+
   ghc-options:       -Wall
                      -Wcompat
                      -Wincomplete-uni-patterns
@@ -193,6 +188,7 @@ test-suite test
                      -Widentities
                      -Wredundant-constraints
                      -Wmissing-export-lists
+                     -Wunused-packages
                      -threaded
                      -rtsopts
                      "-with-rtsopts=-N -I0 -A16m"

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -45,19 +45,13 @@ library
                      , cardano-binary
                      , cardano-crypto-class
                      , cardano-data
-                     , cardano-ledger-alonzo
-                     , cardano-ledger-allegra
-                     , cardano-ledger-babbage
                      , cardano-ledger-byron
-                     , cardano-ledger-conway
                      , cardano-ledger-core
-                     , cardano-ledger-mary
                      , cardano-ledger-shelley
                      , cardano-prelude
                      , cardano-protocol-tpraos
                      , cardano-slotting
 
-                     , ouroboros-network ^>= 0.4
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-protocol
@@ -72,5 +66,6 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
+++ b/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
@@ -47,6 +47,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
 
@@ -64,7 +65,6 @@ test-suite test
 
   build-depends:       base              >=4.14 && <4.17
                      , bytestring
-                     , cardano-slotting
                      , cborg
                      , containers
                      , QuickCheck
@@ -72,7 +72,6 @@ test-suite test
                      , tasty
                      , tasty-quickcheck
 
-                     , ouroboros-network-protocols
                      , ouroboros-network-mock
                      , ouroboros-consensus
                      , ouroboros-consensus-mock
@@ -88,6 +87,7 @@ test-suite test
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts

--- a/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -65,7 +65,6 @@ library
 
                      , ouroboros-network-api
                      , ouroboros-network-mock
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
 
   default-language:    Haskell2010
@@ -77,6 +76,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -Wno-unticked-promoted-constructors
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -42,7 +42,6 @@ library
     bytestring,
     cardano-binary,
     cardano-crypto-class,
-    cardano-data,
     cardano-ledger-binary,
     cardano-ledger-core,
     cardano-ledger-shelley,
@@ -54,7 +53,6 @@ library
     nothunks,
     ouroboros-consensus,
     serialise,
-    small-steps,
     text
   ghc-options:
     -Wall
@@ -65,6 +63,7 @@ library
     -Widentities
     -Wredundant-constraints
     -Wmissing-export-lists
+    -Wunused-packages
   if flag(asserts)
     ghc-options:
       -fno-ignore-asserts

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -35,7 +35,6 @@ library
                      , cardano-data
                      , cardano-ledger-core:{cardano-ledger-core, testlib}
                      , cardano-protocol-tpraos
-                     , cardano-slotting
                      , containers        >=0.5   && <0.7
                      , generic-random
                      , quiet             >=0.2   && <0.3
@@ -43,7 +42,6 @@ library
                      , microlens
                      , QuickCheck
                      , cardano-strict-containers
-                     , transformers
 
                        -- cardano-ledger
                      , cardano-ledger-allegra
@@ -60,7 +58,6 @@ library
                      , small-steps
 
                      , ouroboros-network-api
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
                      , ouroboros-consensus-protocol
                      , ouroboros-consensus-protocol:ouroboros-consensus-protocol-test
@@ -76,6 +73,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
 
 test-suite test
@@ -107,7 +105,6 @@ test-suite test
                      , cardano-ledger-shelley
                      , cardano-protocol-tpraos
 
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
                      , ouroboros-consensus-protocol
                      , ouroboros-consensus-test
@@ -123,6 +120,7 @@ test-suite test
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -58,24 +58,19 @@ library
                      , bytestring        >=0.10  && <0.12
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-praos
                      , cardano-data
                      , cardano-protocol-tpraos
-                     , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
-                     , data-default-class
                      , deepseq
                      , measures
                      , microlens
                      , mtl               >=2.2   && <2.3
                      , nothunks
-                     , orphans-deriving-via
                      , serialise         >=0.2   && <0.3
                      , cardano-strict-containers
                      , text              >=1.2   && <1.3
-                     , transformers
                      , vector-map
 
                        -- cardano-ledger
@@ -90,10 +85,8 @@ library
                      , small-steps
 
                      , ouroboros-network-api
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
                      , ouroboros-consensus-protocol
-                     , ouroboros-consensus-diffusion
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -104,5 +97,6 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -84,7 +84,6 @@ library
                      , cardano-crypto-class
                      , cardano-ledger-binary:{testlib}
                      , cardano-prelude
-                     , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
                      , contra-tracer
@@ -112,7 +111,6 @@ library
                      , template-haskell
                      , text              >=1.2   && <1.3
                      , time
-                     , transformers
                      , tree-diff
                      , utf8-string
 
@@ -136,6 +134,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
 
 test-suite test-consensus
@@ -178,13 +177,11 @@ test-suite test-consensus
                      , quickcheck-state-machine
                      , quiet
                      , serialise
-                     , sop-core
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck
                      , temporary
                      , time
-                     , transformers
                      , tree-diff
 
                      , io-classes
@@ -210,6 +207,7 @@ test-suite test-consensus
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts
@@ -254,7 +252,6 @@ test-suite test-storage
                      , binary
                      , bytestring
                      , cardano-crypto-class
-                     , cardano-slotting
                      , cborg
                      , containers
                      , contra-tracer
@@ -268,14 +265,12 @@ test-suite test-storage
                      , quickcheck-state-machine >=0.7.0
                      , random
                      , serialise
-                     , cardano-strict-containers
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck
                      , temporary
                      , text
                      , time
-                     , transformers
                      , tree-diff
                      , vector
 
@@ -283,7 +278,6 @@ test-suite test-storage
                      , io-sim
                      , ouroboros-network-api
                      , ouroboros-network-mock
-                     , ouroboros-network-protocols
                      , ouroboros-consensus
                      , ouroboros-consensus-test
 
@@ -296,6 +290,7 @@ test-suite test-storage
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
 
 test-suite test-infra
@@ -326,6 +321,7 @@ test-suite test-infra
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts
 
 benchmark bench-mempool
@@ -341,13 +337,12 @@ benchmark bench-mempool
                      , contra-tracer
                      , deepseq
                      , nothunks
-                     , QuickCheck
                      , serialise         >=0.2   && <0.3
                      , strict-stm
-                     , transformers
                      , tree-diff
                      , tasty-bench
                      , tasty-hunit
+                     , transformers
 
                      , ouroboros-consensus
                      , ouroboros-consensus-test
@@ -360,6 +355,7 @@ benchmark bench-mempool
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -Wno-unticked-promoted-constructors
                        -rtsopts
                        "-with-rtsopts=-A32m"

--- a/ouroboros-consensus-tutorials/ouroboros-consensus-tutorials.cabal
+++ b/ouroboros-consensus-tutorials/ouroboros-consensus-tutorials.cabal
@@ -45,4 +45,5 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
                        -fno-ignore-asserts

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -350,6 +350,7 @@ library
                        -Widentities
                        -Wredundant-constraints
                        -Wmissing-export-lists
+                       -Wunused-packages
 
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts


### PR DESCRIPTION
# Description

- [ ] Add the `Wunused-packages` flag to the [style guide](https://github.com/input-output-hk/ouroboros-consensus/blob/main/docs/StyleGuide.md).

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers.
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
