### PR TITLE
StandardHash with NFData constraint

### DIFF
--- a/ouroboros-network/api/bench/BenchBlock.hs
+++ b/ouroboros-network/api/bench/BenchBlock.hs
@@ -8,6 +8,7 @@
 -- | A simple block for benchmarking 'AnchoredFragment's.
 module BenchBlock where
 
+import Control.DeepSeq (NFData)
 import Crypto.Hash.SHA256 qualified as SHA256
 import Data.ByteString.Builder
 import Data.ByteString.Short (ShortByteString)
@@ -20,7 +21,7 @@ import Ouroboros.Network.Block
 -- | A 32 byte hash, just like for Cardano mainnet.
 newtype BenchHash = BenchHash { getBenchHash :: ShortByteString }
   deriving stock (Generic)
-  deriving newtype (Eq, Ord)
+  deriving newtype (Eq, Ord, NFData)
   deriving anyclass (NoThunks)
 
 instance Show BenchHash where

--- a/ouroboros-network/api/lib/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/api/lib/Ouroboros/Network/Block.hs
@@ -179,14 +179,16 @@ class ( Eq       (HeaderHash b)
       , Show     (HeaderHash b)
       , Typeable (HeaderHash b)
       , NoThunks (HeaderHash b)
+      , NFData   (HeaderHash b)
       ) => StandardHash (b :: k)
 
 data ChainHash b = GenesisHash | BlockHash !(HeaderHash b)
   deriving (Generic)
 
-deriving instance StandardHash block => Eq   (ChainHash block)
-deriving instance StandardHash block => Ord  (ChainHash block)
-deriving instance StandardHash block => Show (ChainHash block)
+deriving instance StandardHash block => Eq     (ChainHash block)
+deriving instance StandardHash block => Ord    (ChainHash block)
+deriving instance StandardHash block => Show   (ChainHash block)
+deriving instance StandardHash block => NFData (ChainHash block)
 
 instance (StandardHash block, Typeable block) => NoThunks (ChainHash block)
   -- use generic instance
@@ -210,21 +212,14 @@ castHash (BlockHash h) = BlockHash (coerce h)
 newtype Point block = Point
     { getPoint :: WithOrigin (Point.Block SlotNo (HeaderHash block))
     }
-  deriving (Generic)
-
-instance NFData (Point block) where
-  rnf point = rnf (pointSlot point)
-              `seq`
-              pointHash point
-              `seq`
-              ()
-
+  deriving Generic
 
 deriving newtype instance StandardHash block => Eq       (Point block)
 deriving newtype instance StandardHash block => Ord      (Point block)
 deriving via (Quiet (Point block))
                  instance StandardHash block => Show     (Point block)
 deriving newtype instance StandardHash block => NoThunks (Point block)
+deriving newtype instance StandardHash block => NFData   (Point block)
 deriving newtype instance ToJSON (Point.Block SlotNo (HeaderHash block)) => ToJSON (Point block)
 deriving newtype instance FromJSON (Point.Block SlotNo (HeaderHash block)) => FromJSON (Point block)
 
@@ -273,6 +268,7 @@ data Tip b =
 deriving instance StandardHash b => Eq       (Tip b)
 deriving instance StandardHash b => Show     (Tip b)
 deriving instance StandardHash b => NoThunks (Tip b)
+deriving instance StandardHash b => NFData   (Tip b)
 instance ShowProxy b => ShowProxy (Tip b) where
     showProxy _ = "Tip " ++ showProxy (Proxy :: Proxy b)
 

--- a/ouroboros-network/api/lib/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
+++ b/ouroboros-network/api/lib/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
@@ -107,9 +107,14 @@ data SomeHashableBlock =
               , ToCBOR (HeaderHash blk)
               , FromCBOR (HeaderHash blk)
               , ToJSON (HeaderHash blk)
-              , Typeable blk) => SomeHashableBlock !(Proxy blk) !(HeaderHash blk)
+              , Typeable blk
+              , NFData (HeaderHash blk)
+              ) => SomeHashableBlock !(Proxy blk) !(HeaderHash blk)
 
 type instance HeaderHash SomeHashableBlock = SomeHashableBlock
+instance NFData SomeHashableBlock where
+    rnf (SomeHashableBlock point hash) = rnf point
+                                   `seq` rnf hash
 
 -- we need this since `Point` is parameterised with `SomeHashableBlock`
 -- in the snapshot

--- a/ouroboros-network/api/tests-lib/Ouroboros/Network/Mock/ConcreteBlock.hs
+++ b/ouroboros-network/api/tests-lib/Ouroboros/Network/Mock/ConcreteBlock.hs
@@ -153,13 +153,13 @@ instance (StandardHash b, Hashable (HeaderHash b)) => Hashable (ChainHash b)
 --
 newtype ConcreteHeaderHash = HeaderHash Int
   deriving stock   (Show, Eq, Ord, Generic)
-  deriving newtype (Hashable, NoThunks)
+  deriving newtype (Hashable, NoThunks, NFData)
 
 -- | The hash of all the information in a 'BlockBody'.
 --
 newtype BodyHash = BodyHash Int
   deriving stock  (Show, Eq, Ord, Generic)
-  deriving newtype Hashable
+  deriving newtype (Hashable, NFData)
 
 {-------------------------------------------------------------------------------
   HasHeader instances

--- a/ouroboros-network/changelog.d/20260209_143345_coot_clean_cabal_project.md
+++ b/ouroboros-network/changelog.d/20260209_143345_coot_clean_cabal_project.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Added NFData constraint to `StandardHash`.
+

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -182,6 +182,7 @@ benchmark api-bench
     base >=4.14 && <4.23,
     bytestring,
     cryptohash-sha256,
+    deepseq,
     nothunks,
     ouroboros-network:api,
     tasty-bench,


### PR DESCRIPTION
# Description

Added `NFData` constraint to `StandardHash`.  This allows to do `ouroboros-cosnensus` integration.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
