### PR TITLE
mempool addtx fifo backport

### DIFF
--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -146,12 +146,15 @@ test-suite test-consensus
                        Test.Consensus.MiniProtocol.ChainSync.Client
                        Test.Consensus.MiniProtocol.LocalStateQuery.Server
                        Test.Consensus.Mempool
+                       Test.Consensus.Mempool.Fairness
+                       Test.Consensus.Mempool.Fairness.TestBlock
                        Test.Consensus.Node
                        Test.Consensus.ResourceRegistry
                        Test.Consensus.Util.MonadSTM.RAWLock
                        Test.Consensus.Util.Versioned
 
   build-depends:       base
+                     , async
                      , binary
                      , bytestring
                      , cardano-binary
@@ -160,6 +163,7 @@ test-suite test-consensus
                      , cborg
                      , containers
                      , contra-tracer
+                     , deepseq
                      , directory
                      , generics-sop
                      , mtl
@@ -167,6 +171,7 @@ test-suite test-consensus
                      , QuickCheck
                      , quickcheck-state-machine
                      , quiet
+                     , random
                      , serialise
                      , sop-core
                      , tasty

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -464,6 +464,8 @@ testInitLedgerWithState = TestLedger GenesisPoint
 newtype instance Ticked (LedgerState (TestBlockWith ptype)) = TickedTestLedger {
       getTickedTestLedger :: LedgerState (TestBlockWith ptype)
     }
+  deriving stock Generic
+  deriving anyclass NoThunks
 
 testInitExtLedgerWithState :: PayloadDependentState ptype -> ExtLedgerState (TestBlockWith ptype)
 testInitExtLedgerWithState st = ExtLedgerState {

--- a/ouroboros-consensus-test/test-consensus/Main.hs
+++ b/ouroboros-consensus-test/test-consensus/Main.hs
@@ -8,6 +8,7 @@ import qualified Test.Consensus.HardFork.Forecast (tests)
 import qualified Test.Consensus.HardFork.History (tests)
 import qualified Test.Consensus.HardFork.Summary (tests)
 import qualified Test.Consensus.Mempool (tests)
+import qualified Test.Consensus.Mempool.Fairness (tests)
 import qualified Test.Consensus.MiniProtocol.ChainSync.Client (tests)
 import qualified Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests)
 import qualified Test.Consensus.Node (tests)
@@ -25,6 +26,7 @@ tests =
   , Test.Consensus.MiniProtocol.ChainSync.Client.tests
   , Test.Consensus.MiniProtocol.LocalStateQuery.Server.tests
   , Test.Consensus.Mempool.tests
+  , Test.Consensus.Mempool.Fairness.tests
   , Test.Consensus.Node.tests
   , Test.Consensus.ResourceRegistry.tests
   , Test.Consensus.Util.MonadSTM.RAWLock.tests

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -25,6 +25,7 @@ import           Test.Tasty hiding (after)
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck hiding (Fixed)
 
