### PR TITLE
Initialise local root peers result

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -116,7 +116,10 @@ localRootPeersProvider tracer
                        }
                        readLocalRootPeers
                        rootPeersGroupVar =
-    atomically readLocalRootPeers >>= loop
+        atomically (do domainsGroups <- readLocalRootPeers
+                       writeTVar rootPeersGroupVar (getLocalRootPeersGroups Map.empty domainsGroups)
+                       return domainsGroups)
+    >>= loop
   where
     -- | Loop function that monitors DNS Domain resolution threads and restarts
     -- if either these threads fail or detects the local configuration changed.


### PR DESCRIPTION
This patch fixes a bug where results `TVar` was never initialised if all
local root peers were provided with their IP addresses, and thus the
node didn't try to connect to any of its local root peers.

We add `LocalRootPeersResult` to `TestTraceEvent` which is used to track
values committed to the `TVar` which holds local root peers with
resolved dns names.  It is more robust to use `traceTVarIO` than to
relay on `TraceLocalRootPeers` events, as  we can force the latter to be
traced even if there's no dns name to be resolved.  This captures the
case where local root peers contains only IP addresses.
