### PR TITLE
Bump versions

### DIFF
--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for cardano-ping
 
+## 0.2.0.0 -- 2023-05-08
+
+* Support for `NodeToNodeV_12` and `NodeToClientV_16`, e.g. support for
+  querying `NodeToNodeVersionData` / `NodeToClientVersionData`.
+* Support `NodeToNodeV_11` and `NodeToClientV_15` (peer sharing).
+
 ## 0.1.0.0 -- 2022-12-14
 
 * This code was originally from the cardano-ping executable component of the `network-mux` package.

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -1,7 +1,6 @@
-cabal-version: 3.0
-
+cabal-version:          3.0
 name:                   cardano-ping
-version:                0.1.0.1
+version:                0.2.0.0
 synopsis:               Utility for pinging cardano nodes
 description:            Utility for pinging cardano nodes.
 license:                Apache-2.0

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Revision history for ouroboros-network-api
 
+## 0.4.0.0 -- 2023-05-08
+
+### Breakin changes
+
+* Added `NodeToNodeV_12` and `NodeToClientV_16` which support handshake query.
+* Added `query` flag to `NodeToClientVersionData` and `NodeToNodeVersionData`.
+* Introduced `HandshakeCallbacks` record.
+
+### Non-breaking changes
+
+* Added `Querable` type class.
+
 ## 0.3.0.0 -- 2023-04-28
 
 * Removed `encoddedTipSize` and `encodedPointSize`.

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -1,7 +1,6 @@
-cabal-version:       3.0
-
+cabal-version:          3.0
 name:                   ouroboros-network-api
-version:                0.3.0.0
+version:                0.4.0.0
 synopsis:               A networking api shared with ouroboros-consensus
 description:            A networking api shared with ouroboros-consensus.
 license:                Apache-2.0

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -54,6 +54,9 @@ data NodeToNodeVersion
     --   This version is needed to support the new  Peer Sharing miniprotocol
     --   older versions that are negotiated will appear as not participating
     --   in Peer Sharing to newer versions.
+    | NodeToNodeV_12
+    -- ^ Changes:
+    --
     -- * Adds `query` to NodeToClientVersionData.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
@@ -65,12 +68,14 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     encodeTerm NodeToNodeV_9  = CBOR.TInt 9
     encodeTerm NodeToNodeV_10 = CBOR.TInt 10
     encodeTerm NodeToNodeV_11 = CBOR.TInt 11
+    encodeTerm NodeToNodeV_12 = CBOR.TInt 12
 
     decodeTerm (CBOR.TInt 7) = Right NodeToNodeV_7
     decodeTerm (CBOR.TInt 8) = Right NodeToNodeV_8
     decodeTerm (CBOR.TInt 9) = Right NodeToNodeV_9
     decodeTerm (CBOR.TInt 10) = Right NodeToNodeV_10
     decodeTerm (CBOR.TInt 11) = Right NodeToNodeV_11
+    decodeTerm (CBOR.TInt 12) = Right NodeToNodeV_12
     decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
                                         <> T.pack (show n)
                                     , Just n
@@ -135,7 +140,7 @@ instance Queryable NodeToNodeVersionData where
 
 nodeToNodeCodecCBORTerm :: NodeToNodeVersion -> CodecCBORTerm Text NodeToNodeVersionData
 nodeToNodeCodecCBORTerm version
-  | version >= NodeToNodeV_11 =
+  | version >= NodeToNodeV_12 =
     let encodeTerm :: NodeToNodeVersionData -> CBOR.Term
         encodeTerm NodeToNodeVersionData { networkMagic, diffusionMode, peerSharing, query }
           = CBOR.TList $
@@ -168,6 +173,46 @@ nodeToNodeCodecCBORTerm version
                                   2 -> PeerSharingPublic
                                   _ -> error "decodeTerm: impossible happened!",
                   query = query
+                }
+          | x < 0 || x > 0xffffffff
+          = Left $ T.pack $ "networkMagic out of bound: " <> show x
+          | otherwise -- peerSharing < 0 || peerSharing > 2
+          = Left $ T.pack $ "peerSharing out of bound: " <> show peerSharing
+        decodeTerm _ t
+          = Left $ T.pack $ "unknown encoding: " ++ show t
+     in CodecCBORTerm {encodeTerm, decodeTerm = decodeTerm version }
+  | version >= NodeToNodeV_11 =
+    let encodeTerm :: NodeToNodeVersionData -> CBOR.Term
+        encodeTerm NodeToNodeVersionData { networkMagic, diffusionMode, peerSharing }
+          = CBOR.TList $
+              [ CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
+              , CBOR.TBool (case diffusionMode of
+                             InitiatorOnlyDiffusionMode         -> True
+                             InitiatorAndResponderDiffusionMode -> False)
+              , CBOR.TInt (case peerSharing of
+                             NoPeerSharing      -> 0
+                             PeerSharingPrivate -> 1
+                             PeerSharingPublic  -> 2)
+              ]
+
+        decodeTerm :: NodeToNodeVersion -> CBOR.Term -> Either Text NodeToNodeVersionData
+        decodeTerm _ (CBOR.TList [CBOR.TInt x, CBOR.TBool diffusionMode, CBOR.TInt peerSharing])
+          | x >= 0
+          , x <= 0xffffffff
+          , peerSharing >= 0
+          , peerSharing <= 2
+          = Right
+              NodeToNodeVersionData {
+                  networkMagic = NetworkMagic (fromIntegral x),
+                  diffusionMode = if diffusionMode
+                                  then InitiatorOnlyDiffusionMode
+                                  else InitiatorAndResponderDiffusionMode,
+                  peerSharing = case peerSharing of
+                                  0 -> NoPeerSharing
+                                  1 -> PeerSharingPrivate
+                                  2 -> PeerSharingPublic
+                                  _ -> error "decodeTerm: impossible happened!",
+                  query = False
                 }
           | x < 0 || x > 0xffffffff
           = Left $ T.pack $ "networkMagic out of bound: " <> show x

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Revision history for ouroboros-network-framework
 
