### PR TITLE
Cardano tests hanging when using `ghc-8.10.7`

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE MonoLocalBinds       #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -fno-strictness #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.Node () where
 
@@ -22,7 +20,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection ()
 import           Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage ()
 import           Ouroboros.Consensus.HardFork.Combinator.Node.Metrics ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
-import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
 
@@ -59,7 +57,7 @@ getSameConfigValue getValue blockConfig = getSameValue values
 instance ( CanHardFork xs
            -- Instances that must be defined for specific values of @b@:
          , LedgerTablesCanHardFork xs
-         , LedgerSupportsMempool (HardForkBlock xs)
+         , HasTickedLedgerTables (LedgerState (HardForkBlock xs))
          , SupportedNetworkProtocolVersion (HardForkBlock xs)
          , SerialiseHFC xs
          ) => RunNode (HardForkBlock xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -fno-strictness #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.Node () where
 


### PR DESCRIPTION
# Description

The problem that this PR solves was a tricky one. We observed that the `ouroboros-consensus-cardano-tools:test` tests would hang indefinitely when using `ghc-8.10.7`,  causing the Cicero CI to time out.

* At first, we suspected that the tests were indefinitely hanging when evaluating `projectLedgerTables` on a `CardanoBlock` ledger state. It was not clear however, why this was the case: a trace message would be printed before evaluating `projectLedgerTables`, but a trace message inside the implementation of `projectLedgerTables` would not be printed.
* As a next step in finding a solution, we turned off compiler optimisations altogether (`-O0`), which solved the issue. However, this would not be a viable fix, since it would cause significant performance regressions for consensus, and by dependency, also the node. 
* Further investigation showed that the strictness analyser was a likely culprit, since using `-fno-strictness` in `ouroboros-consensus`  would prevent the tests from hanging. 
* Considering that the part of the code that was hanging was related to `CardanoBlock` (and therefore the HardFork Combinator), we chose to narrow down the offending module to one of the HFC modules in `ouroboros-consensus`. We achieved this by disabling the strictness analyser on a per-module basis using `{-# OPTIONS_GHC -fno-strictness #-}`. The offending module turned out to be [Ouroboros.Consensus.HardFork.Combinator.Node](https://github.com/input-output-hk/ouroboros-network/blob/4ac5a6bae0444baaff6eab43d023db12431b7730/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs).
* This brings us to the problematic code:

  ```haskell
  instance ( CanHardFork xs
             -- Instances that must be defined for specific values of @b@:
           , LedgerTablesCanHardFork xs
           , LedgerSupportsMempool (HardForkBlock xs)
           , SupportedNetworkProtocolVersion (HardForkBlock xs)
           , SerialiseHFC xs
           ) => RunNode (HardForkBlock xs)
  ```

  This instance has a superclass constraint `LedgerSupportsMempool (HardForkBlock xs)`, but this exactly matches an instance that already exists. This would normally cause a compiler warning that suggests either (i) to use the already existing instance, or (ii) enable `{-# LANGUAGE MonoLocalBinds #-}`. This module used option (ii) to remove the warning, but this seems to have caused the problem where the tests were indefinitely hanging.

* **The solution**: we remove the `{-# LANGUAGE MonoLocalBinds #-}` pragma and the `LedgerSupportsMempool (HardForkBlock xs)` constraint. We ensure that the `RunNode (HardForkBlock xs)` instance uses the existing `LedgerSupportsMempool (HardForkBlock xs)` instance by adding some other superclass constraints that are required for `LedgerSupportsMempool (HardForkBlock xs)` to hold.

# Checklist

- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [x] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](https://github.com/input-output-hk/ouroboros-consensus/blob/main/docs/ReleaseProcess.md#adding-a-changelog-fragment).
    - [x] Any changes in the Consensus API (every exposed function, type or module) that has changed its name, has been deleted, has been moved, or altered in some other significant way must leave behind a `DEPRECATED` warning that notifies downstream consumers. If deprecating a whole module, remember to add it to `./scripts/ci/check-stylish.sh` as otherwise `stylish-haskell` would un-deprecate it.
    - [x] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
