### PR TITLE
Release ouroboros-network-0.6.0.0 and its dependencies

### DIFF
--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -32,7 +32,7 @@ library
                         si-timers,
                         strict-stm,
 
-                        network-mux                   >=0.3      && <0.4,
+                        network-mux                  ^>=0.4,
                         tdigest                      ^>=0.3,
                         text                          >=1.2.4    && <2.1,
 

--- a/monoidal-synchronisation/CHANGELOG.md
+++ b/monoidal-synchronisation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for monoidal-synchronisation
 
+## 0.1.0.3
+
+### Non-breaking changes
+
+* Use `io-classes-1.1`
+
+### Non-breaking changes
+
+* `ghc-9.4` and `ghc-9.6` compatibility.
+
 ## 0.1.0.2
 
 * Version compatible with `ghc-9.2`

--- a/monoidal-synchronisation/monoidal-synchronisation.cabal
+++ b/monoidal-synchronisation/monoidal-synchronisation.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   monoidal-synchronisation
-version:                0.1.0.2
+version:                0.1.0.3
 synopsis:               Monoidal synchronisation
 description:            Monoidal synchronisation.
 license:                Apache-2.0

--- a/network-mux/CHANGELOG.md
+++ b/network-mux/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Revision history for mux
 
-## Next version
+## 0.4.0.0 -- 2023-04-28
 
 ### Breaking
 
-* Renamed `MuxTraceShutdown` as `MuxTraceStopping`
+* Use `io-classes-1.1`.
+* Renamed `MuxTraceShutdown` as `MuxTraceStopping`.
 * Fixed a typo now the mux stopping exception carries message: `Mux stopping`.
+
 
 ## 0.3.0.0 -- 2023-01-25
 

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   network-mux
-version:                0.3.0.0
+version:                0.4.0.0
 synopsis:               Multiplexing library
 description:            Multiplexing library.
 license:                Apache-2.0

--- a/ntp-client/CHANGELOG.md
+++ b/ntp-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for ntp-client
 
-## 0.1.0.0 -- 2022-12-13
+## 0.0.1.1 -- 2023-04-28
+
+### Non-breaking changes
+
+* `ghc-9.4` and `ghc-9.6` compatiblity.
+
+## 0.0.1.0 -- 2022-12-13
 
 * Initial release

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   ntp-client
-version:                0.0.1
+version:                0.0.1.1
 synopsis:               NTP client
 description:            NTP client.
 license:                Apache-2.0

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for ouroboros-network-api
 
+## 0.3.0.0 -- 2023-04-28
+
+* Removed `encoddedTipSize` and `encodedPointSize`.
+* `HeaderHash` is kind polymorphic.
+
 ## 0.2.0.0 -- 2023-04-19
 
 ### Breaking

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                   ouroboros-network-api
-version:                0.2.0.0
+version:                0.3.0.0
 synopsis:               A networking api shared with ouroboros-consensus
 description:            A networking api shared with ouroboros-consensus.
 license:                Apache-2.0
@@ -65,7 +65,7 @@ library
                        contra-tracer,
 
                        io-classes       ^>=1.1,
-                       network-mux      ^>=0.3,
+                       network-mux      ^>=0.4,
                        strict-stm,
                        si-timers,
                        typed-protocols  ^>=0.1.0.4,

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Revision history for ouroboros-network-framework
 
-## next version
+## 0.5.0.0 -- 2023-04-28
 
-## 0.4.0.0 - 2023-04-19
+### Breaking changes
+
+* Use `io-classes-1.1`. 
+
+### Non-breaking changes
+
+* `ghc-9.4` and `ghc-9.6` compatibility.
+
+## 0.4.0.0 -- 2023-04-19
 
 ### Non breaking
 

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                   ouroboros-network-framework
-version:                0.4.0.0
+version:                0.5.0.0
 synopsis:               Ouroboros network framework
 description:            Ouroboros network framework.
 license:                Apache-2.0
@@ -86,15 +86,16 @@ library
                      , contra-tracer
 
                      , io-classes     ^>=1.1
-                     , monoidal-synchronisation
-                                       >=0.1   && < 0.2
-                     , network         >=3.1.2.2 && < 3.2
-                     , network-mux    ^>=0.3
-                     , ouroboros-network-api
-                                      ^>=0.2
-                     , ouroboros-network-testing
                      , si-timers
                      , strict-stm
+
+                     , monoidal-synchronisation
+                                      ^>=0.1.0.3
+                     , network         >=3.1.2.2 && < 3.2
+                     , network-mux    ^>=0.4
+                     , ouroboros-network-api
+                                      ^>=0.3
+                     , ouroboros-network-testing
                      , typed-protocols >=0.1   && < 0.2
                      , typed-protocols-cborg
                                       ^>=0.1

--- a/ouroboros-network-mock/CHANGELOG.md
+++ b/ouroboros-network-mock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for ouroboros-network-mock
 