+## 0.6.0.0 -- 2023-05-08
+
+### Breaking changes
+
+* Handshake support for querying:
+  * Use `ouroboros-network-api-0.4.0.0`
+  * Added `haQueryVersion` to `HandshakeArguments`
+  * `handshakeServerPeer` recieves extra argument `vData -> Bool`
+  * Added `MsgQueryReply` to `Handshake` mini-protocol.
+  * Added `Ouroboros.Network.Protocol.Handshake.Client.handshakeCleintPeerTestVersions`
+  * Added `HandshakeResult` and `HandshakeException` types.
+
+### Non-breaking changes
+
 ## 0.5.0.0 -- 2023-04-28
 
 ### Breaking changes

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -1,7 +1,6 @@
-cabal-version:       3.0
-
+cabal-version:          3.0
 name:                   ouroboros-network-framework
-version:                0.5.0.0
+version:                0.6.0.0
 synopsis:               Ouroboros network framework
 description:            Ouroboros network framework.
 license:                Apache-2.0
@@ -94,7 +93,7 @@ library
                      , network         >=3.1.2.2 && < 3.2
                      , network-mux    ^>=0.4
                      , ouroboros-network-api
-                                      ^>=0.3
+                                      ^>=0.4
                      , ouroboros-network-testing
                      , typed-protocols >=0.1   && < 0.2
                      , typed-protocols-cborg

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ouroboros-network-protocols
 
+## 0.5.0.1 -- 2023-05-08
+
+* Updated to newer version of `ouroboros-network-api`.
+
 ## 0.5.0.0 -- 2023-04-28
 
 ### Breaking changes

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -1,7 +1,6 @@
-cabal-version:       3.0
-
+cabal-version:          3.0
 name:                   ouroboros-network-protocols
-version:                0.5.0.0
+version:                0.5.0.1
 synopsis:               Ouroboros Network Protocols
 description:            Ouroboros Network Protocols.
 license:                Apache-2.0

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
@@ -20,18 +20,18 @@ versionTable = { * oldVersionNumber => oldNodeToClientVersionData
                }
 
 
-; Version 15 introduces the version query flag
+; Version 16 introduces the version query flag
 ; as of version 2 (which is no longer supported) we set 15th bit to 1
-;               15
-versionNumber = 32783
+;               16
+versionNumber = 32784
 
 ; as of version 2 (which is no longer supported) we set 15th bit to 1
-;                  9     / 10    / 11    / 12    / 13    / 14
-oldVersionNumber = 32777 / 32778 / 32779 / 32780 / 32781 / 32782
+;                  9     / 10    / 11    / 12    / 13    / 14    / 15
+oldVersionNumber = 32777 / 32778 / 32779 / 32780 / 32781 / 32782 / 32783
 
 anyVersionNumber = versionNumber / oldVersionNumber
 
-; As of version 15
+; As of version 16
 nodeToClientVersionData = [networkMagic, query]
 
 oldNodeToClientVersionData = networkMagic

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v11.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v11.cddl
@@ -6,25 +6,22 @@ handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
-    / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
 msgAcceptVersion   = [1, versionNumber, nodeToNodeVersionData]
 msgRefuse          = [2, refuseReason]
-msgQueryReply      = [3, versionTable]
 
 versionTable = { * versionNumber => nodeToNodeVersionData }
 
 versionNumber = 11
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing, query ]
+nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
 initiatorAndResponderDiffusionMode = bool
 ; range between 0 and 2
 peerSharing = 0..2
-query = bool
 
 refuseReason
     = refuseReasonVersionMismatch
@@ -34,4 +31,5 @@ refuseReason
 refuseReasonVersionMismatch      = [0, [ *versionNumber ] ]
 refuseReasonHandshakeDecodeError = [1, versionNumber, tstr]
 refuseReasonRefused              = [2, versionNumber, tstr]
+
 

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v12.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v12.cddl
@@ -1,25 +1,30 @@
 ;
-; NodeToNode Handshake, v7 to v10
+; NodeToNode Handshake, v12
 ;
 
 handshakeMessage
     = msgProposeVersions
     / msgAcceptVersion
     / msgRefuse
