### PR TITLE
dns: limit concurrency when resolving dns names

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 * Support for decoding Handshake Query Reply in wireshark dissector.
 * Support for decoding CBOR payload in wireshark dissector.
+* Limit concurrency used by dns resolution.  We only resolve up to 8 dns names
+  concurrently for public / ledger peers and up to 2 for local root peers.
+  This will affect how quickly node connects to ledger peers when it starts.
 
 ## 0.8.1.1
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Simple.hs
@@ -55,6 +55,7 @@ withPeerSelectionActions
   => Tracer m (TraceLocalRootPeers peeraddr exception)
   -> Tracer m TracePublicRootPeers
   -> (IP -> Socket.PortNumber -> peeraddr)
+  -> DNSSemaphore m
   -> DNSActions resolver exception m
   -> STM m PeerSelectionTargets
   -> STM m [(Int, Map RelayAccessPoint PeerAdvertise)]
@@ -81,6 +82,7 @@ withPeerSelectionActions
   localRootTracer
   publicRootTracer
   toPeerAddr
+  dnsSemaphore
   dnsActions
   readTargets
   readLocalRootPeers
@@ -143,6 +145,7 @@ withPeerSelectionActions
     requestConfiguredRootPeers n =
       publicRootPeersProvider publicRootTracer
                               toPeerAddr
+                              dnsSemaphore
                               DNS.defaultResolvConf
                               readPublicRootPeers
                               dnsActions

--- a/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -85,7 +85,7 @@ import           Ouroboros.Network.PeerSelection.PeerMetric
                      (PeerMetricsConfiguration (..), newPeerMetric)
 import           Ouroboros.Network.PeerSelection.RootPeersDNS
                      (DomainAccessPoint (..), LookupReqs (..),
-                     RelayAccessPoint (..))
+                     RelayAccessPoint (..), newLocalAndPublicRootDNSSemaphore)
 import           Ouroboros.Network.Protocol.Handshake (HandshakeArguments (..))
 import           Ouroboros.Network.Protocol.Handshake.Codec
                      (VersionDataCodec (..), noTimeLimitsHandshake,
@@ -199,6 +199,7 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
       $ \ nodeKernel nodeKernelThread -> do
         dnsTimeoutScriptVar <- LazySTM.newTVarIO (aDNSTimeoutScript na)
         dnsLookupDelayScriptVar <- LazySTM.newTVarIO (aDNSLookupDelayScript na)
+        dnsSemaphore <- newLocalAndPublicRootDNSSemaphore
         peerMetrics <- newPeerMetric PeerMetricsConfiguration { maxEntriesToTrack = 180 }
 
         peerSharingRegistry <- PeerSharingRegistry <$> newTVarIO mempty
@@ -249,6 +250,7 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
                                                      (iDomainMap ni)
                                                      dnsTimeoutScriptVar
                                                      dnsLookupDelayScriptVar)
+              , Diff.P2P.diLocalAndPublicRootDnsSemaphore = dnsSemaphore
               }
 
             appsExtra :: Diff.P2P.ApplicationsExtra NtNAddr m ()

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -2255,10 +2255,12 @@ _governorFindingPublicRoots :: Int
                             -> STM IO (Map RelayAccessPoint PeerAdvertise)
                             -> PeerSharing
                             -> IO Void
-_governorFindingPublicRoots targetNumberOfRootPeers readDomains peerSharing =
+_governorFindingPublicRoots targetNumberOfRootPeers readDomains peerSharing = do
+    dnsSemaphore <- newLocalAndPublicRootDNSSemaphore
     publicRootPeersProvider
       tracer
       (curry IP.toSockAddr)
+      dnsSemaphore
       DNS.defaultResolvConf
       readDomains
       (ioDNSActions LookupReqAAndAAAA) $ \requestPublicRootPeers -> do


### PR DESCRIPTION
We use two semaphores.  One to limit concurrency of dns name resolution of local root peers to at most `2`; and another one to limit concurrency for public & ledger peers to at most `8`.