### PR TITLE
Fix random peer sharing selection

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Non-breaking changes
 
+* Fix random selection of peers to peershare with.
+
 ## 0.10.0.1 -- 2023-11-16
 
 ### Non-breaking changes


### PR DESCRIPTION

# Description

randomRs will generate the same pseudorandom stream of numbers when called with the same generator. By storing and splitting the generator in a TVar every call to computePeerSharingPeers can pick different peers for peersharing.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
