### PR TITLE
mempool: use fifo behaviour for threads using addtx 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2023-03-29T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-03-29T00:00:00Z
+  , cardano-haskell-packages 2023-04-04T00:00:00Z
 
 packages: ./cardano-ping
           ./ouroboros-network-testing

--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -21,7 +21,7 @@ library
   build-depends:       base              >=4.14 && <4.17,
                        bytestring        >=0.10 && <0.12,
                        containers,
-                       io-classes,
+                       io-classes        ^>= 0.5,
                        ouroboros-network-api,
                        ouroboros-network,
                        ouroboros-network-framework,

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -27,9 +27,9 @@ library
                         cborg                         >=0.2.8    && <0.3,
                         bytestring                    >=0.10     && <0.12,
                         contra-tracer                 >=0.1      && <0.2,
-                        io-classes                    >=0.3      && <0.4,
+                        io-classes                    >=0.5      && <0.6,
                         network-mux                   >=0.3      && <0.4,
-                        strict-stm                    >=0.2      && <0.3,
+                        strict-stm                    >=0.5      && <0.6,
                         tdigest                       >=0.2.1.1  && <0.3,
                         text                          >=1.2.4    && <2.1,
 

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -45,8 +45,8 @@ common demo-deps
 
 library
   build-depends:       base            >=4.14 && <4.17,
-                       io-classes     ^>=0.3,
-                       strict-stm     ^>=0.2,
+                       io-classes     ^>=0.5,
+                       strict-stm     ^>=0.5,
                        contra-tracer   >=0.1 && <0.2,
                        monoidal-synchronisation
                                        >=0.1 && <0.2,
@@ -126,7 +126,7 @@ test-suite test
   build-depends:       base >=4.14 && <4.17,
                        io-classes,
                        strict-stm,
-                       io-sim            >=0.3 && < 0.4,
+                       io-sim            >=0.5 && < 0.6,
                        contra-tracer,
                        network-mux,
                        Win32-network,

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -88,7 +88,7 @@ library
     , filepath
     , fs-api
     , hashable
-    , io-classes                   ^>=0.3
+    , io-classes                   ^>=0.5
     , mtl
     , ouroboros-consensus          ==0.3.1.0
     , ouroboros-network            ^>=0.4.0.1

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -193,7 +193,6 @@ test-suite test-consensus
     , random
     , serialise
     , tasty
-    , tasty-expected-failure
     , tasty-hunit
     , tasty-quickcheck
     , temporary

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -37,6 +37,7 @@
 module Test.Consensus.BlockchainTime.Simple (tests) where
 
 import           Control.Applicative (Alternative (..))