+## 0.1.0.1 -- 2023-04-28
+
+###  Non-breaking changes
+
+* `ghc-9.4` and `ghc-9.6` compatibility.
+
 ## 0.1.0.0 -- 2022-11-17
 
 * Initial release

--- a/ouroboros-network-mock/ouroboros-network-mock.cabal
+++ b/ouroboros-network-mock/ouroboros-network-mock.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                   ouroboros-network-mock
-version:                0.1.0.0
+version:                0.1.0.1
 synopsis:               Ouroboros Network Chain for testing purposes
 description:            Ouroboros Network Chain for testing purposes.
 license:                Apache-2.0

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for ouroboros-network-protocols
 
+## 0.5.0.0 -- 2023-04-28
+
+### Breaking changes
+
+* `io-classes-1.1` support.
+
+### Non-breaking changes
+
+* `ghc-9.4` and `ghc-9.6` compatibility.
+
 ## 0.4.0.0 -- 2023-04-19
 
 - Release

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                   ouroboros-network-protocols
-version:                0.4.0.0
+version:                0.5.0.0
 synopsis:               Ouroboros Network Protocols
 description:            Ouroboros Network Protocols.
 license:                Apache-2.0
@@ -202,7 +202,7 @@ test-suite test
                        ouroboros-network-api,
                        ouroboros-network-mock,
                        ouroboros-network-protocols:testlib,
-                       ouroboros-network-testing
+                       ouroboros-network-testing ^>= 0.3
 
   ghc-options:         -Wall
                        -Wunused-packages

--- a/ouroboros-network-testing/CHANGELOG.md
+++ b/ouroboros-network-testing/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for ouroboros-network-testing
 
+## 0.3.0.0
+
+### Breaking changes
+
+* `io-classes-1.1` support.
+
+### Non-breaking changes
+
+* `ghc-9.4` and `ghc-9.6` compatibility.
+
 ## 0.2.0.1
 
 * Release a version compatible with `ghc-9.2`
@@ -13,7 +23,7 @@
 * `keydTimeout` does not ignore tail (PR #4086)
 * Added `Delay` constructor to `ScriptDelay`
 
-### Non breaking changes
+### Non-breaking changes
 
 * Added `Ouroboros.Network.Testing.Data.Signal.fromEventsWith` (PR #4086)
 * Added `NonFailingAbsBearerInfo` with its arbitrary instances and

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                   ouroboros-network-testing
-version:                0.2.0.1
+version:                0.3.0.0
 synopsis:               Common modules used for testing in ouroboros-network and ouroboros-consensus
 description:            Common modules used for testing in ouroboros-network and ouroboros-consensus.
 license:                Apache-2.0

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Revision history for ouroboros-network
 
-## next version
+## 0.6.0.0
+
+### Breaking changes
+
+* Use `io-classes-1.1`.
+
+### Non-breaking changes
+
+* `ghc-9.4` and `ghc-9.6` compatiblity.
 
 ## 0.5.0.0 -- 2023-04-19
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                   ouroboros-network
-version:                0.5.0.0
+version:                0.6.0.0
 synopsis:               A networking layer for the Ouroboros blockchain protocol
 description:            A networking layer for the Ouroboros blockchain protocol.
 license:                Apache-2.0
@@ -122,9 +122,9 @@ library
                        io-classes-mtl   ^>=0.1,
                        network-mux,
                        si-timers,
-                       ouroboros-network-api,
-                       ouroboros-network-framework ^>=0.4,
-                       ouroboros-network-protocols ^>=0.4,
+                       ouroboros-network-api       ^>=0.3,
+                       ouroboros-network-framework ^>=0.5,
+                       ouroboros-network-protocols ^>=0.5,
                        strict-stm,
                        typed-protocols   >=0.1.0.4 && <1.0,
   if !os(windows)
@@ -219,7 +219,7 @@ test-suite test
                        ouroboros-network-protocols,
                        ouroboros-network-protocols:testlib,
                        ouroboros-network-framework:testlib,
-                       ouroboros-network-testing,
+                       ouroboros-network-testing ^>= 0.3,
                        si-timers,
                        strict-stm,
                        typed-protocols,


### PR DESCRIPTION

# Description

* `ntp-client-0.0.1.1`
* `cardano-ping`: new revision
* `monoidal-synchronisation-0.1.0.3`
* `network-mux-0.4.0.0`
* `ouroboros-network-api-0.3.0.0`
* `ouroboros-network-framework-0.5.0.0`
* `ouroboros-network-mock-0.1.0.1`
* `ouroboros-network-protocols-0.5.0.0`
* `ouroboros-network-testing-0.3.0.0`
* `ouroboros-network-0.6.0.0`

`cardano-client` was bumped earlier to `0.2.0.0`, and also needs to be
released.

This PR is required by input-output-hk/ouroboros-consensus#50.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
