### PR TITLE
[DO NOT MERGE]: Use iog-contra-tracer instead of contra-tracer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,9 +16,9 @@ repository cardano-haskell-packages
 index-state: 2023-03-29T00:00:00Z
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-04-26T13:39:43Z
+  , hackage.haskell.org 2023-05-04T00:55:55Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-04-26T13:43:33Z
+  , cardano-haskell-packages 2023-05-12T08:34:58Z
 
 packages: ./cardano-ping
           ./monoidal-synchronisation

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -25,7 +25,7 @@ library
                         aeson                         >=2.1.1.0  && <3,
                         cborg                         >=0.2.8    && <0.3,
                         bytestring                    >=0.10     && <0.12,
-                        contra-tracer                 >=0.1      && <0.2,
+                        iog-contra-tracer,
 
                         io-classes                   ^>=1.1,
                         si-timers,

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -48,7 +48,7 @@ library
                        io-classes     ^>=1.1,
                        strict-stm,
                        si-timers,
-                       contra-tracer   >=0.1 && <0.2,
+                       iog-contra-tracer,
                        monoidal-synchronisation
                                        >=0.1 && <0.2,
 
@@ -129,7 +129,7 @@ test-suite test
                        si-timers,
                        strict-stm,
                        io-sim,
-                       contra-tracer,
+                       iog-contra-tracer,
                        network-mux,
                        Win32-network,
 
@@ -170,7 +170,7 @@ executable mux-demo
   build-depends:       base >=4.14 && <4.19,
                        network-mux,
                        io-classes,
-                       contra-tracer,
+                       iog-contra-tracer,
                        stm,
 
                        bytestring,

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -27,7 +27,7 @@ library
                       , base            >=4.14 && <4.19
                       , binary          >=0.8 && <0.11
                       , bytestring      >=0.10 && <0.12
-                      , contra-tracer   >=0.1 && <0.2
+                      , iog-contra-tracer
                       , network         >= 3.1.2 && <3.2
                       , stm             >=2.4 && <2.6
                       , time            >=1.9.1 && <1.14
@@ -69,7 +69,7 @@ executable demo-ntp-client
      buildable: False
   build-depends:        async           >=2.2 && <2.3
                       , base            >=4.14 && <4.19
-                      , contra-tracer   >=0.1 && <0.2
+                      , iog-contra-tracer
                       , Win32-network   >=0.1 && <0.2
                       , ntp-client
   default-language:   Haskell2010

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -63,7 +63,7 @@ library
 
                        cardano-slotting,
                        cardano-strict-containers,
-                       contra-tracer,
+                       iog-contra-tracer,
 
                        io-classes       ^>=1.1,
                        network-mux      ^>=0.4,

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -82,7 +82,7 @@ library
                      , quiet
 
                      , cardano-prelude
-                     , contra-tracer
+                     , iog-contra-tracer
 
                      , io-classes     ^>=1.1
                      , si-timers
@@ -176,7 +176,7 @@ test-suite test
                      , tasty
                      , tasty-quickcheck
 
-                     , contra-tracer
+                     , iog-contra-tracer
 
                      , io-sim
                      , io-classes
@@ -221,7 +221,7 @@ executable demo-ping-pong
                        bytestring,
                        directory,
 
-                       contra-tracer,
+                       iog-contra-tracer,
 
                        ouroboros-network-api,
                        ouroboros-network-framework,
@@ -249,7 +249,7 @@ executable demo-connection-manager
                        optparse-applicative,
                        random,
 
-                       contra-tracer,
+                       iog-contra-tracer,
 
                        io-classes,
                        network-mux,

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -168,7 +168,7 @@ library testlib
                        tasty-quickcheck,
                        text,
 
-                       contra-tracer,
+                       iog-contra-tracer,
 
                        io-classes,
                        io-sim,

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -60,7 +60,7 @@ library
                        TypeInType
   build-depends:       base              >=4.14 && <4.19,
                        containers,
-                       contra-tracer,
+                       iog-contra-tracer,
                        deque            ^>=0.4,
                        io-classes       ^>=1.1,
                        io-sim,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -114,7 +114,7 @@ library
                        cardano-prelude,
                        cardano-slotting,
                        cardano-strict-containers,
-                       contra-tracer,
+                       iog-contra-tracer,
                        monoidal-synchronisation,
 
                        io-classes       ^>=1.1,
@@ -204,7 +204,7 @@ test-suite test
 
                        cardano-prelude,
                        cardano-slotting,
-                       contra-tracer,
+                       iog-contra-tracer,
                        nothunks,
 
                        io-classes,
@@ -249,7 +249,7 @@ executable demo-chain-sync
                        serialise,
                        stm,
 
-                       contra-tracer,
+                       iog-contra-tracer,
 
                        typed-protocols,
                        ouroboros-network-api,


### PR DESCRIPTION
This takes the commit that provided the `0.5.0.1` release to CHaP and replaces `contra-tracer` with `iog-contra-tracer`.

The problem is that both Hackage and CHaP have packages named `contra-tracer` which unfortunately are incompatible.