### PR TITLE
Refactor PeerSelection.RootPeersDNS

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Updated code to accommodate changes on `PeerSharing` data type.
 * Fixed Server2 [sim test](https://github.com/input-output-hk/ouroboros-network/issues/4607) by synchronizing connection/disconnection events.
 * Changed connection manager `readState` function to be in `STM` instead of `m`
+* Added `waitForOutboundDemotion` function to Connection
+  Manager's API
 
 ## 0.10.0.01 -- 2023-11-02
 

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Non-breaking changes
 
+* Updated code to accommodate changes on `PeerSharing` data type.
+* Fixed Server2 [sim test](https://github.com/input-output-hk/ouroboros-network/issues/4607) by synchronizing connection/disconnection events.
+* Changed connection manager `readState` function to be in `STM` instead of `m`
+
 ## 0.10.0.01 -- 2023-11-02
 
 ### Non-breaking changes
@@ -26,8 +30,6 @@
 * `demo-ping-pong`: improved tracer.
 * Fixed a bug in `connection-manager` which could result in leaking
   a connection.
-
-* Fix Server2 [sim test](https://github.com/input-output-hk/ouroboros-network/issues/4607) by synchronizing connection/disconnection events.
 
 ## 0.9.0.0 -- 2023-08-21
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -630,13 +630,20 @@ withConnectionManager ConnectionManagerArguments {
         waitForOutboundDemotion addr = do
           state <- readState
           case Map.lookup addr state of
-            Nothing                  -> return ()
-            Just UnknownConnectionSt -> return ()
-            Just InboundIdleSt {}    -> return ()
-            Just InboundSt {}        -> return ()
-            Just WaitRemoteIdleSt    -> return ()
-            Just TerminatedSt        -> return ()
-            Just _                   -> retry
+            Nothing                        -> return ()
+            Just UnknownConnectionSt       -> return ()
+            Just InboundIdleSt {}          -> return ()
+            Just InboundSt {}              -> return ()
+            Just WaitRemoteIdleSt          -> return ()
+            Just TerminatedSt              -> return ()
+            Just (UnnegotiatedSt Inbound)  -> return ()
+            Just (UnnegotiatedSt Outbound) -> retry
+            Just ReservedOutboundSt        -> retry
+            Just OutboundUniSt             -> retry
+            Just OutboundIdleSt {}         -> retry
+            Just OutboundDupSt {}          -> retry
+            Just DuplexSt                  -> retry
+            Just TerminatingSt             -> retry
 
         connectionManager :: ConnectionManager muxMode socket peerAddr
                                                handle handleError m

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -615,15 +615,14 @@ withConnectionManager ConnectionManagerArguments {
           return (freshIdSupply, v)
 
     let readState
-          :: m (Map peerAddr AbstractState)
-        readState =
-          atomically $ do
-              state <- readTMVar stateVar
-              traverse ( fmap (abstractState . Known)
-                       . readTVar
-                       . connVar
-                       )
-                       state
+          :: STM m (Map peerAddr AbstractState)
+        readState = do
+          state <- readTMVar stateVar
+          traverse ( fmap (abstractState . Known)
+                   . readTVar
+                   . connVar
+                   )
+                   state
 
         connectionManager :: ConnectionManager muxMode socket peerAddr
                                                handle handleError m

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -541,7 +541,7 @@ data ConnectionManager (muxMode :: MuxMode) socket peerAddr handle handleError m
               (InboundConnectionManager  muxMode socket peerAddr handle handleError m),
 
         readState
-          :: m (Map peerAddr AbstractState)
+          :: STM m (Map peerAddr AbstractState)
       }
 
 --

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -541,7 +541,14 @@ data ConnectionManager (muxMode :: MuxMode) socket peerAddr handle handleError m
               (InboundConnectionManager  muxMode socket peerAddr handle handleError m),
 
         readState
-          :: STM m (Map peerAddr AbstractState)
+          :: STM m (Map peerAddr AbstractState),
+
+        -- | This STM action will block until the given connection is fully
+        -- closed/terminated. If the connection manager doesn't have any connection to
+        -- that peer it won't block.
+        waitForOutboundDemotion
+          :: peerAddr
+          -> STM m ()
       }
 
 --

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -346,7 +346,13 @@ inboundGovernor trTracer tracer inboundInfoChannel
               let state' = updateRemoteState connId (RemoteIdle timeoutSTM) state
 
               return (Just connId, state')
-            UnsupportedState {} ->
+            -- It could happen that the connection got deleted by connection
+            -- manager due to some async exception so we need to unregister it
+            -- from the inbound governor state.
+            UnsupportedState UnknownConnectionSt -> do
+              let state' = unregisterConnection connId state
+              return (Just connId, state')
+            UnsupportedState {} -> do
               return (Just connId, state)
 
         -- @

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -56,6 +56,19 @@
 
 * Increase keyed timeout on a testnet test that was failing.
 
+* Adds new constructor to `PeerStatus`: `PeerReallyCold`. This is in order to
+  fix a possible race where a node would be asynchronously demoted to cold
+  state, put into the cold set and wrongly forgotten, while its connection
+  was not yet cleaned up. This could lead to the peer being added to the known
+  set and promoted leading to a `TrConnectionExists` trace in the logs, which
+  is disallowed. With this being said, `PeerCold` status is now an
+  intermediate status that means the peer is cold but its connection still
+  lingers. This extra information warns the governor not to move the peer to
+  the cold set just yet.
+
+  Yes it can mean that the governor could promote the peer to hot, however it
+  will promptly fail since no mux will be running anyway.
+
 ## 0.9.1.0 -- 2023-08-22
 
 ### Breaking changes

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -56,7 +56,7 @@
 
 * Increase keyed timeout on a testnet test that was failing.
 
-* Adds new constructor to `PeerStatus`: `PeerReallyCold`. This is in order to
+* Adds new constructor to `PeerStatus`: `PeerCooling`. This is in order to
   fix a possible race where a node would be asynchronously demoted to cold
   state, put into the cold set and wrongly forgotten, while its connection
   was not yet cleaned up. This could lead to the peer being added to the known

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -33,6 +33,11 @@
 
 ### Breaking changes
 
+* Refactors `PeerSelection.RootPeersDNS` module, enabling more sharing between
+  modules and providing just better module organisation overall.
+    * Tweaks exports and imports
+    * Shares semaphores with `withPeerSelectionActions` and `ledgerPeersThread`
+
 ### Non-breaking changes
 
 * Updated KeepAlive client to collect a rtt sample for the first packet.

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -46,12 +46,14 @@ library
                        Ouroboros.Network.NodeToClient
                        Ouroboros.Network.Tracers
                        Ouroboros.Network.PeerSelection.Types
-                       Ouroboros.Network.PeerSelection.LedgerPeers
                        Ouroboros.Network.PeerSelection.PeerMetric
                        Ouroboros.Network.PeerSelection.PeerSelectionActions
                        Ouroboros.Network.PeerSelection.PeerStateActions
                        Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
-                       Ouroboros.Network.PeerSelection.RootPeersDNS
+                       Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore
+                       Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
+                       Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                       Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
                        Ouroboros.Network.PeerSelection.Governor
                        Ouroboros.Network.PeerSelection.State.EstablishedPeers
                        Ouroboros.Network.PeerSelection.State.KnownPeers

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
@@ -77,8 +77,6 @@ import qualified Ouroboros.Network.Mock.Chain as Chain
 import           Ouroboros.Network.Mock.ProducerState
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers
-                     (LedgerPeersConsensusInterface)
 import           Ouroboros.Network.Util.ShowProxy
 
 import           Ouroboros.Network.Mock.ConcreteBlock
@@ -91,6 +89,8 @@ import           Ouroboros.Network.NodeToNode (blockFetchMiniProtocolNum,
                      chainSyncMiniProtocolNum, keepAliveMiniProtocolNum,
                      peerSharingMiniProtocolNum)
 import qualified Ouroboros.Network.PeerSelection.PeerSharing as PSTypes
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (LedgerPeersConsensusInterface)
 import           Ouroboros.Network.PeerSharing (bracketPeerSharingClient,
                      peerSharingClient, peerSharingServer)
 import           Ouroboros.Network.Protocol.PeerSharing.Client

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Policies.hs
@@ -38,7 +38,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 tests :: TestTree
 tests = testGroup "Policies"
   [ testProperty "HotToWarm" prop_hotToWarm
-  , testProperty "WarmToCold" prop_randomDemotion
+  , testProperty "WarmToCooling" prop_randomDemotion
   ]
 
 newtype ArbitrarySockAddr = ArbitrarySockAddr SockAddr deriving (Eq, Ord, Show)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -52,7 +52,6 @@ import           Network.Socket (SockAddr)
 import           Ouroboros.Network.PeerSelection.Governor hiding
                      (PeerSelectionState (..), peerSharing)
 import qualified Ouroboros.Network.PeerSelection.Governor as Governor
-import           Ouroboros.Network.PeerSelection.RootPeersDNS
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.State.LocalRootPeers as LocalRootPeers
@@ -71,10 +70,19 @@ import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 import           Control.Concurrent.Class.MonadSTM.Strict (newTVarIO)
 import           Control.Monad.Class.MonadTime.SI
 import           Control.Monad.IOSim
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer (..))
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+                     (RelayAccessPoint)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
+                     (DNSLookupType (..), ioDNSActions)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore
+                     (newLedgerAndPublicRootDNSSemaphore)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (IsLedgerPeer (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
+                     (publicRootPeersProvider)
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers
                      (HotValency (..), LocalRootPeers, WarmValency (..))
 import           Ouroboros.Network.Protocol.PeerSharing.Type
@@ -2855,7 +2863,7 @@ _governorFindingPublicRoots :: Int
                             -> PeerSharing
                             -> IO Void
 _governorFindingPublicRoots targetNumberOfRootPeers readDomains peerSharing = do
-    dnsSemaphore <- newLocalAndPublicRootDNSSemaphore
+    dnsSemaphore <- newLedgerAndPublicRootDNSSemaphore
     publicRootPeersProvider
       tracer
       (curry IP.toSockAddr)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -1225,7 +1225,7 @@ prop_governor_target_known_big_ledger_peers_below env =
 prop_governor_target_known_1_valid_subset :: GovernorMockEnvironment
                                           -> Property
 prop_governor_target_known_1_valid_subset env =
-    let events = Signal.eventsFromListUpToTime (Time (60 * 60))
+    let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
                . selectPeerSelectionTraceEvents
                . runGovernorInMockEnvironment
                $ env

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -2046,7 +2046,7 @@ prop_governor_target_established_below env =
               (\case TracePromoteColdFailed _ _ peer _ _ ->
                        --TODO: the environment does not yet cause this to happen
                        -- it requires synchronous failure in the establish action
-                       Just (Set.singleton peer)
+                       Just $! Set.singleton peer
                      --TODO: what about TraceDemoteWarmDone ?
                      -- these are also not immediate candidates
                      -- why does the property not fail for not tracking these?
@@ -2054,18 +2054,18 @@ prop_governor_target_established_below env =
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerCooling) . fmap fst $ status)
+                         !failures = Map.keysSet (Map.filter (==PeerCooling) . fmap fst $ status)
                      TraceDemoteLocalAsynchronous status
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerCooling) . fmap fst $ status)
+                         !failures = Map.keysSet (Map.filter (==PeerCooling) . fmap fst $ status)
                      TracePromoteWarmFailed _ _ peer _ ->
-                       Just (Set.singleton peer)
+                       Just $! Set.singleton peer
                      TraceDemoteWarmFailed _ _ peer _ ->
-                       Just (Set.singleton peer)
+                       Just $! Set.singleton peer
                      TraceDemoteHotFailed _ _ peer _ ->
-                       Just (Set.singleton peer)
+                       Just $! Set.singleton peer
                      _ -> Nothing
               )
           . selectGovEvents

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -18,14 +18,15 @@ import           Data.Text.Encoding (encodeUtf8)
 import           Data.Word (Word32)
 
 import           Ouroboros.Network.PeerSelection.Governor
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer (..))
-import           Ouroboros.Network.PeerSelection.RootPeersDNS
-                     (DomainAccessPoint (..), RelayAccessPoint (..))
 
 import qualified Data.IP as IP
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+                     (DomainAccessPoint (..), RelayAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (IsLedgerPeer (..))
 import           Ouroboros.Network.Testing.Utils (ShrinkCarefully,
                      prop_shrink_nonequal, prop_shrink_valid)
 import           Test.QuickCheck

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Json.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Json.hs
@@ -1,11 +1,11 @@
 module Test.Ouroboros.Network.PeerSelection.Json (tests) where
 
 import           Data.Aeson (decode, encode, fromJSON, toJSON)
-import           Ouroboros.Network.PeerSelection.RootPeersDNS
-                     (DomainAccessPoint (..), RelayAccessPoint (..))
 import           Test.Ouroboros.Network.PeerSelection.Instances ()
 
 import           Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+                     (DomainAccessPoint, RelayAccessPoint)
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/KnownPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/KnownPeers.hs
@@ -4,9 +4,7 @@ import           Data.Map (Map)
 import           Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint
-                     (RelayAccessPoint)
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
-                     (IsLedgerPeer)
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import           Test.Ouroboros.Network.PeerSelection.Instances ()
 import           Test.QuickCheck (Property, counterexample)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/KnownPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/KnownPeers.hs
@@ -1,10 +1,12 @@
 
 module Test.Ouroboros.Network.PeerSelection.KnownPeers (tests) where
 import           Data.Map (Map)
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer,
-                     RelayAccessPoint)
 import           Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+                     (RelayAccessPoint)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (IsLedgerPeer)
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import           Test.Ouroboros.Network.PeerSelection.Instances ()
 import           Test.QuickCheck (Property, counterexample)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -452,8 +452,8 @@ mockPeerSelectionActions' tracer
       atomically $ do
         status <- readTVar conn
         case status of
-          PeerHot        -> error "activatePeerConnection of hot peer"
-          PeerWarm       -> writeTVar conn PeerHot
+          PeerHot     -> error "activatePeerConnection of hot peer"
+          PeerWarm    -> writeTVar conn PeerHot
           --TODO: check it's just a race condition and not just wrong:
           --
           -- We throw 'ActivationError' for the following reason:
@@ -463,8 +463,8 @@ mockPeerSelectionActions' tracer
           -- errored.  Otherwise 'jobPromoteWarmPeer' will try to update the
           -- state as if the transition went fine which will violate
           -- 'invariantPeerSelectionState'.
-          PeerCold       -> throwIO ActivationError
-          PeerReallyCold -> throwIO ActivationError
+          PeerCooling -> throwIO ActivationError
+          PeerCold    -> throwIO ActivationError
 
     deactivatePeerConnection :: PeerConn m -> m ()
     deactivatePeerConnection (PeerConn peeraddr _ conn) = do
@@ -472,13 +472,13 @@ mockPeerSelectionActions' tracer
       atomically $ do
         status <- readTVar conn
         case status of
-          PeerHot        -> writeTVar conn PeerWarm
+          PeerHot     -> writeTVar conn PeerWarm
           --TODO: check it's just a race condition and not just wrong:
-          PeerWarm       -> return ()
+          PeerWarm    -> return ()
           -- See the note in 'activatePeerConnection' why we throw an exception
           -- here.
-          PeerCold       -> throwIO DeactivationError
-          PeerReallyCold -> throwIO DeactivationError
+          PeerCooling -> throwIO DeactivationError
+          PeerCold    -> throwIO DeactivationError
 
     closePeerConnection :: PeerConn m -> m ()
     closePeerConnection (PeerConn peeraddr _ conn) = do
@@ -486,11 +486,11 @@ mockPeerSelectionActions' tracer
       atomically $ do
         status <- readTVar conn
         case status of
-          PeerHot        -> writeTVar conn PeerReallyCold
+          PeerHot     -> writeTVar conn PeerCold
           --TODO: check it's just a race condition and not just wrong:
-          PeerWarm       -> writeTVar conn PeerReallyCold
-          PeerCold       -> writeTVar conn PeerReallyCold
-          PeerReallyCold -> return ()
+          PeerWarm    -> writeTVar conn PeerCold
+          PeerCooling -> writeTVar conn PeerCold
+          PeerCold    -> return ()
         conns <- readTVar connsVar
         let !conns' = Map.delete peeraddr conns
         writeTVar connsVar conns'

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -71,10 +71,12 @@ import           Test.Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRoo
                      (tests)
 import           Test.Ouroboros.Network.PeerSelection.PeerGraph
 
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsBigLedgerPeer,
-                     IsLedgerPeer)
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type
+                     (IsBigLedgerPeer)
 import           Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
