### PR TITLE
AcceptedConnectionsLimit: add json instances

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Non-breaking changes
 
 * Split `test` component into `io-tests` and `sim-tests`.
+* Added `ToJSON` and `FromJSON` instances for `AcceptedConnectionsLimit`
 
 ## 0.9.0.0 -- 2023-08-21
 

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -69,6 +69,7 @@ library
 
   -- other-extensions:
   build-depends:       base            >=4.12  && <4.19
+                     , aeson
                      , async           >=2.1   && <2.3
                      , bytestring      >=0.10  && <0.12
                      , cborg           >=0.2.1 && <0.3

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Rage limiting of accepted connections
 --
@@ -18,6 +19,8 @@ import           Control.Tracer (Tracer, traceWith)
 import           Data.Typeable (Typeable)
 import           Data.Word
 import           Text.Printf
+
+import           Data.Aeson.Types
 
 
 -- | Policy which governs how to limit the number of accepted connections.
@@ -41,6 +44,28 @@ data AcceptedConnectionsLimit = AcceptedConnectionsLimit {
   }
   deriving (Eq, Ord, Show)
 
+instance ToJSON AcceptedConnectionsLimit where
+  toJSON AcceptedConnectionsLimit
+          { acceptedConnectionsHardLimit
+          , acceptedConnectionsSoftLimit
+          , acceptedConnectionsDelay
+          } =
+    object [ "AcceptedConnectionsLimit" .=
+      object [ "hardLimit" .=
+                  toJSON acceptedConnectionsHardLimit
+             , "softLimit" .=
+                  toJSON acceptedConnectionsSoftLimit
+             , "delay" .=
+                  toJSON acceptedConnectionsDelay
+             ]
+           ]
+
+instance FromJSON AcceptedConnectionsLimit where
+  parseJSON = withObject "AcceptedConnectionsLimit" $ \v ->
+    AcceptedConnectionsLimit
+      <$> v .: "hardLimit"
+      <*> v .: "softLimit"
+      <*> v .: "delay"
 
 -- | Rate limiting instruction.
 --


### PR DESCRIPTION
Contributes to fixing https://github.com/input-output-hk/cardano-node/issues/5470

# Description

We are getting rid of some orphan instances we have [here in cardano-node](https://github.com/input-output-hk/cardano-node/blob/396739ca42a3b09fc5e3df698f34cec391f795aa/cardano-node/src/Cardano/Node/Orphans.hs#L43): that's PR https://github.com/input-output-hk/cardano-node/pull/5466. That is why we need to add Json instances for `AcceptedConnectionsLimit`.

This PR adds `aeson` as a dependency to `ouroboros-network-framework`. At the same time I'm writing this, aeson 2.1.2.1 is pulled: please let me know which version bound you want to specify (if any) in the cabal project. Right now, I've  omitted specifying the version.

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

# Checklist

- Branch
    - [X] Updated changelog files.
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - NA The documentation has been properly updated
    - NA New tests are added if needed and existing tests are updated
    - NA If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [X] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
