### PR TITLE
cardano-client: use non experimental versions of node-to-client protocol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       uses: input-output-hk/setup-haskell@v1
       id: setup-haskell
       with:
-        cabal-version: "3.8.1.0"
+        cabal-version: "3.10.1.0"
 
     - uses: actions/checkout@v3
 

--- a/cabal.project
+++ b/cabal.project
@@ -103,7 +103,7 @@ constraints:
   , measures >= 0.1.0.0
   , orphans-deriving-via >= 0.1.0.0
   , strict-containers >= 0.1.0.0
-  , plutus-core >= 1.0.0.1
+  , plutus-core >= 1.1.1.0
   , plutus-ledger-api >= 1.0.0.1
   , plutus-tx >= 1.0.0.0
   , plutus-tx-plugin >= 1.0.0.0
@@ -138,6 +138,8 @@ constraints:
   , small-steps ^>= 0.1.1.1
   , small-steps-test ^>= 0.1.1.1
   , vector-map ^>= 0.1.1.1
+
+  , hedgehog < 1.3
 
 allow-newer:
     Unique:hashable

--- a/cardano-client/CHANGELOG.md
+++ b/cardano-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-client
 
+## 0.1.0.3 -- 2023-06-30
+
+* Only use non-experimental `node-to-client` protocol versions.
+
 ## 0.1.0.2 -- 2023-01-25
 
 * Update dependencies after repository restructure

--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-client
-version:                0.1.0.2
+version:                0.1.0.3
 synopsis:               An API for ouroboros-network
 description:            An API for ouroboros-network.
 license:                Apache-2.0

--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -50,7 +50,8 @@ import           Ouroboros.Consensus.Network.NodeToClient (ClientCodecs,
                      cChainSyncCodec, cStateQueryCodec, cTxSubmissionCodec,
                      clientCodecs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                     (BlockNodeToClientVersion, supportedNodeToClientVersions)
+                     (BlockNodeToClientVersion, latestReleasedNodeVersion,
+                     supportedNodeToClientVersions)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 
 subscribe ::
@@ -97,8 +98,10 @@ versionedProtocols ::
        NodeToClientVersionData
        (OuroborosApplication appType LocalAddress bytes m a b)
 versionedProtocols codecConfig networkMagic callback =
-    foldMapVersions applyVersion $
-      Map.toList $ supportedNodeToClientVersions (Proxy @blk)
+      foldMapVersions applyVersion
+    . filter (\(v, _) -> Just v <= snd (latestReleasedNodeVersion (Proxy @blk)))
+    . Map.toList
+    $ supportedNodeToClientVersions (Proxy @blk)
   where
     applyVersion ::
          (NodeToClientVersion, BlockNodeToClientVersion blk)

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -100,6 +100,7 @@ library
                      , optparse-applicative
                      , QuickCheck
                      , quickcheck-state-machine
+                                                    <0.7.2
                      , quiet             >=0.2   && <0.3
                      , random
                      , serialise         >=0.2   && <0.3

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -327,7 +327,7 @@ library
      build-depends:    Win32            >= 2.6.1.0
   else
      build-depends:    unix
-                     , unix-bytestring
+                     , unix-bytestring ^>= 0.3.7.6
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
Bump `cardano-client` to `0.1.0.3`.
