### PR TITLE
cardano-ping: more often honor json flag when printing output

### DIFF
--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Breaking changes
 
+### Non-breaking changes
+
+## 0.2.0.7 -- 2023-10-20
+
 * In presence of flag `-j`, output json when printing
   `network_rtt`, `handshake_rtt`, `negotiated_version` and `queried_versions`.
-
-### Non-breaking changes
 
 ## 0.2.0.6 -- 2023-08-09
 

--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* In presence of flag `-j`, output json when printing
+  `network_rtt`, `handshake_rtt`, `negotiated_version` and `queried_versions`.
+
 ### Non-breaking changes
 
 ## 0.2.0.6 -- 2023-08-09

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   cardano-ping
-version:                0.2.0.6
+version:                0.2.0.7
 synopsis:               Utility for pinging cardano nodes
 description:            Utility for pinging cardano nodes.
 license:                Apache-2.0


### PR DESCRIPTION
Contributes to fixing https://github.com/input-output-hk/cardano-cli/issues/197

# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

This PR changes the output of the ping command in presence of `-j`. For example, it transforms:

```shell
> cardano-cli ping -m 4 -u $CARDANO_NODE_SOCKET_PATH -j
$HOME/dev/sanchonet/node.socket network rtt: 0.000
$HOME/dev/sanchonet/node.socket handshake rtt: 0.003084784s
$HOME/dev/sanchonet/node.socket Negotiated version NodeToClientVersionV16 4
] }
> cardano-cli ping -h relay0.bluecheesestakehouse.com -j -p 5000 -Q
47.196.34.59:5000 network rtt: 0.124
47.196.34.59:5000 handshake rtt: 0.123472665s
47.196.34.59:5000 Queried versions [NodeToNodeVersionV11 764824073 InitiatorAndResponder,NodeToNodeVersionV10 764824073 InitiatorAndResponder,NodeToNodeVersionV9 764824073 InitiatorAndResponder,NodeToNodeVersionV8 764824073 InitiatorAndResponder,NodeToNodeVersionV7 764824073 InitiatorAndResponder]
```

into:

```shell
> cardano-cli ping -m 4 -u $CARDANO_NODE_SOCKET_PATH -j
$HOME/dev/sanchonet/node.socket {"network_rtt":2.8964e-5}
$HOME/dev/sanchonet/node.socket {"handshake_rtt":2.265816e-3}
$HOME/dev/sanchonet/node.socket {"negotiated_version":{"magic":4,"version":"NodeToClientVersionV16"}}
] }
> cardano-cli ping -h relay0.bluecheesestakehouse.com -j -p 5000 -Q
47.196.34.59:5000 {"network_rtt":0.126}
47.196.34.59:5000 {"handshake_rtt":0.127}
47.196.34.59:5000 {"queried_versions":[{"initiator":"InitiatorAndResponder","magic":764824073,"version":"NodeToNodeVersionV11"},{"initiator":"InitiatorAndResponder","magic":764824073,"version":"NodeToNodeVersionV10"},{"initiator":"InitiatorAndResponder","magic":764824073,"version":"NodeToNodeVersionV9"},{"initiator":"InitiatorAndResponder","magic":764824073,"version":"NodeToNodeVersionV8"},{"initiator":"InitiatorAndResponder","magic":764824073,"version":"NodeToNodeVersionV7"}]}
```

This is relevant to users (see the discussion in https://github.com/input-output-hk/cardano-cli/issues/197) to make parsing `cardano-cli`'s output easier.

I voluntarily went low tech in this PR. We could better separate non-json output from json output (i.e. presence or absence of `-j`), but didn't want to create a large diff. If we want to have a clearer API afterwards, I can do it as a second step.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - NA The documentation has been properly updated
    - NA New tests are added if needed and existing tests are updated
    - NA If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - NA Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [X] Reviewer requested
