### PR TITLE
KeepAlive Client collect samples on first packet

### DIFF
--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-breaking changes
 
+* Make it possible for KeepAlive client to collect a rtt sample for the first packet.
+
 ## 0.5.3.0 -- 2023-10-26
 
 ### Non-breaking changes

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/KeepAlive/Direct.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/KeepAlive/Direct.hs
@@ -1,19 +1,28 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes     #-}
 
 module Ouroboros.Network.Protocol.KeepAlive.Direct where
 
 import           Ouroboros.Network.Protocol.KeepAlive.Client
 import           Ouroboros.Network.Protocol.KeepAlive.Server
 
-direct :: Monad m
+
+direct :: forall a b m. Monad m
        => KeepAliveServer m a
        -> KeepAliveClient m b
        -> m (a, b)
-direct KeepAliveServer { recvMsgDone }
-       (SendMsgDone mdone) =
-    (,) <$> recvMsgDone <*> mdone
-direct KeepAliveServer { recvMsgKeepAlive }
-       (SendMsgKeepAlive _cookie mclient) = do
-    server <- recvMsgKeepAlive
-    client <- mclient
-    direct server client
+direct srv (KeepAliveClient clientM) = do
+  go srv =<< clientM
+ where
+   go :: Monad m
+      => KeepAliveServer m a
+      -> KeepAliveClientSt m b
+      -> m (a, b)
+   go KeepAliveServer { recvMsgDone }
+          (SendMsgDone mdone) =
+       (,) <$> recvMsgDone <*> mdone
+   go KeepAliveServer { recvMsgKeepAlive }
+          (SendMsgKeepAlive _cookie mclient) = do
+       server <- recvMsgKeepAlive
+       client <- mclient
+       go server client

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/KeepAlive/Examples.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/KeepAlive/Examples.hs
@@ -16,9 +16,9 @@ keepAliveClientApply :: forall acc m. Monad m
                     -> Int
                     -- ^ count of number of requests
                     -> KeepAliveClient m acc
-keepAliveClientApply f = go
+keepAliveClientApply f aa an = KeepAliveClient $ return (go aa an)
   where
-    go :: acc -> Int -> KeepAliveClient m acc
+    go :: acc -> Int -> KeepAliveClientSt m acc
     go acc n
       | n <= 0
       = SendMsgDone (pure acc)

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Non-breaking changes
 
+* Update KeepAlive client to collect a rtt sample for the first packet.
 * Less aggresive churning of established and known peers.
 * Add peer sharing to wireshark dissector.
 * Adds ledger peers to diffusion simulation

--- a/ouroboros-network/src/Ouroboros/Network/KeepAlive.hs
+++ b/ouroboros-network/src/Ouroboros/Network/KeepAlive.hs
@@ -52,7 +52,9 @@ keepAliveClient
     -> KeepAliveClient m ()
 keepAliveClient tracer inRng controlMessageSTM peer dqCtx KeepAliveInterval { keepAliveInterval } =
     let (cookie, rng) = random inRng in
-    SendMsgKeepAlive (Cookie cookie) (go rng Nothing)
+    KeepAliveClient $ do
+      startTime <- getMonotonicTime
+      return $ SendMsgKeepAlive (Cookie cookie) (go rng startTime)
   where
     payloadSize = 2
 
@@ -70,32 +72,24 @@ keepAliveClient tracer inRng controlMessageSTM peer dqCtx KeepAliveInterval { ke
                  then return Continue
                  else retry
 
-    go :: StdGen -> Maybe Time -> m (KeepAliveClient m ())
-    go rng startTime_m = do
+    go :: StdGen -> Time -> m (KeepAliveClientSt m ())
+    go rng startTime = do
       endTime <- getMonotonicTime
-      case startTime_m of
-           Just startTime -> do
-               let rtt = diffTime endTime startTime
-                   sample = fromSample startTime endTime payloadSize
-               gsv' <- atomically $ do
-                   m <- readTVar dqCtx
-                   assert (peer `M.member` m) $ do
-                     let (gsv', m') = M.updateLookupWithKey
-                             (\_ a -> if sampleTime a == Time 0 -- Ignore the initial dummy value
-                                         then Just sample
-                                         else Just $ sample <> a
-                             ) peer m
-                     writeTVar dqCtx m'
-                     return $ fromJust gsv'
-               traceWith tracer $ AddSample peer rtt gsv'
+      let rtt = diffTime endTime startTime
+          sample = fromSample startTime endTime payloadSize
+      gsv' <- atomically $ do
+          m <- readTVar dqCtx
+          assert (peer `M.member` m) $ do
+            let (gsv', m') = M.updateLookupWithKey
+                    (\_ a -> if sampleTime a == Time 0 -- Ignore the initial dummy value
+                                then Just sample
+                                else Just $ sample <> a
+                    ) peer m
+            writeTVar dqCtx m'
+            return $ fromJust gsv'
+      traceWith tracer $ AddSample peer rtt gsv'
 
-           Nothing        -> return ()
-
-      let keepAliveInterval' = case startTime_m of
-                                    Just _  -> keepAliveInterval
-                                    Nothing -> 0 -- The first time we send a packet directly.
-
-      delayVar <- registerDelay keepAliveInterval'
+      delayVar <- registerDelay keepAliveInterval
       decision <- atomically (decisionSTM delayVar)
       now <- getMonotonicTime
       case decision of
@@ -103,7 +97,7 @@ keepAliveClient tracer inRng controlMessageSTM peer dqCtx KeepAliveInterval { ke
         Quiesce   -> error "keepAlive: impossible happened"
         Continue  ->
             let (cookie, rng') = random rng in
-            pure (SendMsgKeepAlive (Cookie cookie) $ go rng' $ Just now)
+            pure (SendMsgKeepAlive (Cookie cookie) $ go rng' now)
         Terminate -> pure (SendMsgDone (pure ()))
 
 


### PR DESCRIPTION
# Description
Update the KeepAlive client so that it collect RTT samples for the first packet. Previusly two request where sent, one after the other because the first couldn't be used to get a sample.
Fixes #4689 

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