+import           Control.Monad.Class.MonadMVar (MonadMVar)
 import qualified Control.Monad.Class.MonadSTM.Internal as LazySTM
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.IOSim
@@ -333,6 +334,7 @@ newtype OverrideDelay m a = OverrideDelay {
            , MonadCatch
            , MonadMask
            , MonadMonotonicTime
+           , MonadMVar
            , MonadTime
            , MonadThread
            , MonadFork

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Fairness.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Fairness.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+-- | Tests fairness aspects of the mempool.
+--
+-- See 'testTxSizeFairness' for more details on the tests we run in this module.
+module Test.Consensus.Mempool.Fairness (
+    testTxSizeFairness
+  , tests
+  ) where
+
+import qualified Cardano.Slotting.Time as Time
+import           Control.Arrow ((***))
+import           Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import           Control.Exception (assert)
+import           Control.Monad (forever, void)
+import qualified Control.Tracer as Tracer
+import           Data.Foldable (asum)
+import qualified Data.List as List
+import           Data.Void (Void, vacuous)
+import           Data.Word (Word32)
+import           Ouroboros.Consensus.Config.SecurityParam as Consensus
+import qualified Ouroboros.Consensus.HardFork.History as HardFork
+import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
+import           Ouroboros.Consensus.Mempool (Mempool)
+import qualified Ouroboros.Consensus.Mempool as Mempool
+import           Ouroboros.Consensus.Util.IOLike (STM, atomically, retry)
+import           System.Random (randomIO)
+import           Test.Consensus.Mempool.Fairness.TestBlock
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (testCase, (@?), (@?=))
+import           Test.Util.TestBlock (testInitLedgerWithState)
+
+tests :: TestTree
+tests = testGroup "Mempool fairness"
+                  [ testCase "There is no substantial bias in added transaction sizes" $
+                              testTxSizeFairness TestParams { mempoolMaxCapacity =   100
+                                                            , smallTxSize        =     1
+                                                            , largeTxSize        =    10
+                                                            , nrOftxsToCollect   = 1_000
+                                                            , toleranceThreshold =     0.2 -- Somewhat arbitrarily chosen.
+                                                            }
+                  ]
+
+type TestMempool = Mempool IO TestBlock Mempool.TicketNo
+
+-- | Test if the mempool treats small and large transactions in the same way.
+--
+-- We run the following test:
+--
+-- - Given a mempool 'mp'.
+-- - Concurrently:
+--     - Run 'N' threads that add small transactions to 'mp'.
+--     - Run 'N' threads that add large transactions to 'mp'.
+--     - Remove transactions from 'mp' one by one, with a small delay between
+--       removals. Collect the removed transactions.
+--
+-- We give the threads that add small transactions a head start to make sure
+-- that the mempool fills up with small transactions. In this way the thread
+-- that removes transactions one by one will remove small transactions first.
+-- Then, if the mempool is fair, it will not always try to add a small
+-- transaction as soon as it can, but it will eventually wait until enough
+-- capacity has been freed (by the remover thread) so that a large transaction
+-- can be added.
+--
+-- After collecting 'M' removed transactions, let 'diff' be the difference between
+-- the number of small and large transactions that were added to 'mp', then we
+-- check that:
+--
+-- > diff / M <= toleranceThreshold
+--
+-- See 'TestParams' for an explanation of the different parameters that
+-- influence this test.
+testTxSizeFairness :: TestParams -> IO ()
+testTxSizeFairness TestParams { mempoolMaxCapacity, smallTxSize, largeTxSize, nrOftxsToCollect, toleranceThreshold } = do
+    ----------------------------------------------------------------------------
+    --  Obtain a mempool.
+    ----------------------------------------------------------------------------
+    let
+      ledgerItf = Mempool.LedgerInterface {
+              Mempool.getCurrentLedgerState = pure $ testInitLedgerWithState ()
+          }
+
+      sampleLedgerConfig =
+          HardFork.defaultEraParams (Consensus.SecurityParam 10) (Time.slotLengthFromSec 2)
+    mempool <- Mempool.openMempoolWithoutSyncThread
+                   ledgerItf
+                   sampleLedgerConfig
+                   (Mempool.MempoolCapacityBytesOverride
+                      (Mempool.MempoolCapacityBytes mempoolMaxCapacity))
+                   Tracer.nullTracer
+                   genTxSize
+
+    ----------------------------------------------------------------------------
+    --  Add and collect transactions
+    ----------------------------------------------------------------------------
+    let waitForSmallAddersToFillMempool = threadDelay 1_000
+    txs <- runConcurrently [
+                                           adders  mempool smallTxSize
+      , waitForSmallAddersToFillMempool >> adders  mempool largeTxSize
+      , waitForSmallAddersToFillMempool >> remover mempool             nrOftxsToCollect
+      ]
+
+
+    ----------------------------------------------------------------------------
+    --  Count the small and large transactions
+    ----------------------------------------------------------------------------
+    let
+      nrSmall :: Double
+      nrLarge :: Double
+      (nrSmall, nrLarge) = (fromIntegral . length *** fromIntegral . length)
+                         $ List.partition  (<= smallTxSize)
+                         $ fmap txSize txs
+    length txs @?= nrOftxsToCollect
+    theRatioOfTheDifferenceBetween nrSmall nrLarge `isBelow` toleranceThreshold
+  where
+    theRatioOfTheDifferenceBetween x y = (abs (x - y) / (x + y), x, y)
+
+    -- At the end of the tests the proportion of small and large
+    -- transactions that were added should be rouhgly the same. We tolerate
+    -- the given theshold.
+    isBelow (ratioDiff, nrSmall, nrLarge) threshold = ratioDiff <= threshold
+      @? (    "The difference between the number of large and small transactions added "
+           <> "exeeds the threshold (" <> show threshold <> ")\n"
+           <> "Total number of small transactions that were added: " <> show nrSmall <> "\n"
+           <> "Total number of large transactions that were added: " <> show nrLarge <> "\n"
+           <> "Difference / Total: " <> show ratioDiff
+         )
+
+runConcurrently :: [IO a] -> IO a
+runConcurrently = Async.runConcurrently . asum . fmap Async.Concurrently
+
+-- | Test parameters.
+--
+-- When choosing the parameters bear in mind that:
+--
+-- - The smaller the difference between 'smallTxSize' and 'largeTxSize', the
+--   harder it will be detect potential differences in way the mempool handles
+--   small and large transactions.
+--
+-- - The larger the capacity, the higher the chance large transactions can be
+--   added before the mempool is saturated.
+--
+data TestParams = TestParams {
+    mempoolMaxCapacity :: Word32
+  , smallTxSize        :: Word32
+    -- ^ Size of what we consider to be a small transaction.
+  , largeTxSize        :: Word32
+    -- ^ Size of what we consider to be a large transaction.
+  , nrOftxsToCollect   :: Int
+    -- ^ How many added transactions we count.
+  , toleranceThreshold :: Double
+    -- ^ We tolerate a certain ratio between the difference of small and large
+    -- transactions added, and the total transactions that were added. For
+    -- instance, given a threshold of 0.2, if we measure the sizes of 100 added
+    -- transactions, the difference between the number small and large
+    -- transactions we counted should not be larger than 20.
+  }
+
+-- | Add transactions with the specified size to the mempool.
+--
+-- We launch a fixed number of adder threads.
+--
+-- This process does not finish. Hence the 'a' type parameter.
+adders ::
+     TestMempool
+     -- ^ Mempool to which transactions will be added
+  -> Word32
+     -- ^ Transaction size
+  -> IO a
+adders mempool fixedTxSize = vacuous $ runConcurrently $ fmap adder [0..2]
+  where
+    adder :: Int -> IO Void
+    adder _i = forever $ do
+        -- We pick a random number for the transaction id.
+        thisTxId <- randomIO
+        void $ Mempool.addTxs mempool [mkGenTx thisTxId fixedTxSize]
+
+-- | Remove the given number of transactions and return them.
+--
+remover ::
+     TestMempool
+     -- ^ Mempool to remove transactions from.
+  -> Int
+  -- ^ Number of transactions to remove.
+  -> IO [Tx]
+remover mempool total = do
+    let result = loop [] total
+    removedTxs <- result
+    assert (length removedTxs == total) result
+  where
+    -- Remove transactions one by one till we reach 'n'.
+    loop txs 0 = pure txs -- Note that the transactions will come out in reverse
+                          -- order wrt the order in which they were added to the
+                          -- mempool. That is ok since we only care about the
+                          -- transaction sizes.
+    loop txs n = do
+        -- We wait 1ms to give the other threads the possibility to add
+        -- transactions.
+        threadDelay 1000
+        gtx <- atomically $ getATxFromTheMempool
+        Mempool.removeTxs mempool [Mempool.txId gtx]
+        loop (unGenTx gtx:txs) (n-1)
+      where
+        getATxFromTheMempool =
+          getTxsInSnapshot mempool >>= \case
+              []  -> retry
+              x:_ -> pure x
+
+-- TODO: consider moving this to O.C.Mempool.API
+getTxsInSnapshot :: TestMempool -> STM IO [Mempool.GenTx TestBlock]
+getTxsInSnapshot mempool = fmap txsInSnapshot
+                         $ Mempool.getSnapshot mempool
+  where
+    txsInSnapshot = fmap (Mempool.txForgetValidated . fst)
+                  . Mempool.snapshotTxs

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Fairness/TestBlock.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool/Fairness/TestBlock.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+module Test.Consensus.Mempool.Fairness.TestBlock (
+    TestBlock
+  , Tx
+  , genTxSize
+  , mkGenTx
+  , txSize
+  , unGenTx
+  ) where
+
+import           Control.DeepSeq (NFData)
+import           Data.Word (Word32)
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+import qualified Ouroboros.Consensus.Block as Block
+import qualified Ouroboros.Consensus.Ledger.Abstract as Ledger
+import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
+import qualified Test.Util.TestBlock as TestBlock
+import           Test.Util.TestBlock (TestBlockWith)
+
+type TestBlock = TestBlockWith Tx
+  -- We use 'Test.Util.TestBlock' because, even though it contains a lot of
+  -- information we do not actually need for the mempool fairness tests, it
+  -- already defines most of the many type classes that are needed to open a
+  -- mempool.
+
+-- | The fairness test for transaction sizes only cares about said aspect.
+--
+-- We do need to keep track of the transaction id.
+--
+-- All transactions will be accepted by the mempool.
+data Tx = Tx { txNumber :: Int, txSize ::  Word32 }
+  deriving stock (Eq, Ord, Generic, Show)
+  deriving anyclass (NoThunks, NFData)
+
+{-------------------------------------------------------------------------------
+  Payload semantics
+-------------------------------------------------------------------------------}
+
+instance TestBlock.PayloadSemantics Tx where
+  type PayloadDependentState Tx = ()
+
+  type PayloadDependentError Tx = ()
+
+  applyPayload st _tx = Right st
+
+
+data instance Block.CodecConfig TestBlock = TestBlockCodecConfig
+  deriving (Show, Generic, NoThunks)
+
+data instance Block.StorageConfig TestBlock = TestBlockStorageConfig
+  deriving (Show, Generic, NoThunks)
+
+
+{-------------------------------------------------------------------------------
+  Mempool support
+-------------------------------------------------------------------------------}
+
+newtype instance Ledger.GenTx TestBlock = TestBlockGenTx { unGenTx :: Tx }
+  deriving stock (Generic)
+  deriving newtype (Show, NoThunks, Eq, Ord, NFData)
+
+newtype instance Ledger.Validated (Ledger.GenTx TestBlock) =
+    ValidatedGenTx (Ledger.GenTx TestBlock)
+  deriving stock (Generic)
+  deriving newtype (Show, NoThunks)
+
+newtype instance Ledger.TxId (Ledger.GenTx TestBlock) = TestBlockTxId Tx
+  deriving stock (Generic)
+  deriving newtype (Show, Ord, Eq)
+  deriving anyclass (NoThunks)
+
+instance Ledger.HasTxId (Ledger.GenTx TestBlock) where
+  txId (TestBlockGenTx tx) = TestBlockTxId tx
+
+genTxSize :: Ledger.GenTx TestBlock -> Word32
+genTxSize = txSize . unGenTx
+
+mkGenTx :: Int -> Word32 -> Ledger.GenTx TestBlock
+mkGenTx anId aSize = TestBlockGenTx $ Tx { txNumber = anId, txSize = aSize }
+
+instance Ledger.LedgerSupportsMempool TestBlock where
+  applyTx _cfg _shouldIntervene _slot gtx st = pure (st, ValidatedGenTx gtx)
+
+  reapplyTx _cfg _slot _gtx gst = pure gst
+
+  txsMaxBytes _ = error "The tests should override this value"
+                  -- The tests should be in control of the mempool capacity,
+                  -- since the judgement on whether the mempool is fair depends
+                  -- on this parameter.
+
+  txInBlockSize = txSize . unGenTx
+
+  txForgetValidated (ValidatedGenTx tx) = tx
+
+{-------------------------------------------------------------------------------
+  Ledger support
+-------------------------------------------------------------------------------}
+
+type instance Ledger.ApplyTxErr TestBlock = ()

--- a/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
+++ b/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
@@ -1,0 +1,33 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Remove function `tryAddTxs` from the mempool API. The implementation of this
+  function did not guarantee fairness, and therefore transactions could starve.
+  This function was replaced by `addTx`.
+- Add a `addTx` function to the mempool API. This function tries to add a single
+  transaction and blocks if the mempool if full. The mempool is now fair, which
+  means that no transaction will be starved, provided that transactions are
+  eventually removed from the mempool. Fairness is achieved by introducing two
+  FIFO queues. Remote clients have to queue in both of them, whereas local
+  clients only have to queue in the local clients' queue. This gives local
+  clients priority over remote ones.
+
+

--- a/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
+++ b/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
@@ -28,7 +28,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
   This function was replaced by `addTx`.
 - Add a `addTx` function to the mempool API. This function tries to add a single
   transaction and blocks if the mempool can not accept the given transaction. 
-  This means that entry to a mempool is now a (per-node) FIFO. This also ensure
+  This means that entry to a mempool is now a (per-peer) FIFO. This also ensure
   that transactions will always progress, irrespective of size.
   The refactoring introduces two FIFO queues. Remote clients have to queue in both
   of them, whereas local clients only have to queue in the local clients' queue. 

--- a/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
+++ b/ouroboros-consensus/changelog.d/20230406_131026_dcoutts_mempool-addtx-fifo.md
@@ -19,15 +19,20 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Breaking
 
-- Remove function `tryAddTxs` from the mempool API. The implementation of this
-  function did not guarantee fairness, and therefore transactions could starve.
+- Remove function `tryAddTxs` from the mempool API. The implementation (Shelly Era)
+  of this function relied on the fairness of 'service-in-random-order', and 
+  endeavoured to maximally fill the mempool. Since the Babbage Era there is an 
+  increased variation in representational size of transactions for a given cost 
+  of processing. This means that, under certain conditions, representationally
+  large transactions could be stalled in progress between mempools.
   This function was replaced by `addTx`.
 - Add a `addTx` function to the mempool API. This function tries to add a single
-  transaction and blocks if the mempool if full. The mempool is now fair, which
-  means that no transaction will be starved, provided that transactions are
-  eventually removed from the mempool. Fairness is achieved by introducing two
-  FIFO queues. Remote clients have to queue in both of them, whereas local
-  clients only have to queue in the local clients' queue. This gives local
-  clients priority over remote ones.
+  transaction and blocks if the mempool can not accept the given transaction. 
+  This means that entry to a mempool is now a (per-node) FIFO. This also ensure
+  that transactions will always progress, irrespective of size.
+  The refactoring introduces two FIFO queues. Remote clients have to queue in both
+  of them, whereas local clients only have to queue in the local clients' queue. 
+  This gives local clients a higher precedence to get into their local mempool under
+  heavy load situations.
 
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -69,6 +69,10 @@ class ( UpdateLedger blk
   txInvariant = const True
 
   -- | Apply an unvalidated transaction
+  --
+  -- The mempool expects that the ledger checks the sanity of the transaction'
+  -- size. The mempool implementation will add any valid transaction as long as
+  -- there is at least one byte free in the mempool.
   applyTx :: LedgerConfig blk
           -> WhetherToIntervene
           -> SlotNo -- ^ Slot number of the block containing the tx

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -9,6 +9,7 @@ module Ouroboros.Consensus.Mempool.API (
     -- * Mempool
     Mempool (..)
   , MempoolAddTxResult (..)
+  , AddTxOnBehalfOf(..)
   , isMempoolTxAdded
   , isMempoolTxRejected
   , mempoolTxAddedToMaybe
@@ -127,7 +128,7 @@ data Mempool m blk idx = Mempool {
       -- @STM m@; we keep it in @m@ instead to leave open the possibility of
       -- persistence.
       --
-      addTx      :: WhetherToIntervene
+      addTx      :: AddTxOnBehalfOf
                  -> GenTx blk
                  -> m (MempoolAddTxResult blk)
 
@@ -225,7 +226,7 @@ addTxs
   => Mempool m blk idx
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]
-addTxs mempool = mapM (addTx mempool DoNotIntervene)
+addTxs mempool = mapM (addTx mempool AddTxForRemotePeer)
 
 -- | A wrapper around 'addTx' that adds a sequence of transactions on behalf of
 -- a local client. This reports more errors for local clients, see 'Intervene'.
@@ -239,7 +240,16 @@ addLocalTxs
   => Mempool m blk idx
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]
-addLocalTxs mempool = mapM (addTx mempool Intervene)
+addLocalTxs mempool = mapM (addTx mempool AddTxForLocalClient)
+
+-- | Who are we adding a tx on behalf of, a remote peer or a local client?
+--
+-- This affects two things:
+--
+-- 1. how certain errors are treated: we want to be helpful to local clients.
+-- 2. priority of service: local clients are prioritised over remote peers.
+--
+data AddTxOnBehalfOf = AddTxForRemotePeer | AddTxForLocalClient
 
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -60,24 +60,10 @@ import           Ouroboros.Consensus.Util.IOLike
 -- * It supports wallets that submit dependent transactions (where later
 --   transaction depends on outputs from earlier ones).
 --
--- When only one thread is operating on the mempool, operations that mutate the
--- state based on the input arguments (tryAddTxs and removeTxs) will produce the
--- same result whether they process transactions one by one or all in one go, so
--- this equality holds:
---
--- > void (tryAddTxs wti txs) === forM_ txs (tryAddTxs wti . (:[]))
--- > void (trAddTxs wti [x,y]) === tryAddTxs wti x >> void (tryAddTxs wti y)
---
--- This shows that @'tryAddTxs' wti@ is an homomorphism from '++' and '>>',
--- which informally makes these operations "distributive".
 data Mempool m blk idx = Mempool {
-      -- | Add a bunch of transactions (oldest to newest)
+      -- | Add a single transaction to the mempool.
       --
-      -- As long as we keep the mempool entirely in-memory this could live in
-      -- @STM m@; we keep it in @m@ instead to leave open the possibility of
-      -- persistence.
-      --
-      -- The new transactions provided will be validated, /in order/, against
+      -- The new transaction provided will be validated, /in order/, against
       -- the ledger state obtained by applying all the transactions already in
       -- the Mempool to it. Transactions which are found to be invalid, with
       -- respect to the ledger state, are dropped, whereas valid transactions
@@ -91,29 +77,28 @@ data Mempool m blk idx = Mempool {
       -- the mempool via a call to 'syncWithLedger' or by the background
       -- thread that watches the ledger for changes.
       --
-      -- This function will return two lists
+      -- This action returns one of two results
       --
-      -- 1. A list containing the following transactions:
+      --  * A 'MempoolTxAdded' value if the transaction provided was found to
+      --    be valid. This transactions is now in the Mempool.
       --
-      --    * Those transactions provided which were found to be valid, as a
-      --      'MempoolTxAdded' value. These transactions are now in the Mempool.
-      --    * Those transactions provided which were found to be invalid, along
-      --      with their accompanying validation errors, as a
-      --      'MempoolTxRejected' value. These transactions are not in the
-      --      Mempool.
+      --  * A 'MempoolTxRejected' value if the transaction provided was found
+      --    to be invalid, along with its accompanying validation errors. This
+      --    transactions is not in the Mempool.
       --
-      -- 2. A list containing the transactions that have not yet been added, as
-      --    the capacity of the Mempool has been reached. I.e., there is no
-      --    space in the Mempool to add the first transaction in this list. Note
-      --    that we won't try to add smaller transactions after that first
-      --    transaction because they might depend on the first transaction.
+      -- Note that this is a blocking action. It will block until the
+      -- transaction fits into the mempool. This includes transactions that
+      -- turn out to be invalid: the action waits for there to be space for
+      -- the transaction before it gets validated.
+      --
+      -- Note that it is safe to use this from multiple threads concurrently.
       --
       -- POSTCONDITION:
       -- > let prj = \case
       -- >       MempoolTxAdded vtx        -> txForgetValidated vtx
       -- >       MempoolTxRejected tx _err -> tx
-      -- > (processed, toProcess) <- tryAddTxs wti txs
-      -- > map prj processed ++ toProcess == txs
+      -- > processed <- addTx wti txs
+      -- > prj processed == tx
       --
       -- Note that previously valid transaction that are now invalid with
       -- respect to the current ledger state are dropped from the mempool, but
@@ -138,11 +123,13 @@ data Mempool m blk idx = Mempool {
       -- an index of transaction hashes that have been included on the
       -- blockchain.
       --
-      tryAddTxs      :: WhetherToIntervene
-                     -> [GenTx blk]
-                     -> m ( [MempoolAddTxResult blk]
-                          , [GenTx blk]
-                          )
+      -- As long as we keep the mempool entirely in-memory this could live in
+      -- @STM m@; we keep it in @m@ instead to leave open the possibility of
+      -- persistence.
+      --
+      addTx      :: WhetherToIntervene
+                 -> GenTx blk
+                 -> m (MempoolAddTxResult blk)
 
       -- | Manually remove the given transactions from the mempool.
     , removeTxs      :: [GenTxId blk] -> m ()
@@ -225,63 +212,35 @@ isMempoolTxRejected :: MempoolAddTxResult blk -> Bool
 isMempoolTxRejected MempoolTxRejected{} = True
 isMempoolTxRejected _                   = False
 
--- | Wrapper around 'implTryAddTxs' that blocks until all transaction have
--- either been added to the Mempool or rejected.
+-- | A wrapper around 'addTx' that adds a sequence of transactions on behalf of
+-- a remote peer.
 --
--- This function does not sync the Mempool contents with the ledger state in
--- case the latter changes, it relies on the background thread to do that.
+-- Note that transactions are added one by one, and can interleave with other
+-- concurrent threads using 'addTx'.
 --
--- See the necessary invariants on the Haddock for 'tryAddTxs'.
+--
+-- See 'addTx' for further details.
 addTxs
   :: forall m blk idx. MonadSTM m
   => Mempool m blk idx
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]
-addTxs mempool = addTxsHelper mempool DoNotIntervene
+addTxs mempool = mapM (addTx mempool DoNotIntervene)
 
--- | Variation on 'addTxs' that is more forgiving when possible
+-- | A wrapper around 'addTx' that adds a sequence of transactions on behalf of
+-- a local client. This reports more errors for local clients, see 'Intervene'.
 --
--- See 'Intervene'.
+-- Note that transactions are added one by one, and can interleave with other
+-- concurrent threads using 'addTx'.
+--
+-- See 'addTx' for further details.
 addLocalTxs
   :: forall m blk idx. MonadSTM m
   => Mempool m blk idx
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]
-addLocalTxs mempool = addTxsHelper mempool Intervene
+addLocalTxs mempool = mapM (addTx mempool Intervene)
 
--- | See 'addTxs'
-addTxsHelper
-  :: forall m blk idx. MonadSTM m
-  => Mempool m blk idx
-  -> WhetherToIntervene
-  -> [GenTx blk]
-  -> m [MempoolAddTxResult blk]
-addTxsHelper mempool wti = \txs -> do
-    (processed, toAdd) <- tryAddTxs mempool wti txs
-    case toAdd of
-      [] -> return processed
-      _  -> go [processed] toAdd
-  where
-    go
-      :: [[MempoolAddTxResult blk]]
-         -- ^ The outer list is in reverse order, but all the inner lists will
-         -- be in the right order.
-      -> [GenTx blk]
-      -> m [MempoolAddTxResult blk]
-    go acc []         = return (concat (reverse acc))
-    go acc txs@(tx:_) = do
-      let firstTxSize = getTxSize mempool tx
-      -- Wait until there's at least room for the first transaction we're
-      -- trying to add, otherwise there's no point in trying to add it.
-      atomically $ do
-        curSize <- msNumBytes . snapshotMempoolSize <$> getSnapshot mempool
-        MempoolCapacityBytes capacity <- getCapacity mempool
-        check (curSize + firstTxSize <= capacity)
-      -- It is possible that between the check above and the call below, other
-      -- transactions are added, stealing our spot, but that's fine, we'll
-      -- just recurse again without progress.
-      (added, toAdd) <- tryAddTxs mempool wti txs
-      go (added:acc) toAdd
 
 {-------------------------------------------------------------------------------
   Ledger state considered for forging

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -61,6 +61,36 @@ import           Ouroboros.Consensus.Util.IOLike
 -- * It supports wallets that submit dependent transactions (where later
 --   transaction depends on outputs from earlier ones).
 --
+-- The mempool provides fairness guarantees for the case of multiple threads
+-- performing 'addTx' concurrently. Implementations of this interface must
+-- provide this guarantee, and users of this interface may rely on it.
+-- Specifically, multiple threads that continuously use 'addTx' will, over
+-- time, get a share of the mempool resource (measured by the number of txs
+-- only, not their sizes) roughly proportional to their \"weight\". The weight
+-- depends on the 'AddTxOnBehalfOf': either acting on behalf of remote peers
+-- ('AddTxForRemotePeer') or on behalf of a local client
+-- ('AddTxForLocalClient'). The weighting for threads acting on behalf of
+-- remote peers is the same for all remote peers, so all remote peers will get
+-- a roughly equal share of the resource. The weighting for local clients is
+-- the same for all local clients but /may/ be higher than the weighting for
+-- remote peers. The weighting is not unboundedly higher however, so there is
+-- still (weighted) fairness between remote peers and local clients. Thus
+-- local clients will also get a roughly equal share of the resource, but that
+-- share may be strictly greater than the share for each remote peer.
+-- Furthermore, this implies local clients cannot starve remote peers, despite
+-- their higher weighting.
+--
+-- This fairness specification in terms of weighting is deliberately
+-- non-specific, which allows multiple strategies. The existing default
+-- strategy (for the implementation in "Ouroboros.Consensus.Mempool") is as
+-- follows. The design uses two FIFOs, to give strictly in-order behaviour.
+-- All remote peers get equal weight and all local clients get equal weight.
+-- The relative weight between remote and local is that if there are N remote
+-- peers and M local clients, each local client gets weight 1/(M+1), while all
+-- of the N remote peers together also get total weight 1/(M+1). This means
+-- individual remote peers get weight 1/(N * (M+1)). Intuitively: a single local
+-- client has the same weight as all the remote peers put together.
+--
 data Mempool m blk idx = Mempool {
       -- | Add a single transaction to the mempool.
       --
@@ -248,6 +278,8 @@ addLocalTxs mempool = mapM (addTx mempool AddTxForLocalClient)
 --
 -- 1. how certain errors are treated: we want to be helpful to local clients.
 -- 2. priority of service: local clients are prioritised over remote peers.
+--
+-- See 'Mempool' for a discussion of fairness and priority.
 --
 data AddTxOnBehalfOf = AddTxForRemotePeer | AddTxForLocalClient
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -23,7 +23,7 @@ module Ouroboros.Consensus.Mempool.Impl (
   ) where
 
 import           Control.Monad.Except
-import           Control.Monad.Class.MonadMVar (MVar, newEmptyMVar)
+import           Control.Monad.Class.MonadMVar (MVar, newMVar)
 import           Data.Typeable
 
 import           Control.Tracer
@@ -41,7 +41,7 @@ import           Ouroboros.Consensus.Mempool.Impl.Pure
 import           Ouroboros.Consensus.Mempool.Impl.Types
 import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, zeroTicketNo)
 import           Ouroboros.Consensus.Util (whenJust)
-import           Ouroboros.Consensus.Util.IOLike hiding (newEmptyMVar)
+import           Ouroboros.Consensus.Util.IOLike hiding (newMVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Watcher (..), forkLinkedWatcher)
 
@@ -168,8 +168,8 @@ initMempoolEnv ledgerInterface cfg capacityOverride tracer txSize = do
     st <- atomically $ getCurrentLedgerState ledgerInterface
     let (slot, st') = tickLedgerState cfg (ForgeInUnknownSlot st)
     isVar <- newTVarIO $ initInternalState capacityOverride zeroTicketNo slot st'
-    addTxRemoteFifo <- newEmptyMVar
-    addTxAllFifo    <- newEmptyMVar
+    addTxRemoteFifo <- newMVar ()
+    addTxAllFifo    <- newMVar ()
     return MempoolEnv
       { mpEnvLedger           = ledgerInterface
       , mpEnvLedgerCfg        = cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -114,7 +114,7 @@ mkMempool mpEnv = Mempool
     }
    where MempoolEnv{ mpEnvStateVar = istate
                    , mpEnvAddTxsRemoteFifo = remoteFifo
-                   , mpEnvAddTxsAllFifo    = allFifo
+                   , mpEnvAddTxsAllFifo = allFifo
                    , mpEnvLedgerCfg = cfg
                    , mpEnvTxSize = txSize
                    , mpEnvTracer = trcr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -96,7 +96,7 @@ mkMempool
      )
   => MempoolEnv m blk -> Mempool m blk TicketNo
 mkMempool mpEnv = Mempool
-    { tryAddTxs      = implTryAddTxs istate cfg txSize trcr
+    { addTx          = implAddTx istate cfg txSize trcr
     , removeTxs      = \txs -> do
         mTrace <- atomically $ do
           is <- readTVar istate

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -54,16 +54,18 @@ implAddTx ::
      )
   => StrictTVar m (InternalState blk)
      -- ^ The InternalState TVar.
-  -> MVar m () -- ^ The FIFO for remote peers
-  -> MVar m () -- ^ The FIFO for all remote peers and local clients
+  -> MVar m ()
+      -- ^ The FIFO for remote peers
+  -> MVar m ()
+      -- ^ The FIFO for all remote peers and local clients
   -> LedgerConfig blk
      -- ^ The configuration of the ledger.
   -> (GenTx blk -> TxSizeInBytes)
      -- ^ The function to calculate the size of a
      -- transaction.
   -> Tracer m (TraceEventMempool blk)
-     -- ^ The tracer.
   -> AddTxOnBehalfOf
+     -- ^ Whether we're acting on behalf of a remote peer or a local client.
   -> GenTx blk
      -- ^ The transaction to add to the mempool.
   -> m (MempoolAddTxResult blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -11,7 +11,7 @@
 
 module Ouroboros.Consensus.Mempool.Impl.Pure (
     -- * Mempool
-    implTryAddTxs
+    implAddTx
   , pureGetSnapshotFor
   , pureRemoveTxs
   , pureSyncWithLedger
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.Mempool.Impl.Pure (
   ) where
 
 import           Control.Exception (assert)
+import           Control.Tracer
 import           Data.Maybe (isJust, isNothing)
 import qualified Data.Set as Set
 
@@ -42,42 +43,9 @@ import           Ouroboros.Consensus.Util.IOLike
   Mempool Implementation
 -------------------------------------------------------------------------------}
 
--- | Result of trying to add a transaction to the mempool.
-data TryAddTxs blk =
-    -- | No space is left in the mempool and no more transactions could be
-    -- added.
-    NoSpaceLeft
-    -- | A transaction was processed.
-  | TryAddTxs
-      (Maybe (InternalState blk))
-      -- ^ If the transaction was accepted, the new state that can be written to
-      -- the TVar.
-      (MempoolAddTxResult blk)
-      -- ^ The result of trying to add the transaction to the mempool.
-      (TraceEventMempool blk)
-      -- ^ The event emitted by the operation.
-
--- | Add a list of transactions (oldest to newest) by interpreting a 'TryAddTxs'
--- from 'pureTryAddTxs'.
+-- | Add a single transaction to the mempool, blocking if there is no space.
 --
--- This function returns two lists: the transactions that were added or
--- rejected, and the transactions that could not yet be added, because the
--- Mempool capacity was reached. See 'addTxs' for a function that blocks in
--- case the Mempool capacity is reached.
---
--- Transactions are added one by one, updating the Mempool each time one was
--- added successfully.
---
--- See the necessary invariants on the Haddock for 'API.tryAddTxs'.
---
--- This function does not sync the Mempool contents with the ledger state in
--- case the latter changes, it relies on the background thread to do that.
---
--- INVARIANT: The code needs that read and writes on the state are coupled
--- together or inconsistencies will arise. To ensure that STM transactions are
--- short, each iteration of the helper function is a separate STM transaction.
-implTryAddTxs
-  :: forall m blk.
+implAddTx ::
      ( MonadSTM m
      , LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
@@ -92,28 +60,82 @@ implTryAddTxs
   -> Tracer m (TraceEventMempool blk)
      -- ^ The tracer.
   -> WhetherToIntervene
-  -> [GenTx blk]
-     -- ^ The list of transactions to add to the mempool.
-  -> m ([MempoolAddTxResult blk], [GenTx blk])
-implTryAddTxs istate cfg txSize trcr wti =
-    go []
-  where
-    go acc = \case
-      []     -> pure (reverse acc, [])
-      tx:txs -> join $ atomically $ do
-        is <- readTVar istate
-        case pureTryAddTxs cfg txSize wti tx is of
-          NoSpaceLeft             -> pure $ pure (reverse acc, tx:txs)
-          TryAddTxs is' result ev -> do
-            whenJust is' (writeTVar istate)
-            pure $ do
-              traceWith trcr ev
-              go (result:acc) txs
+  -> GenTx blk
+     -- ^ The transaction to add to the mempool.
+  -> m (MempoolAddTxResult blk)
+implAddTx istate cfg txSize trcr wti tx = do
+    (result, ev) <- atomically $ do
+      outcome <- implTryAddTx istate cfg txSize wti tx
+      case outcome of
+        TryAddTx _ result ev -> do return (result, ev)
 
--- | Craft a 'TryAddTxs' value containing the resulting state if applicable, the
+        -- or block until space is available to fit the next transaction
+        NoSpaceLeft          -> retry
+
+    traceWith trcr ev
+    return result
+
+-- | Result of trying to add a transaction to the mempool.
+data TryAddTx blk =
+    -- | No space is left in the mempool and no more transactions could be
+    -- added.
+    NoSpaceLeft
+    -- | A transaction was processed.
+  | TryAddTx
+      (Maybe (InternalState blk))
+      -- ^ If the transaction was accepted, the new state that can be written to
+      -- the TVar.
+      (MempoolAddTxResult blk)
+      -- ^ The result of trying to add the transaction to the mempool.
+      (TraceEventMempool blk)
+      -- ^ The event emitted by the operation.
+
+-- | Add a single transaction by interpreting a 'TryAddTx' from 'pureTryAddTx'.
+--
+-- This function returns whether the transaction was added or rejected, or if
+-- the Mempool capacity is reached. See 'implAddTx' for a function that blocks
+-- in case the Mempool capacity is reached.
+--
+-- Transactions are added one by one, updating the Mempool each time one was
+-- added successfully.
+--
+-- See the necessary invariants on the Haddock for 'API.tryAddTxs'.
+--
+-- This function does not sync the Mempool contents with the ledger state in
+-- case the latter changes, it relies on the background thread to do that.
+--
+-- INVARIANT: The code needs that read and writes on the state are coupled
+-- together or inconsistencies will arise. To ensure that STM transactions are
+-- short, each iteration of the helper function is a separate STM transaction.
+implTryAddTx
+  :: forall m blk.
+     ( MonadSTM m
+     , LedgerSupportsMempool blk
+     , HasTxId (GenTx blk)
+     )
+  => StrictTVar m (InternalState blk)
+     -- ^ The InternalState TVar.
+  -> LedgerConfig blk
+     -- ^ The configuration of the ledger.
+  -> (GenTx blk -> TxSizeInBytes)
+     -- ^ The function to calculate the size of a
+     -- transaction.
+  -> WhetherToIntervene
+  -> GenTx blk
+     -- ^ The transaction to add to the mempool.
+  -> STM m (TryAddTx blk)
+implTryAddTx istate cfg txSize wti tx = do
+        is <- readTVar istate
+        let outcome = pureTryAddTx cfg txSize wti tx is
+        case outcome of
+          TryAddTx (Just is') _ _ -> writeTVar istate is'
+          _                       -> return ()
+        return outcome
+
+-- | Craft a 'TryAddTx' value containing the resulting state if applicable, the
 -- tracing event and the result of adding this transaction. See the
--- documentation of 'implTryAddTxs' for some more context.
-pureTryAddTxs
+-- documentation of 'implTryAddTx' for some more context.
+pureTryAddTx
   :: ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      )
@@ -126,8 +148,8 @@ pureTryAddTxs
      -- ^ The transaction to add to the mempool.
   -> InternalState blk
      -- ^ The current internal state of the mempool.
-  -> TryAddTxs blk
-pureTryAddTxs cfg txSize wti tx is
+  -> TryAddTx blk
+pureTryAddTx cfg txSize wti tx is
   | let size    = txSize tx
         curSize = msNumBytes  $ isMempoolSize is
   , curSize + size > getMempoolCapacityBytes (isCapacity is)
@@ -138,7 +160,7 @@ pureTryAddTxs cfg txSize wti tx is
       -- ('tx'). So if it's not in 'vrInvalid', it must be in 'vrNewValid'.
       Right vtx ->
         assert (isJust (vrNewValid vr)) $
-          TryAddTxs
+          TryAddTx
             (Just is')
             (MempoolTxAdded vtx)
             (TraceMempoolAddedTx
@@ -149,7 +171,7 @@ pureTryAddTxs cfg txSize wti tx is
       Left err ->
         assert (isNothing (vrNewValid vr))  $
           assert (length (vrInvalid vr) == 1) $
-            TryAddTxs
+            TryAddTx
               Nothing
               (MempoolTxRejected tx err)
               (TraceMempoolRejectedTx

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl/Pure.hs
@@ -177,6 +177,10 @@ implTryAddTx istate cfg txSize wti tx = do
 -- | Craft a 'TryAddTx' value containing the resulting state if applicable, the
 -- tracing event and the result of adding this transaction. See the
 -- documentation of 'implTryAddTx' for some more context.
+--
+-- It returns 'NoSpaceLeft' only when the current mempool size is bigger or
+-- equal than then mempool capacity. Otherwise it will validate the transaction
+-- and add it to the mempool if there is at least one byte free on the mempool.
 pureTryAddTx
   :: ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
@@ -192,12 +196,10 @@ pureTryAddTx
      -- ^ The current internal state of the mempool.
   -> TryAddTx blk
 pureTryAddTx cfg txSize wti tx is
-  | let size    = txSize tx
-        curSize = msNumBytes  $ isMempoolSize is
-  , curSize + size > getMempoolCapacityBytes (isCapacity is)
-  = NoSpaceLeft
-  | otherwise
-  = case eVtx of
+  | let curSize = msNumBytes  $ isMempoolSize is
+  , curSize < getMempoolCapacityBytes (isCapacity is)
+  = -- We add the transaction if there is at least one byte free left in the mempool.
+  case eVtx of
       -- We only extended the ValidationResult with a single transaction
       -- ('tx'). So if it's not in 'vrInvalid', it must be in 'vrNewValid'.
       Right vtx ->
@@ -221,6 +223,8 @@ pureTryAddTx cfg txSize wti tx is
                err
                (isMempoolSize is)
               )
+  | otherwise
+  = NoSpaceLeft
     where
       (eVtx, vr) = extendVRNew cfg txSize wti tx $ validationResultFromIS is
       is'        = internalStateFromVR vr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -30,6 +30,7 @@ import           NoThunks.Class (NoThunks (..))
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadMVar
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM.Internal
 import           Control.Monad.Class.MonadThrow
@@ -146,6 +147,21 @@ instance MonadSTM m => MonadSTM (WithEarlyExit m) where
 
   newTMVarIO      = lift . newTMVarIO
   newEmptyTMVarIO = lift   newEmptyTMVarIO
+
+instance (MonadMVar m, MonadMask m, MonadEvaluate m)
+      => MonadMVar (WithEarlyExit m) where
+  type MVar (WithEarlyExit m) = MVar m
+
+  newEmptyMVar          = lift    newEmptyMVar
+  takeMVar              = lift .  takeMVar
+  putMVar               = lift .: putMVar
+  tryTakeMVar           = lift .  tryTakeMVar
+  tryPutMVar            = lift .: tryPutMVar
+  isEmptyMVar           = lift .  isEmptyMVar
+
+  newMVar               = lift .  newMVar
+  readMVar              = lift .  readMVar
+  swapMVar              = lift .: swapMVar
 
 instance MonadCatch m => MonadThrow (WithEarlyExit m) where
   throwIO = lift . throwIO

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -49,6 +49,7 @@ import qualified Cardano.Crypto.KES as KES
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadMVar
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime hiding (MonadTime (..))
@@ -64,6 +65,7 @@ import           Data.Functor (void)
 -------------------------------------------------------------------------------}
 
 class ( MonadAsync              m
+      , MonadMVar               m
       , MonadEventlog           m
       , MonadFork               m
       , MonadST                 m


### PR DESCRIPTION
A backport of #4436 starting from `ouroboros-consensus-0.1.0.3`, in case it's needed in a point release.

Note that this doesn't yet bump versions (i.e. to 0.1.0.4).