### PR TITLE
coot/ping v11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,15 +31,28 @@ jobs:
         shell: bash
 
     steps:
+    - name: Install dependencies
+      run: sudo apt install -y fd-find
+
     - uses: actions/checkout@v3
+
+    - name: git fetch
+      run: git fetch origin master:master
+
     - name: Check changelogs
       run: ./scripts/ci/check-changelogs.sh
 
   check-cabal-files:
     name: Check cabal files
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
     steps:
+    - name: Install dependencies
+      run: sudo apt install -y fd-find
+
     - name: Install Haskell
       uses: input-output-hk/setup-haskell@v1
       id: setup-haskell

--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for cardano-ping
 
+## 0.2.0.2 -- 2023-06-08
+
+* Support `NodeToNodeV_11` and `NodeToClientV_16`.
+* Fix delay/timeout bugs (miliseconds were used instead of seconds).
+* Print query even if --quiet flag is given.
+* Instead of a boolean flag print `InitiatorOnly` or `InitiatorAndResponder`.
+* Fixed encoding of `NodeToNodeV_11`.
+
+
 ## 0.2.0.1 -- 2023-05-26
 
 * Support `ghc-9.6`.

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -28,8 +28,7 @@ library
                         bytestring                    >=0.10     && <0.12,
                         contra-tracer                 >=0.1      && <0.2,
 
-                        io-classes                   ^>=1.1,
-                        si-timers,
+                        si-timers                    ^>=1.1,
                         strict-stm,
 
                         network-mux                  ^>=0.4,

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   cardano-ping
-version:                0.2.0.1
+version:                0.2.0.2
 synopsis:               Utility for pinging cardano nodes
 description:            Utility for pinging cardano nodes.
 license:                Apache-2.0

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -107,6 +107,7 @@ supportedNodeToNodeVersions magic =
   , NodeToNodeVersionV9  magic InitiatorOnly
   , NodeToNodeVersionV10 magic InitiatorOnly
   , NodeToNodeVersionV11 magic InitiatorOnly
+  , NodeToNodeVersionV12 magic InitiatorOnly
   ]
 
 supportedNodeToClientVersions :: Word32 -> [NodeVersion]
@@ -118,6 +119,7 @@ supportedNodeToClientVersions magic =
   , NodeToClientVersionV13 magic
   , NodeToClientVersionV14 magic
   , NodeToClientVersionV15 magic
+  , NodeToClientVersionV16 magic
   ]
 
 data InitiatorOnly = InitiatorOnly | InitiatorAndResponder

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -472,7 +472,7 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount, pi
           Left err ->
             eprint $ printf "%s Version negotiation error %s\n" peerStr err
           Right version -> do
-            unless pingOptsQuiet $ printf "%s Negotiated version %s\n" peerStr (show version)
+            unless (pingOptsQuiet || pingOptsHandshakeQuery) $ printf "%s Negotiated version %s\n" peerStr (show version)
             unless pingOptsHandshakeQuery $ do
               keepAlive bearer timeoutfn peerStr version (tdigest []) 0
               -- send terminating message

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -240,6 +240,7 @@ handshakeReqEnc versions query =
        <> CBOR.encodeInt (fromIntegral magic)
        <> CBOR.encodeBool mode
        <> CBOR.encodeInt 0 -- NoPeerSharing
+       <> CBOR.encodeBool query
       | otherwise =
           CBOR.encodeWord vn
       <>  CBOR.encodeListLen 2

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -467,7 +467,7 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount, pi
       Left err -> eprint $ printf "%s Decoding error %s" peerStr (show err)
       Right (_, Left err) -> eprint $ printf "%s Protocol error %s" peerStr (show err)
       Right (_, Right recVersions) -> do
-        when (pingOptsHandshakeQuery && not pingOptsQuiet) $ printf "%s Queried versions %s\n" peerStr (show recVersions)
+        when pingOptsHandshakeQuery $ printf "%s Queried versions %s\n" peerStr (show recVersions)
         case acceptVersions recVersions of
           Left err ->
             eprint $ printf "%s Version negotiation error %s\n" peerStr err

--- a/scripts/ci/check-cabal-files.sh
+++ b/scripts/ci/check-cabal-files.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-for x in $(fd -e cabal); do
+FD="$(which fdfind 2>/dev/null || which fd 2>/dev/null)"
+
+set -eo pipefail
+
+for x in $($FD -e cabal); do
   (
     d=$(dirname $x)
     echo "== $d =="

--- a/scripts/ci/check-changelogs.sh
+++ b/scripts/ci/check-changelogs.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 
+FD="$(which fdfind 2>/dev/null || which fd 2>/dev/null)"
+
 set -eo pipefail
 
 function check_project () {
   project=$1
   n=$()
-  if [[ -n $(git diff --name-only master..HEAD -- $project) ]];then
-    if [[ -z $(git diff --name-only master..HEAD -- $project/CHANGELOG.md) ]]; then
+  if [[ -n $(git diff --name-only origin/master..HEAD -- $project) ]];then
+    if [[ -z $(git diff --name-only origin/master..HEAD -- $project/CHANGELOG.md) ]]; then
       echo "$project was modified but its CHANGELOG was not updated"
       exit 1
     fi
   fi
 }
 
-for cbl in $(fd -e 'cabal'); do
+for cbl in $($FD -e 'cabal'); do
   check_project $(dirname $cbl)
 done


### PR DESCRIPTION
- cardano-ping: fixed encoding of NodeToNodeV_11
- cardano-ping: introduce InitiatorOnly type
- cardano-ping: added new supported versions
- cardano-ping: print query even if --quiet is given
- cardano-ping-0.2.0.2
