### PR TITLE
Fix misleading names in `estimateBlockSize` test

### DIFF
--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -545,20 +545,20 @@ prop_estimateBlockSize ccfg (WithVersion version (Coherent blk))
          <> show actualBlockSize <> " > "
          <> show expectedBlockSize)
       (property False)
-  | actualBlockSize < expectedBlockSize - allowedUnderestimate
+  | actualBlockSize < expectedBlockSize - allowedOverestimate
   = counterexample
-      ("actualBlockSize < expectedBlockSize - allowedUnderestimate: "
+      ("actualBlockSize < expectedBlockSize - allowedOverestimate: "
          <> show actualBlockSize <> " > "
          <> show expectedBlockSize <> " - "
-         <> show allowedUnderestimate)
+         <> show allowedOverestimate)
       (property False)
   | otherwise
   = classify (actualBlockSize == expectedBlockSize) "exact"
-  $ classify (actualBlockSize <  expectedBlockSize) "underestimate"
+  $ classify (actualBlockSize <  expectedBlockSize) "overestimate"
   $ property True
   where
-    allowedUnderestimate :: SizeInBytes
-    allowedUnderestimate = 10
+    allowedOverestimate :: SizeInBytes
+    allowedOverestimate = 10
 
     actualBlockSize :: SizeInBytes
     actualBlockSize =


### PR DESCRIPTION
# Description

The Haddocks of [`estimateBlockSize`][estimateBlockSize] state:

> An upper bound on the size in bytes of the block corresponding to the header. This can be an overestimate, but not an underestimate.

In this test, we also check that we don't overestimate too much, but we never accept an underestimation.

[estimateBlockSize]: https://input-output-hk.github.io/ouroboros-network/ouroboros-consensus/Ouroboros-Consensus-Node-Run.html#v:estimateBlockSize

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [ ] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
