### PR TITLE
Fix erroneously failing ChainDB QSM test

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -265,6 +265,7 @@ test-suite test-storage
                      , binary
                      , bytestring
                      , cardano-crypto-class
+                     , cardano-slotting
                      , cborg
                      , containers
                      , contra-tracer

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -61,6 +61,7 @@ module Test.Ouroboros.Storage.ChainDB.StateMachine (
     -- * Model
   , MaxClockSkew (..)
   , Model
+  , ShouldGarbageCollect (..)
     -- * Running the model
   , runCmdsLockstep
     -- * System under test
@@ -69,6 +70,7 @@ module Test.Ouroboros.Storage.ChainDB.StateMachine (
   , close
   , mkTestCfg
   , open
+  , persistBlks
     -- * Specifying block components
   , AllComponents
   , allComponents

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Unit.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Unit.hs
@@ -12,11 +12,17 @@
 module Test.Ouroboros.Storage.ChainDB.Unit (tests) where
 
 
-import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Maybe (isJust)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.ExpectedFailure (expectFailBecause)
+import           Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+import           Test.Util.Tracer (recordingTracerTVar)
+
+import           Cardano.Slotting.Slot (WithOrigin (..))
+
 import           Ouroboros.Consensus.Block.Abstract (Point, blockPoint,
                      blockSlot)
 import           Ouroboros.Consensus.Block.RealPoint
@@ -39,6 +45,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (closeRegistry,
                      unsafeNewRegistry)
 import           Ouroboros.Network.Block (ChainUpdate (..))
 import qualified Ouroboros.Network.Mock.Chain as Mock
+
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 import           Test.Ouroboros.Storage.ChainDB.Model (Model)
 import qualified Test.Ouroboros.Storage.ChainDB.StateMachine as SM
@@ -47,12 +54,8 @@ import           Test.Ouroboros.Storage.ChainDB.StateMachine (AllComponents,
                      ShouldGarbageCollect (..), TestConstraints, allComponents,
                      close, mkTestCfg, open)
 import           Test.Ouroboros.Storage.TestBlock
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.ExpectedFailure (expectFailBecause)
-import           Test.Tasty.HUnit (Assertion, assertFailure, testCase)
 import           Test.Util.ChainDB (MinimalChainDbArgs (..), emptyNodeDBs,
                      fromMinimalChainDbArgs, nodeDBsVol)
-import           Test.Util.Tracer (recordingTracerTVar)
 
 
 tests :: TestTree

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Unit.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Unit.hs
@@ -64,12 +64,12 @@ tests = testGroup "Unit tests"
     [ testCase "model" $ runModelIO followerInstructionOnEmptyChain
     , testCase "system" $ runSystemIO followerInstructionOnEmptyChain
     ]
-  , testGroup "ouroboros-network-4183"
+  , testGroup (ouroborosNetworkIssue 4183)
     [ testCase "model" $ runModelIO ouroboros_network_4183
-    , expectFailBecause ("Issue not fixed, see " <> ouroborosNetworkIssue 4183)
+    , expectFailBecause "Issue not fixed"
       $ testCase "system" $ runSystemIO ouroboros_network_4183
     ]
-  , testGroup "ouroboros-network-3999"
+  , testGroup (ouroborosNetworkIssue 3999)
     [ testCase "model" $ runModelIO ouroboros_network_3999
     , testCase "system" $ runSystemIO ouroboros_network_3999
     ]


### PR DESCRIPTION
# Description

There is a difference in behaviour of iterator over dead forks between the ChainDB state machine model and the system-under-test. The reason is that the iterator for the model does not take into account that blocks on a dead fork might have been garbage collected. This PR does two things:
- Adapt the model to take into account potentially garbage-collected blocks in its iterator implementation
- Add a unit test to bound the behaviour of iterators over dead forks for the system-under-test and the model.


Closes #3999.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated

- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
