### PR TITLE
Trace which backingstore is currently in use

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -90,3 +90,9 @@ source-repository-package
   location: https://github.com/stevana/quickcheck-state-machine
   tag: dba5d7edea6304c410d13182747d2cc483f134f3
   --sha256: 13za4y26w2wi1fd9l3q40ln2ixm3pqccs0bawbbf230asdci56nf
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/lmdb-simple
+  tag: fb86d051e0c517aea3f5c27723fcc88586be8bfe
+  --sha256: 14bcznx0xhif1za17h2102axqyvyqzf1ki3kzhjxfj5a0q66n3m1

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/BackingStore/LMDB.hs
@@ -94,6 +94,7 @@ data Db m l = Db {
   }
 
 newtype LMDBLimits = MkLMDBLimits {unLMDBLimits :: LMDB.Limits}
+  deriving (Show, Eq)
 
 {-# COMPLETE LMDBLimits #-}
 -- | Configuration to use for LMDB backing store initialisation.


### PR DESCRIPTION
# Description

Resolves #4373.

On startup, the LedgerDB will now emit a trace that details which backing store implementation was initialised. Moreover, we simplify tracing in the `OnDisk` tests, and default it to `nullTracer`, since the traces are very noisy.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [x] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - [x] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
