### PR TITLE
Enable benchmark builds in GitHub Actions by default using `benchmarks: True`

### DIFF
--- a/.github/workflows/cabal.project.local.Windows
+++ b/.github/workflows/cabal.project.local.Windows
@@ -2,6 +2,7 @@ max-backjumps: 5000
 reorder-goals: True
 ignore-project: False
 tests: True
+benchmarks: True
 
 program-options
   ghc-options: -Werror

--- a/cabal.project
+++ b/cabal.project
@@ -49,6 +49,7 @@ packages: ./cardano-ping
           ./cardano-client
 
 tests: True
+benchmarks: True
 
 package cardano-ping
   flags: +asserts


### PR DESCRIPTION
# Description

The Consensus Mempool benchmark is the only benchmark executable currently on the main branch, but benchmark builds are disabled by default by cabal. As such, our GitHub Actions workflow also does not build benchmark executables. This PR enables benchmark building in GitHub Actions by default, by adding `benchmarks: True` in the relevant `cabal.project.local` file. 

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