-import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (IsLedgerPeer)
 import           Ouroboros.Network.PeerSelection.Types (PeerStatus (..))
 import           Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharingAmount,
                      PeerSharingResult (..))

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -561,12 +561,7 @@ tracerTracePeerSelection :: Tracer (IOSim s) (TracePeerSelection PeerAddr)
 tracerTracePeerSelection = contramap GovernorEvent tracerTestTraceEvent
 
 tracerDebugPeerSelection :: Tracer (IOSim s) (DebugPeerSelection PeerAddr)
-tracerDebugPeerSelection = contramap (GovernorDebug . voidDebugPeerSelection)
-                                     tracerTestTraceEvent
-  where
-    voidDebugPeerSelection :: DebugPeerSelection peeraddr -> DebugPeerSelection peeraddr
-    voidDebugPeerSelection (TraceGovernorState btime wtime state) =
-                            TraceGovernorState btime wtime (const () <$> state)
+tracerDebugPeerSelection = GovernorDebug `contramap` tracerTestTraceEvent
 
 tracerTracePeerSelectionCounters :: Tracer (IOSim s) PeerSelectionCounters
 tracerTracePeerSelectionCounters = contramap GovernorCounters tracerTestTraceEvent

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -99,6 +99,7 @@ type ConnectionScript = TimedScript AsyncDemotion
 
 data AsyncDemotion = ToWarm
                    | ToCold
