### PR TITLE
Lower the time to cache DNS errors

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -10,6 +10,7 @@
   are captured by the `DNSPeersKind` type, which also distinguishes the type
   of ledger peer.
 * Added `dispatchLookupWithTTL`
+* Lower the time to cache DNS errors to at most 15min.
 
 ### Breaking changes
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/LocalRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/LocalRootPeers.hs
@@ -306,13 +306,13 @@ ttlForResults ttls = clipTTLBelow
 -- | Limit insane TTL choices.
 clipTTLAbove, clipTTLBelow :: DiffTime -> DiffTime
 clipTTLBelow = max 60     -- between 1min
-clipTTLAbove = min 86400  -- and 24hrs
+clipTTLAbove = min 900    -- and 15min
 
 -- | Policy for TTL for negative results
--- Cache negative response for 3hrs
+-- Cache negative response for 15min
 -- Otherwise, use exponential backoff, up to a limit
 ttlForDnsError :: DiffTime -> DNS.DNSError -> DiffTime
-ttlForDnsError _   DNS.NameError = 10800
+ttlForDnsError _   DNS.NameError = 900
 ttlForDnsError ttl _             = clipTTLAbove (ttl * 2 + 5)
 
 -- | `withAsyncAll`, but the actions are tagged with a context

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
@@ -155,11 +155,11 @@ ttlForResults ttls = clipTTLBelow
 -- | Limit insane TTL choices.
 clipTTLAbove, clipTTLBelow :: DiffTime -> DiffTime
 clipTTLBelow = max 60     -- between 1min
-clipTTLAbove = min 86400  -- and 24hrs
+clipTTLAbove = min 900    -- and 15min
 
 -- | Policy for TTL for negative results
--- Cache negative response for 3hrs
+-- Cache negative response for 15 minutes
 -- Otherwise, use exponential backoff, up to a limit
 ttlForDnsError :: DNSError -> DiffTime -> DiffTime
-ttlForDnsError DNS.NameError _ = 10800
+ttlForDnsError DNS.NameError _ = 900
 ttlForDnsError _           ttl = clipTTLAbove (ttl * 2 + 5)


### PR DESCRIPTION
# Description

Antithesis, [https://github.com/cardano-foundation/antithesis/](https://github.com/cardano-foundation/antithesis/), discovered a problem with the unreasonably long TTL for DNS errors (up to 24h).
This lowers the time to cache DNS errors to at most 15min. 

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
