### PR TITLE
dmq-node: removed KES evolution config

### DIFF
--- a/dmq-node/changelog.d/20251118_165634_coot_dmq_node_removed_evolution_config.md
+++ b/dmq-node/changelog.d/20251118_165634_coot_dmq_node_removed_evolution_config.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Removed KES evolution configuration & genesis file from the DMQ configuration.

--- a/dmq-node/src/DMQ/Configuration.hs
+++ b/dmq-node/src/DMQ/Configuration.hs
@@ -90,10 +90,6 @@ data Configuration' f =
     dmqcPortNumber                                 :: f PortNumber,
     dmqcConfigFile                                 :: f FilePath,
     dmqcTopologyFile                               :: f FilePath,
-    dmqcShelleyGenesisFile                         :: f FilePath,
-    -- ^ shelley genesis file, e.g.
-    -- `/configuration/cardano/mainnet-shelley-genesis.json` in `cardano-node`
-    -- repo.
     dmqcAcceptedConnectionsLimit                   :: f AcceptedConnectionsLimit,
     dmqcDiffusionMode                              :: f DiffusionMode,
     dmqcTargetOfRootPeers                          :: f Int,
@@ -214,7 +210,6 @@ defaultConfiguration = Configuration {
       dmqcPortNumber                                 = I 3_141,
       dmqcConfigFile                                 = I "dmq.configuration.yaml",
       dmqcTopologyFile                               = I "dmq.topology.json",
-      dmqcShelleyGenesisFile                         = I "mainnet-shelley-genesis.json",
       dmqcAcceptedConnectionsLimit                   = I defaultAcceptedConnectionsLimit,
       dmqcDiffusionMode                              = I InitiatorAndResponderDiffusionMode,
       dmqcTargetOfRootPeers                          = I targetNumberOfRootPeers,
@@ -305,8 +300,6 @@ instance FromJSON PartialConfig where
       dmqcDiffusionMode <- Last <$> v .:? "DiffusionMode"
       dmqcPeerSharing <- Last <$> v .:? "PeerSharing"
 
-      dmqcShelleyGenesisFile <- Last <$> v .:? "ShelleyGenesisFile"
-
       dmqcTargetOfRootPeers                 <- Last <$> v .:? "TargetNumberOfRootPeers"
       dmqcTargetOfKnownPeers                <- Last <$> v .:? "TargetNumberOfKnownPeers"
       dmqcTargetOfEstablishedPeers          <- Last <$> v .:? "TargetNumberOfEstablishedPeers"
@@ -383,7 +376,6 @@ instance ToJSON Configuration where
            , "LocalAddress"                               .= unI dmqcLocalAddress
            , "ConfigFile"                                 .= unI dmqcConfigFile
            , "TopologyFile"                               .= unI dmqcTopologyFile
-           , "ShelleyGenesisFile"                         .= unI dmqcShelleyGenesisFile
            , "AcceptedConnectionsLimit"                   .= unI dmqcAcceptedConnectionsLimit
            , "DiffusionMode"                              .= unI dmqcDiffusionMode
            , "TargetOfRootPeers"                          .= unI dmqcTargetOfRootPeers

--- a/dmq-node/src/DMQ/NodeToNode.hs
+++ b/dmq-node/src/DMQ/NodeToNode.hs
@@ -196,7 +196,6 @@ ntnApps
     , peerSharingRegistry
     , peerSharingAPI
     , mempool
-    , evolutionConfig
     , sigChannelVar
     , sigMempoolSem
     , sigSharedTxStateVar
@@ -235,7 +234,7 @@ ntnApps
     -- mempool.
     mempoolWriter = Mempool.getWriter sigId
                                       (pure ()) -- TODO not needed
-                                      (\_ -> validateSig evolutionConfig)
+                                      (\_ -> validateSig)
                                       (\_ -> True)
                                       mempool
 

--- a/dmq-node/src/DMQ/Protocol/SigSubmission/Type.hs
+++ b/dmq-node/src/DMQ/Protocol/SigSubmission/Type.hs
@@ -47,7 +47,6 @@ import Cardano.Crypto.DSIGN.Class (ContextDSIGN, DSIGNAlgorithm, VerKeyDSIGN)
 import Cardano.Crypto.DSIGN.Class qualified as DSIGN
 import Cardano.Crypto.KES.Class (KESAlgorithm (..), Signable)
 import Cardano.KESAgent.KES.Crypto as KES
-import Cardano.KESAgent.KES.Evolution qualified as KES
 import Cardano.KESAgent.KES.OCert (KESPeriod (..), OCert (..), OCertSignable,
            validateOCert)
 
@@ -291,11 +290,9 @@ validateSig :: forall crypto.
                , ContextKES (KES crypto) ~ ()
                , Signable (KES crypto) ByteString
                )
-            => KES.EvolutionConfig
-            -> Sig crypto
+            => Sig crypto
             -> Either SigValidationError ()
-validateSig _ec
-            Sig { sigSignedBytes = signedBytes,
+validateSig Sig { sigSignedBytes = signedBytes,
                   sigKESPeriod,
                   sigOpCertificate = SigOpCertificate ocert@OCert {
                       ocertKESPeriod,

--- a/dmq-node/test/DMQ/Protocol/SigSubmission/Test.hs
+++ b/dmq-node/test/DMQ/Protocol/SigSubmission/Test.hs
@@ -832,7 +832,7 @@ prop_validateSig
   -> Property
 prop_validateSig constr = ioProperty $ do
     sig <- runWithConstr constr
-    return $ case validateSig KES.defEvolutionConfig sig of
+    return $ case validateSig sig of
       Left err -> counterexample ("KES seed: " ++ show (ctx constr))
                 . counterexample ("KES vk key: " ++ show (ocertVkHot . getSigOpCertificate . sigOpCertificate $ sig))
                 . counterexample (show sig)


### PR DESCRIPTION
It is not used, without we don't need genesis file in the configuration.