+                   | ToReallyCold
                    | Noop
   deriving (Eq, Show)
 
@@ -204,11 +205,13 @@ simpleGraphRep (graph, vertexInfo, lookupVertex) =
 instance Arbitrary AsyncDemotion where
     arbitrary = frequency [ (2, pure ToWarm)
                           , (2, pure ToCold)
+                          , (2, pure ToReallyCold)
                           , (6, pure Noop)
                           ]
-    shrink ToWarm = [ToCold, Noop]
-    shrink ToCold = [Noop]
-    shrink Noop   = []
+    shrink ToWarm       = [ToCold, Noop]
+    shrink ToCold       = [ToReallyCold, Noop]
+    shrink ToReallyCold = [Noop]
+    shrink Noop         = []
 
 
 instance Arbitrary GovernorScripts where

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -98,8 +98,8 @@ interpretPeerShareTime PeerShareTimeTimeout = 25
 type ConnectionScript = TimedScript AsyncDemotion
 
 data AsyncDemotion = ToWarm
+                   | ToCooling
                    | ToCold
-                   | ToReallyCold
                    | Noop
   deriving (Eq, Show)
 
@@ -204,14 +204,14 @@ simpleGraphRep (graph, vertexInfo, lookupVertex) =
 
 instance Arbitrary AsyncDemotion where
     arbitrary = frequency [ (2, pure ToWarm)
+                          , (2, pure ToCooling)
                           , (2, pure ToCold)
-                          , (2, pure ToReallyCold)
                           , (6, pure Noop)
                           ]
-    shrink ToWarm       = [ToCold, Noop]
-    shrink ToCold       = [ToReallyCold, Noop]
-    shrink ToReallyCold = [Noop]
-    shrink Noop         = []
+    shrink ToWarm    = [ToCooling, Noop]
+    shrink ToCooling = [ToCold, Noop]
+    shrink ToCold    = [Noop]
+    shrink Noop      = []
 
 
 instance Arbitrary GovernorScripts where

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -672,8 +672,7 @@ prop_diffusion_nofail defaultBearerInfo diffScript =
         -- lastTime = fst (last trace)
 
      -- run in `IO` so we can catch the pure 'AssertionFailed' exception
-     in -- classifySimulatedTime lastTime $
-        ioProperty $ do
+     in ioProperty $ do
        r <-
          evaluate ( foldl' (flip seq) True
                 $ [ assertPeerSelectionState st ()
@@ -2055,27 +2054,23 @@ prop_diffusion_async_demotions defaultBearerInfo diffScript =
                            Just $ Left (Just failures)
                          where
                            failures = Set.singleton peeraddr
-                       DiffusionPeerSelectionTrace (TraceDemoteWarmDone _ _ addr) ->
-                           Just $ Left failures
-                         where
-                           failures = Just $ Set.singleton addr
-                       DiffusionPeerSelectionTrace (TraceDemoteWarmBigLedgerPeerDone _ _ addr) ->
-                           Just $ Left failures
-                         where
-                           failures = Just $ Set.singleton addr
-                       DiffusionPeerSelectionTrace (TraceDemoteHotDone _ _ addr) ->
-                           Just $ Left failures
-                         where
-                           failures = Just $ Set.singleton addr
-                       DiffusionPeerSelectionTrace (TraceDemoteHotBigLedgerPeerDone _ _ addr) ->
-                           Just $ Left failures
-                         where
-                           failures = Just $ Set.singleton addr
                        DiffusionPeerSelectionTrace (TraceDemoteWarmFailed _ _ peeraddr _) ->
                            Just $ Left (Just failures)
                          where
                            failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TracePromoteColdFailed _ _ peeraddr _ _) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
                        DiffusionPeerSelectionTrace (TracePromoteWarmFailed _ _ peeraddr _) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TraceDemoteWarmDone _ _ peeraddr) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TracePromoteColdBigLedgerPeerFailed _ _ peeraddr _ _) ->
                            Just $ Left (Just failures)
                          where
                            failures = Set.singleton peeraddr
@@ -2088,6 +2083,10 @@ prop_diffusion_async_demotions defaultBearerInfo diffScript =
                          where
                            failures = Set.singleton peeraddr
                        DiffusionPeerSelectionTrace (TraceDemoteWarmBigLedgerPeerFailed _ _ peeraddr _) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TraceDemoteWarmBigLedgerPeerDone _ _ peeraddr) ->
                            Just $ Left (Just failures)
                          where
                            failures = Set.singleton peeraddr

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -1957,6 +1957,14 @@ prop_diffusion_async_demotions defaultBearerInfo diffScript =
                            Just $ Right demotions
                          where
                            demotions = Set.singleton (remoteAddress connId)
+                       DiffusionPeerSelectionActionsTrace (PeerStatusChanged (WarmToCooling connId)) ->
+                           Just $ Right demotions
+                         where
+                           demotions = Set.singleton (remoteAddress connId)
+                       DiffusionConnectionManagerTrace (TrConnectionCleanup connId) ->
+                           Just $ Left failures
+                         where
+                           failures = Just $ Set.singleton (remoteAddress connId)
                        DiffusionPeerSelectionTrace (TraceDemoteAsynchronous status) ->
                            Just $ Left (Just failures)
                          where
@@ -1973,7 +1981,39 @@ prop_diffusion_async_demotions defaultBearerInfo diffScript =
                            Just $ Left (Just failures)
                          where
                            failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TraceDemoteWarmDone _ _ addr) ->
