### PR TITLE
Improve outbound governor memory footprint

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,7 +15,7 @@ repository cardano-haskell-packages
 -- repeat the index-state for hackage to work around haskell.nix parsing limitation
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-11-09T00:00:00Z
+  , hackage.haskell.org 2023-11-21T00:00:00Z 
 
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2023-11-08T10:10:42Z

--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1699489383,
-        "narHash": "sha256-qXFHtyAUo//dweY+Y8/X3zUrDbtUKgIQYeRwIcmbFyw=",
+        "lastModified": 1700526178,
+        "narHash": "sha256-2FD4zzJuid/O9AGAOk0uTEgmUxR/xe+Qkwd974NWIn0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "2245fcb232e0d8e228758bae9d8b74e9fd295190",
+        "rev": "bccdb0a797bdcc97b8c60bf55374c1d646dadc2c",
         "type": "github"
       },
       "original": {

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -41,7 +41,7 @@ common demo-deps
 
 library
   build-depends:       base            >=4.14 && <4.19,
-                       io-classes     ^>=1.3,
+                       io-classes     ^>=1.3.1,
                        strict-stm,
                        si-timers,
                        contra-tracer   >=0.1 && <0.2,

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -66,7 +66,7 @@ library
                        cardano-strict-containers,
                        contra-tracer,
 
-                       io-classes       ^>=1.3,
+                       io-classes       ^>=1.3.1,
                        network-mux      ^>=0.4,
                        strict-stm,
                        si-timers,

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -87,7 +87,7 @@ library
                      , cardano-prelude
                      , contra-tracer
 
-                     , io-classes     ^>=1.3
+                     , io-classes     ^>=1.3.1
                      , si-timers
                      , strict-stm
 

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -97,7 +97,7 @@ library
                        bytestring        >=0.10 && <0.12,
                        cborg             >=0.2.1 && <0.3,
 
-                       io-classes       ^>=1.3,
+                       io-classes       ^>=1.3.1,
                        si-timers,
 
                        ouroboros-network-api

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -62,7 +62,7 @@ library
                        containers,
                        contra-tracer,
                        deque            ^>=0.4,
-                       io-classes       ^>=1.3,
+                       io-classes       ^>=1.3.1,
                        io-sim,
                        pretty-simple,
                        psqueues          >=0.2.3 && <0.3,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -125,7 +125,7 @@ library
                        monoidal-synchronisation,
                        strict-checked-vars ^>= 0.1.0.3,
 
-                       io-classes       ^>=1.3,
+                       io-classes       ^>=1.3.1,
                        io-classes-mtl   ^>=0.1,
                        network-mux,
                        si-timers,

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -16,7 +16,7 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime.SI
 import           Control.Monad.Class.MonadTimer.SI
 import           Control.Monad.IOSim hiding (SimResult)
-import           Control.Tracer (Tracer (..), showTracing, traceWith)
+import           Control.Tracer (Tracer (..), nullTracer, traceWith)
 import qualified Data.IP as IP
 import           Data.List (foldl', intercalate, isPrefixOf, nub, sortOn)
 import qualified Data.List.NonEmpty as NonEmpty
@@ -329,7 +329,7 @@ verboseTracer :: forall a m.
                        , Show a
                        )
                => Tracer m a
-verboseTracer = threadAndTimeTracer $ showTracing $ Tracer say
+verboseTracer = nullTracer -- threadAndTimeTracer $ Tracer (say . show)
 
 threadAndTimeTracer :: forall a m.
                        ( MonadAsync m
@@ -338,5 +338,5 @@ threadAndTimeTracer :: forall a m.
                     => Tracer m (WithThreadAndTime a) -> Tracer m a
 threadAndTimeTracer tr = Tracer $ \s -> do
     !now <- getMonotonicTime
-    !tid <- myThreadId
-    traceWith tr $ WithThreadAndTime now (show tid) s
+    !tid <- show <$> myThreadId
+    traceWith tr $! WithThreadAndTime now tid s

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -541,7 +541,6 @@ envEventCredits  TraceEnvRequestPublicRootPeers = 0
 envEventCredits  TraceEnvRequestBigLedgerPeers  = 0
 envEventCredits  TraceEnvPublicRootTTL          = 60
 envEventCredits  TraceEnvBigLedgerPeersTTL      = 60
-envEventCredits (TraceEnvPeerShareTTL _)        = 30
 
 envEventCredits (TraceEnvSetTargets PeerSelectionTargets {
                    targetNumberOfRootPeers = _,

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -1726,7 +1726,7 @@ prop_governor_target_known_5_no_shrink_below env =
               --
               -- By subtracting a sum of `y` and `y'` we also do not account
               -- forgetting big ledger peers.
-              (\(x,y) (x',y') -> x Set.\\ x' Set.\\ (y <> y'))
+              (\(x,y) (x',y') -> x Set.\\ x' Set.\\ y Set.\\ y')
           $ (,) <$> govKnownPeersSig
                 <*> bigLedgerPeersSig
 
@@ -2254,22 +2254,22 @@ prop_governor_target_active_below env =
               (\case TracePromoteWarmFailed _ _ peer _ ->
                        --TODO: the environment does not yet cause this to happen
                        -- it requires synchronous failure in the establish action
-                       Just (Set.singleton peer)
+                       Just $! Set.singleton peer
                      TraceDemoteWarmFailed _ _ peer _ ->
-                       Just (Set.singleton peer)
+                       Just $! Set.singleton peer
                      TraceDemoteHotFailed _ _ peer _ ->
-                       Just (Set.singleton peer)
+                       Just $! Set.singleton peer
                      --TODO
                      TraceDemoteAsynchronous status
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
+                         !failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
                      TraceDemoteLocalAsynchronous status
                        | Set.null failures -> Nothing
                        | otherwise         -> Just failures
                        where
-                         failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
+                         !failures = Map.keysSet (Map.filter (==PeerWarm) . fmap fst $ status)
                      _ -> Nothing
               )
           . selectGovEvents
@@ -2928,13 +2928,13 @@ takeFirstNHours h = takeWhile (\(t,_) -> t < Time (60*60*h))
 
 selectEnvEvents :: Events TestTraceEvent -> Events TraceMockEnv
 selectEnvEvents = Signal.selectEvents
-                    (\case MockEnvEvent e -> Just e
+                    (\case MockEnvEvent e -> Just $! e
                            _              -> Nothing)
 
 selectGovEvents :: Events TestTraceEvent
                 -> Events (TracePeerSelection PeerAddr)
 selectGovEvents = Signal.selectEvents
-                    (\case GovernorEvent e -> Just e
+                    (\case GovernorEvent e -> Just $! e
                            _               -> Nothing)
 
 selectGovState :: Eq a
@@ -2944,9 +2944,9 @@ selectGovState :: Eq a
 selectGovState f =
     Signal.nub
   -- TODO: #3182 Rng seed should come from quickcheck.
-  . Signal.fromChangeEvents (f $ Governor.emptyPeerSelectionState (mkStdGen 42) [])
+  . Signal.fromChangeEvents (f $! Governor.emptyPeerSelectionState (mkStdGen 42) [])
   . Signal.selectEvents
-      (\case GovernorDebug (TraceGovernorState _ _ st) -> Just (f st)
+      (\case GovernorDebug (TraceGovernorState _ _ st) -> Just $! f st
              _                                         -> Nothing)
 
 selectEnvTargets :: Eq a
@@ -2958,7 +2958,7 @@ selectEnvTargets f =
   . fmap f
   . Signal.fromChangeEvents nullPeerSelectionTargets
   . Signal.selectEvents
-      (\case TraceEnvSetTargets targets -> Just targets
+      (\case TraceEnvSetTargets targets -> Just $! targets
              _                          -> Nothing)
   . selectEnvEvents
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -229,7 +229,6 @@ data TraceMockEnv = TraceEnvAddPeers       !PeerGraph
                   | TraceEnvSetPublicRoots !(Map PeerAddr (PeerAdvertise, IsLedgerPeer))
                   | TraceEnvPublicRootTTL
                   | TraceEnvBigLedgerPeersTTL
-                  | TraceEnvPeerShareTTL   !PeerAddr
                   | TraceEnvSetTargets     !PeerSelectionTargets
                   | TraceEnvPeersDemote    !AsyncDemotion !PeerAddr
                   | TraceEnvEstablishConn  !PeerAddr
@@ -315,9 +314,7 @@ mockPeerSelectionActions' tracer
                             bigLedgerPeers,
                             peerSharing
                           }
-                          PeerSelectionPolicy {
-                            policyPeerShareRetryTime
-                          }
+                          _
                           scripts
                           targetsVar
                           connsVar =
@@ -366,9 +363,6 @@ mockPeerSelectionActions' tracer
       let Just (peerShareScript, _, _) = Map.lookup addr scripts
       mPeerShare <- stepScript peerShareScript
       traceWith tracer (TraceEnvPeerShareRequest addr mPeerShare)
-      _ <- async $ do
-        threadDelay policyPeerShareRetryTime
-        traceWith tracer (TraceEnvPeerShareTTL addr)
       case mPeerShare of
         Nothing                -> do
           threadDelay 1

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -177,7 +177,7 @@ validGovernorMockEnvironment GovernorMockEnvironment {
    .&&. foldl (\p (a,_) -> p .&&. counterexample ("in sane targets: " ++ show a) (sanePeerSelectionTargets a))
               (property True) targets
    .&&. counterexample "big ledger peers not a subset of public roots"
-        (bigLedgerPeers `Set.isSubsetOf` (Map.keysSet publicRootPeers))
+        (bigLedgerPeers `Set.isSubsetOf` Map.keysSet publicRootPeers)
   where
     allPeersSet = allPeers peerGraph
 
@@ -222,26 +222,26 @@ exploreGovernorInMockEnvironment :: Testable test
 exploreGovernorInMockEnvironment optsf mockEnv k =
     exploreSimTrace optsf (governorAction mockEnv) k
 
-data TraceMockEnv = TraceEnvAddPeers       PeerGraph
-                  | TraceEnvSetLocalRoots  (LocalRootPeers PeerAddr)
+data TraceMockEnv = TraceEnvAddPeers       !PeerGraph
+                  | TraceEnvSetLocalRoots  !(LocalRootPeers PeerAddr)
                   | TraceEnvRequestPublicRootPeers
                   | TraceEnvRequestBigLedgerPeers
-                  | TraceEnvSetPublicRoots (Map PeerAddr (PeerAdvertise, IsLedgerPeer))
+                  | TraceEnvSetPublicRoots !(Map PeerAddr (PeerAdvertise, IsLedgerPeer))
                   | TraceEnvPublicRootTTL
                   | TraceEnvBigLedgerPeersTTL
-                  | TraceEnvPeerShareTTL   PeerAddr
-                  | TraceEnvSetTargets     PeerSelectionTargets
-                  | TraceEnvPeersDemote    AsyncDemotion PeerAddr
-                  | TraceEnvEstablishConn  PeerAddr
-                  | TraceEnvActivatePeer   PeerAddr
-                  | TraceEnvDeactivatePeer PeerAddr
-                  | TraceEnvCloseConn      PeerAddr
+                  | TraceEnvPeerShareTTL   !PeerAddr
+                  | TraceEnvSetTargets     !PeerSelectionTargets
+                  | TraceEnvPeersDemote    !AsyncDemotion !PeerAddr
+                  | TraceEnvEstablishConn  !PeerAddr
+                  | TraceEnvActivatePeer   !PeerAddr
+                  | TraceEnvDeactivatePeer !PeerAddr
+                  | TraceEnvCloseConn      !PeerAddr
 
-                  | TraceEnvRootsResult      [PeerAddr]
-                  | TraceEnvBigLedgerPeersResult (Set PeerAddr)
-                  | TraceEnvPeerShareRequest PeerAddr (Maybe ([PeerAddr], PeerShareTime))
-                  | TraceEnvPeerShareResult  PeerAddr [PeerAddr]
-                  | TraceEnvPeersStatus      (Map PeerAddr PeerStatus)
+                  | TraceEnvRootsResult      ![PeerAddr]
+                  | TraceEnvBigLedgerPeersResult !(Set PeerAddr)
+                  | TraceEnvPeerShareRequest !PeerAddr !(Maybe ([PeerAddr], PeerShareTime))
+                  | TraceEnvPeerShareResult  !PeerAddr ![PeerAddr]
+                  | TraceEnvPeersStatus      !(Map PeerAddr PeerStatus)
   deriving Show
 
 mockPeerSelectionActions :: forall m.
@@ -542,10 +542,10 @@ mockPeerSelectionPolicy GovernorMockEnvironment {
 -- Utils for properties
 --
 
-data TestTraceEvent = GovernorDebug    (DebugPeerSelection PeerAddr)
-                    | GovernorEvent    (TracePeerSelection PeerAddr)
-                    | GovernorCounters PeerSelectionCounters
-                    | MockEnvEvent     TraceMockEnv
+data TestTraceEvent = GovernorDebug    !(DebugPeerSelection PeerAddr)
+                    | GovernorEvent    !(TracePeerSelection PeerAddr)
+                    | GovernorCounters !PeerSelectionCounters
+                    | MockEnvEvent     !TraceMockEnv
                    -- Warning: be careful with writing properties that rely
                    -- on trace events from both the governor and from the
                    -- environment. These events typically occur in separate

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -550,7 +550,59 @@ data TestTraceEvent = GovernorDebug    !(DebugPeerSelection PeerAddr)
   deriving Show
 
 tracerTracePeerSelection :: Tracer (IOSim s) (TracePeerSelection PeerAddr)
-tracerTracePeerSelection = contramap GovernorEvent tracerTestTraceEvent
+tracerTracePeerSelection = contramap f tracerTestTraceEvent
+  where
+    -- make the tracer strict
+    f :: TracePeerSelection PeerAddr -> TestTraceEvent
+    f a@(TraceLocalRootPeersChanged !_ !_)                   = GovernorEvent a
+    f a@(TraceTargetsChanged !_ !_)                          = GovernorEvent a
+    f a@(TracePublicRootsRequest !_ !_)                      = GovernorEvent a
+    f a@(TracePublicRootsResults !_ !_ !_)                   = GovernorEvent a
+    f a@(TracePublicRootsFailure !_ !_ !_)                   = GovernorEvent a
+    f a@(TraceForgetColdPeers !_ !_ !_)                      = GovernorEvent a
+    f a@(TraceBigLedgerPeersRequest !_ !_)                   = GovernorEvent a
+    f a@(TraceBigLedgerPeersResults !_ !_ !_)                = GovernorEvent a
+    f a@(TraceBigLedgerPeersFailure !_ !_ !_)                = GovernorEvent a
+    f a@(TraceForgetBigLedgerPeers !_ !_ !_)                 = GovernorEvent a
+    f a@(TracePeerShareRequests !_ !_ !_ !_)                 = GovernorEvent a
+    f a@(TracePeerShareResults !_)                           = GovernorEvent a
+    f a@(TracePeerShareResultsFiltered !_)                   = GovernorEvent a
+    f a@(TraceKnownInboundConnection !_ !_)                  = GovernorEvent a
+    f a@(TracePromoteColdPeers !_ !_ !_)                     = GovernorEvent a
+    f a@(TracePromoteColdLocalPeers !_ !_)                   = GovernorEvent a
+    f a@(TracePromoteColdFailed !_ !_ !_ !_ !_)              = GovernorEvent a
+    f a@(TracePromoteColdDone !_ !_ !_)                      = GovernorEvent a
+    f a@(TracePromoteColdBigLedgerPeers !_ !_ !_)            = GovernorEvent a
+    f a@(TracePromoteColdBigLedgerPeerFailed !_ !_ !_ !_ !_) = GovernorEvent a
+    f a@(TracePromoteColdBigLedgerPeerDone !_ !_ !_)         = GovernorEvent a
+    f a@(TracePromoteWarmPeers !_ !_ !_)                     = GovernorEvent a
+    f a@(TracePromoteWarmLocalPeers !_ !_)                   = GovernorEvent a
+    f a@(TracePromoteWarmFailed !_ !_ !_ !_)                 = GovernorEvent a
+    f a@(TracePromoteWarmDone !_ !_ !_)                      = GovernorEvent a
+    f a@(TracePromoteWarmAborted !_ !_ !_)                   = GovernorEvent a
+    f a@(TracePromoteWarmBigLedgerPeers !_ !_ !_)            = GovernorEvent a
+    f a@(TracePromoteWarmBigLedgerPeerFailed !_ !_ !_ !_)    = GovernorEvent a
+    f a@(TracePromoteWarmBigLedgerPeerDone !_ !_ !_)         = GovernorEvent a
+    f a@(TracePromoteWarmBigLedgerPeerAborted !_ !_ !_)      = GovernorEvent a
+    f a@(TraceDemoteWarmPeers !_ !_ !_)                      = GovernorEvent a
+    f a@(TraceDemoteWarmFailed !_ !_ !_ !_)                  = GovernorEvent a
+    f a@(TraceDemoteWarmDone !_ !_ !_)                       = GovernorEvent a
+    f a@(TraceDemoteWarmBigLedgerPeers !_ !_ !_)             = GovernorEvent a
+    f a@(TraceDemoteWarmBigLedgerPeerFailed !_ !_ !_ !_)     = GovernorEvent a
+    f a@(TraceDemoteWarmBigLedgerPeerDone !_ !_ !_)          = GovernorEvent a
+    f a@(TraceDemoteHotPeers !_ !_ !_)                       = GovernorEvent a
+    f a@(TraceDemoteLocalHotPeers !_ !_)                     = GovernorEvent a
+    f a@(TraceDemoteHotFailed !_ !_ !_ !_)                   = GovernorEvent a
+    f a@(TraceDemoteHotDone !_ !_ !_)                        = GovernorEvent a
+    f a@(TraceDemoteHotBigLedgerPeers !_ !_ !_)              = GovernorEvent a
+    f a@(TraceDemoteHotBigLedgerPeerFailed !_ !_ !_ !_)      = GovernorEvent a
+    f a@(TraceDemoteHotBigLedgerPeerDone !_ !_ !_)           = GovernorEvent a
+    f a@(TraceDemoteAsynchronous !_)                         = GovernorEvent a
+    f a@(TraceDemoteLocalAsynchronous !_)                    = GovernorEvent a
+    f a@(TraceDemoteBigLedgerPeersAsynchronous !_)           = GovernorEvent a
+    f a@TraceGovernorWakeup                                  = GovernorEvent a
+    f a@(TraceChurnWait !_)                                  = GovernorEvent a
+    f a@(TraceChurnMode !_)                                  = GovernorEvent a
 
 tracerDebugPeerSelection :: Tracer (IOSim s) (DebugPeerSelection PeerAddr)
 tracerDebugPeerSelection = GovernorDebug `contramap` tracerTestTraceEvent

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -526,7 +526,7 @@ peerSelectionGovernorLoop tracer
       now <- getMonotonicTime
       let Decision { decisionTrace, decisionJobs, decisionState } =
             timedDecision now
-          newCounters = peerStateToCounters decisionState
+          !newCounters = peerStateToCounters decisionState
       traverse_ (traceWith tracer) decisionTrace
       traceWithCache countersTracer
                      (countersCache decisionState)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -400,7 +401,7 @@ jobPromoteColdPeer PeerSelectionActions {
       --TODO: decide if we should do timeouts here or if we should make that
       -- the responsibility of establishPeerConnection
       peerconn <- establishPeerConnection isBigLedgerPeer peeraddr
-      let peerSharing = peerConnToPeerSharing peerconn
+      let !peerSharing = peerConnToPeerSharing peerconn
 
       return $ Completion $ \st@PeerSelectionState {
                                bigLedgerPeers,
@@ -614,7 +615,7 @@ aboveTargetBigLedgerPeers actions
                                               <> selectedToDemote
                         },
         decisionJobs  = [ jobDemoteEstablishedPeer actions policy peeraddr peerconn
-                        | (peeraddr, peerconn) <- Map.assocs selectedToDemote' ]
+                        | (!peeraddr, !peerconn) <- Map.assocs selectedToDemote' ]
       }
 
   | otherwise

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -666,25 +666,25 @@ jobDemoteEstablishedPeer PeerSelectionActions{peerStateActions = PeerStateAction
                                      peerSet
                                      establishedPeers in
         Decision {
-        decisionTrace = if peeraddr `Set.member` bigLedgerPeers
-                        then [TraceDemoteWarmBigLedgerPeerFailed
-                               targetNumberOfEstablishedBigLedgerPeers
-                               (Set.size $ EstablishedPeers.toSet establishedPeers
-                                           `Set.intersection`
-                                           bigLedgerPeers)
-                               peeraddr e]
-                        else [TraceDemoteWarmFailed
-                               targetNumberOfEstablishedPeers
-                               (Set.size $ EstablishedPeers.toSet establishedPeers
-                                    Set.\\ bigLedgerPeers)
-                               peeraddr e],
-        decisionState = st {
-                          inProgressDemoteWarm = inProgressDemoteWarm',
-                          fuzzRng = fuzzRng',
-                          knownPeers = knownPeers',
-                          establishedPeers = establishedPeers'
-                        },
-        decisionJobs  = []
+          decisionTrace = if peeraddr `Set.member` bigLedgerPeers
+                          then [TraceDemoteWarmBigLedgerPeerFailed
+                                 targetNumberOfEstablishedBigLedgerPeers
+                                 (Set.size $ EstablishedPeers.toSet establishedPeers
+                                             `Set.intersection`
+                                             bigLedgerPeers)
+                                 peeraddr e]
+                          else [TraceDemoteWarmFailed
+                                 targetNumberOfEstablishedPeers
+                                 (Set.size $ EstablishedPeers.toSet establishedPeers
+                                      Set.\\ bigLedgerPeers)
+                                 peeraddr e],
+          decisionState = st {
+                            inProgressDemoteWarm = inProgressDemoteWarm',
+                            fuzzRng = fuzzRng',
+                            knownPeers = knownPeers',
+                            establishedPeers = establishedPeers'
+                          },
+          decisionJobs  = []
       }
 
     job :: m (Completion m peeraddr peerconn)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -89,9 +90,11 @@ belowTarget actions
           -- peer share requests available, ask for at 1 peer to each.
           --
           -- This is to increase diversity.
-          numPeersToReq      = min 255 (max 1 (objective `div` numPeerShareReqs))
+          numPeersToReq :: PeerSharingAmount
+          !numPeersToReq     = fromIntegral
+                             $ min 255 (max 1 (objective `div` numPeerShareReqs))
           selForPSWithAmount = Set.toList
-                             $ Set.map (\a -> (fromIntegral numPeersToReq, a))
+                             $ Set.map (\a -> (numPeersToReq, a))
                                        selectedForPeerShare
       return $ \now -> Decision {
         decisionTrace = [TracePeerShareRequests
@@ -133,7 +136,7 @@ belowTarget actions
 
 
 jobPeerShare :: forall m peeraddr peerconn.
-             (MonadAsync m, MonadTimer m, Ord peeraddr)
+                (MonadAsync m, MonadTimer m, Ord peeraddr)
              => PeerSelectionActions peeraddr peerconn m
              -> PeerSelectionPolicy peeraddr m
              -> [(PeerSharingAmount, peeraddr)]

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -439,7 +439,7 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
 -- This data type should not expose too much information and keep only
 -- essential data needed for computing the peer sharing request result
 --
-data PublicPeerSelectionState peeraddr =
+newtype PublicPeerSelectionState peeraddr =
   PublicPeerSelectionState {
     availableToShare :: Set peeraddr
   }
@@ -461,12 +461,11 @@ toPublicState :: Ord peeraddr
 toPublicState PeerSelectionState { knownPeers
                                  , establishedPeers
                                  } =
-  let availableNow = EstablishedPeers.availableForPeerShare establishedPeers
-      availableNowWithPermission =
-        Set.filter (`KnownPeers.canPeerShareRequest` knownPeers) availableNow
-   in PublicPeerSelectionState {
-        availableToShare = availableNowWithPermission
-      }
+   PublicPeerSelectionState {
+     availableToShare =
+         Set.filter (`KnownPeers.canPeerShareRequest` knownPeers)
+       $ EstablishedPeers.availableForPeerShare establishedPeers
+   }
 
 -- Peer selection counters.
 --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -472,23 +472,23 @@ toPublicState PeerSelectionState { knownPeers
 data PeerSelectionCounters = PeerSelectionCounters {
       -- | All cold peers including ledger peers, root peers, big ledger peers
       -- and peers discovered through peer sharing.
-      coldPeers          :: Int,
+      coldPeers          :: !Int,
       -- | All warm peers including ledger peers, root peers, big ledger peers,
       -- local root peers and peers discovered through peer sharing.
-      warmPeers          :: Int,
+      warmPeers          :: !Int,
       -- | All hot peers including ledger peers, root peers, big ledger peers,
       -- local root peers and peers discovered through peer sharing.
-      hotPeers           :: Int,
+      hotPeers           :: !Int,
       -- | Cold big ledger peers.
-      coldBigLedgerPeers :: Int,
+      coldBigLedgerPeers :: !Int,
       -- | Warm big ledger peers.
-      warmBigLedgerPeers :: Int,
+      warmBigLedgerPeers :: !Int,
       -- | Hot big ledger peers.
-      hotBigLedgerPeers  :: Int,
+      hotBigLedgerPeers  :: !Int,
       -- | Local root peers with one entry per group. First entry is the number
       -- of warm peers in that group the second is the number of hot peers in
       -- that group.
-      localRoots         :: [(Int, Int)]
+      localRoots         :: ![(Int, Int)]
     } deriving (Eq, Show)
 
 peerStateToCounters :: Ord peeraddr => PeerSelectionState peeraddr peerconn -> PeerSelectionCounters

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE DeriveFunctor             #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
@@ -721,7 +722,7 @@ data Guarded m a =
     -- synchronisation, possibly with a timeout, to
     -- the governor main loop.
     --
-  | Guarded'   !(Maybe (Min Time)) (FirstToFinish m a)
+  | Guarded'   !(Maybe (Min Time)) !(FirstToFinish m a)
 
 
 -- | 'Guarded' constructor which provides an action, possibly with a timeout,
@@ -729,9 +730,9 @@ data Guarded m a =
 -- synchronisation.
 --
 pattern Guarded :: Maybe (Min Time) -> m a -> Guarded m a
-pattern Guarded a b <- Guarded' a (FirstToFinish b)
+pattern Guarded a b <- Guarded' !a (FirstToFinish !b)
   where
-    Guarded a b = Guarded' a (FirstToFinish b)
+    Guarded !a !b = Guarded' a (FirstToFinish b)
 
 {-# COMPLETE GuardedSkip, Guarded #-}
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -345,11 +345,12 @@ ledgerPeersThread inRng dnsSemaphore toPeerAddr tracer readUseLedgerAfter
     pickDomainAddrs :: (StdGen, Set peerAddr)
                     -> Set peerAddr
                     -> (StdGen, Set peerAddr)
-    pickDomainAddrs (rng, pickedAddrs) addrs | Set.null addrs = (rng, pickedAddrs)
-    pickDomainAddrs (rng, pickedAddrs) addrs =
-        let (ix, rng') = randomR (0, Set.size addrs - 1) rng
-            !pickedAddr = Set.elemAt ix addrs in
-        (rng', Set.insert pickedAddr pickedAddrs)
+    pickDomainAddrs (rng,  pickedAddrs) addrs | Set.null addrs = (rng, pickedAddrs)
+    pickDomainAddrs (rng, !pickedAddrs) addrs =
+        let (ix, rng')   = randomR (0, Set.size addrs - 1) rng
+            !pickedAddr  = Set.elemAt ix addrs
+            pickedAddrs' = Set.insert pickedAddr pickedAddrs
+        in (rng', pickedAddrs')
 
 
     -- Divide the picked peers form the ledger into addresses we can use
@@ -359,9 +360,10 @@ ledgerPeersThread inRng dnsSemaphore toPeerAddr tracer readUseLedgerAfter
                   -> (Set peerAddr, [DomainAccessPoint])
     partitionPeer (addrs, domains) (RelayDomainAccessPoint domain) =
       (addrs, domain : domains)
-    partitionPeer (addrs, domains) (RelayAccessAddress ip port) =
-      let !addr = toPeerAddr ip port
-       in (Set.insert addr addrs, domains)
+    partitionPeer (!addrs, domains) (RelayAccessAddress ip port) =
+      let !addr  = toPeerAddr ip port
+          addrs' = Set.insert addr addrs
+       in (addrs', domains)
 
 -- | For a LedgerPeers worker thread and submit request and receive responses.
 --


### PR DESCRIPTION

# Description

I run `cabal run ouroboros-network:sim-tests -- -p '/PeerSelection.progresses/' +RTS -t -RTS`
optionally with `-N4`. Below are the results.

# Unoptimised
```
<<ghc: 35570273736 bytes, 8606 GCs, 823497/2268168 avg/max bytes residency (690 samples), 11M in use, 0.001 INIT (0.000 elapsed), 11.840 MUT (11.824 elapsed), 1.364 GC (1.371 elapsed) :ghc>>
<<ghc: 35569891816 bytes, 8606 GCs, 833172/2822640 avg/max bytes residency (674 samples), 11M in use, 0.001 INIT (0.000 elapsed), 11.591 MUT (11.568 elapsed), 1.351 GC (1.358 elapsed) :ghc>>
<<ghc: 35570152208 bytes, 8606 GCs, 839346/2894024 avg/max bytes residency (688 samples), 12M in use, 0.001 INIT (0.001 elapsed), 12.092 MUT (12.075 elapsed), 1.469 GC (1.475 elapsed) :ghc>>
```
## `-N4`
```
<<ghc: 35566896400 bytes, 2529 GCs, 2069056/7172688 avg/max bytes residency (307 samples), 39M in use, 0.002 INIT (0.001 elapsed), 15.837 MUT (4.226 elapsed), 2.079 GC (0.805 elapsed) :ghc>>
<<ghc: 35567056840 bytes, 2488 GCs, 2014886/7764896 avg/max bytes residency (310 samples), 38M in use, 0.001 INIT (0.001 elapsed), 15.835 MUT (4.201 elapsed), 2.061 GC (0.799 elapsed) :ghc>>
<<ghc: 35567023304 bytes, 2492 GCs, 2032549/6684632 avg/max bytes residency (306 samples), 39M in use, 0.001 INIT (0.001 elapsed), 15.788 MUT (4.187 elapsed), 2.032 GC (0.791 elapsed) :ghc>>
```
# Optimised
```
<<ghc: 35694618112 bytes, 8638 GCs, 830121/2715632 avg/max bytes residency (666 samples), 11M in use, 0.000 INIT (0.000 elapsed), 12.274 MUT (12.256 elapsed), 1.452 GC (1.459 elapsed) :ghc>>
<<ghc: 35694541536 bytes, 8638 GCs, 825957/2724136 avg/max bytes residency (668 samples), 11M in use, 0.000 INIT (0.000 elapsed), 12.421 MUT (12.406 elapsed), 1.419 GC (1.426 elapsed) :ghc>>
<<ghc: 35694425144 bytes, 8638 GCs, 819758/2531536 avg/max bytes residency (671 samples), 11M in use, 0.001 INIT (0.000 elapsed), 11.854 MUT (11.838 elapsed), 1.397 GC (1.404 elapsed) :ghc>>
```
## `-N4`
```
<<ghc: 35691456424 bytes, 2513 GCs, 1932057/7059928 avg/max bytes residency (312 samples), 36M in use, 0.001 INIT (0.001 elapsed), 15.870 MUT (4.214 elapsed), 2.025 GC (0.802 elapsed) :ghc>>
<<ghc: 35691356248 bytes, 2502 GCs, 2008709/7795608 avg/max bytes residency (301 samples), 38M in use, 0.001 INIT (0.001 elapsed), 15.869 MUT (4.215 elapsed), 2.068 GC (0.817 elapsed) :ghc>>
<<ghc: 35691420256 bytes, 2515 GCs, 1989430/6552568 avg/max bytes residency (305 samples), 39M in use, 0.002 INIT (0.001 elapsed), 15.846 MUT (4.203 elapsed), 2.028 GC (0.800 elapsed) :ghc>>
```
# Checklist

- Branch
    - [ ] Updated changelog files.
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
