### PR TITLE
Don't build on darwin with Cicero for now

### DIFF
--- a/nix/cells/automation/pipelines.nix
+++ b/nix/cells/automation/pipelines.nix
@@ -21,7 +21,7 @@
       bulk.text = ''
         nix eval .#hydraJobs --apply __attrNames --json |
         nix-systems -i |
-        jq 'with_entries(select(.key != "x86_64-darwin"))' | # temporarily don't build on darwin
+        jq 'with_entries(select(.key | endswith("-darwin") | not)' | # temporarily don't build on darwin
         jq 'with_entries(select(.value))' # filter out systems that we cannot build for
       '';
       each.text =


### PR DESCRIPTION
# Description

Recently, aarch64-darwin machines were added. We do not want to build on those on CI at least for now, see #4461.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](https://github.com/input-output-hk/ouroboros-consensus/blob/main/docs/ReleaseProcess.md#adding-a-changelog-fragment).
    - [ ] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
