### PR TITLE
Update chainsync timeout

### DIFF
--- a/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/Ouroboros/Consensus/Node.hs
@@ -701,17 +701,20 @@ stdChainSyncTimeout = do
     -- f = 0.05
     -- The timeout is randomly picked per bearer to avoid all bearers
     -- going down at the same time in case of a long streak of empty
-    -- slots. TODO: workaround until peer selection governor.
-    mustReplyTimeout <- Just <$> randomElem [90, 135, 180, 224, 269]
+    -- slots.
+    -- To avoid global synchronosation the timeout is picked uniformly
+    -- from the interval 135 - 269, corresponds to the a 99.9% to
+    -- 99.9999% thresholds.
+    -- TODO: The timeout should be drawn at random everytime chainsync
+    --       enters the must reply state. A static per connection timeout
+    --       leads to selection preassure for connections with a large
+    --       timeout, see #4244.
+    mustReplyTimeout <- Just <$> realToFrac <$> randomRIO (135,269 :: Double)
     return NTN.ChainSyncTimeout
       { canAwaitTimeout  = shortWait
       , intersectTimeout = shortWait
       , mustReplyTimeout
       }
-  where
-    randomElem xs = do
-      ix <- randomRIO (0, length xs - 1)
-      return $ xs !! ix
 
 stdVersionDataNTN :: NetworkMagic
                   -> DiffusionMode


### PR DESCRIPTION
Increase the minimum timeout from 90s to 135s and switch from picking from an array of 5 values to a range of timeouts.
This change reduces the risk of synchronosation among nodes in the network.

# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The tests in WallClock.delay* can fail under load (quite rarely), see #3894

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

 - ThreadNet tests that involve two eras might fail with a node failing to pipeline, see #4285

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

_description of the pull request, if it fixes a particular issue it should link the PR to a particular issue, see [ref](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)_

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
