### PR TITLE
Use action for deploying haddocks

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -31,17 +31,17 @@ jobs:
       # FIXME: this is arguably a bug, and pkg-config should return the right values!
       LD_LIBRARY_PATH: '/usr/local/lib'
 
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
-    - uses: actions/checkout@v3
-
-    - uses: cachix/install-nix-action@v20
-
-    - name: Select build directory
-      run: |
-        CABAL_BUILDDIR="dist-newstyle"
-
-        echo "CABAL_BUILDDIR=$CABAL_BUILDDIR"
-        echo "CABAL_BUILDDIR=$CABAL_BUILDDIR" >> $GITHUB_ENV
+    - name: Checkout ouroboros-network repository
+      uses: actions/checkout@v3
 
     - name: Configure to use libsodium
       run: |
@@ -83,13 +83,10 @@ jobs:
     - name: Update Hackage index
       run: cabal update
 
-    - name: Checkout ouroboros-network repository
-      uses: actions/checkout@v3
-
-    - name: Build dependencies
+    - name: Build plan
       run: cabal --builddir="$CABAL_BUILDDIR" build --dry-run --enable-tests all
 
-    - name: build Haddock documentation 🔧
+    - name: Build Haddock documentation 🔧
       run: |
         mkdir ./haddocks
         ./scripts/haddocs.sh ./haddocks
@@ -108,13 +105,11 @@ jobs:
           done
         done
 
-    - name: deploy to gh-pages 🚀
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Upload artifacts
+      uses: actions/upload-pages-artifact@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./haddocks
-        keep_files: true  # to keep the consensus report
-        force_orphan: true  # to trim down the size of the branch
-        user_name: ${{ github.actor }}
-        user_email: 'marcin.szamotulski@iohk.io'
-        commit_message: ${{ github.event.head_commit.message }}
+        path: ./haddocks
+
+    - name: Deploy 🚀
+      id: deployment
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -29,7 +29,7 @@ jobs:
       # we need the LD_LIBRARY_PATH env var here because we ended up installing libsecp256k1 into /usr/local,
       # pkg-config, *does* return the proper location, but the library does not appear to be properly referenced.
       # FIXME: this is arguably a bug, and pkg-config should return the right values!
-      LD_LIBRARY_PATH: ${{ (matrix.os != 'windows-latest' && '/usr/local/lib') || '' }}
+      LD_LIBRARY_PATH: '/usr/local/lib'
 
     steps:
     - uses: actions/checkout@v3
@@ -50,25 +50,17 @@ jobs:
           flags: -external-libsodium-vrf
         EOF
 
-    - name: Workaround runner image issue
-      # https://github.com/actions/runner-images/issues/7061
-      run: sudo chown -R $USER /usr/local/.ghcup
-
     - name: Install Haskell
       uses: haskell/actions/setup@v2
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.6.2.0'
+        cabal-version: '3.10.1.0'
 
     - name: Install build environment
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get -y install libsodium23 libsodium-dev
-        sudo apt-get -y install libsystemd0 libsystemd-dev
-        sudo apt-get -y remove --purge software-properties-common
-        sudo apt-get -y autoremove
+        sudo apt-get -y install libsodium-dev
 
     - name: Install secp256k1
       uses: input-output-hk/setup-secp256k1@v1
@@ -89,18 +81,13 @@ jobs:
         restore-keys: cache-haddock-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-
 
     - name: Update Hackage index
-      run: cabal v2-update
+      run: cabal update
 
     - name: Checkout ouroboros-network repository
       uses: actions/checkout@v3
 
     - name: Build dependencies
-      run: cabal --builddir="$CABAL_BUILDDIR" configure --enable-tests
-
-    - name: Use cabal.project.local.github-pages
-      run: |
-        cat ./cabal.project.local.github-pages >> ./cabal.project.local
-        cat ./cabal.project.local
+      run: cabal --builddir="$CABAL_BUILDDIR" build --dry-run --enable-tests all
 
     - name: build Haddock documentation 🔧
       run: |
@@ -122,13 +109,12 @@ jobs:
         done
 
     - name: deploy to gh-pages 🚀
-      run: |
-        git config --local user.email "marcin.szamotulski@iohk.io"
-        git config --local user.name ${{ github.actor }}
-        git fetch origin gh-pages:gh-pages
-        git checkout gh-pages
-        cp -r ./haddocks/* ./
-        rm -rf haddocks
-        git add -A
-        git commit -m "Deployed haddocks" || true
-        git push https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git HEAD:gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./haddocks
+        keep_files: true  # to keep the consensus report
+        force_orphan: true  # to trim down the size of the branch
+        user_name: ${{ github.actor }}
+        user_email: 'marcin.szamotulski@iohk.io'
+        commit_message: ${{ github.event.head_commit.message }}

--- a/cabal.project.local.github-pages
+++ b/cabal.project.local.github-pages
@@ -1,4 +1,0 @@
-package cardano-crypto-praos
-  flags: -external-libsodium-vrf
-
-tests: False

--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -584,7 +584,7 @@ client protocol.
 \subsection{CDDL encoding specification ($\geq 11$)}\label{handshake-cddl}
 
 \subsubsection{Node to node handshake mini-protocol}
-\lstinputlisting[style=cddl]{../../ouroboros-network/test-cddl/specs/handshake-node-to-node-v11.cddl}
+\lstinputlisting[style=cddl]{../../ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v11.cddl}
 
 \section{Chain-Sync mini-protocol}
 \label{chain-sync-protocol}
@@ -1392,7 +1392,7 @@ function application all the way to diffusion and share the relevant parts of
 \texttt{PeerSelectionState} with this function via a \texttt{TVar}.
 
 \subsection{CDDL encoding specification}
-\lstinputlisting[style=cddl]{../../ouroboros-network/test-cddl/specs/peer-sharing.cddl}
+\lstinputlisting[style=cddl]{../../ouroboros-network-protocols/test-cddl/specs/peer-sharing.cddl}
 
 \section{Pipelining of Mini Protocols}
 \label{pipelining}


### PR DESCRIPTION
# Description

The github pages branch is quite big (in bytes):

```
❯ git rev-list --disk-usage --objects HEAD..origin/gh-pages
608733389
```

And the history is mostly useless. The implemented approach is the one [suggested by Github nowadays](https://github.com/actions/deploy-pages). Also took the opportunity to fix the network docs, see [this](https://github.com/input-output-hk/ouroboros-network/actions/runs/4866977561/jobs/8679075814#step:17:5318)

Note that this is also observed in every clone of the repository:
```
❯ time git clone git@github.com:input-output-hk/ouroboros-network network 
Cloning into 'network'...
remote: Enumerating objects: 271897, done.
remote: Counting objects: 100% (6115/6115), done.
remote: Compressing objects: 100% (1058/1058), done.
remote: Total 271897 (delta 4998), reused 5786 (delta 4786), pack-reused 265782
Receiving objects: 100% (271897/271897), 619.25 MiB | 8.46 MiB/s, done.
Resolving deltas: 100% (206772/206772), done.
git clone git@github.com:input-output-hk/ouroboros-network network  59,39s user 2,67s system 71% cpu 1:26,88 total
```
