### PR TITLE
Makes KnownPeers.insert idempotent

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+- Removes `updatePeerSharing` from `KnownPeers` module API
+
 ### Non-breaking changes
 
 ## 0.9.0.0 -- 2023-08-09

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -165,6 +165,7 @@ test-suite test
                        Test.Ouroboros.Network.TxSubmission
                        Test.Ouroboros.Network.PeerSelection
                        Test.Ouroboros.Network.PeerSelection.Instances
+                       Test.Ouroboros.Network.PeerSelection.KnownPeers
                        Test.Ouroboros.Network.PeerSelection.LocalRootPeers
                        Test.Ouroboros.Network.PeerSelection.RootPeersDNS
                        Test.Ouroboros.Network.PeerSelection.Json

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/BigLedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/BigLedgerPeers.hs
@@ -116,12 +116,12 @@ jobReqBigLedgerPeers PeerSelectionActions{ requestBigLedgerPeers }
 
             knownPeers'
                      = KnownPeers.insert
-                         (Map.fromSet (\_ -> ( NoPeerSharing
+                         (Map.fromSet (\_ -> ( Just NoPeerSharing
                                                -- the peer sharing flag will be
                                                -- updated once we negotiate
                                                -- the connection
-                                             , DoNotAdvertisePeer
-                                             , IsLedgerPeer
+                                             , Just DoNotAdvertisePeer
+                                             , Just IsLedgerPeer
                                              ))
                                       newPeers)
                          (knownPeers st)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -413,9 +413,9 @@ jobPromoteColdPeer PeerSelectionActions {
         let establishedPeers' = EstablishedPeers.insert peeraddr peerconn
                                                         establishedPeers
             -- Update PeerSharing value in KnownPeers
-            -- Overwrite the previous value
-            knownPeers'       = KnownPeers.updatePeerSharing peeraddr
-                                                             peerSharing
+            -- This will compute the appropriate peer sharing value using
+            -- 'combinePeerInformation'
+            knownPeers'       = KnownPeers.insert (Map.singleton peeraddr (Just peerSharing, Nothing, Nothing))
                               $ KnownPeers.clearTepidFlag peeraddr $
                                     KnownPeers.resetFailCount
                                         peeraddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -21,9 +21,6 @@ import           Control.Monad.Class.MonadTime.SI
 import           Control.Monad.Class.MonadTimer.SI
 
 import           Ouroboros.Network.PeerSelection.Governor.Types
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer (..))
-import           Ouroboros.Network.PeerSelection.PeerAdvertise
-                     (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import           Ouroboros.Network.PeerSelection.State.KnownPeers
@@ -190,9 +187,9 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                 knownPeers = KnownPeers.insert
                                                (Map.fromList
                                                 $ map (\a -> ( a
-                                                             , ( NoPeerSharing
-                                                               , DoAdvertisePeer
-                                                               , IsNotLedgerPeer))
+                                                             , ( Nothing
+                                                               , Nothing
+                                                               , Nothing))
                                                       )
                                                       newPeers)
                                                (knownPeers st),
@@ -234,9 +231,9 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                  knownPeers = KnownPeers.insert
                                                 (Map.fromList
                                                  $ map (\a -> ( a
-                                                              , ( NoPeerSharing
-                                                                , DoAdvertisePeer
-                                                                , IsNotLedgerPeer))
+                                                              , ( Nothing
+                                                                , Nothing
+                                                                , Nothing))
                                                        )
                                                        newPeers)
                                                 (knownPeers st),
@@ -298,9 +295,9 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                              knownPeers = KnownPeers.insert
                                             (Map.fromList
                                              $ map (\a -> ( a
-                                                          , ( NoPeerSharing
-                                                            , DoAdvertisePeer
-                                                            , IsNotLedgerPeer))
+                                                          , ( Nothing
+                                                            , Nothing
+                                                            , Nothing))
                                                    )
                                                    newPeers)
                                             (knownPeers st),

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -35,10 +35,6 @@ import           Ouroboros.Network.PeerSelection.Governor.ActivePeers
                      (jobDemoteActivePeer)
 import           Ouroboros.Network.PeerSelection.Governor.Types hiding
                      (PeerSelectionCounters (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer (..))
-import           Ouroboros.Network.PeerSelection.PeerAdvertise
-                     (PeerAdvertise (..))
-import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.State.LocalRootPeers as LocalRootPeers
@@ -122,7 +118,7 @@ inboundPeers PeerSelectionActions{
     return $ \_ ->
       let -- If peer happens to already be present in the Known Peer set
           -- 'insert' is going to do its due diligence before adding.
-          newEntry    = Map.singleton addr (ps, DoAdvertisePeer, IsNotLedgerPeer)
+          newEntry    = Map.singleton addr (Just ps, Nothing, Nothing)
           knownPeers' = KnownPeers.insert newEntry knownPeers
        in Decision {
             decisionTrace = [TraceKnownInboundConnection addr ps],
@@ -318,7 +314,7 @@ localRoots actions@PeerSelectionActions{ readLocalRootPeers
           removed      = LocalRootPeers.toMap localRootPeers  Map.\\
                          LocalRootPeers.toMap localRootPeers'
           -- LocalRoots are not ledger!
-          addedInfoMap = Map.map (\a -> (NoPeerSharing, a, IsNotLedgerPeer)) added
+          addedInfoMap = Map.map (\a -> (Nothing, Just a, Nothing)) added
           removedSet   = Map.keysSet removed
           knownPeers'  = KnownPeers.insert addedInfoMap knownPeers
                         -- We do not immediately remove old ones from the

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/RootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/RootPeers.hs
@@ -118,7 +118,7 @@ jobReqPublicRootPeers PeerSelectionActions{ requestPublicRootPeers
             knownPeers'      = KnownPeers.insert
                                  -- When we don't know about the PeerSharing information
                                  -- we default to NoPeerSharing
-                                 (Map.map (\(a, b) -> (NoPeerSharing, a, b)) newPeers)
+                                 (Map.map (\(a, b) -> (Just NoPeerSharing, Just a, Just b)) newPeers)
                                  (knownPeers st)
 
             -- We got a successful response to our request, but if we're still

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -13,6 +13,7 @@ import qualified Test.Ouroboros.Network.NodeToClient.Version (tests)
 import qualified Test.Ouroboros.Network.NodeToNode.Version (tests)
 import qualified Test.Ouroboros.Network.PeerSelection (tests)
 import qualified Test.Ouroboros.Network.PeerSelection.Json (tests)
+import qualified Test.Ouroboros.Network.PeerSelection.KnownPeers
 import qualified Test.Ouroboros.Network.PeerSelection.LocalRootPeers
 import qualified Test.Ouroboros.Network.PeerSelection.MockEnvironment
 import qualified Test.Ouroboros.Network.PeerSelection.PeerMetric
@@ -42,6 +43,7 @@ tests =
   , Test.Ouroboros.Network.BlockFetch.tests
   , Test.Ouroboros.Network.PeerSelection.tests
   , Test.Ouroboros.Network.PeerSelection.Json.tests
+  , Test.Ouroboros.Network.PeerSelection.KnownPeers.tests
   , Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.MockEnvironment.tests
   , Test.Ouroboros.Network.PeerSelection.PeerMetric.tests

--- a/ouroboros-network/test/Test/LedgerPeers.hs
+++ b/ouroboros-network/test/Test/LedgerPeers.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
@@ -52,7 +53,9 @@ instance Arbitrary ArbitraryPortNumber where
               $ map (ArbitraryPortNumber . read . show)
               $ ([1000..1100] :: [Int])
 
-newtype ArbitraryRelayAccessPoint = ArbitraryRelayAccessPoint RelayAccessPoint
+newtype ArbitraryRelayAccessPoint =
+  ArbitraryRelayAccessPoint { getArbitraryRelayAccessPoint :: RelayAccessPoint }
+  deriving (Eq, Ord) via RelayAccessPoint
 
 instance Arbitrary ArbitraryRelayAccessPoint where
     arbitrary =

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/KnownPeers.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/KnownPeers.hs
@@ -1,0 +1,31 @@
+
+module Test.Ouroboros.Network.PeerSelection.KnownPeers (tests) where
+import           Data.Map (Map)
+import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer,
+                     RelayAccessPoint)
+import           Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
+import           Test.Ouroboros.Network.PeerSelection.Instances ()
+import           Test.QuickCheck (Property, counterexample)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+  testGroup "Ouroboros.Network.PeerSelection"
+  [ testGroup "KnownPeers"
+    [ testProperty "insert is idempotent" prop_insert_idempotent
+    ]
+  ]
+
+prop_insert_idempotent
+  :: Map RelayAccessPoint (Maybe PeerSharing, Maybe PeerAdvertise, Maybe IsLedgerPeer)
+  -> Property
+prop_insert_idempotent m =
+  let knownPeers = KnownPeers.insert m KnownPeers.empty
+      knownPeers' = KnownPeers.insert m knownPeers
+   in counterexample ("KnownPeers 1: " ++ show knownPeers ++ "\n"
+                    ++ "KnownPeers 2: " ++ show knownPeers') $
+      knownPeers == knownPeers'
+


### PR DESCRIPTION
# Description

Closes #4616 

- Make sure we always insert the `PeerSharing` value using `combinePeerInformation` function
- Add test for `KnownPeers.insert` to check if it is idempotent