### PR TITLE
Add exports to from Cardano.Network.Ping

### DIFF
--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-ping
 
+## Next
+
+* Expose more `InitiatorOnly`, `handshakeDec`, `handshakeReq` and `isSameVersionAndMagic` from `Cardano.Network.Ping`.
+
 ## 0.2.0.9 -- 2023-11-16
 
 ### Non-breaking changes

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Network.Ping
   ( PingOpts(..)
@@ -15,11 +14,15 @@ module Cardano.Network.Ping
   , NodeVersion(..)
   , HandshakeFailure(..)
   , StatPoint(..)
+  , InitiatorOnly(..)
   , mainnetMagic
   , pingClient
   , logger
   , supportedNodeToNodeVersions
   , supportedNodeToClientVersions
+  , handshakeDec
+  , handshakeReq
+  , isSameVersionAndMagic
   ) where
 
 import           Control.Exception (bracket)
@@ -603,30 +606,6 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount, pi
         then encodeToLazyText $ object ["queried_versions" .= toJSONList recVersions]
         else TL.pack $ printf "Queried versions %s" (show recVersions)
 
-    isSameVersionAndMagic :: NodeVersion -> NodeVersion -> Bool
-    isSameVersionAndMagic v1 v2 = extract v1 == extract v2
-      where extract :: NodeVersion -> (Int, Word32)
-            extract (NodeToClientVersionV9 m)  = (-9, m)
-            extract (NodeToClientVersionV10 m) = (-10, m)
-            extract (NodeToClientVersionV11 m) = (-11, m)
-            extract (NodeToClientVersionV12 m) = (-12, m)
-            extract (NodeToClientVersionV13 m) = (-13, m)
-            extract (NodeToClientVersionV14 m) = (-14, m)
-            extract (NodeToClientVersionV15 m) = (-15, m)
-            extract (NodeToClientVersionV16 m) = (-16, m)
-            extract (NodeToNodeVersionV1 m)    = (1, m)
-            extract (NodeToNodeVersionV2 m)    = (2, m)
-            extract (NodeToNodeVersionV3 m)    = (3, m)
-            extract (NodeToNodeVersionV4 m _)  = (4, m)
-            extract (NodeToNodeVersionV5 m _)  = (5, m)
-            extract (NodeToNodeVersionV6 m _)  = (6, m)
-            extract (NodeToNodeVersionV7 m _)  = (7, m)
-            extract (NodeToNodeVersionV8 m _)  = (8, m)
-            extract (NodeToNodeVersionV9 m _)  = (9, m)
-            extract (NodeToNodeVersionV10 m _) = (10, m)
-            extract (NodeToNodeVersionV11 m _) = (11, m)
-            extract (NodeToNodeVersionV12 m _) = (12, m)
-
     peerString :: IO String
     peerString =
       case Socket.addrFamily peer of
@@ -679,3 +658,28 @@ pingClient stdout stderr PingOpts{pingOptsQuiet, pingOptsJson, pingOptsCount, pi
             else traceWith stdout $ LogMsg $ LBS.Char.pack $ show point <> "\n"
           MT.threadDelay keepAliveDelay
           keepAlive bearer timeoutfn peerStr version td' (cookie + 1)
+
+
+isSameVersionAndMagic :: NodeVersion -> NodeVersion -> Bool
+isSameVersionAndMagic v1 v2 = extract v1 == extract v2
+  where extract :: NodeVersion -> (Int, Word32)
+        extract (NodeToClientVersionV9 m)  = (-9, m)
+        extract (NodeToClientVersionV10 m) = (-10, m)
+        extract (NodeToClientVersionV11 m) = (-11, m)
+        extract (NodeToClientVersionV12 m) = (-12, m)
+        extract (NodeToClientVersionV13 m) = (-13, m)
+        extract (NodeToClientVersionV14 m) = (-14, m)
+        extract (NodeToClientVersionV15 m) = (-15, m)
+        extract (NodeToClientVersionV16 m) = (-16, m)
+        extract (NodeToNodeVersionV1 m)    = (1, m)
+        extract (NodeToNodeVersionV2 m)    = (2, m)
+        extract (NodeToNodeVersionV3 m)    = (3, m)
+        extract (NodeToNodeVersionV4 m _)  = (4, m)
+        extract (NodeToNodeVersionV5 m _)  = (5, m)
+        extract (NodeToNodeVersionV6 m _)  = (6, m)
+        extract (NodeToNodeVersionV7 m _)  = (7, m)
+        extract (NodeToNodeVersionV8 m _)  = (8, m)
+        extract (NodeToNodeVersionV9 m _)  = (9, m)
+        extract (NodeToNodeVersionV10 m _) = (10, m)
+        extract (NodeToNodeVersionV11 m _) = (11, m)
+        extract (NodeToNodeVersionV12 m _) = (12, m)


### PR DESCRIPTION
# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

Expose more functions from cardano-ping. A prerequisite for: https://github.com/input-output-hk/cardano-node/pull/5536

# Checklist

- Branch
    - [ ] Updated changelog files.
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
