### PR TITLE
Remove the reference to blockForgeUTCTime from FromConsensus haddock

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -203,8 +203,7 @@ data ChainSelStarvation
 -------------------------------------------------------------------------------}
 
 -- | A new type used to emphasize the precondition of
--- 'Ouroboros.Network.BlockFetch.ConsensusInterface.headerForgeUTCTime' and
--- 'Ouroboros.Network.BlockFetch.ConsensusInterface.blockForgeUTCTime' at each
+-- 'Ouroboros.Network.BlockFetch.ConsensusInterface.headerForgeUTCTime' at each
 -- call site.
 --
 -- At time of writing, the @a@ is either a header or a block. The headers are


### PR DESCRIPTION
# Description
This tiny PR remove the reference to the `blockForgeUTCTime` function, which is not part of `BlockFetchConsensusInterface` anymore as of `ouroboros-network-api-0.11.0.0`. Discovered while working on https://github.com/IntersectMBO/ouroboros-consensus/pull/1288.

