### PR TITLE
Fixes async demotions to Cold not being noticed

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 ### Non-breaking changes
 
-* Fix random selection of peers to peershare with.
+* Fix random selection of peers to peer share with.
+* Fix asynchronous demotions to `Cold` (`CoolingToCold`) not being noticed, hence
+  making peers stay in the `inProgressDemotedToCold` set forever.
 
 ## 0.10.0.1 -- 2023-11-16
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -151,9 +151,7 @@ connections PeerSelectionActions{
       -- Get previously cooling peers
       monitorStatus <- traverse monitorPeerConnection
                                 (EstablishedPeers.toMap establishedPeers)
-          -- filter previously cooling peers from the demotion sets
       let demotions = asynchronousDemotions monitorStatus
-                      `Map.withoutKeys` inProgressDemoteToCold
       check (not (Map.null demotions))
       let (demotedToWarm, demotedToCoolingOrCold) = Map.partition ((==PeerWarm) . fst) demotions
           (demotedToCold, demotedToCooling) = Map.partition ((==PeerCold) . fst) demotedToCoolingOrCold
@@ -299,7 +297,8 @@ connections PeerSelectionActions{
     asyncDemotion peeraddr (PeerCold, returnCommand)
       | peeraddr `EstablishedPeers.member` establishedPeers || peeraddr `Set.member` activePeers
       , peeraddr `Set.notMember` inProgressDemoteWarm
-      , peeraddr `Set.notMember` inProgressDemoteHot = Just (PeerCold, returnCommand)
+      , peeraddr `Set.notMember` inProgressDemoteHot
+      , peeraddr `Set.member` inProgressDemoteToCold = Just (PeerCold, returnCommand)
 
     asyncDemotion _        _                          = Nothing
 


### PR DESCRIPTION
# Description

This fixes the bug where when a peer disconnected it could no longer be connected to due to the governor not picking it up.