### PR TITLE
Support ghc-9.12

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -21,7 +21,7 @@ library
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   build-depends:
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     bytestring >=0.10 && <0.13,
     cborg,
     containers,

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -27,7 +27,7 @@ library
   exposed-modules: Cardano.Network.Ping
   build-depends:
     aeson >=2.1.1.0 && <3,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     bytestring >=0.10 && <0.13,
     cborg >=0.2.8 && <0.3,
     contra-tracer >=0.1 && <0.3,

--- a/monoidal-synchronisation/monoidal-synchronisation.cabal
+++ b/monoidal-synchronisation/monoidal-synchronisation.cabal
@@ -16,7 +16,7 @@ extra-doc-files: CHANGELOG.md
 
 library
   exposed-modules: Data.Monoid.Synchronisation
-  build-depends: base >=4.14 && <4.21
+  build-depends: base >=4.14 && <4.22
   hs-source-dirs: src
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -37,7 +37,7 @@ test-suite test
   other-modules: Test.Data.Monoid.Synchronisation
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     io-classes,
     io-sim,
     monoidal-synchronisation,

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     Win32-network >=0.1 && <0.3,
     async >=2.2 && <2.3,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     binary >=0.8 && <0.11,
     bytestring >=0.10 && <0.13,
     contra-tracer >=0.1 && <0.2,
@@ -63,7 +63,7 @@ test-suite test
   type: exitcode-stdio-1.0
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     binary >=0.8 && <0.11,
     tasty,
     tasty-quickcheck,
@@ -89,7 +89,7 @@ executable demo-ntp-client
   build-depends:
     Win32-network >=0.1 && <0.3,
     async >=2.2 && <2.3,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     contra-tracer >=0.1 && <0.2,
     ntp-client,
 

--- a/ouroboros-network-mock/ouroboros-network-mock.cabal
+++ b/ouroboros-network-mock/ouroboros-network-mock.cabal
@@ -35,7 +35,7 @@ library
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   build-depends:
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     bytestring,
     cborg,
     containers,

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -97,7 +97,7 @@ library
     TypeInType
 
   build-depends:
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     bytestring >=0.10 && <0.13,
     cborg >=0.2.1 && <0.3,
     containers,
@@ -178,7 +178,7 @@ library testlib
 
   build-depends:
     QuickCheck >=2.14 && <2.16,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     bytestring,
     cardano-slotting:testlib ^>=0.2.0 || <0.2.0.2,
     cardano-strict-containers,
@@ -229,7 +229,7 @@ test-suite test
     -- Possibly due to ByteString
     -- generator changes.
     QuickCheck >=2.14 && <2.16,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     ouroboros-network-api,
     ouroboros-network-mock,
     ouroboros-network-protocols:testlib,
@@ -257,7 +257,7 @@ test-suite cddl
   default-extensions: ImportQualifiedPost
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     bytestring,
     cborg,
     containers,
@@ -297,7 +297,7 @@ test-suite bench
   main-is: Main.hs
   default-language: Haskell2010
   build-depends:
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     bytestring,
     cborg,
     containers,

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -64,7 +64,7 @@ library
 
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     cborg >=0.2.1 && <0.3,
     containers,
     contra-tracer,
@@ -101,7 +101,7 @@ test-suite test
   other-modules: Test.Ouroboros.Network.Data.AbsBearerInfo.Test
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.21,
+    base >=4.14 && <4.22,
     ouroboros-network-testing,
     tasty,
     tasty-quickcheck,

--- a/quickcheck-monoids/quickcheck-monoids.cabal
+++ b/quickcheck-monoids/quickcheck-monoids.cabal
@@ -24,7 +24,7 @@ library
   exposed-modules: Test.QuickCheck.Monoids
   build-depends:
     QuickCheck,
-    base <4.21,
+    base <4.22,
 
   hs-source-dirs: src
   default-language: Haskell2010


### PR DESCRIPTION
Updated to the branch to support `ghc-9.12`, unreleased revisions where published to CHaP in IntersectMBO/cardano-haskell-packages#1235.