### PR TITLE
Make chainsync idle timeout configurable

### DIFF
--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+* Make chainsync idle timeout configurable.
+
 ### Non-breaking changes
 
 * Make it possible for KeepAlive client to collect a rtt sample for the first packet.

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -56,6 +56,7 @@ data ChainSyncTimeout = ChainSyncTimeout
   { canAwaitTimeout  :: Maybe DiffTime
   , intersectTimeout :: Maybe DiffTime
   , mustReplyTimeout :: Maybe DiffTime
+  , idleTimeout      :: Maybe DiffTime
   }
 
 -- | Time Limits
@@ -73,11 +74,12 @@ timeLimitsChainSync csTimeouts = ProtocolTimeLimits stateToLimit
       { canAwaitTimeout
       , intersectTimeout
       , mustReplyTimeout
+      , idleTimeout
       } = csTimeouts
 
     stateToLimit :: forall (pr :: PeerRole) (st :: ChainSync header point tip).
                     PeerHasAgency pr st -> Maybe DiffTime
-    stateToLimit (ClientAgency TokIdle)                = Just 3673
+    stateToLimit (ClientAgency TokIdle)                = idleTimeout
     stateToLimit (ServerAgency (TokNext TokCanAwait))  = canAwaitTimeout
     stateToLimit (ServerAgency (TokNext TokMustReply)) = mustReplyTimeout
     stateToLimit (ServerAgency TokIntersect)           = intersectTimeout

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+* Make chainsync idle timeout configurable.
+
 ### Non-breaking changes
 
 * Updated types to accommodate `PeerSharing` data type changes.

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -1074,6 +1074,7 @@ diffusionSimulation
                 { canAwaitTimeout  = shortWait
                 , intersectTimeout = shortWait
                 , mustReplyTimeout
+                , idleTimeout      = Nothing
                 }
 
           limitsAndTimeouts :: NodeKernel.LimitsAndTimeouts BlockHeader Block


### PR DESCRIPTION
# Description

Make chainsync's idle timeout configurable. Intended to be used by test tools such as traffic generators.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
