### PR TITLE
Added `cardano-slotting < 0.2.0.2` constraint

### DIFF
--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -177,7 +177,7 @@ library testlib
     Test.Ouroboros.Network.Protocol.Utils
 
   build-depends:
-    QuickCheck,
+    QuickCheck >=2.14 && <2.16,
     base >=4.14 && <4.21,
     bytestring,
     cardano-slotting:testlib ^>=0.2.0 || <0.2.0.2,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -209,7 +209,7 @@ library sim-tests-lib
   visibility: public
   hs-source-dirs: sim-tests-lib
   build-depends:
-    QuickCheck,
+    QuickCheck <2.16,
     aeson,
     array,
     base >=4.14 && <4.22,
@@ -330,7 +330,7 @@ test-suite io-tests
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   build-depends:
-    QuickCheck,
+    QuickCheck <2.16,
     base >=4.14 && <4.22,
     bytestring,
     contra-tracer,


### PR DESCRIPTION
# Description

cardano-slotting-0.2.0.2 contains incompatible changes.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
