### PR TITLE
Install nix in CI to build the spec docs

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -35,6 +35,10 @@ jobs:
     - name: Checkout ouroboros-network repository
       uses: actions/checkout@v3
 
+      # we need nix to later build the spec documents
+    - name: Install Nix
+      uses: cachix/install-nix-action@v20
+
     - name: Install Haskell
       uses: haskell/actions/setup@v2
       id: setup-haskell


### PR DESCRIPTION
# Description

I accidentally removed Nix, and [the build job](https://github.com/input-output-hk/ouroboros-network/actions/runs/4942509759/jobs/8843276426#step:8:17) didn't fail so this went unnoticed.

