### PR TITLE
Updated Sig type according to CIP-137 update

### DIFF
--- a/decentralized-message-queue/test/Test/DMQ/Protocol/SigSubmission.hs
+++ b/decentralized-message-queue/test/Test/DMQ/Protocol/SigSubmission.hs
@@ -58,13 +58,17 @@ instance Arbitrary POSIXTime where
   -- shrink via Word32 (e.g. in seconds)
   shrink posix = realToFrac <$> shrink (floor @_ @Word32 posix)
 
-instance Arbitrary SigKesSignature where
-  arbitrary = SigKesSignature <$> arbitrary
-  shrink = map SigKesSignature . shrink . getSigKesSignature
+instance Arbitrary SigKESSignature where
+  arbitrary = SigKESSignature <$> arbitrary
+  shrink = map SigKESSignature . shrink . getSigKESSignature
 
 instance Arbitrary SigOpCertificate where
   arbitrary = SigOpCertificate <$> arbitrary
   shrink = map SigOpCertificate . shrink . getSigOpCertificate
+
+instance Arbitrary SigColdKey where
+  arbitrary = SigColdKey <$> arbitrary
+  shrink = map SigColdKey . shrink . getSigColdKey
 
 instance Arbitrary Sig where
   arbitrary = Sig <$> arbitrary
@@ -72,7 +76,9 @@ instance Arbitrary Sig where
                   <*> arbitrary
                   <*> arbitrary
                   <*> arbitrary
-  shrink sig@Sig { sigId, sigBody, sigExpiresAt, sigOpCertificate, sigKesSignature } =
+                  <*> arbitrary
+                  <*> arbitrary
+  shrink sig@Sig { sigId, sigBody, sigKESSignature, sigKESPeriod, sigOpCertificate, sigExpiresAt } =
     [ sig { sigId = sigId' }
     | sigId' <- shrink sigId
     ]
@@ -81,16 +87,24 @@ instance Arbitrary Sig where
     | sigBody' <- shrink sigBody
     ]
     ++
-    [ sig { sigExpiresAt = sigExpiresAt' }
-    | sigExpiresAt' <- shrink sigExpiresAt
-    ]
-    ++
     [ sig { sigOpCertificate = sigOpCertificate' }
     | sigOpCertificate' <- shrink sigOpCertificate
     ]
     ++
-    [ sig { sigKesSignature = sigKesSignature' }
-    | sigKesSignature' <- shrink sigKesSignature
+    [ sig { sigKESSignature = sigKESSignature' }
+    | sigKESSignature' <- shrink sigKESSignature
+    ]
+    ++
+    [ sig { sigKESPeriod = sigKESPeriod' }
+    | sigKESPeriod' <- shrink sigKESPeriod
+    ]
+    ++
+    [ sig { sigColdKey = sigColdKey' }
+    | sigColdKey' <- shrink (sigColdKey sig)
+    ]
+    ++
+    [ sig { sigExpiresAt = sigExpiresAt' }
+    | sigExpiresAt' <- shrink sigExpiresAt
     ]
 
 


### PR DESCRIPTION

# Description

Removed `SigRaw` and `SigPayload` types, as they are not needed.
Mithril only signs body of the message with the KES key, not the whole
message.

See cardano-scaling/CIPs#15.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
