### PR TITLE
Disable PeerSharing completely for NTNV_11-12

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Non-breaking changes
 
-* Fixed Codec to disable `PeerSharing` with buggy versions 11 and 12.
+* Fixed Codec to disable `PeerSharing` completely with buggy NTNt versions 11 and 12.
 * Disable `PeerSharing` with `InitiatorOnly` nodes, since they do not run
   peer sharing server side and can not reply to requests.
 - Fixed `Acceptable` instance of `NodeToNodeVersionData` to only negotiate

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Non-breaking changes
 
-* Fixed Codec to disable `PeerSharing` completely with buggy NTNt versions 11 and 12.
+* Fixed handshake codec: disabled `PeerSharing` for `node-to-node` versions 11 and 12.
 * Disable `PeerSharing` with `InitiatorOnly` nodes, since they do not run
   peer sharing server side and can not reply to requests.
 - Fixed `Acceptable` instance of `NodeToNodeVersionData` to only negotiate

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Non-breaking changes
 
 * Fix random selection of peers to peershare with.
+* Fixed bug where peers with 'DoNotAdvertisePeer' flag were being shared
+* Fixed peer sharing pool of peers to be shared being confused with the pool
+  of peers to request to.
 
 ## 0.10.0.1 -- 2023-11-16
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -1305,7 +1305,7 @@ prop_governor_target_known_2_opportunity_taken env =
         govAvailableEstablishedPeersSig =
           selectGovState
             (\x ->
-              KnownPeers.getAvailablePeerSharingPeers
+              KnownPeers.getPeerSharingRequestPeers
                 (EstablishedPeers.availableForPeerShare
                                     (Governor.establishedPeers x)
                 Set.\\ (Governor.inProgressDemoteToCold x))

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -130,7 +130,7 @@ belowTarget actions
                              Set.\\ inProgressDemoteToCold
     -- Only ask peers which have the correct willingness permission flags
     canAsk                   =
-      KnownPeers.getAvailablePeerSharingPeers availableForPeerShare knownPeers
+      KnownPeers.getPeerSharingRequestPeers availableForPeerShare knownPeers
 
 
 jobPeerShare :: forall m peeraddr peerconn.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -456,16 +456,12 @@ emptyPublicPeerSelectionState =
 -- Peer Sharing mechanisms so we can know about which peers are available and
 -- possibly other needed context.
 --
-toPublicState :: Ord peeraddr
-              => PeerSelectionState peeraddr peerconn
+toPublicState :: PeerSelectionState peeraddr peerconn
               -> PublicPeerSelectionState peeraddr
 toPublicState PeerSelectionState { knownPeers
-                                 , establishedPeers
                                  } =
    PublicPeerSelectionState {
-     availableToShare =
-         Set.filter (`KnownPeers.canPeerShareRequest` knownPeers)
-       $ EstablishedPeers.availableForPeerShare establishedPeers
+     availableToShare = KnownPeers.getPeerSharingResponsePeers knownPeers
    }
 
 -- Peer selection counters.


### PR DESCRIPTION
# Description

Disable PeerSharing completely for NTNV_11-12. I overlooked the fact that the handshake response is also encoded so locally the node will agree on something and send something different over the wire. The fix is to completely disable PeerSharing for older versions.

This also fixes a bug in the pool of peers available to share.