+                           Just $ Left failures
+                         where
+                           failures = Just $ Set.singleton addr
+                       DiffusionPeerSelectionTrace (TraceDemoteWarmBigLedgerPeerDone _ _ addr) ->
+                           Just $ Left failures
+                         where
+                           failures = Just $ Set.singleton addr
+                       DiffusionPeerSelectionTrace (TraceDemoteHotDone _ _ addr) ->
+                           Just $ Left failures
+                         where
+                           failures = Just $ Set.singleton addr
+                       DiffusionPeerSelectionTrace (TraceDemoteHotBigLedgerPeerDone _ _ addr) ->
+                           Just $ Left failures
+                         where
+                           failures = Just $ Set.singleton addr
+                       DiffusionPeerSelectionTrace (TraceDemoteWarmFailed _ _ peeraddr _) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TracePromoteWarmFailed _ _ peeraddr _) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TracePromoteWarmBigLedgerPeerFailed _ _ peeraddr _) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
                        DiffusionPeerSelectionTrace (TraceDemoteHotBigLedgerPeerFailed _ _ peeraddr _) ->
+                           Just $ Left (Just failures)
+                         where
+                           failures = Set.singleton peeraddr
+                       DiffusionPeerSelectionTrace (TraceDemoteWarmBigLedgerPeerFailed _ _ peeraddr _) ->
                            Just $ Left (Just failures)
                          where
                            failures = Set.singleton peeraddr

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -1381,13 +1381,13 @@ prop_diffusion_target_established_local defaultBearerInfo diffScript =
                          | otherwise         -> Just failures
                          where
                            failures =
-                             Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
+                             Map.keysSet (Map.filter (==PeerCooling) . fmap fst $ status)
                        TraceDemoteLocalAsynchronous status
                          | Set.null failures -> Nothing
                          | otherwise         -> Just failures
                          where
                            failures =
-                             Map.keysSet (Map.filter (==PeerCold) . fmap fst $ status)
+                             Map.keysSet (Map.filter (==PeerCooling) . fmap fst $ status)
                        TracePromoteWarmFailed _ _ peer _ ->
                          Just (Set.singleton peer)
                        _ -> Nothing
@@ -1569,7 +1569,7 @@ prop_diffusion_target_active_below defaultBearerInfo diffScript =
                          | Set.null failures -> Nothing
                          | otherwise -> Just failures
                          where
-                           failures = Map.keysSet (Map.filter ((==PeerCold) . fst) status)
+                           failures = Map.keysSet (Map.filter ((==PeerCooling) . fst) status)
                        _ -> Nothing
                 )
             . selectDiffusionPeerSelectionEvents
@@ -1953,7 +1953,7 @@ prop_diffusion_async_demotions defaultBearerInfo diffScript =
                        _            -> False)
             . Signal.fromEventsWith (Right Set.empty)
             . Signal.selectEvents
