### PR TITLE
Fix NonP2P to P2P interop problem

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next version
 
+### Non breaking
+
+- Fix interop problems between NonP2P and P2P nodes (PR #4465)
+
 ### Breaking
 
 - Removed `TrImpossibleConnection` trace (PR #4385)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -522,14 +522,14 @@ fromSnocket tblVar sn sd = go <$> Snocket.accept sn sd
         Snocket.Accepted sd' remoteAddr -> do
           -- TOOD: we don't need to that on each accept
           localAddr <- Snocket.getLocalAddr sn sd'
-          atomically $ addConnection tblVar remoteAddr localAddr Nothing
+          atomically $ addConnection tblVar remoteAddr localAddr ConnectionInbound Nothing
           pure (remoteAddr, sd', close remoteAddr localAddr sd', go next)
         Snocket.AcceptFailure err ->
           -- the is no way to construct 'Server.Socket'; This will be removed in a later commit!
           throwIO err
 
     close remoteAddr localAddr sd' = do
-        removeConnection tblVar remoteAddr localAddr
+        removeConnection tblVar remoteAddr localAddr ConnectionInbound
         Snocket.close sn sd'
 
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -710,6 +710,7 @@ runServerThread NetworkServerTracers { nstMuxTracer
       d <- beforeConnectTx t connAddr st
       case d of
         AllowConnection st'    -> pure $ AcceptConnection st' (ConnectionId sockAddr connAddr) versions
+        OnlyAccept st'         -> pure $ AcceptConnection st' (ConnectionId sockAddr connAddr) versions
         DisallowConnection st' -> pure $ RejectConnection st' (ConnectionId sockAddr connAddr)
 
 -- | Run a server application. It will listen on the given address for incoming

--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/PeerState.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/PeerState.hs
@@ -495,6 +495,7 @@ unregisterConsumer addr  tid (PeerStates peerStates) =
 data ConnectDecision s
     = AllowConnection !s
     | DisallowConnection !s
+    | OnlyAccept !s
   deriving Functor
 
 -- | Check state before connecting to a remote peer.  We will connect only if
@@ -518,6 +519,7 @@ runBeforeConnect sVar beforeConnect addr = do
       case d of
         AllowConnection s    -> True  <$ writeTVar sVar s
         DisallowConnection s -> False <$ writeTVar sVar s
+        OnlyAccept s         -> False <$ writeTVar sVar s
 
 
 -- | 'BeforeConnect' callback: it updates peer state and return boolean value
@@ -584,7 +586,7 @@ beforeConnectTx  t  addr (PeerStates s) =
                    then -- prodT ≤ t < consT
                         -- allow the remote peer to connect to us, but we're
                         -- still not allowed to connect to it.
-                        (DisallowConnection (), Just $ SuspendedConsumer Set.empty consT)
+                        (OnlyAccept (), Just $ SuspendedConsumer Set.empty consT)
                    else -- consT ≤ t < prodT
                         -- the local consumer is suspended shorter than local
                         -- producer; In this case we suspend both until `prodT`.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Worker.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Worker.hs
@@ -324,7 +324,7 @@ subscriptionLoop
               -> SubscriptionTarget m addr
               -> m ()
     innerStep conThreads valencyVar !remoteAddr sTargetNext = do
-      r <- refConnection tbl remoteAddr valencyVar
+      r <- refConnection tbl remoteAddr ConnectionOutbound valencyVar
       case r of
         ConnectionTableCreate ->
           case wpSelectAddress remoteAddr localAddresses of
@@ -423,7 +423,7 @@ subscriptionLoop
             v <- readValencyCounter valencyVar
             if v > 0
               then do
-                addConnection tbl remoteAddr localAddr (Just valencyVar)
+                addConnection tbl remoteAddr localAddr ConnectionOutbound (Just valencyVar)
                 CompleteApplicationResult
                   { carState
                   , carThreads
@@ -470,7 +470,7 @@ subscriptionLoop
                     writeTQueue resQ (Res (ApplicationResult t' remoteAddr a))
                   Left (SomeException e) ->
                     writeTQueue resQ (Res (ApplicationError t' remoteAddr e))
-                removeConnectionSTM tbl remoteAddr localAddr
+                removeConnectionSTM tbl remoteAddr localAddr ConnectionOutbound
 
 -- | Almost the same as 'Ouroboros.Network.Server.Socket.mainLoop'.
 -- 'mainLoop' reads from the result queue and runs the 'CompleteApplication'

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for ouroboros-network
 
+## next version
+
+### Non breaking
+
+- Fix interop problems between NonP2P and P2P nodes (PR #4465)
+
 ## 0.4.0.1 -- 2023-02-24
 
 ### Non-Breaking

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -583,12 +583,12 @@ remoteNetworkErrorPolicy = ErrorPolicies {
                         -- 'responder'.  If a 'responder' throws 'MuxError' we
                         -- might not want to shutdown the consumer (which is
                         -- using different connection), as we do below:
-                        MuxBearerClosed              -> Just (SuspendPeer shortDelay shortDelay)
-                        MuxIOException{}             -> Just (SuspendPeer shortDelay shortDelay)
-                        MuxSDUReadTimeout            -> Just (SuspendPeer shortDelay shortDelay)
-                        MuxSDUWriteTimeout           -> Just (SuspendPeer shortDelay shortDelay)
-                        MuxShutdown {}               -> Just (SuspendPeer shortDelay shortDelay)
-                        MuxCleanShutdown             -> Just (SuspendPeer shortDelay shortDelay)
+                        MuxBearerClosed              -> Just (SuspendPeer veryShortDelay shortDelay)
+                        MuxIOException{}             -> Just (SuspendPeer veryShortDelay shortDelay)
+                        MuxSDUReadTimeout            -> Just (SuspendPeer veryShortDelay shortDelay)
+                        MuxSDUWriteTimeout           -> Just (SuspendPeer veryShortDelay shortDelay)
+                        MuxShutdown {}               -> Just (SuspendPeer veryShortDelay shortDelay)
+                        MuxCleanShutdown             -> Just (SuspendPeer veryShortDelay shortDelay)
 
         , ErrorPolicy
             $ \(e :: MuxRuntimeError)


### PR DESCRIPTION
# Description
P2P nodes uses the server port number for outbound connections. This can confuse NonP2P nodes into thinking that they already have a connection to them.

This PR changes the NonP2P connection table to take connection direction into account, similar to @dcoutts  patches in https://github.com/input-output-hk/ouroboros-network/compare/dcoutts/old-connection-table .
The P2P nodes reuse of the server port also means that incoming connections from a P2P node can be refused by a NonP2P node if the peer is "suspended". This suspension never affected NonP2P nodes since they reconnect from a new ephemeral port each time. This PR lets NonP2P nodes differentiate between if it should refuse to accept new connections from a peer or if it should avoid creating new connections to a peer.

Fixes #4465 .
<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The tests in WallClock.delay* can fail under load (quite rarely), see #3894

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

 - ThreadNet tests that involve two eras might fail with a node failing to pipeline, see #4285

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->


# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
