### PR TITLE
Update CHaP and remove constraints

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2023-02-22T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-02-23T15:33:46Z
+  , cardano-haskell-packages 2023-03-22T15:33:46Z
 
 packages: ./cardano-ping
           ./ouroboros-network-testing
@@ -79,75 +79,6 @@ package ouroboros-consensus-shelley
 
 package ouroboros-consensus-cardano
   flags: +asserts
-
-constraints:
-  -- CONSTRAINTS FOR UPSTREAM CARDANO PACKAGES
-  -- These should all be constraints in upstream packages, but are currently missing.
-  -- We should a) fix these upstream and b) revise the constraints on the released
-  -- version in CHaP.
-  -- TODO Unfortunately revisions in CHaP don't work yet, revisit this when we fix it.
-  -- See https://github.com/input-output-hk/haskell.nix/issues/1675
-
-  -- bizarre issue: in earlier versions they define their own 'GEq', in newer
-  -- ones they reuse the one from 'some', but there isn't e.g. a proper version
-  -- constraint from dependent-sum-template (which is the library we actually use).
-  , dependent-sum > 0.6.2.0
-  -- plutus-core: needs a constraint here, fixed on plutus master but not in the released version
-  , algebraic-graphs >= 0.7
-
-  -- TODO: these should be set in cabal files, but avoiding setting them in lower dependencies for initial CHaP release
-  , cardano-prelude >= 0.1.0.1
-  , base-deriving-via >= 0.1.0.0
-  , cardano-binary >= 1.5.0
-  , cardano-binary-test >= 1.3.0
-  , cardano-crypto-class >= 2.0.0.1 && < 2.2.0.0
-  , cardano-crypto-praos >= 2.0.0.0.1 && < 2.2.0.0
-  , cardano-crypto-tests >= 2.0.0.0.1 && < 2.2.0.0
-  , cardano-slotting >= 0.1.0.0
-  , measures >= 0.1.0.0
-  , orphans-deriving-via >= 0.1.0.0
-  , strict-containers >= 0.1.0.0
-  , plutus-core >= 1.0.0.1
-  , plutus-ledger-api >= 1.0.0.1
-  , plutus-tx >= 1.0.0.0
-  , plutus-tx-plugin >= 1.0.0.0
-  , prettyprinter-configurable >= 0.1.0.0
-  , plutus-ghc-stub >= 8.6.5
-  , word-array >= 0.1.0.0
-  , typed-protocols >= 0.1.0.1
-  , typed-protocols-examples >= 0.1.0.1
-  -- cardano-ledger
-  , cardano-ledger-alonzo >= 1.0.0.0
-  , cardano-ledger-babbage >= 1.0.0.0
-  , cardano-ledger-conway >= 1.0.0.0
-  , cardano-ledger-allegra >= 1.0.0.0
-  , cardano-ledger-mary >= 1.0.0.0
-  , cardano-ledger-shelley >= 1.0.0.0
-  , cardano-ledger-alonzo-test >= 1.0.0.0
-  , cardano-ledger-babbage-test >= 1.0.0.0
-  , cardano-ledger-conway-test >= 1.0.0.0
-  , cardano-ledger-shelley-test >= 1.0.0.0
-  , cardano-ledger-shelley-ma-test >= 1.0.0.0
-  , cardano-ledger-binary >= 1.0.0.0
-  , cardano-protocol-tpraos >= 1.0.0.0
-  , cardano-ledger-pretty >= 1.0.0.0
-  , cardano-data >= 1.0.0.0
-  , non-integral >= 1.0.0.0
-  , set-algebra >= 1.0.0.0
-  , small-steps >= 1.0.0.0
-  , small-steps-test >= 1.0.0.0
-  , vector-map >= 1.0.0.0
-  -- Byron era
-  , cardano-ledger-core >= 1.0.0.0
-  , cardano-crypto-test >= 1.5.0.0
-  , cardano-crypto-wrapper >= 1.5.0.0
-  , cardano-ledger-byron-test >= 1.5.0.0
-  , cardano-ledger-byron >= 1.0.0.0
-  , byron-spec-ledger >= 1.0.0.0
-  , byron-spec-chain >= 1.0.0.0
-
-allow-newer:
-    Unique:hashable
 
 -- TODO: remove this once fs-api and fs-sim are published to CHaP.
 source-repository-package

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/cardano-haskell-packages/",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "3db1f9f235b25ad6fc41c555c167912ceead5164",
-        "sha256": "1bm0742yb3k2nz2w1ham61dhha3vdk723lz9k4pgl81imi40mn2a",
+        "rev": "07bb6c7f3d5f6245fbc7b222ea082487736bdb67",
+        "sha256": "1mnms5r7bwjz2raw5v7mnl8svzl7jz6lqv64d1a9ccql3dhyp4wy",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/3db1f9f235b25ad6fc41c555c167912ceead5164.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/07bb6c7f3d5f6245fbc7b222ea082487736bdb67.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hackage.nix": {


### PR DESCRIPTION
I amended many things in CHaP, the constraints are no longer needed.

# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The tests in WallClock.delay* can fail under load (quite rarely), see #3894

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

 - ThreadNet tests that involve two eras might fail with a node failing to pipeline, see #4285

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

_description of the pull request, if it fixes a particular issue it should link the PR to a particular issue, see [ref](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)_

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [x] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [x] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
