### PR TITLE
Allow inner decoded in CBORinCBOR to fail

### DIFF
--- a/ouroboros-network/api/lib/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/api/lib/Ouroboros/Network/Block.hs
@@ -69,6 +69,7 @@ module Ouroboros.Network.Block
   , fromSerialised
   ) where
 
+import Cardano.Binary (DecoderError)
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Decoding qualified as Dec
 import Codec.CBOR.Encoding (Encoding)
@@ -453,7 +454,7 @@ wrapCBORinCBOR enc = encode . mkSerialised enc
 -- It is non-incremental: see
 -- https://github.com/IntersectMBO/ouroboros-network/issues/5114
 --
-unwrapCBORinCBOR :: (forall s. Decoder s (Lazy.ByteString -> a))
+unwrapCBORinCBOR :: (forall s. Decoder s (Lazy.ByteString -> Either DecoderError a))
                  -> (forall s. Decoder s a)
 unwrapCBORinCBOR dec = fromSerialised dec =<< decode
 
@@ -465,14 +466,16 @@ mkSerialised enc = Serialised . Write.toLazyByteString . enc
 --
 -- Unlike a regular 'Decoder', which has an implicit input stream,
 -- 'fromSerialised' takes the 'Serialised' value as an argument.
-fromSerialised :: (forall s. Decoder s (Lazy.ByteString -> a))
+fromSerialised :: (forall s. Decoder s (Lazy.ByteString -> Either DecoderError a))
                -> Serialised a -> (forall s. Decoder s a)
 fromSerialised dec (Serialised payload) =
     case Read.deserialiseFromBytes dec payload of
       Left (Read.DeserialiseFailure _ reason) -> fail reason
       Right (trailing, mkA)
         | not (Lazy.null trailing) -> fail "trailing bytes in CBOR-in-CBOR"
-        | otherwise                -> return (mkA payload)
+        | otherwise                -> case mkA payload of
+                                        Left err  -> fail $ show err
+                                        Right res -> pure res
 
 -- | CBOR-in-CBOR
 --

--- a/ouroboros-network/changelog.d/20260116_135155_georgy.lukyanov_annotator_integration_main.md
+++ b/ouroboros-network/changelog.d/20260116_135155_georgy.lukyanov_annotator_integration_main.md
@@ -1,0 +1,17 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Change the type of `unwrapCBORinCBOR` and `fromSerialised` to allow inner decoders that may fail.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -336,7 +336,7 @@ codecWrapped :: MonadST m
                       m ByteString
 codecWrapped =
     codecBlockFetch
-      (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const <$> S.decode))
+      (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const . Right <$> S.decode))
       S.encode                  S.decode
 
 codecSerialised :: MonadST m

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -477,7 +477,7 @@ codecWrapped :: ( MonadST m
                       S.DeserialiseFailure
                       m ByteString
 codecWrapped =
-    codecChainSync (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const <$> S.decode))
+    codecChainSync (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const . Right <$> S.decode))
                    S.encode                  S.decode
                    (encodeTip S.encode)      (decodeTip S.decode)
 


### PR DESCRIPTION
# Description

This change is need to integrate a change in the `Annotator` interface in the sibling package `cardano-ledger` into the downstream `ouroboros-consensus-cardano` package.

See this Ledger PR for the details of the change in Ledger: https://github.com/IntersectMBO/cardano-ledger/pull/5363

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
