### PR TITLE
Bring back the separate step for deps in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,9 @@ jobs:
         key: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ steps.cache-keys.outputs.DIST_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ steps.cache-keys.outputs.weeknum }}
         restore-keys: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ steps.cache-keys.outputs.DIST_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
+    - name: Build dependencies
+      run: cabal build --only-dependencies all -j
+
     - name: Build projects [build]
       run: cabal build all -j
 


### PR DESCRIPTION
# Description

This step was deleted because of the dependency on `ouroboros-consensus` but as `cardano-client` no longer depends on it, we should be able to bring it back.