-                (\case DiffusionPeerSelectionActionsTrace (PeerStatusChanged (HotToCold connId)) ->
+                (\case DiffusionPeerSelectionActionsTrace (PeerStatusChanged (HotToCooling connId)) ->
                            Just $ Right demotions
                          where
                            demotions = Set.singleton (remoteAddress connId)
@@ -1968,15 +1968,15 @@ prop_diffusion_async_demotions defaultBearerInfo diffScript =
                        DiffusionPeerSelectionTrace (TraceDemoteAsynchronous status) ->
                            Just $ Left (Just failures)
                          where
-                           failures = Map.keysSet (Map.filter ((==PeerCold) . fst) status)
+                           failures = Map.keysSet (Map.filter ((==PeerCooling) . fst) status)
                        DiffusionPeerSelectionTrace (TraceDemoteBigLedgerPeersAsynchronous status) ->
                            Just $ Left (Just failures)
                          where
-                           failures = Map.keysSet (Map.filter ((==PeerCold) . fst) status)
+                           failures = Map.keysSet (Map.filter ((==PeerCooling) . fst) status)
                        DiffusionPeerSelectionTrace (TraceDemoteLocalAsynchronous status) ->
                            Just $ Left (Just failures)
                          where
-                           failures = Map.keysSet (Map.filter ((==PeerCold) . fst) status)
+                           failures = Map.keysSet (Map.filter ((==PeerCooling) . fst) status)
                        DiffusionPeerSelectionTrace (TraceDemoteHotFailed _ _ peeraddr _) ->
                            Just $ Left (Just failures)
                          where
@@ -2646,9 +2646,9 @@ prop_diffusion_peer_selection_actions_no_dodgy_traces defaultBearerInfo (HotDiff
                                         -> False
                                     (WithTime _ (PeerStatusChangeFailure tr _)
                                       , _) -> case tr of
-                                                HotToCold{}  -> False
-                                                WarmToCold{} -> False
-                                                _            -> True
+                                                HotToCooling{}  -> False
+                                                WarmToCooling{} -> False
+                                                _               -> True
                                     _   -> True
                             )
                 )
@@ -2665,8 +2665,8 @@ prop_diffusion_peer_selection_actions_no_dodgy_traces defaultBearerInfo (HotDiff
     getConnId :: PeerStatusChangeType addr -> Maybe (ConnectionId addr)
     getConnId (HotToWarm connId) = Just connId
     getConnId (WarmToHot connId) = Just connId
-    getConnId (WarmToCold connId) = Just connId
-    getConnId (HotToCold connId) = Just connId
+    getConnId (WarmToCooling connId) = Just connId
+    getConnId (HotToCooling connId)  = Just connId
     getConnId (ColdToWarm (Just localAddress) remoteAddress) = Just ConnectionId { localAddress, remoteAddress }
     getConnId _ = Nothing
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -45,7 +45,6 @@ import           Ouroboros.Network.PeerSelection.Governor hiding
                      (PeerSelectionState (..))
 import qualified Ouroboros.Network.PeerSelection.Governor as Governor
 import           Ouroboros.Network.PeerSelection.PeerStateActions
-import           Ouroboros.Network.PeerSelection.RootPeersDNS
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.LocalRootPeers as LocalRootPeers
@@ -86,6 +85,10 @@ import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+                     (DomainAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
+                     (TraceLocalRootPeers (..))
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers
                      (HotValency (..), WarmValency (..))
 import           Test.Ouroboros.Network.LedgerPeers (LedgerPools (..))

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -662,7 +662,7 @@ prop_diffusion_nofail defaultBearerInfo diffScript =
               . withTimeNameTraceEvents
                  @DiffusionTestTrace
                  @NtNAddr
-              . Trace.fromList (MainReturn (Time 0) () [])
+              . traceFromList
               . fmap (\(t, tid, tl, te) -> SimEvent t tid tl te)
               . take 125000
               . traceEvents

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -80,15 +80,8 @@ import           Ouroboros.Network.PeerSelection.Governor
                      (DebugPeerSelection (..), PeerSelectionTargets (..),
                      TracePeerSelection)
 import qualified Ouroboros.Network.PeerSelection.Governor as PeerSelection
-import           Ouroboros.Network.PeerSelection.LedgerPeers
-                     (LedgerPeersConsensusInterface (..), UseLedgerAfter (..),
-                     accPoolStake)
 import           Ouroboros.Network.PeerSelection.PeerStateActions
                      (PeerSelectionActionsTrace)
-import           Ouroboros.Network.PeerSelection.RootPeersDNS
-                     (DomainAccessPoint (..), LookupReqs (..), PortNumber,
-                     RelayAccessPoint (..), TraceLocalRootPeers,
-                     TracePublicRootPeers)
 import           Ouroboros.Network.Protocol.BlockFetch.Codec
                      (byteLimitsBlockFetch, timeLimitsBlockFetch)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
@@ -129,6 +122,17 @@ import           Ouroboros.Network.BlockFetch (TraceFetchClientState,
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+                     (DomainAccessPoint (..), PortNumber, RelayAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
+                     (DNSLookupType)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (LedgerPeersConsensusInterface (..), TraceLedgerPeers,
+                     UseLedgerAfter (..), accPoolStake)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
+                     (TraceLocalRootPeers)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
+                     (TracePublicRootPeers)
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers
                      (HotValency (..), WarmValency (..))
 import           Ouroboros.Network.Protocol.PeerSharing.Codec
@@ -885,6 +889,7 @@ data DiffusionSimulationTrace
 data DiffusionTestTrace =
       DiffusionLocalRootPeerTrace (TraceLocalRootPeers NtNAddr SomeException)
     | DiffusionPublicRootPeerTrace TracePublicRootPeers
+    | DiffusionLedgerPeersTrace TraceLedgerPeers
     | DiffusionPeerSelectionTrace (TracePeerSelection NtNAddr)
     | DiffusionPeerSelectionActionsTrace (PeerSelectionActionsTrace NtNAddr NtNVersion)
     | DiffusionDebugPeerSelectionTrace (DebugPeerSelection NtNAddr)
@@ -1177,7 +1182,7 @@ diffusionSimulation
                      $ nodeTracer)
 
     domainResolver :: StrictTVar m (Map Domain [(IP, TTL)])
-                   -> LookupReqs
+                   -> DNSLookupType
                    -> [DomainAccessPoint]
                    -> m (Map DomainAccessPoint (Set NtNAddr))
     -- TODO: we can take into account the `LookupReqs` and return only `IPv4`
@@ -1212,6 +1217,11 @@ diffusionSimulation
                                                        $ nodeTracer
         , Diff.P2P.dtTracePublicRootPeersTracer        = contramap
                                                           DiffusionPublicRootPeerTrace
+                                                       . tracerWithName ntnAddr
+                                                       . tracerWithTime
+                                                       $ nodeTracer
+        , Diff.P2P.dtTraceLedgerPeersTracer            = contramap
+                                                          DiffusionLedgerPeersTrace
                                                        . tracerWithName ntnAddr
                                                        . tracerWithTime
                                                        $ nodeTracer

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -1230,18 +1230,12 @@ diffusionSimulation
                                                        . tracerWithName ntnAddr
                                                        . tracerWithTime
                                                        $ nodeTracer
-        , Diff.P2P.dtDebugPeerSelectionInitiatorTracer = contramap
-                                                          ( DiffusionDebugPeerSelectionTrace
-                                                          . voidDebugPeerSelection
-                                                          )
+        , Diff.P2P.dtDebugPeerSelectionInitiatorTracer = contramap DiffusionDebugPeerSelectionTrace
                                                        . tracerWithName ntnAddr
                                                        . tracerWithTime
                                                        $ nodeTracer
         , Diff.P2P.dtDebugPeerSelectionInitiatorResponderTracer
-            = contramap
-               ( DiffusionDebugPeerSelectionTrace
-               . voidDebugPeerSelection
-               )
+            = contramap DiffusionDebugPeerSelectionTrace
             . tracerWithName ntnAddr
             . tracerWithTime
             $ nodeTracer
@@ -1279,10 +1273,6 @@ diffusionSimulation
         , Diff.P2P.dtLocalServerTracer                 = nullTracer
         , Diff.P2P.dtLocalInboundGovernorTracer        = nullTracer
       }
-      where
-        voidDebugPeerSelection :: DebugPeerSelection peeraddr -> DebugPeerSelection peeraddr
-        voidDebugPeerSelection (TraceGovernorState btime wtime state) =
-                                TraceGovernorState btime wtime (const () <$> state)
 
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Common.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Common.hs
@@ -30,8 +30,8 @@ import qualified Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit,
                      ConnectionId, DiffusionMode)
 import qualified Ouroboros.Network.NodeToNode as NodeToNode
-import           Ouroboros.Network.PeerSelection.LedgerPeers
-                     (LedgerPeersConsensusInterface, TraceLedgerPeers)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (LedgerPeersConsensusInterface)
 import           Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharingAmount)
 import           Ouroboros.Network.Snocket (FileDescriptor)
 import           Ouroboros.Network.Socket (SystemdSocketTracer)
@@ -101,10 +101,6 @@ data Tracers ntnAddr ntnVersion ntcAddr ntcVersion m = Tracers {
       -- | Diffusion initialisation tracer
     , dtDiffusionTracer
         :: Tracer m (DiffusionTracer ntnAddr ntcAddr)
-
-      -- | Ledger Peers tracer
-    , dtLedgerPeersTracer
-        :: Tracer m TraceLedgerPeers
     }
 
 
@@ -118,7 +114,6 @@ nullTracers = Tracers {
   , dtLocalMuxTracer       = nullTracer
   , dtLocalHandshakeTracer = nullTracer
   , dtDiffusionTracer      = nullTracer
-  , dtLedgerPeersTracer    = nullTracer
   }
 
 -- | Common DiffusionArguments interface between P2P and NonP2P

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1169,7 +1169,7 @@ run tracers tracersExtra args argsExtra apps appsExtra = do
                    _ <- Signals.installHandler
                      Signals.sigUSR1
                      (Signals.Catch
-                       (do state <- readState connectionManager
+                       (do state <- atomically $ readState connectionManager
                            traceWith (dtConnectionManagerTracer tracersExtra)
                                      (TrState state)
                        )

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -38,7 +38,6 @@ module Ouroboros.Network.NodeToNode
   , cleanNetworkMutableState
   , withServer
     -- * P2P Governor
-  , DomainAccessPoint (..)
   , PeerAdvertise (..)
   , PeerSelectionTargets (..)
     -- * Subscription Workers
@@ -138,8 +137,6 @@ import           Ouroboros.Network.PeerSelection.Governor.Types
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
-import           Ouroboros.Network.PeerSelection.RootPeersDNS
-                     (DomainAccessPoint (..))
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version hiding (Accept)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -68,6 +68,7 @@ belowTargetBigLedgerPeers actions
                             activePeers,
                             inProgressPromoteWarm,
                             inProgressDemoteWarm,
+                            inProgressDemoteToCold,
                             targets = PeerSelectionTargets {
                                         targetNumberOfActiveBigLedgerPeers
                                       }
@@ -83,6 +84,7 @@ belowTargetBigLedgerPeers actions
                                Set.\\ activePeers
                                Set.\\ inProgressPromoteWarm
                                Set.\\ inProgressDemoteWarm
+                               Set.\\ inProgressDemoteToCold
         numPeersToPromote = targetNumberOfActiveBigLedgerPeers
                           - numActiveBigLedgerPeers
                           - numPromoteInProgressBigLedgerPeers
@@ -135,7 +137,8 @@ belowTargetLocal actions
                    establishedPeers,
                    activePeers,
                    inProgressPromoteWarm,
-                   inProgressDemoteWarm
+                   inProgressDemoteWarm,
+                   inProgressDemoteToCold
                  }
     -- Are there any groups of local peers that are below target?
   | not (null groupsBelowTarget)
@@ -153,6 +156,7 @@ belowTargetLocal actions
                      Set.\\ activePeers
                      Set.\\ inProgressPromoteWarm
                      Set.\\ inProgressDemoteWarm
+                     Set.\\ inProgressDemoteToCold
                 numPromoteInProgress = Set.size inProgressPromoteWarm
           , not (Set.null availableToPromote)
           , (HotValency hotTarget, members, membersActive) <- groupsBelowTarget
@@ -229,6 +233,7 @@ belowTargetOther actions
                    establishedPeers,
                    activePeers,
                    inProgressPromoteWarm,
+                   inProgressDemoteToCold,
                    inProgressDemoteWarm,
                    targets = PeerSelectionTargets {
                                targetNumberOfActivePeers
@@ -243,6 +248,7 @@ belowTargetOther actions
                                Set.\\ activePeers
                                Set.\\ inProgressPromoteWarm
                                Set.\\ inProgressDemoteWarm
+                               Set.\\ inProgressDemoteToCold
                                Set.\\ LocalRootPeers.keysSet localRootPeers
                                Set.\\ bigLedgerPeers
         numPeersToPromote = targetNumberOfActivePeers
@@ -475,6 +481,7 @@ aboveTargetBigLedgerPeers actions
                             establishedPeers,
                             activePeers,
                             inProgressDemoteHot,
+                            inProgressDemoteToCold,
                             targets = PeerSelectionTargets {
                                         targetNumberOfActiveBigLedgerPeers
                                       }
@@ -496,6 +503,7 @@ aboveTargetBigLedgerPeers actions
   , let availableToDemote = activePeers
                               `Set.intersection` bigLedgerPeers
                               Set.\\ inProgressDemoteHot
+                              Set.\\ inProgressDemoteToCold
                               Set.\\ LocalRootPeers.keysSet localRootPeers
   , not (Set.null availableToDemote)
   = Guarded Nothing $ do
@@ -545,7 +553,8 @@ aboveTargetLocal actions
                    localRootPeers,
                    establishedPeers,
                    activePeers,
-                   inProgressDemoteHot
+                   inProgressDemoteHot,
+                   inProgressDemoteToCold
                  }
     -- Are there any groups of local peers that are below target?
   | let groupsAboveTarget =
@@ -566,7 +575,11 @@ aboveTargetLocal actions
                                        `Set.intersection`
                                      activePeers)
                                        Set.\\ inProgressDemoteHot
+                                       Set.\\ inProgressDemoteToCold
                 numDemoteInProgress = Set.size inProgressDemoteHot
+                                    + Set.size (Set.intersection inProgressDemoteToCold
+                                                                 activePeers
+                                               )
           , not (Set.null availableToDemote)
           , (HotValency hotTarget, members, membersActive) <- groupsAboveTarget
           , let membersAvailableToDemote = Set.intersection
@@ -622,6 +635,7 @@ aboveTargetOther actions
                    establishedPeers,
                    activePeers,
                    inProgressDemoteHot,
+                   inProgressDemoteToCold,
                    targets = PeerSelectionTargets {
                                targetNumberOfActivePeers
                              }
@@ -644,6 +658,7 @@ aboveTargetOther actions
                               Set.\\ inProgressDemoteHot
                               Set.\\ LocalRootPeers.keysSet localRootPeers
                               Set.\\ bigLedgerPeers
+                              Set.\\ inProgressDemoteToCold
   , not (Set.null availableToDemote)
   = Guarded Nothing $ do
       selectedToDemote <- pickPeers st

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -23,7 +23,7 @@ import           Control.Monad.Class.MonadTimer.SI
 import           System.Random (randomR)
 
 import           Ouroboros.Network.PeerSelection.Governor.Types
-import           Ouroboros.Network.PeerSelection.LedgerPeers
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type
                      (IsBigLedgerPeer (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import           Ouroboros.Network.PeerSelection.State.KnownPeers (setTepidFlag)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs
@@ -577,9 +577,9 @@ aboveTargetLocal actions
                                        Set.\\ inProgressDemoteHot
                                        Set.\\ inProgressDemoteToCold
                 numDemoteInProgress = Set.size inProgressDemoteHot
-                                    + Set.size (Set.intersection inProgressDemoteToCold
-                                                                 activePeers
-                                               )
+                                    + Set.size (inProgressDemoteToCold
+                                                `Set.intersection`
+                                                activePeers)
           , not (Set.null availableToDemote)
           , (HotValency hotTarget, members, membersActive) <- groupsAboveTarget
           , let membersAvailableToDemote = Set.intersection
@@ -647,6 +647,7 @@ aboveTargetOther actions
   , let numPeersToDemote = numActivePeers
                          - targetNumberOfActivePeers
                          - numDemoteInProgress
+                         - (Set.size inProgressDemoteToCold)
   , numPeersToDemote > 0
 
     -- Are there any hot peers we actually can pick to demote?

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/BigLedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/BigLedgerPeers.hs
@@ -18,10 +18,11 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime.SI
 
 import           Ouroboros.Network.PeerSelection.Governor.Types
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer (..))
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (IsLedgerPeer (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.State.LocalRootPeers as LocalRootPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -175,7 +175,6 @@ belowTargetOther actions
                    knownPeers,
                    establishedPeers,
                    inProgressPromoteCold,
-                   inProgressDemoteToCold,
                    targets = PeerSelectionTargets {
                                targetNumberOfEstablishedPeers
                              }
@@ -202,7 +201,6 @@ belowTargetOther actions
           availableToPromote = availableToConnect
                                  Set.\\ EstablishedPeers.toSet establishedPeers
                                  Set.\\ inProgressPromoteCold
-                                 Set.\\ inProgressDemoteToCold
           numPeersToPromote  = targetNumberOfEstablishedPeers
                              - numEstablishedPeers
                              - numConnectInProgress
@@ -255,7 +253,6 @@ belowTargetBigLedgerPeers actions
                             knownPeers,
                             establishedPeers,
                             inProgressPromoteCold,
-                            inProgressDemoteToCold,
                             targets = PeerSelectionTargets {
                                         targetNumberOfEstablishedBigLedgerPeers
                                       }
@@ -283,7 +280,6 @@ belowTargetBigLedgerPeers actions
           availableToPromote = availableToConnect
                                  Set.\\ EstablishedPeers.toSet establishedPeers
                                  Set.\\ inProgressPromoteCold
-                                 Set.\\ inProgressDemoteToCold
           numPeersToPromote  = targetNumberOfEstablishedBigLedgerPeers
                              - numEstablishedPeers
                              - numConnectInProgress

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -79,7 +79,8 @@ belowTargetLocal actions
                    localRootPeers,
                    knownPeers,
                    establishedPeers,
-                   inProgressPromoteCold
+                   inProgressPromoteCold,
+                   inProgressDemoteToCold
                  }
 
     -- Are there any groups of local peers that are below target?
@@ -96,6 +97,7 @@ belowTargetLocal actions
                   localAvailableToConnect
                      Set.\\ localEstablishedPeers
                      Set.\\ localConnectInProgress
+                     Set.\\ inProgressDemoteToCold
           , not (Set.null availableToPromote)
           , (WarmValency warmTarget, members, membersEstablished) <- groupsBelowTarget
           , let membersAvailableToPromote = Set.intersection members availableToPromote
@@ -173,6 +175,7 @@ belowTargetOther actions
                    knownPeers,
                    establishedPeers,
                    inProgressPromoteCold,
+                   inProgressDemoteToCold,
                    targets = PeerSelectionTargets {
                                targetNumberOfEstablishedPeers
                              }
@@ -199,6 +202,7 @@ belowTargetOther actions
           availableToPromote = availableToConnect
                                  Set.\\ EstablishedPeers.toSet establishedPeers
                                  Set.\\ inProgressPromoteCold
+                                 Set.\\ inProgressDemoteToCold
           numPeersToPromote  = targetNumberOfEstablishedPeers
                              - numEstablishedPeers
                              - numConnectInProgress
@@ -251,6 +255,7 @@ belowTargetBigLedgerPeers actions
                             knownPeers,
                             establishedPeers,
                             inProgressPromoteCold,
+                            inProgressDemoteToCold,
                             targets = PeerSelectionTargets {
                                         targetNumberOfEstablishedBigLedgerPeers
                                       }
@@ -278,6 +283,7 @@ belowTargetBigLedgerPeers actions
           availableToPromote = availableToConnect
                                  Set.\\ EstablishedPeers.toSet establishedPeers
                                  Set.\\ inProgressPromoteCold
+                                 Set.\\ inProgressDemoteToCold
           numPeersToPromote  = targetNumberOfEstablishedBigLedgerPeers
                              - numEstablishedPeers
                              - numConnectInProgress
@@ -472,6 +478,7 @@ aboveTargetOther actions
                    activePeers,
                    inProgressDemoteWarm,
                    inProgressPromoteWarm,
+                   inProgressDemoteToCold,
                    targets = PeerSelectionTargets {
                                targetNumberOfEstablishedPeers
                              }
@@ -503,15 +510,18 @@ aboveTargetOther actions
                                    - numActivePeers)
                             - Set.size (inProgressDemoteWarm  Set.\\ bigLedgerPeers)
                             - Set.size (inProgressPromoteWarm Set.\\ bigLedgerPeers)
-  , numPeersToDemote > 0
-  = Guarded Nothing $ do
 
-      let availableToDemote :: Set peeraddr
-          availableToDemote = EstablishedPeers.toSet establishedPeers
-                                Set.\\ activePeers
-                                Set.\\ LocalRootPeers.keysSet localRootPeers
-                                Set.\\ inProgressDemoteWarm
-                                Set.\\ inProgressPromoteWarm
+        availableToDemote :: Set peeraddr
+        availableToDemote = EstablishedPeers.toSet establishedPeers
+                              Set.\\ activePeers
+                              Set.\\ LocalRootPeers.keysSet localRootPeers
+                              Set.\\ inProgressDemoteWarm
+                              Set.\\ inProgressPromoteWarm
+                              Set.\\ inProgressDemoteToCold
+
+  , numPeersToDemote > 0
+  , not (Set.null availableToDemote)
+  = Guarded Nothing $ do
       selectedToDemote <- pickPeers st
                             policyPickWarmPeersToDemote
                             availableToDemote
@@ -551,6 +561,7 @@ aboveTargetBigLedgerPeers actions
                             activePeers,
                             inProgressDemoteWarm,
                             inProgressPromoteWarm,
+                            inProgressDemoteToCold,
                             targets = PeerSelectionTargets {
                                         targetNumberOfEstablishedBigLedgerPeers
                                       }
@@ -577,15 +588,18 @@ aboveTargetBigLedgerPeers actions
                                      - Set.size inProgressDemoteWarm
                                      - Set.size inProgressPromoteWarm
 
+        availableToDemote :: Set peeraddr
+        availableToDemote = EstablishedPeers.toSet establishedPeers
+                             `Set.intersection` bigLedgerPeers
+                              Set.\\ activePeers
+                              Set.\\ inProgressDemoteWarm
+                              Set.\\ inProgressPromoteWarm
+                              Set.\\ inProgressDemoteToCold
+
   , numBigLedgerPeersToDemote > 0
+  , not (Set.null availableToDemote)
   = Guarded Nothing $ do
 
-      let availableToDemote :: Set peeraddr
-          availableToDemote = EstablishedPeers.toSet establishedPeers
-                               `Set.intersection` bigLedgerPeers
-                                Set.\\ activePeers
-                                Set.\\ inProgressDemoteWarm
-                                Set.\\ inProgressPromoteWarm
       selectedToDemote <- pickPeers st
                             policyPickWarmPeersToDemote
                             availableToDemote

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -21,7 +21,7 @@ import           Control.Monad.Class.MonadTime.SI
 import           System.Random (randomR)
 
 import           Ouroboros.Network.PeerSelection.Governor.Types
-import           Ouroboros.Network.PeerSelection.LedgerPeers
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type
                      (IsBigLedgerPeer (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -54,6 +54,7 @@ belowTarget actions
               knownPeers,
               establishedPeers,
               inProgressPeerShareReqs,
+              inProgressDemoteToCold,
               targets = PeerSelectionTargets {
                           targetNumberOfKnownPeers
                         }
@@ -125,6 +126,7 @@ belowTarget actions
     numPeerShareReqsPossible = policyMaxInProgressPeerShareReqs
                              - inProgressPeerShareReqs
     availableForPeerShare    = EstablishedPeers.availableForPeerShare establishedPeers
+                             Set.\\ inProgressDemoteToCold
     -- Only ask peers which have the correct willingness permission flags
     canAsk                   =
       KnownPeers.getAvailablePeerSharingPeers availableForPeerShare knownPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -433,7 +433,7 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
 --     Should also take account of DNS failures for root peer set.
 --     lastSuccessfulNetworkEvent :: Time
      }
-  deriving (Show, Functor)
+  deriving Show
 
 -- | Public 'PeerSelectionState' that can be accessed by Peer Sharing
 -- mechanisms without any problem.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -60,10 +60,12 @@ import           Control.Monad.Class.MonadTime.SI
 import           System.Random (StdGen)
 
 import           Ouroboros.Network.ExitPolicy
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsBigLedgerPeer,
-                     IsLedgerPeer)
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type
+                     (IsBigLedgerPeer)
 import           Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (IsLedgerPeer)
 import           Ouroboros.Network.PeerSelection.State.EstablishedPeers
                      (EstablishedPeers)
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -631,12 +631,9 @@ withPeerStateActions PeerStateActionsArguments {
               PeerCold ->
                 return Nothing
               PeerCooling -> do
-                cmState <- readState spsConnectionManager
-                case Map.lookup (remoteAddress pchConnectionId) cmState of
-                  Just UnknownConnectionSt -> do
-                    writeTVar pchPeerStatus PeerCold
-                    return Nothing
-                  _ -> retry
+                waitForOutboundDemotion spsConnectionManager (remoteAddress pchConnectionId)
+                writeTVar pchPeerStatus PeerCold
+                return Nothing
               _ ->
                   (Just . WithSomeProtocolTemperature . WithEstablished
                     <$> awaitFirstResult SingEstablished pchAppHandles)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSActions.hs
@@ -9,7 +9,7 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
     DNSActions (..)
     -- * DNSActions IO
   , ioDNSActions
-  , LookupReqs (..)
+  , DNSLookupType (..)
     -- * Utils
     -- ** Resource
   , Resource (..)
@@ -45,10 +45,10 @@ import           Network.DNS (DNSError)
 import qualified Network.DNS as DNS
 
 
-data LookupReqs = LookupReqAOnly
-                | LookupReqAAAAOnly
-                | LookupReqAAndAAAA
-                deriving Show
+data DNSLookupType = LookupReqAOnly
+                   | LookupReqAAAAOnly
+                   | LookupReqAAndAAAA
+                   deriving Show
 
 data DNSorIOError exception
     = DNSError !DNSError
@@ -192,7 +192,7 @@ getResolver resolvConf = do
 --
 -- It guarantees that returned TTLs are strictly greater than 0.
 --
-ioDNSActions :: LookupReqs
+ioDNSActions :: DNSLookupType
              -> DNSActions DNS.Resolver IOException IO
 ioDNSActions =
     \reqs -> DNSActions {
@@ -362,7 +362,7 @@ ioDNSActions =
           ]
 
 
-    lookupWithTTL :: LookupReqs
+    lookupWithTTL :: DNSLookupType
                   -> DNS.ResolvConf
                   -> DNS.Resolver
                   -> DNS.Domain

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSSemaphore.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSSemaphore.hs
@@ -1,0 +1,45 @@
+
+module Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore
+  ( -- * DNS semaphore
+    DNSSemaphore
+  , newLedgerAndPublicRootDNSSemaphore
+  , newDNSLocalRootSemaphore
+  , withDNSSemaphore
+  ) where
+
+import           Control.Concurrent.Class.MonadSTM.Strict
+import           Control.Concurrent.Class.MonadSTM.TSem
+import           Control.Monad.Class.MonadThrow
+
+-- | Maximal concurrency when resolving DNS names of root and ledger peers.
+--
+maxDNSConcurrency :: Integer
+maxDNSConcurrency = 8
+
+-- | Maximal concurrency when resolving DNS names of local root peers.
+--
+maxDNSLocalRootConcurrency :: Integer
+maxDNSLocalRootConcurrency = 2
+
+-- | A semaphore used to limit concurrency of dns names resolution.
+--
+newtype DNSSemaphore m = DNSSemaphore (TSem m)
+
+-- | Create a `DNSSemaphore` for root and ledger peers.
+--
+newLedgerAndPublicRootDNSSemaphore :: MonadSTM m => m (DNSSemaphore m)
+newLedgerAndPublicRootDNSSemaphore = DNSSemaphore <$> atomically (newTSem maxDNSConcurrency)
+
+-- | Create a `DNSSemaphore` for local root peers.
+--
+newDNSLocalRootSemaphore :: MonadSTM m => STM m (DNSSemaphore m)
+newDNSLocalRootSemaphore = DNSSemaphore <$> newTSem maxDNSLocalRootConcurrency
+
+-- | Run a computation by attempting to acquire the semaphore first.
+-- On termination or failure free the semaphore
+--
+withDNSSemaphore :: (MonadSTM m, MonadThrow m) => DNSSemaphore m -> m a -> m a
+withDNSSemaphore (DNSSemaphore s) =
+    bracket_ (atomically $ waitTSem s)
+             (atomically $ signalTSem s)
+

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+
+module Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
+  ( -- * DNS based provider for public root peers
+    publicRootPeersProvider
+  , TracePublicRootPeers (..)
+  ) where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Word (Word32)
+
+import           Control.Concurrent.Class.MonadSTM.Strict
+import           Control.Monad (when)
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime.SI
+import           Control.Tracer (Tracer (..), traceWith)
+
+
+import qualified Network.DNS as DNS
+import qualified Network.Socket as Socket
+
+import           Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
+                     (DNSActions (..), DNSorIOError (..), Resource (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore
+                     (DNSSemaphore, withDNSSemaphore)
+
+---------------------------------------------
+-- Public root peer set provider using DNS
+--
+
+data TracePublicRootPeers =
+       TracePublicRootRelayAccessPoint (Map RelayAccessPoint PeerAdvertise)
+     | TracePublicRootDomains [DomainAccessPoint]
+     | TracePublicRootResult  DNS.Domain [(IP, DNS.TTL)]
+     | TracePublicRootFailure DNS.Domain DNS.DNSError
+       --TODO: classify DNS errors, config error vs transitory
+  deriving Show
+
+-- |
+--
+publicRootPeersProvider
+  :: forall peerAddr resolver exception a m.
+     (MonadThrow m, MonadAsync m, Exception exception,
+      Ord peerAddr)
+  => Tracer m TracePublicRootPeers
+  -> (IP -> Socket.PortNumber -> peerAddr)
+  -> DNSSemaphore m
+  -> DNS.ResolvConf
+  -> STM m (Map RelayAccessPoint PeerAdvertise)
+  -> DNSActions resolver exception m
+  -> ((Int -> m (Map peerAddr PeerAdvertise, DiffTime)) -> m a)
+  -> m a
+publicRootPeersProvider tracer
+                        toPeerAddr
+                        dnsSemaphore
+                        resolvConf
+                        readDomains
+                        DNSActions {
+                          dnsResolverResource,
+                          dnsLookupWithTTL
+                        }
+                        action = do
+    domains <- atomically readDomains
+    traceWith tracer (TracePublicRootRelayAccessPoint domains)
+    rr <- dnsResolverResource resolvConf
+    resourceVar <- newTVarIO rr
+    action (requestPublicRootPeers resourceVar)
+  where
+    processResult :: ((DomainAccessPoint, PeerAdvertise), ([DNS.DNSError], [(IP, DNS.TTL)]))
+                  -> m ((DomainAccessPoint, PeerAdvertise), [(IP, DNS.TTL)])
+    processResult ((domain, pa), (errs, result)) = do
+        mapM_ (traceWith tracer . TracePublicRootFailure (dapDomain domain))
+              errs
+        when (not $ null result) $
+            traceWith tracer $ TracePublicRootResult (dapDomain domain) result
+
+        return ((domain, pa), result)
+
+    requestPublicRootPeers
+      :: StrictTVar m (Resource m (Either (DNSorIOError exception) resolver))
+      -> Int
+      -> m (Map peerAddr PeerAdvertise, DiffTime)
+    requestPublicRootPeers resourceVar _numRequested = do
+        domains <- atomically readDomains
+        traceWith tracer (TracePublicRootRelayAccessPoint domains)
+        rr <- atomically $ readTVar resourceVar
+        (er, rr') <- withResource rr
+        atomically $ writeTVar resourceVar rr'
+        case er of
+          Left (DNSError err) -> throwIO err
+          Left (IOError  err) -> throwIO err
+          Right resolver -> do
+            let lookups =
+                  [ ((DomainAccessPoint domain port, pa),)
+                      <$> withDNSSemaphore dnsSemaphore
+                            (dnsLookupWithTTL
+                              resolvConf
+                              resolver
+                              domain)
+                  | (RelayAccessDomain domain port, pa) <- Map.assocs domains ]
+            -- The timeouts here are handled by the 'lookupWithTTL'. They're
+            -- configured via the DNS.ResolvConf resolvTimeout field and defaults
+            -- to 3 sec.
+            results <- withAsyncAll lookups (atomically . mapM waitSTM)
+            results' <- mapM processResult results
+            let successes = [ ( (toPeerAddr ip dapPortNumber, pa)
+                              , ipttl)
+                            | ( (DomainAccessPoint {dapPortNumber}, pa)
+                              , ipttls) <- results'
+                            , (ip, ipttl) <- ipttls
+                            ]
+                !domainsIps = [(toPeerAddr ip port, pa)
+                              | (RelayAccessAddress ip port, pa) <- Map.assocs domains ]
+                !ips      = Map.fromList (map fst successes) `Map.union` Map.fromList domainsIps
+                !ttl      = ttlForResults (map snd successes)
+            -- If all the lookups failed we'll return an empty set with a minimum
+            -- TTL, and the governor will invoke its exponential backoff.
+            return (ips, ttl)
+
+-- Aux
+
+withAsyncAll :: MonadAsync m => [m a] -> ([Async m a] -> m b) -> m b
+withAsyncAll xs0 action = go [] xs0
+  where
+    go as []     = action (reverse as)
+    go as (x:xs) = withAsync x (\a -> go (a:as) xs)
+
+-- | Policy for TTL for positive results
+ttlForResults :: [DNS.TTL] -> DiffTime
+
+-- This case says we have a successful reply but there is no answer.
+-- This covers for example non-existent TLDs since there is no authority
+-- to say that they should not exist.
+ttlForResults []   = ttlForDnsError DNS.NameError 0
+ttlForResults ttls = clipTTLBelow
+                   . clipTTLAbove
+                   . (fromIntegral :: Word32 -> DiffTime)
+                   $ maximum ttls
+
+-- | Limit insane TTL choices.
+clipTTLAbove, clipTTLBelow :: DiffTime -> DiffTime
+clipTTLBelow = max 60     -- between 1min
+clipTTLAbove = min 86400  -- and 24hrs
+
+-- | Policy for TTL for negative results
+-- Cache negative response for 3hrs
+-- Otherwise, use exponential backoff, up to a limit
+ttlForDnsError :: DNS.DNSError -> DiffTime -> DiffTime
+ttlForDnsError DNS.NameError _ = 10800
+ttlForDnsError _           ttl = clipTTLAbove (ttl * 2 + 5)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
@@ -45,10 +45,11 @@ import           Control.Exception (assert)
 import           Control.Monad.Class.MonadTime.SI
 
 import           Data.Maybe (fromMaybe)
-import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer (..))
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
+                     (IsLedgerPeer (..))
 
 
 -------------------------------

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
@@ -12,10 +12,10 @@ data PeerSource = PeerSourceLocalRoot
   deriving (Eq, Ord, Show, Enum)
 
 data PeerStatus =
-       PeerReallyCold
+       PeerCold
      -- ^ Peer is in true cold which means no connection to exists
      -- and the outbound governor is safe to promote it.
-     | PeerCold
+     | PeerCooling
      -- ^ Peer is in cold state but its connection still lingers.
      -- I.e. it is still in progress to be fully demoted.
      | PeerWarm

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Types.hs
@@ -12,7 +12,12 @@ data PeerSource = PeerSourceLocalRoot
   deriving (Eq, Ord, Show, Enum)
 
 data PeerStatus =
-       PeerCold
+       PeerReallyCold
+     -- ^ Peer is in true cold which means no connection to exists
+     -- and the outbound governor is safe to promote it.
+     | PeerCold
+     -- ^ Peer is in cold state but its connection still lingers.
+     -- I.e. it is still in progress to be fully demoted.
      | PeerWarm
      | PeerHot
   deriving (Eq, Ord, Show)


### PR DESCRIPTION
- Refactor `withLedgerPeers` & `resolveDomainAccessPoint`
  - Removes `withLedgerPeers` (only used in tests now)
  - `withPeerSelectionActions` is responsible for fetching and resolving all peers
  - Renames `resolveDomainAccessPoint` to `resolveLedgerPeers`
- Splits `Ouroboros.Network.PeerSelection.RootPeersDNS` into
  - `Ouroboros.Network.PeerSelection.DNS.RootPeers`
  - `Ouroboros.Network.PeerSelection.DNS.LocalRoots`
  - `Ouroboros.Network.PeerSelection.DNS.LedgerPeers`
  - `Ouroboros.Network.PeerSelection.DNS.DNSSemaphore`

Closes #4606 