+import           Control.Monad.Class.MonadMVar (MonadMVar)
 import qualified Control.Monad.Class.MonadSTM.Internal as LazySTM
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Except
@@ -358,6 +359,7 @@ newtype OverrideDelay m a = OverrideDelay {
            , MonadCatch
            , MonadMask
            , MonadMonotonicTime
+           , MonadMVar
            , MonadTime
            , MonadThread
            , MonadFork

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -24,6 +24,11 @@
 -- * Transactions cannot be retrieved after they are removed.
 -- * The mempool capacity is not exceeded
 --
+-- NOTE: the test mempool's default capacity is set to a very large value in
+-- module "Ouroboros.Consensus.Mock.Ledger.Block". This is why the generators do
+-- not care about the mempool capacity when generating transactions for a
+-- mempool with the 'NoMempoolCapacityBytesOverride' option set.
+--
 module Test.Consensus.Mempool (tests) where
 
 import           Cardano.Binary (Encoding, toCBOR)
@@ -78,7 +83,8 @@ tests = testGroup "Mempool"
   , testProperty "result of addTxs"                        prop_Mempool_addTxs_result
   , testProperty "Invalid transactions are never added"    prop_Mempool_InvalidTxsNeverAdded
   , testProperty "result of getCapacity"                   prop_Mempool_getCapacity
-  , testProperty "Mempool capacity implementation"         prop_Mempool_Capacity
+  --   , testProperty "Mempool capacity implementation"         prop_Mempool_Capacity
+  -- FIXME: we should add an issue to test this aspect somehow.
   , testProperty "Added valid transactions are traced"     prop_Mempool_TraceValidTxs
   , testProperty "Rejected invalid txs are traced"         prop_Mempool_TraceRejectedTxs
   , testProperty "Removed invalid txs are traced"          prop_Mempool_TraceRemovedTxs
@@ -208,63 +214,6 @@ prop_Mempool_getCapacity mcts =
   where
     MempoolCapacityBytesOverride testCapacity = testMempoolCapOverride testSetup
     MempoolCapTestSetup (TestSetupWithTxs testSetup _txsToAdd) = mcts
-
--- | Test the correctness of 'tryAddTxs' when the Mempool is (or will be) at
--- capacity.
---
--- Ignore the "100% empty Mempool" label in the test output, that is there
--- because we reuse 'withTestMempool' and always start with an empty Mempool
--- and 'LedgerState'.
-prop_Mempool_Capacity :: MempoolCapTestSetup -> Property
-prop_Mempool_Capacity (MempoolCapTestSetup testSetupWithTxs) =
-  withTestMempool testSetup $ \TestMempool { mempool } -> do
-    capacity <- atomically (getCapacity mempool)
-    curSize <- msNumBytes . snapshotMempoolSize <$>
-      atomically (getSnapshot mempool)
-    res@(processed, unprocessed) <- tryAddTxs mempool DoNotIntervene (map fst txsToAdd)
-    return $
-      counterexample ("Initial size: " <> show curSize)    $
-      classify (null processed)   "no transactions added"  $
-      classify (null unprocessed) "all transactions added" $
-      blindErrors res === expectedResult capacity curSize
-  where
-    TestSetupWithTxs testSetup txsToAdd = testSetupWithTxs
-
-    -- | Convert 'MempoolAddTxResult' into a 'Bool':
-    -- isMempoolTxAdded -> True, isMempoolTxRejected -> False.
-    blindErrors
-      :: ([MempoolAddTxResult TestBlock], [GenTx TestBlock])
-      -> ([(GenTx TestBlock, Bool)], [GenTx TestBlock])
-    blindErrors (processed, toAdd) = (processed', toAdd)
-      where
-        processed' = [ case txAddRes of
-                         MempoolTxAdded vtx        -> (txForgetValidated vtx, True)
-                         MempoolTxRejected tx _err -> (tx, False)
-                     | txAddRes <- processed ]
-
-    expectedResult
-      :: MempoolCapacityBytes
-      -> Word32  -- ^ Current mempool size
-      -> ([(GenTx TestBlock, Bool)], [GenTx TestBlock])
-    expectedResult (MempoolCapacityBytes capacity) = \curSize ->
-        go curSize [] txsToAdd
-      where
-        go
-          :: Word32
-          -> [(GenTx TestBlock, Bool)]
-          -> [(GenTx TestBlock, Bool)]
-          -> ([(GenTx TestBlock, Bool)], [GenTx TestBlock])
-        go curSize processed = \case
-          []
-            -> (reverse processed, [])
-          (tx, valid):txsToAdd'
-            | let curSize' = curSize + txSize tx
-            , curSize' <= capacity
-            -> go (if valid then curSize' else curSize)
-                  ((tx, valid):processed)
-                  txsToAdd'
-            | otherwise
-            -> (reverse processed, tx:map fst txsToAdd')
 
 -- | Test that all valid transactions added to a 'Mempool' via 'addTxs' are
 -- appropriately represented in the trace of events.
@@ -738,6 +687,11 @@ data TestMempool m = TestMempool
 
 -- NOTE: at the end of the test, this function also checks whether the Mempool
 -- contents are valid w.r.t. the current ledger.
+--
+-- NOTE: the test mempool's default capacity is set to a very large value in
+-- module "Ouroboros.Consensus.Mock.Ledger.Block". This is why the generators do
+-- not care about the mempool capacity when generating transactions for a
+-- mempool with the 'NoMempoolCapacityBytesOverride' option set.
 withTestMempool
   :: forall prop. Testable prop
   => TestSetup

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Fairness.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Fairness.hs
@@ -31,14 +31,12 @@ import           Ouroboros.Consensus.Util.IOLike (STM, atomically, retry)
 import           System.Random (randomIO)
 import           Test.Consensus.Mempool.Fairness.TestBlock
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.ExpectedFailure (expectFail)
 import           Test.Tasty.HUnit (testCase, (@?), (@?=))
 import           Test.Util.TestBlock (testInitLedgerWithState)
 
 tests :: TestTree
 tests = testGroup "Mempool fairness"
-                  [ expectFail $
-                    testCase "There is no substantial bias in added transaction sizes" $
+                  [ testCase "There is no substantial bias in added transaction sizes" $
                               testTxSizeFairness TestParams { mempoolMaxCapacity =   100
                                                             , smallTxSize        =     1
                                                             , largeTxSize        =    10

--- a/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
+++ b/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
@@ -1,0 +1,33 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Remove function `tryAddTxs` from the mempool API. The implementation of this
+  function did not guarantee fairness, and therefore transactions could starve.
+  This function was replaced by `addTx`.
+- Add a `addTx` function to the mempool API. This function tries to add a single
+  transaction and blocks if the mempool if full. The mempool is now fair, which
+  means that no transaction will be starved, provided that transactions are
+  eventually removed from the mempool. Fairness is achieved by introducing two
+  FIFO queues. Remote clients have to queue in both of them, whereas local
+  clients only have to queue in the local clients' queue. This gives local
+  clients priority over remote ones.
+
+

--- a/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
+++ b/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
@@ -28,7 +28,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
   This function was replaced by `addTx`.
 - Add a `addTx` function to the mempool API. This function tries to add a single
   transaction and blocks if the mempool can not accept the given transaction. 
-  This means that entry to a mempool is now a (per-node) FIFO. This also ensure
+  This means that entry to a mempool is now a (per-peer) FIFO. This also ensure
   that transactions will always progress, irrespective of size.
   The refactoring introduces two FIFO queues. Remote clients have to queue in both
   of them, whereas local clients only have to queue in the local clients' queue. 

--- a/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
+++ b/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
@@ -19,15 +19,20 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Breaking
 
-- Remove function `tryAddTxs` from the mempool API. The implementation of this
-  function did not guarantee fairness, and therefore transactions could starve.
+- Remove function `tryAddTxs` from the mempool API. The implementation (Shelly Era)
+  of this function relied on the fairness of 'service-in-random-order', and 
+  endeavoured to maximally fill the mempool. Since the Babbage Era there is an 
+  increased variation in representational size of transactions for a given cost 
+  of processing. This means that, under certain conditions, representationally
+  large transactions could be stalled in progress between mempools.
   This function was replaced by `addTx`.
 - Add a `addTx` function to the mempool API. This function tries to add a single
-  transaction and blocks if the mempool if full. The mempool is now fair, which
-  means that no transaction will be starved, provided that transactions are
-  eventually removed from the mempool. Fairness is achieved by introducing two
-  FIFO queues. Remote clients have to queue in both of them, whereas local
-  clients only have to queue in the local clients' queue. This gives local
-  clients priority over remote ones.
+  transaction and blocks if the mempool can not accept the given transaction. 
+  This means that entry to a mempool is now a (per-node) FIFO. This also ensure
+  that transactions will always progress, irrespective of size.
+  The refactoring introduces two FIFO queues. Remote clients have to queue in both
+  of them, whereas local clients only have to queue in the local clients' queue. 
+  This gives local clients a higher precedence to get into their local mempool under
+  heavy load situations.
 
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -309,7 +309,7 @@ library
     , filelock
     , fs-api
     , hashable
-    , io-classes                   ^>=0.3
+    , io-classes                   ^>=0.5
     , measures
     , mtl                          >=2.2   && <2.3
     , nothunks                     >=0.1.2 && <0.2
@@ -323,7 +323,7 @@ library
     , serialise                    >=0.2   && <0.3
     , sop-core                     >=0.5   && <0.6
     , streaming
-    , strict-stm                   ^>=0.2
+    , strict-stm                   ^>=0.5
     , text                         >=1.2   && <1.3
     , these                        >=1.1   && <1.2
     , time

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -68,6 +68,10 @@ class ( UpdateLedger blk
   txInvariant = const True
 
   -- | Apply an unvalidated transaction
+  --
+  -- The mempool expects that the ledger checks the sanity of the transaction'
+  -- size. The mempool implementation will add any valid transaction as long as
+  -- there is at least one byte free in the mempool.
   applyTx :: LedgerConfig blk
           -> WhetherToIntervene
           -> SlotNo -- ^ Slot number of the block containing the tx

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -38,7 +38,7 @@ module Ouroboros.Consensus.Mempool.Impl.Common (
   ) where
 
 import           Control.Exception (assert)
-import           Control.Monad.Class.MonadMVar (MVar, newEmptyMVar)
+import           Control.Monad.Class.MonadMVar (MVar, newMVar)
 import           Control.Monad.Trans.Except (runExcept)
 import           Control.Tracer
 import           Data.Maybe (isNothing)
@@ -60,7 +60,7 @@ import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Util (repeatedly)
-import           Ouroboros.Consensus.Util.IOLike hiding (newEmptyMVar)
+import           Ouroboros.Consensus.Util.IOLike hiding (newEmptyMVar, newMVar)
 {-------------------------------------------------------------------------------
   Internal State
 -------------------------------------------------------------------------------}
@@ -205,8 +205,8 @@ initMempoolEnv ledgerInterface cfg capacityOverride tracer txSize = do
     st <- atomically $ getCurrentLedgerState ledgerInterface
     let (slot, st') = tickLedgerState cfg (ForgeInUnknownSlot st)
     isVar <- newTVarIO $ initInternalState capacityOverride TxSeq.zeroTicketNo slot st'
-    addTxRemoteFifo <- newEmptyMVar
-    addTxAllFifo    <- newEmptyMVar
+    addTxRemoteFifo <- newMVar ()
+    addTxAllFifo    <- newMVar ()
     return MempoolEnv
       { mpEnvLedger           = ledgerInterface
       , mpEnvLedgerCfg        = cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
@@ -117,7 +117,7 @@ mkMempool mpEnv = Mempool
     }
    where MempoolEnv { mpEnvStateVar = istate
                     , mpEnvAddTxsRemoteFifo = remoteFifo
-                    , mpEnvAddTxsAllFifo    = allFifo
+                    , mpEnvAddTxsAllFifo = allFifo
                     , mpEnvLedgerCfg = cfg
                     , mpEnvTxSize = txSize
                     , mpEnvTracer = trcr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
@@ -107,7 +107,7 @@ mkMempool
      )
   => MempoolEnv m blk -> Mempool m blk
 mkMempool mpEnv = Mempool
-    { addTx          = implAddTx istate cfg txSize trcr
+    { addTx          = implAddTx istate remoteFifo allFifo cfg txSize trcr
     , removeTxs      = implRemoveTxs mpEnv
     , syncWithLedger = implSyncWithLedger mpEnv
     , getSnapshot    = snapshotFromIS <$> readTVar istate
@@ -116,6 +116,8 @@ mkMempool mpEnv = Mempool
     , getTxSize      = txSize
     }
    where MempoolEnv { mpEnvStateVar = istate
+                    , mpEnvAddTxsRemoteFifo = remoteFifo
+                    , mpEnvAddTxsAllFifo    = allFifo
                     , mpEnvLedgerCfg = cfg
                     , mpEnvTxSize = txSize
                     , mpEnvTracer = trcr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Init.hs
@@ -107,7 +107,7 @@ mkMempool
      )
   => MempoolEnv m blk -> Mempool m blk
 mkMempool mpEnv = Mempool
-    { tryAddTxs      = implTryAddTxs istate cfg txSize trcr
+    { addTx          = implAddTx istate cfg txSize trcr
     , removeTxs      = implRemoveTxs mpEnv
     , syncWithLedger = implSyncWithLedger mpEnv
     , getSnapshot    = snapshotFromIS <$> readTVar istate

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Update.hs
@@ -44,16 +44,18 @@ implAddTx ::
      )
   => StrictTVar m (InternalState blk)
      -- ^ The InternalState TVar.
-  -> MVar m () -- ^ The FIFO for remote peers
-  -> MVar m () -- ^ The FIFO for all remote peers and local clients
+  -> MVar m ()
+      -- ^ The FIFO for remote peers
+  -> MVar m ()
+      -- ^ The FIFO for all remote peers and local clients
   -> LedgerConfig blk
      -- ^ The configuration of the ledger.
   -> (GenTx blk -> TxSizeInBytes)
      -- ^ The function to calculate the size of a
      -- transaction.
   -> Tracer m (TraceEventMempool blk)
-     -- ^ The tracer.
   -> AddTxOnBehalfOf
+     -- ^ Whether we're acting on behalf of a remote peer or a local client.
   -> GenTx blk
      -- ^ The transaction to add to the mempool.
   -> m (MempoolAddTxResult blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Update.hs
@@ -13,6 +13,7 @@ module Ouroboros.Consensus.Mempool.Update (
   ) where
 
 import           Control.Exception (assert)
+import           Control.Monad.Class.MonadMVar (MVar, MonadMVar, withMVar)
 import           Control.Tracer
 import           Data.Maybe (isJust, isNothing)
 import qualified Data.Set as Set
@@ -37,11 +38,14 @@ import           Ouroboros.Consensus.Util.IOLike
 --
 implAddTx ::
      ( MonadSTM m
+     , MonadMVar m
      , LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      )
   => StrictTVar m (InternalState blk)
      -- ^ The InternalState TVar.
+  -> MVar m () -- ^ The FIFO for remote peers
+  -> MVar m () -- ^ The FIFO for all remote peers and local clients
   -> LedgerConfig blk
      -- ^ The configuration of the ledger.
   -> (GenTx blk -> TxSizeInBytes)
@@ -49,21 +53,59 @@ implAddTx ::
      -- transaction.
   -> Tracer m (TraceEventMempool blk)
      -- ^ The tracer.
-  -> WhetherToIntervene
+  -> AddTxOnBehalfOf
   -> GenTx blk
      -- ^ The transaction to add to the mempool.
   -> m (MempoolAddTxResult blk)
-implAddTx istate cfg txSize trcr wti tx = do
-    (result, ev) <- atomically $ do
-      outcome <- implTryAddTx istate cfg txSize wti tx
-      case outcome of
-        TryAddTx _ result ev -> do return (result, ev)
+implAddTx istate remoteFifo allFifo cfg txSize trcr onbehalf tx =
+    -- To ensure fair behaviour between threads that are trying to add
+    -- transactions, we make them all queue in a fifo. Only the one at the head
+    -- of the queue gets to actually wait for space to get freed up in the
+    -- mempool. This avoids small transactions repeatedly squeezing in ahead of
+    -- larger transactions.
+    --
+    -- The fifo behaviour is implemented using a simple MVar. And take this
+    -- MVar lock on a transaction by transaction basis. So if several threads
+    -- are each trying to add several transactions, then they'll interleave at
+    -- transaction granularity, not batches of transactions.
+    --
+    -- To add back in a bit of deliberate unfairness, we want to prioritise
+    -- transactions being added on behalf of local clients, over ones being
+    -- added on behalf of remote peers. We do this by using a pair of mvar
+    -- fifos: remote peers must wait on both mvars, while local clients only
+    -- need to wait on the second.
+    case onbehalf of
+      AddTxForRemotePeer ->
+        withMVar remoteFifo $ \() ->
+        withMVar allFifo $ \() ->
+          -- This action can also block. Holding the MVars means
+          -- there is only a single such thread blocking at once.
+          implAddTx'
 
-        -- or block until space is available to fit the next transaction
-        NoSpaceLeft          -> retry
+      AddTxForLocalClient ->
+        withMVar allFifo $ \() ->
+          -- As above but skip the first MVar fifo so we will get
+          -- service sooner if there's lots of other remote
+          -- threads waiting.
+          implAddTx'
+  where
+    implAddTx' = do
+      (result, ev) <- atomically $ do
+        outcome <- implTryAddTx istate cfg txSize
+                                (whetherToIntervene onbehalf)
+                                tx
+        case outcome of
+          TryAddTx _ result ev -> do return (result, ev)
 
-    traceWith trcr ev
-    return result
+          -- or block until space is available to fit the next transaction
+          NoSpaceLeft          -> retry
+
+      traceWith trcr ev
+      return result
+
+    whetherToIntervene :: AddTxOnBehalfOf -> WhetherToIntervene
+    whetherToIntervene AddTxForRemotePeer  = DoNotIntervene
+    whetherToIntervene AddTxForLocalClient = Intervene
 
 -- | Result of trying to add a transaction to the mempool.
 data TryAddTx blk =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -23,6 +23,7 @@ import           Control.Monad
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadMVar
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM.Internal
 import           Control.Monad.Class.MonadThrow
@@ -144,6 +145,21 @@ instance MonadSTM m => MonadSTM (WithEarlyExit m) where
 
   newTMVarIO      = lift . newTMVarIO
   newEmptyTMVarIO = lift   newEmptyTMVarIO
+
+instance (MonadMVar m, MonadMask m, MonadEvaluate m)
+      => MonadMVar (WithEarlyExit m) where
+  type MVar (WithEarlyExit m) = MVar m
+
+  newEmptyMVar          = lift    newEmptyMVar
+  takeMVar              = lift .  takeMVar
+  putMVar               = lift .: putMVar
+  tryTakeMVar           = lift .  tryTakeMVar
+  tryPutMVar            = lift .: tryPutMVar
+  isEmptyMVar           = lift .  isEmptyMVar
+
+  newMVar               = lift .  newMVar
+  readMVar              = lift .  readMVar
+  swapMVar              = lift .: swapMVar
 
 instance MonadCatch m => MonadThrow (WithEarlyExit m) where
   throwIO = lift . throwIO

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -46,6 +46,7 @@ import qualified Cardano.Crypto.KES as KES
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadMVar
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime hiding (MonadTime (..))
@@ -60,6 +61,7 @@ import           Ouroboros.Consensus.Util.Orphans ()
 -------------------------------------------------------------------------------}
 
 class ( MonadAsync              m
+      , MonadMVar               m
       , MonadEventlog           m
       , MonadFork               m
       , MonadST                 m

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -65,9 +65,9 @@ library
                        cardano-strict-containers,
                        contra-tracer,
 
-                       io-classes       ^>=0.3,
+                       io-classes       ^>=0.5,
                        network-mux      ^>=0.3,
-                       strict-stm       ^>=0.2,
+                       strict-stm       ^>=0.5,
                        typed-protocols  ^>=0.1,
 
   ghc-options:         -Wall

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -93,7 +93,7 @@ library
                      , ouroboros-network-api
                                       ^>=0.1
                      , ouroboros-network-testing
-                     , strict-stm     ^>=0.2
+                     , strict-stm     ^>=0.5
                      , typed-protocols
                      , typed-protocols-cborg
                                       ^>=0.1

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -98,7 +98,7 @@ library
                        bytestring        >=0.10 && <0.12,
                        cborg             >=0.2.1 && <0.3,
 
-                       io-classes       ^>=0.3,
+                       io-classes       ^>=0.5,
                        ouroboros-network-api,
                        serialise,
                        typed-protocols   >=0.1 && <1.0,

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -62,7 +62,7 @@ library
                        containers,
                        contra-tracer,
                        deque,
-                       io-classes       ^>=0.3,
+                       io-classes       ^>=0.5,
                        io-sim,
                        psqueues          >=0.2.3 && <0.3,
                        tasty,


### PR DESCRIPTION
Change the behaviour for multiple concurrent threads using `addTx`/`addTxs`: provide simple fifo behaviour.

The first change also refactors the `addTxs` implementation to simplify it by removing unused features.

This uses MVars for the fifo behaviour, and depends on some MVar fixes in `io-classes`: https://github.com/input-output-hk/io-sim/pull/70 specifically the change for MVar being injective. We need that to provide the `MonadMVar (WithEarlyExit m)` instance, which is necessary to add `MonadMVar` into `IOLike`.

Still TODO:

* The `io-classes` PR needs merging, and the various consensus/network packages will need updating to the new version (just bumping version bounds as far as I have found so far).
* There is a test for the existing complicated behaviour (batch, non-blocking) of `implTryAddTxs` which no longer makes sense. What this test is testing for will need to be rethought.