### PR TITLE
Fix issue #4491

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -158,7 +158,7 @@ localRootPeersProvider tracer
       -- Launch DomainAddress monitoring threads and wait for threads to error
       -- or for local configuration changes.
       domainsGroups' <-
-        withAsyncAll (monitorDomain rr rootPeersGroups `map` domains) $ \as -> do
+        withAsyncAll (monitorDomain rr `map` domains) $ \as -> do
           res <- atomically $
                   -- wait until any of the monitoring threads errors
                   ((\(a, res) ->
@@ -212,12 +212,9 @@ localRootPeersProvider tracer
 
     monitorDomain
       :: Resource m (DNSorIOError exception) resolver
-      -> Seq (Int, Map peerAddr PeerAdvertise)
-      -- ^ Static configuration, this always comes from the source
-      -- STM transaction 'readDomainGroups'.
       -> (Int, DomainAccessPoint, PeerAdvertise)
       -> m Void
-    monitorDomain rr0 rpgStatic (index, domain, advertisePeer) =
+    monitorDomain rr0 (index, domain, advertisePeer) =
         go rr0 0
       where
         go :: Resource m (DNSorIOError exception) resolver
@@ -240,13 +237,7 @@ localRootPeersProvider tracer
             Right results -> do
               rootPeersGroups <- atomically $ do
                 rootPeersGroups <- readTVar rootPeersGroupsVar
-                    -- We should get the entry from the static configuration in
-                    -- order to garbage collect old lookup values for this
-                    -- entry. It's important not to overwrite the statically
-                    -- configured IPs, that's why we get the entry from the
-                    -- statically configured rootPeersGroups list.
-                    --
-                let (target, entry)  = rpgStatic `Seq.index` index
+                let (target, entry)  = rootPeersGroups `Seq.index` index
                     resultsMap       = Map.fromList (map fst results)
                     -- Discard old values and only keep current lookup result.
                     --

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -653,6 +653,10 @@ prop_local_resolvesDomainsCorrectly mockRoots@(MockRoots localRoots lDNSMap _ _)
 -- resolved ip addresses to the correct group where the domain address was
 -- (in the initial configuration specification). This property tests whether
 -- after a successful DNS lookup the result list is updated correctly.
+--
+-- Correctly means: Updates in the right place and does not overwrite the
+-- previous state.
+--
 prop_local_updatesDomainsCorrectly :: MockRoots
                                    -> Script DNSTimeout
                                    -> Script DNSLookupDelay
@@ -670,6 +674,21 @@ prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _ _)
 
         r = foldl' (\(b, (t, x)) (t', y) ->
                     case (x, y) of
+                      -- Last result groups value, Current result groups value
+                      (TraceLocalRootGroups lrpg, TraceLocalRootGroups lrpg') ->
+                        let -- Get all IPs present in last group at position
+                            -- 'index'
+                            ipsAtIndex = Map.keys
+                                       $ foldMap snd lrpg
+
+                            -- Get all IPs present in current group at position
+                            -- 'index'
+                            ipsAtIndex' = Map.keys
+                                        $ foldMap snd lrpg'
+
+                            arePreserved = all (`elem` ipsAtIndex') ipsAtIndex
+
+                         in (arePreserved && b, (t', y))
                       -- Last DNS lookup result   , Current result groups value
                       (TraceLocalRootResult da res, TraceLocalRootGroups lrpg) ->
                             -- create and index db for each group
@@ -706,7 +725,6 @@ prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _ _)
               (True, head tr)
               (tail tr)
      in property (fst r)
-
 
 -- | The 'localRootPeersProvider' monitors each domain address for DNS
 -- resolving. It then should update the local result group correctly, but it


### PR DESCRIPTION
Updates the result local root groups TVar with up to date information instead of static one.

Also adds & fixes tests to check for this particular case.

Closes #4491