### PR TITLE
SizeInBytes: Derive Serialise

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/SizeInBytes.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/SizeInBytes.hs
@@ -4,6 +4,7 @@
 
 module Ouroboros.Network.SizeInBytes (SizeInBytes (..)) where
 
+import           Codec.Serialise (Serialise)
 import           Control.DeepSeq (NFData (..))
 import           Data.Word (Word32)
 
@@ -14,6 +15,7 @@ newtype SizeInBytes = SizeInBytes { getSizeInBytes :: Word32 }
   deriving Enum     via Word32
   deriving Num      via Word32
   deriving Real     via Word32
+  deriving Serialise     via Word32
   deriving Integral via Word32
   deriving NoThunks via Word32
   deriving newtype NFData


### PR DESCRIPTION
# Description

This PR adds lets `SizeInBytes` derive a `Serialise` instance, which we need to fix issue [#532](https://github.com/input-output-hk/ouroboros-consensus/issues/532) in  `ouroboros-consensus`.

