### PR TITLE
release scripts

### DIFF
--- a/scripts/build-with-chap.sh
+++ b/scripts/build-with-chap.sh
@@ -45,8 +45,8 @@ fi
 cabal_files=$(fd -ae 'cabal')
 for cf in $cabal_files; do
   name=$(cat $cf | grep '^name:' | awk '{ print $2 }')
-  if [[ -d "$CHAP_DIR/_sources/$name" ]]; then
-    version=$(ls -1 $CHAP_DIR/_sources/$name | sort -V | tail -1)
+  version=$(cat $cf | grep '^version:' | awk '{ print $2 }')
+  if [[ -d "$CHAP_DIR/_sources/$name/$version" ]]; then
     rev=$(yq .github.rev $CHAP_DIR/_sources/$name/$version/meta.toml)
     git restore --source=$rev -- $name
     tb=0
@@ -57,7 +57,7 @@ for cf in $cabal_files; do
       cp $revdir/$rev "$name/$name.cabal"
     fi
   else
-    echo "WARNING: $name not in cardano-haskell-packages"
+    echo "WARNING: $name-$version not in cardano-haskell-packages"
   fi
 done
 

--- a/scripts/release-to-chap.sh
+++ b/scripts/release-to-chap.sh
@@ -81,24 +81,27 @@ else
     git switch main
     git pull
   fi
-  BRANCH="network/release-$(date -I)"
+  BRANCH="network/release-$(date +%Y-%m-%d-%H-%m-%S)"
   if [[ $TEST == 1 ]];then
     BRANCH="${BRANCH}-DO_NOT_MERGE"
   fi
   git switch -c $BRANCH
 
+  # Gather packages to publish on CHaP
+  publish=""
   for cf in $cabal_files; do
     name=$(cat $cf | grep '^name:' | awk '{ print $2 }')
     version=$(cat $cf | grep '^version:' | awk '{ print $2 }')
     dir="$CHAP_DIR/_sources/$name/$version"
     if [[ !(-d $dir) ]];then
-      trace "publishing $name-$version"
-      ./scripts/add-from-github.sh $REPO_URL $gitsha $name
+      publish="$publish $name"
       if [[ $TEST == 0 ]];then
         git --git-dir "$gitdir/.git" tag "$name-$version" $gitsha
       fi
     fi
   done
+  trace "Publishing:$publish"
+  ./scripts/add-from-github.sh $REPO_URL $gitsha $publish
 
   git --no-pager log --oneline origin/main..HEAD
 


### PR DESCRIPTION
* build with chap: use versions from the git repo rather than the latest
  version in CHaP, this allows to build older releases
* release to CHaP:
  * better branch name
  * use `add-from-github.sh` once, to avoid GitHub rate limits