+    / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
 msgAcceptVersion   = [1, versionNumber, nodeToNodeVersionData]
 msgRefuse          = [2, refuseReason]
+msgQueryReply      = [3, versionTable]
 
 versionTable = { * versionNumber => nodeToNodeVersionData }
 
-versionNumber = 7 / 8 / 9 / 10
+versionNumber = 12
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
+nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing, query ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
 initiatorAndResponderDiffusionMode = bool
+; range between 0 and 2
+peerSharing = 0..2
+query = bool
 
 refuseReason
     = refuseReasonVersionMismatch
@@ -29,3 +34,4 @@ refuseReason
 refuseReasonVersionMismatch      = [0, [ *versionNumber ] ]
 refuseReasonHandshakeDecodeError = [1, versionNumber, tstr]
 refuseReasonRefused              = [2, versionNumber, tstr]
+

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -834,7 +834,7 @@ prop_query_version_NodeToNode_ST
                     (cborTermVersionDataCodec (fmap transformNodeToNodeVersionData nodeToNodeCodecCBORTerm))
                     clientVersions
                     serverVersions
-                    (>= NodeToNodeV_11)
+                    (>= NodeToNodeV_12)
                     (\(ArbitraryNodeToNodeVersionData vd) -> ArbitraryNodeToNodeVersionData $ vd {NTN.query = True})
 
 -- | Run 'prop_query_version' in the IO monad.
@@ -851,7 +851,7 @@ prop_query_version_NodeToNode_IO
                     (cborTermVersionDataCodec (fmap transformNodeToNodeVersionData nodeToNodeCodecCBORTerm))
                     clientVersions
                     serverVersions
-                    (>= NodeToNodeV_11)
+                    (>= NodeToNodeV_12)
                     (\(ArbitraryNodeToNodeVersionData vd) -> ArbitraryNodeToNodeVersionData $ vd {NTN.query = True})
 
 -- | Run 'prop_query_version' with SimNet.
@@ -868,7 +868,7 @@ prop_query_version_NodeToNode_SimNet
                     (cborTermVersionDataCodec (fmap transformNodeToNodeVersionData nodeToNodeCodecCBORTerm))
                     clientVersions
                     serverVersions
-                    (>= NodeToNodeV_11)
+                    (>= NodeToNodeV_12)
                     (\(ArbitraryNodeToNodeVersionData vd) -> ArbitraryNodeToNodeVersionData $ vd {NTN.query = True})
 
 -- | Run 'prop_query_version' in the simulation monad.
@@ -885,7 +885,7 @@ prop_query_version_NodeToClient_ST
                     (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
                     clientVersions
                     serverVersions
-                    (>= NodeToClientV_15)
+                    (>= NodeToClientV_16)
                     (\vd -> vd {NTC.query = True})
 
 -- | Run 'prop_query_version' in the IO monad.
@@ -902,7 +902,7 @@ prop_query_version_NodeToClient_IO
                     (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
                     clientVersions
                     serverVersions
-                    (>= NodeToClientV_15)
+                    (>= NodeToClientV_16)
                     (\vd -> vd {NTC.query = True})
 
 -- | Run 'prop_query_version' with SimNet.
@@ -919,7 +919,7 @@ prop_query_version_NodeToClient_SimNet
                     (cborTermVersionDataCodec nodeToClientCodecCBORTerm)
                     clientVersions
                     serverVersions
-                    (>= NodeToClientV_15)
+                    (>= NodeToClientV_16)
                     (\vd -> vd {NTC.query = True})
 
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Revision history for ouroboros-network
 
-## next version
+## 0.7.0.0
 
 ### Breaking changes
 
 * Added `DiffusionError` constructor of `Ouroboros.Network.Diffusion.Failure` which kind is now `Type`.
+
+### Non-breaking changes
+
+* Compatible with `ouroboros-network-framework-0.6.0.0` and
+  `ouroboros-network-api-0.4.0.0`
 
 ## 0.6.0.0
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -1,7 +1,6 @@
-cabal-version:       3.0
-
+cabal-version:          3.0
 name:                   ouroboros-network
-version:                0.6.0.0
+version:                0.7.0.0
 synopsis:               A networking layer for the Ouroboros blockchain protocol
 description:            A networking layer for the Ouroboros blockchain protocol.
 license:                Apache-2.0
@@ -122,9 +121,9 @@ library
                        io-classes-mtl   ^>=0.1,
                        network-mux,
                        si-timers,
-                       ouroboros-network-api       ^>=0.3,
-                       ouroboros-network-framework ^>=0.5,
-                       ouroboros-network-protocols ^>=0.5,
+                       ouroboros-network-api       ^>=0.4,
+                       ouroboros-network-framework ^>=0.6,
+                       ouroboros-network-protocols ^>=0.5.0.1,
                        strict-stm,
                        typed-protocols   >=0.1.0.4 && <1.0,
   if !os(windows)


### PR DESCRIPTION
* `ouroboros-network-api-0.4.0.0`
* `ouroboros-network-framework-0.6.0.0`
* `ouroboros-network-protocols-0.5.0.0`
* `ouroboros-network-0.7.0.0`
* `cardano-ping-0.2.0.0`
