### PR TITLE
Be less aggresive when churning peers

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### Breaking changes
 
-- Removes `updatePeerSharing` from `KnownPeers` module API
+### Non-breaking changes
+
+* Less aggresive churning of established and known peers.
+
+## 0.9.1.0 -- 2023-08-22
+
+### Breaking changes
+
+* Removes `updatePeerSharing` from `KnownPeers` module API
 
 ### Non-breaking changes
 


### PR DESCRIPTION
Be less aggresive when churning established and known peers. Active peers are established peers and established peers are known peers. This means that when churning established peers and known peers we where churning too many peers.

This patch changes the churn behaviour so that we aim to only churn 20% of the established peers that are not also hot peers, and 20% of the known peers that are not also established peers.

This makes it possible to run the node with fewer established peers which reduces the overall number of connections in the network.

# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

_description of the pull request, if it fixes a particular issue it should link the PR to a particular issue, see [ref](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)_

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
