### PR TITLE
Network specs: more details for `MsgNoBlocks`

### DIFF
--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -931,7 +931,7 @@ The block fetching mechanism enables a node to download a range of blocks.
 \item [\MsgRequestRange{} {\boldmath $(range)$}]
   The client requests a {\boldmath $range$} of blocks from the server.
 \item [\MsgNoBlocks]
-  The server tells the client that it does not have blocks.
+  The server tells the client that it does not have all of the blocks in the requested {\boldmath $range$}.
 \item [\MsgStartBatch]
   The server starts block streaming.
 \item [\MsgBlock{} {\boldmath $(body)$}]


### PR DESCRIPTION
Make it clear that the server does not acknowledge range requests it can only partially fulfil.