### PR TITLE
Dependency wrangling

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -52,5 +52,5 @@ package ouroboros-network
 
 if impl(ghc >= 9.6)
   allow-newer:
-    , *:base
+    -- https://github.com/protolude/protolude/pull/143
     , protolude:*

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -34,7 +34,7 @@ library
                         network-mux                  ^>=0.4,
                         tdigest                      ^>=0.3,
                         text                          >=1.2.4    && <2.1,
-                        transformers                  >=0.5      && <0.6,
+                        transformers                  >=0.5      && <0.7,
 
                         -- The Windows version of network-3.1.2 is missing
                         -- functions, see


### PR DESCRIPTION
* Allow `transformers == 0.6.*`.
* Drop `*:base` from ghc-9.6 `allow-newer` stanza.
