### PR TITLE
Add Idle timeouts

### DIFF
--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Non-breaking changes
 
 * Improved cdd specs by using `any` (PR #4638)
+* Add a 3673s timeout to chainsync's StIdle state.
+* Add a 97s timeout to keepalive's StClient state.
 
 ## 0.5.2.0 -- 2023-09-08
 

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -77,7 +77,7 @@ timeLimitsChainSync csTimeouts = ProtocolTimeLimits stateToLimit
 
     stateToLimit :: forall (pr :: PeerRole) (st :: ChainSync header point tip).
                     PeerHasAgency pr st -> Maybe DiffTime
-    stateToLimit (ClientAgency TokIdle)                = waitForever
+    stateToLimit (ClientAgency TokIdle)                = Just 3673
     stateToLimit (ServerAgency (TokNext TokCanAwait))  = canAwaitTimeout
     stateToLimit (ServerAgency (TokNext TokMustReply)) = mustReplyTimeout
     stateToLimit (ServerAgency TokIntersect)           = intersectTimeout

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/KeepAlive/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/KeepAlive/Codec.hs
@@ -89,7 +89,7 @@ timeLimitsKeepAlive = ProtocolTimeLimits { timeLimitForState }
   where
     timeLimitForState :: PeerHasAgency (pr :: PeerRole) (st :: KeepAlive)
                       -> Maybe DiffTime
-    timeLimitForState (ClientAgency TokClient) = waitForever
+    timeLimitForState (ClientAgency TokClient) = Just 97
     timeLimitForState (ServerAgency TokServer) = Just 60 -- TODO: #2505 should be 10s.
 
 


### PR DESCRIPTION
# Description

Add timeouts to chainsync's TokIdle state and keepalive's TokClient state.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
