### PR TITLE
Fixed handling of ECONNABORTED in the simple server

### DIFF
--- a/ouroboros-network/changelog.d/20251022_101356_coot_simple_server_econnaborted_handling.md
+++ b/ouroboros-network/changelog.d/20251022_101356_coot_simple_server_econnaborted_handling.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- framework: improved handling of `ECONNABORTED` in the simple server.
+

--- a/ouroboros-network/framework/lib/Ouroboros/Network/Server.hs
+++ b/ouroboros-network/framework/lib/Ouroboros/Network/Server.hs
@@ -28,6 +28,7 @@ module Ouroboros.Network.Server
   , InboundGovernor.RemoteTransition
   , InboundGovernor.RemoteTransitionTrace
   , isECONNABORTED
+  , server_CONNABORTED_DELAY
   ) where
 
 import Control.Applicative (Alternative)

--- a/ouroboros-network/framework/lib/Ouroboros/Network/Server/Simple.hs
+++ b/ouroboros-network/framework/lib/Ouroboros/Network/Server/Simple.hs
@@ -17,10 +17,9 @@ module Ouroboros.Network.Server.Simple
 import Control.Applicative (Alternative)
 import Control.Concurrent.JobPool qualified as JobPool
 import Control.Monad.Class.MonadAsync
-import Control.Monad.Class.MonadFork (MonadFork)
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadThrow
-import Control.Monad.Class.MonadTimer.SI (MonadDelay, MonadTimer)
+import Control.Monad.Class.MonadTimer.SI
 import Control.Tracer (Tracer, traceWith)
 import Data.ByteString.Lazy qualified as BL
 import Data.Functor (void)
@@ -32,7 +31,7 @@ import Network.Mux qualified as Mx
 import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.Mux
 import Ouroboros.Network.Protocol.Handshake
-import Ouroboros.Network.Server (isECONNABORTED)
+import Ouroboros.Network.Server (isECONNABORTED, server_CONNABORTED_DELAY)
 import Ouroboros.Network.Snocket (Snocket)
 import Ouroboros.Network.Snocket qualified as Snocket
 import Ouroboros.Network.Socket
@@ -111,7 +110,8 @@ with sn tracer muxTracers makeBearer configureSock addr handshakeArgs versions k
         acceptOne (Snocket.AcceptFailure e)
           | Just ioErr <- fromException e
           , isECONNABORTED ioErr
-          = traceWith tracer (AcceptException e)
+          = threadDelay server_CONNABORTED_DELAY
+
         acceptOne (Snocket.AcceptFailure e)
           = do traceWith tracer (AcceptException e)
                throwIO e


### PR DESCRIPTION

# Description

Instead of a busy loop, wait 0.5s before accepting next connection.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
