### PR TITLE
Fix `consensus` and `consensus-test` release 0.4.0.0

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               ouroboros-consensus-diffusion
-version:            0.4.1.0
+version:            0.4.0.0
 synopsis:           Integration for the Ouroboros blockchain protocol
 description:
   Top level integration for consensus & network layers of the Ouroboros blockchain protocol.
@@ -90,7 +90,7 @@ library
     , hashable
     , io-classes                   ^>=0.3
     , mtl
-    , ouroboros-consensus          ==0.4.1.0
+    , ouroboros-consensus          ==0.4.0.0
     , ouroboros-network            ^>=0.4.0.1
     , ouroboros-network-api        ^>=0.1
     , ouroboros-network-framework  ^>=0.3

--- a/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
+++ b/ouroboros-consensus-mock-test/ouroboros-consensus-mock-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               ouroboros-consensus-mock-test
-version:            0.4.1.0
+version:            0.4.0.0
 synopsis:
   Tests of the mock ledger integration in the Ouroboros consensus layer
 
@@ -36,9 +36,9 @@ library
     , bytestring                >=0.10    && <0.12
     , cardano-crypto-class
     , containers                >=0.5     && <0.7
-    , ouroboros-consensus       ^>=0.4.1
-    , ouroboros-consensus-mock  ==0.4.1.0
-    , ouroboros-consensus-test  ==0.4.1.0
+    , ouroboros-consensus       ^>=0.4.0
+    , ouroboros-consensus-mock  ==0.4.0.0
+    , ouroboros-consensus-test  ==0.4.0.0
     , QuickCheck
     , serialise                 >=0.2     && <0.3
 
@@ -65,10 +65,10 @@ test-suite test
     , bytestring
     , cborg
     , containers
-    , ouroboros-consensus            ^>=0.4.1
-    , ouroboros-consensus-mock       ==0.4.1.0
+    , ouroboros-consensus            ^>=0.4.0
+    , ouroboros-consensus-mock       ==0.4.0.0
     , ouroboros-consensus-mock-test
-    , ouroboros-consensus-test       ==0.4.1.0
+    , ouroboros-consensus-test       ==0.4.0.0
     , ouroboros-network-mock
     , QuickCheck
     , serialise

--- a/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               ouroboros-consensus-mock
-version:            0.4.1.0
+version:            0.4.0.0
 synopsis:           Mock ledger integration in the Ouroboros consensus layer
 description:        Mock ledger integration in the Ouroboros consensus layer.
 license:            Apache-2.0
@@ -61,7 +61,7 @@ library
     , hashable
     , mtl                     >=2.2    && <2.3
     , nothunks
-    , ouroboros-consensus     ^>=0.4.1
+    , ouroboros-consensus     ^>=0.4.0
     , ouroboros-network-api
     , ouroboros-network-mock
     , serialise               >=0.2    && <0.3

--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               ouroboros-consensus-protocol
-version:            0.4.1.0
+version:            0.4.0.0
 synopsis:           Cardano consensus protocols
 description:        Cardano consensus protocols.
 license:            Apache-2.0
@@ -53,7 +53,7 @@ library
     , containers
     , mtl
     , nothunks
-    , ouroboros-consensus      ==0.4.1.0
+    , ouroboros-consensus      ==0.4.0.0
     , serialise
     , text
 

--- a/ouroboros-consensus-test/CHANGELOG.md
+++ b/ouroboros-consensus-test/CHANGELOG.md
@@ -9,8 +9,8 @@ Changelog for the following packages:
 
 # Changelog entries
 
-<a id='changelog-0.4.1.0'></a>
-## 0.4.1.0 — 2023-04-10
+<a id='changelog-0.4.0.0'></a>
+## 0.4.0.0 — 2023-04-10
 
 ### Patch
 

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               ouroboros-consensus-test
-version:            0.4.1.0
+version:            0.4.0.0
 synopsis:           Tests of the consensus layer
 description:        Tests of the consensus layer.
 license:            Apache-2.0
@@ -103,8 +103,8 @@ library
     , mtl                            >=2.2    && <2.3
     , nothunks
     , optparse-applicative
-    , ouroboros-consensus            ^>=0.4.1
-    , ouroboros-consensus-diffusion  ^>=0.4.1
+    , ouroboros-consensus            ^>=0.4.0
+    , ouroboros-consensus-diffusion  ^>=0.4.0
     , ouroboros-network
     , ouroboros-network-api
     , ouroboros-network-framework
@@ -178,9 +178,9 @@ test-suite test-consensus
     , io-sim
     , mtl
     , nothunks
-    , ouroboros-consensus                                                 ^>=0.4.1
-    , ouroboros-consensus-diffusion                                       ^>=0.4.1
-    , ouroboros-consensus-mock                                            ==0.4.1.0
+    , ouroboros-consensus                                                 ^>=0.4.0
+    , ouroboros-consensus-diffusion                                       ^>=0.4.0
+    , ouroboros-consensus-mock                                            ==0.4.0.0
     , ouroboros-consensus-test
     , ouroboros-network
     , ouroboros-network-api
@@ -259,7 +259,7 @@ test-suite test-storage
     , io-sim
     , mtl
     , nothunks
-    , ouroboros-consensus       ^>=0.4.1
+    , ouroboros-consensus       ^>=0.4.0
     , ouroboros-consensus-test
     , ouroboros-network-api
     , ouroboros-network-mock
@@ -296,7 +296,7 @@ test-suite test-infra
 
   build-depends:
     , base                      >=4.14    && <4.17
-    , ouroboros-consensus       ==0.4.1.0
+    , ouroboros-consensus       ==0.4.0.0
     , ouroboros-consensus-test
     , QuickCheck
     , tasty
@@ -328,7 +328,7 @@ benchmark bench-mempool
     , contra-tracer
     , deepseq
     , nothunks
-    , ouroboros-consensus       ^>=0.4.1
+    , ouroboros-consensus       ^>=0.4.0
     , ouroboros-consensus-test
     , serialise                 >=0.2    && <0.3
     , strict-stm

--- a/ouroboros-consensus-tutorials/ouroboros-consensus-tutorials.cabal
+++ b/ouroboros-consensus-tutorials/ouroboros-consensus-tutorials.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          ouroboros-consensus-tutorials
-version:       0.4.1.0
+version:       0.4.0.0
 synopsis:
   Tutorials for the consensus layer for the Ouroboros blockchain protocol
 
@@ -39,7 +39,7 @@ library
     , hashable
     , mtl
     , nothunks
-    , ouroboros-consensus    ==0.4.1.0
+    , ouroboros-consensus    ==0.4.0.0
     , ouroboros-network-api
     , serialise
 

--- a/ouroboros-consensus/CHANGELOG.md
+++ b/ouroboros-consensus/CHANGELOG.md
@@ -13,8 +13,8 @@ process](./docs/ReleaseProcess.md).
 
 # Changelog entries
 
-<a id='changelog-0.4.1.0'></a>
-## 0.4.1.0 — 2023-04-10
+<a id='changelog-0.4.0.0'></a>
+## 0.4.0.0 — 2023-04-10
 
 ### Patch
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               ouroboros-consensus
-version:            0.4.1.0
+version:            0.4.0.0
 synopsis:           Consensus layer for the Ouroboros blockchain protocol
 description:        Consensus layer for the Ouroboros blockchain protocol.
 license:            Apache-2.0


### PR DESCRIPTION
The number in the release was wrong. It should have been 0.4.0.0.