### PR TITLE
Use `fs-sim-0.1.0.0` and `fs-api-0.1.0.0`, update cabal `index-state`s

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,12 +13,12 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for some Nix commands you will need to run if you
 -- update either of these.
 -- repeat the index-state for hackage to work around haskell.nix parsing limitation
-index-state: 2023-02-22T00:00:00Z
+index-state: 2023-03-29T00:00:00Z
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-02-22T00:00:00Z
+  , hackage.haskell.org 2023-03-29T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-03-22T15:33:46Z
+  , cardano-haskell-packages 2023-03-29T00:00:00Z
 
 packages: ./cardano-ping
           ./ouroboros-network-testing
@@ -80,13 +80,3 @@ package ouroboros-consensus-shelley
 
 package ouroboros-consensus-cardano
   flags: +asserts
-
--- TODO: remove this once fs-api and fs-sim are published to CHaP.
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/fs-sim
-  tag: 13a1cfa5a82740c5723fb0a279b3f32f98c8b494
-  --sha256: 1q783gsb0hh4i0slvfwp5nppi8h425pkvj0kqr2lpl06y7y2gq41
-  subdir:
-    fs-api
-    fs-sim

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -24,8 +24,9 @@ import qualified Data.Bimap as Bimap
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as PSQ
 import           Data.SOP.Strict
-import           NoThunks.Class (NoThunks (..), OnlyCheckWhnfNamed (..),
-                     allNoThunks, noThunksInKeysAndValues)
+import           NoThunks.Class (InspectHeap (..), InspectHeapNamed (..),
+                     NoThunks (..), OnlyCheckWhnfNamed (..), allNoThunks,
+                     noThunksInKeysAndValues)
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
@@ -33,6 +34,9 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Mock.Chain (Chain (..))
 import           Ouroboros.Network.Util.ShowProxy
+import           System.FS.API (SomeHasFS)
+import           System.FS.API.Types (FsPath, Handle)
+import           System.FS.CRC (CRC (CRC))
 
 {-------------------------------------------------------------------------------
   Condense
@@ -105,3 +109,14 @@ deriving newtype instance NoThunks Time
 instance NoThunks a => NoThunks (K a b) where
   showTypeOf _ = showTypeOf (Proxy @a)
   wNoThunks ctxt (K a) = wNoThunks ("K":ctxt) a
+
+{-------------------------------------------------------------------------------
+  fs-api
+-------------------------------------------------------------------------------}
+
+deriving via InspectHeapNamed "Handle" (Handle h)
+    instance NoThunks (Handle h)
+deriving via InspectHeap FsPath instance NoThunks FsPath
+deriving via OnlyCheckWhnfNamed "SomeHasFS" (SomeHasFS m)
+    instance NoThunks (SomeHasFS m)
+deriving newtype instance NoThunks CRC


### PR DESCRIPTION
# Description

With `fs-sim-0.1.0.0` and `fs-api-0.1.0.0` released to CHaP, we can remove an `s-r-p`. We update the `index-state`s for both Hackage and CHaP in the process.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [x] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
