### PR TITLE
Derive NoThunks for NodeToNodeVersion

### DIFF
--- a/ouroboros-network-api/changelog.d/20251010_112341_agustin.mista_node_to_node_version_nothunks.md
+++ b/ouroboros-network-api/changelog.d/20251010_112341_agustin.mista_node_to_node_version_nothunks.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Added `NoThunks` instance for `NodeToNodeVersion`.
+

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -19,6 +19,7 @@ import Codec.CBOR.Term qualified as CBOR
 
 import Control.DeepSeq
 import GHC.Generics
+import NoThunks.Class (NoThunks)
 import Ouroboros.Network.CodecCBORTerm
 import Ouroboros.Network.Handshake.Acceptable (Accept (..), Acceptable (..))
 import Ouroboros.Network.Handshake.Queryable (Queryable (..))
@@ -70,7 +71,7 @@ data NodeToNodeVersion =
     -- ^ Plomin HF, mandatory on mainnet as of 2025.01.29
   | NodeToNodeV_15
     -- ^ SRV support
-  deriving (Eq, Ord, Enum, Bounded, Show, Generic, NFData)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic, NFData, NoThunks)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
 nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }


### PR DESCRIPTION
This will allow ouroboros-consensus to remove the orphan instance introduced in https://github.com/IntersectMBO/ouroboros-consensus/pull/1669