### PR TITLE
docs: fix typos across documentation and changelogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To build all the required jobs (which are necessary to pass through CI), you can
 nix build -j auto .\#hydraJobs.required
 ```
 
-To inspect what can be build use `nix repl` , for example:
+To inspect what can be built use `nix repl` , for example:
 ```
 nix-repl> :lf .
 nix-repl> hydraJobs.<TAB>
@@ -189,7 +189,7 @@ comes with [`io-sim`]: `io-classes` expose a very similar API that the `base`,
   They all use `DiffTime` rather than `Int`, so you can use fractional values
   if needed.
 
-  Failing to notice this, might lead to bugs where delays which supposed to
+  Failing to notice this, might lead to bugs where delays which are supposed to
   be in the order of seconds will be measured in months (`3*10^6` seconds ~ one
   month)!
 
@@ -294,7 +294,7 @@ need to delete branch created in `cardano-haskell-packages`.
 
 ### Release from master or release/* branch
 
-* First run `./script/release-to-chap.sh -r` to see which changes can be
+* First run `./scripts/release-to-chap.sh -r` to see which changes can be
   published.
 * Update versions in `*.cabal` files according to changelog fragments in `changelog.d` directory
   (using `scriv print` might be helpful to see the changes):
@@ -302,14 +302,14 @@ need to delete branch created in `cardano-haskell-packages`.
   - for a breaking release from a `release/*` branch, bump `y` in `x.y.z.w`
   This policy allows us to introduce breaking changes in already released packages.
 * Collect `CHANGELOG.md` using `scriv collect` (available in `nix develop`)
-* Run `./script/release-to-chap.sh` which will create a branch in
+* Run `./scripts/release-to-chap.sh` which will create a branch in
   `cardano-haskell-packages` repo (pointed by `CARDANO_HASKELL_PACKAGES_DIR`
   environment variable or `/tmp/chap` if it's not defined).
   * To enable pushing this branch, cd to the chap repo and execute:
     `git remote set-url origin git@github.com:IntersectMBO/cardano-haskell-packages.git`
     then return to the previous repo (`cd -`)
-* Before merging that branch, run `./script/build-with-chap.sh`.  It will use the new branch in
-  `cardano-haskell-packages` to restore the `ourobors-network` repository to the
+* Before merging that branch, run `./scripts/build-with-chap.sh`.  It will use the new branch in
+  `cardano-haskell-packages` to restore the `ouroboros-network` repository to the
   state published in `CHaP`.
   * If you need to re-run this script after fixing errors, you will need to delete the tags created
     by the previous run. You can do so with the following command:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Discord](https://img.shields.io/discord/1136727663583698984?style=for-the-badge&color=blue)](https://discord.gg/8ncb7fgG)
 
 This repository contains specification and implementation of the network
-protocols and applications for Ouroboros family of protocols, primiarly used by
+protocols and applications for Ouroboros family of protocols, primarily used by
 [cardano-node], [cardano-cli], [cardano-db-sync] or [cardano-wallet].
 
 The following graph shows the dependency tree.  The top-level package is
@@ -18,7 +18,7 @@ that we abbreviate `ouroboros-{consensus,network}` to `o-{c,n}` in the labels.
 
 ```mermaid
 flowchart TB
-  subgraph ourobors-consensus
+  subgraph ouroboros-consensus
     I[o-c-diffusion]
     L[o-c]
     click I "https://github.com/intersectmbo/ouroboros-consensus/" _blank
@@ -76,7 +76,7 @@ flowchart TB
 * `ouroboros-network-protocols` - implementation of all /node-to-node/
   & /node-to-client/ protocols.  Also contains a testing library which is
   implementing various applications for testing purposes.
-* `ouroboros-network`- top-level integration of all network components also
+* `ouroboros-network` - top-level integration of all network components also
   defines `node-to-node` and `node-to-client` API.  It contains the implementation
   of the outbound governor.
 * `ouroboros-network-mock` & `ouroboros-network-testing` - shared testing code.
@@ -132,7 +132,7 @@ The code of conduct is available [here][code-of-conduct].
 
 The API consists of three layers:
 
-• mini-protocol APIs, which are GADTs for each mini-protocol under `Ouroboros.Network.Protocol` (defined in `ouroboros-network-protocols` package); this hides heavy type machinery of session types.  One only needs the [`Peer`] or [`PeerPipelined`] type  when one is using [`runPeer`] or [`runPeerPipelined`] function and each protocol exposes a function to create it (e.g. [`chainSyncClientPeer`].  There is also API which allows to run a [`Peer`] or [`PipelinedPeer`] with limits (i.e. per state timeouts & per message size limits).
+• mini-protocol APIs, which are GADTs for each mini-protocol under `Ouroboros.Network.Protocol` (defined in `ouroboros-network-protocols` package); this hides heavy type machinery of session types.  One only needs the [`Peer`] or [`PeerPipelined`] type when one is using [`runPeer`] or [`runPeerPipelined`] function and each protocol exposes a function to create it (e.g. [`chainSyncClientPeer`].  There is also API which allows to run a [`Peer`] or [`PipelinedPeer`] with limits (i.e. per state timeouts & per message size limits).
 
 • callback [`MiniProtocolCb`].  The callback is wrapped in `OuroborosApplication` GADT which allows to differentiate the initiator/responder (or client/server) callbacks.
 
@@ -172,7 +172,7 @@ arguments it will specify what arguments it needs.
 [style-guide]: ./docs/StyleGuide.md
 [`MiniProtocolCb`]: https://ouroboros-network.cardano.intersectmbo.org/ouroboros-network-framework/Ouroboros-Network-Mux.html#t:MiniProtocolCb
 [`Peer`]: https://input-output-hk.github.io/typed-protocols/typed-protocols/Network-TypedProtocol-Core.html#t:Peer
-[`PeerPipelines`]: https://input-output-hk.github.io/typed-protocols/typed-protocols/Network-TypedProtocol-Pipelined.html#t:PeerPipelined
+[`PeerPipelined`]: https://input-output-hk.github.io/typed-protocols/typed-protocols/Network-TypedProtocol-Pipelined.html#t:PeerPipelined
 [`runPeer`]: https://ouroboros-network.cardano.intersectmbo.org/ouroboros-network-framework/Ouroboros-Network-Driver.html#v:runPeer
 [`runPipelinedPeer`]: https://ouroboros-network.cardano.intersectmbo.org/ouroboros-network-framework/Ouroboros-Network-Driver.html#v:runPipelinedPeer
 [`chainSyncClientPeer`]: https://ouroboros-network.cardano.intersectmbo.org/ouroboros-network-protocols/Ouroboros-Network-Protocol-ChainSync-Client.html#v:chainSyncClientPeer

--- a/cardano-diffusion/CHANGELOG.md
+++ b/cardano-diffusion/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Breaking
 
 - Initial release of the `cardano-diffusion` package, which is based on
-  `ourorboros-network:cardano-diffusion` with the following modifications:
+  `ouroboros-network:cardano-diffusion` with the following modifications:
   - Removed `Cardano.Network.Types` module. `LedgerStateJudgement` is available
     from the `cardano-diffusion:api` package in
     `Cardano.Network.LedgerStateJudgement` module. `NumberOfBigLedgerPeers` is
@@ -55,7 +55,7 @@ cardano-diffusion:
 - improved approach in general to target-chasing tests in diffusion testnet
   and PeerSelection mock environment tests.
 
-- Addapted tests to changes in the `Ouroboros.Network.TxSubmission.Mempool.Simple` API
+- Adapted tests to changes in the `Ouroboros.Network.TxSubmission.Mempool.Simple` API
 
 - Patched so that it compiles to wasm
 

--- a/cardano-diffusion/changelog.d/20260119_122936_coot_dmq_related_changes.md
+++ b/cardano-diffusion/changelog.d/20260119_122936_coot_dmq_related_changes.md
@@ -1,5 +1,5 @@
 ### Breaking
 
-- Addapted to removal of `ChurnCounters` and `dtTraceChurnCounters` in
+- Adapted to removal of `ChurnCounters` and `dtTraceChurnCounters` in
   `ouroboros-network`.
 

--- a/cardano-diffusion/changelog.d/20260120_113456_coot_dmq_related_changes.md
+++ b/cardano-diffusion/changelog.d/20260120_113456_coot_dmq_related_changes.md
@@ -1,5 +1,5 @@
 ### Breaking
 
-- `Ouroboros.Ntework.Diffusion.Tracers` changed in `ouroboros-network` package,
+- `Ouroboros.Network.Diffusion.Tracers` changed in `ouroboros-network` package,
   see it's changelog for details.
 

--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -98,7 +98,7 @@
 
 ### Breaking changes
 
-* Addapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4997
+* Adapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4997
 
 ### Non-breaking changes
 
@@ -169,14 +169,14 @@
 ## 0.2.0.3 -- 2023-06-09
 
 * For versions strictly lower than `NodeToNodeV_11`, send
-  `InitiatorAndResponder` flag when quering.  For these versions querying is
+  `InitiatorAndResponder` flag when querying.  For these versions querying is
   not recognised by the remote side, and thus it will do handshake negotiation.
 * Only print the query result if querying is supported by the remote side.
 
 ## 0.2.0.2 -- 2023-06-08
 
 * Support `NodeToNodeV_11`, `NodeToNodeV_12` and `NodeToClientV_16`.
-* Fix delay/timeout bugs (miliseconds were used instead of seconds).
+* Fix delay/timeout bugs (milliseconds were used instead of seconds).
 * Print query even if --quiet flag is given.
 * Instead of a boolean flag print `InitiatorOnly` or `InitiatorAndResponder`.
 * Fixed encoding of `NodeToNodeV_11`.

--- a/docs/StyleGuide.md
+++ b/docs/StyleGuide.md
@@ -385,7 +385,7 @@ the rules below, it is good practice to update the code's style to match them.
             } = args
       ```
 
-   d. Using `RecordWildCards` for unpacking large records is discuraged.
+   d. Using `RecordWildCards` for unpacking large records is discouraged.
 
    e. Class or instance contexts: when a class or instance declaration doesn't
       fit onto a single line because of the super-class context, wrap the line
@@ -404,7 +404,7 @@ the rules below, it is good practice to update the code's style to match them.
             => C a where
       ```
 
-   e. Tuples in type signatures:
+   f. Tuples in type signatures:
 
       ```haskell
       foo ::
@@ -417,7 +417,7 @@ the rules below, it is good practice to update the code's style to match them.
            )
       ```
 
-   f. Datatypes:
+   g. Datatypes:
 
       ```haskell
       data Foo =
@@ -436,7 +436,7 @@ the rules below, it is good practice to update the code's style to match them.
           }
       ```
 
-   g. Type synonyms:
+   h. Type synonyms:
 
       ```haskell
       type Foo a b =
@@ -452,7 +452,7 @@ the rules below, it is good practice to update the code's style to match them.
         )
       ```
 
-   h. Function composition:
+   i. Function composition:
 
       ```haskell
       foo = h
@@ -1037,7 +1037,7 @@ the rules below, it is good practice to update the code's style to match them.
     `-fno-warn-x`.
 
     Most often (whenever we can), we use `-Wno-unticked-promoted-constructors`.
-    This allows to use unticked promoted data contructors as types.
+    This allows to use unticked promoted data constructors as types.
 
 21. __HasCallStack__: when using `error` in code paths should be impossible and
     are indicative of bugs, make sure enough `HasCallStack` constraints are in

--- a/docs/network-spec/General.md
+++ b/docs/network-spec/General.md
@@ -129,7 +129,7 @@ should be discontinued.
 
 Instead of integrating version negotiation in the protocol, we may want to
 establish it via the peer discovery system. Part of a `FIND_NODE` response
-could be a list of supported protcol versions and the relevant IP/PORT of the
+could be a list of supported protocol versions and the relevant IP/PORT of the
 server which implements it.
 
 ## Repurposing of the OutboundQueue

--- a/network-mux/CHANGELOG.md
+++ b/network-mux/CHANGELOG.md
@@ -72,7 +72,7 @@
 * Define msHeaderLength instead of using '8'
 * Benchmark for Socket Bearer
 * Use ByteString.Builder for the ingress queues
-* Signal the kernal that we require at least the full SDU's worth of data
+* Signal the kernel that we require at least the full SDU's worth of data
 
 ## 0.7.0.0 -- 2025-02-25
 

--- a/ntp-client/CHANGELOG.md
+++ b/ntp-client/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 ### Non-breaking changes
 
-* `ghc-9.4` and `ghc-9.6` compatiblity.
+* `ghc-9.4` and `ghc-9.6` compatibility.
 
 ## 0.0.1.0 -- 2022-12-13
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Breaking
 
-- All `ouroboros-*` where incorporated into `ouroboros-network`, at the same
+- All `ouroboros-*` were incorporated into `ouroboros-network`, at the same
   time all **Cardano** specific components were pulled into `cardano-diffusion`:
 
   * `ouroboros-network-protocols`                         -> `ouroboros-network:protocols`
@@ -20,7 +20,7 @@
   * `ouroboros-network-framework:io-tests`                -> `ouroboros-network:framework-io-tests`
   * `ouroboros-network-framework:demo-connection-manager` -> `ouroboros-network:demo-connection-manager`
   * `ouroboros-network-framework:demo-ping-pong`          -> `ouroboros-network:demo-ping-pong`
-  * `ouroboros-newtork-mock`                              -> `ouroboros-network:mock`
+  * `ouroboros-network-mock`                              -> `ouroboros-network:mock`
   * `ouroboros-network:testlib`                           -> `ouroboros-network:ouroboros-network-tests-lib`
   * `ouroboros-network:sim-tests`                         -> `ouroboros-network:ouroboros-network-sim-tests`
   * `ouroboros-network:io-tests`                          -> `ouroboros-network:ouroboros-network-io-tests`
@@ -112,7 +112,7 @@ ouroboros-network:api:
   `txids` with errors.
 - `Ouroboros.Network.TxSubmission.Mempool.Simple.getMempoolWriter` changes:
   - supplies the current time to the validation function,
-  - removed `ctx` paramenter,
+  - removed `ctx` parameter,
   - validation happens in an `STM` transaction, which allows acquiring and
     updating validation `ctx`.
 
@@ -190,7 +190,7 @@ ouroboros-network:
 - Added field `eicExtraFlags` to `ExpandedInitiatorContext`.
 - Added field `defaultExtraFlags` to `PeerSelectionGovernorArgs`.
 
-* Limit the number of faulures to 5 before a peer that isn't a localroot, bootstrap peer or public root peer is forgotten.
+* Limit the number of failures to 5 before a peer that isn't a localroot, bootstrap peer or public root peer is forgotten.
 * Decrease the time blockfetch waits for chainsync to exit in case of an error
 * Increase the timeout for chainsync in state StMustReply to between 601 and 911 seconds.
 
@@ -199,7 +199,7 @@ ouroboros-network:
 - Improved `Message TxSubmission` ToJSON instance
 - Improved `Message KeepAlived` ToJSON instance
 - `Ouroboros.Network.TxSubmission.Mempool.Simple` re-export `TxSubmissionMempool{Reader,Writer}` data types.
-- `Ouroboros.Network.TxSubmission.Mempool.Simple` is assiging stable `idx`s to `tx`s.
+- `Ouroboros.Network.TxSubmission.Mempool.Simple` is assigning stable `idx`s to `tx`s.
 <!-- scriv-end-here -->
 
 ## 0.23.0.0 -- 2025-09-10
@@ -226,10 +226,10 @@ ouroboros-network:
 `networkToplogogyToJSON` to `Ouroboros.Network.OrphanInstances`
 * Removed `ToJSON` and `FromJSON` instances for `NetworkTopology extraConfig
   extraFlags` from `Ouroboros.Network.OrphanInstances`.
-* Addded `ToJSON` and `FromJSON` instances for `NetworkTopology
+* Added `ToJSON` and `FromJSON` instances for `NetworkTopology
   UseBootstrapPeers PeerTrustable` to `Cardano.Network.OrphanInstances`
-* Added `localRootPeersGroupFromJSON`, localRootPeersGroupsFromJSON`,
-  `networkTopologyFromJSON to `Ouroboros.Network.OrphanInstances`
+* Added `localRootPeersGroupFromJSON`, `localRootPeersGroupsFromJSON`,
+  `networkTopologyFromJSON` to `Ouroboros.Network.OrphanInstances`
 
 ### Non-breaking changes
 
@@ -318,7 +318,7 @@ ouroboros-network:
 
 * Lowered default established targets:
   - ledger peers:     30 (deadline mode)
-  - big ledgerp pers: 40 (syncing mode)
+  - big ledger peers: 40 (syncing mode)
 
 ## 0.21.0.0 -- 2025-05-13
 
@@ -328,7 +328,7 @@ ouroboros-network:
   support for mux buffered socket bearers
 * added `daEgressPollInterval` to diffusion `Arguments` record
   which specifies the cork duration of mux egress queue at the
-  application layer. This provides a configurable latency/efficieny
+  application layer. This provides a configurable latency/efficiency
   tradeoff.
 
 ### Non-breaking changes
@@ -552,8 +552,8 @@ ouroboros-network:
   * dnsSubscriptionWorker
 * Added `AcquireConnectionError` to `PeerSelectionActionsTrace`
 * Removed deprecated `ReconnectDelay` type alias.
-* Addapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4999
-* Addapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4997
+* Adapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4999
+* Adapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4997
 * Use `LocalRootConfig` instead of a tuple.
 * Extended `LocalRootConfig` with `diffusionMode :: DiffusionMode` field.
 * Added `diConnStateSupply` record field to `Ouroboros.Network.Diffusion.P2P.Interfaces`.
@@ -572,7 +572,7 @@ ouroboros-network:
   bootstrapping a node in Genesis consensus mode, or in general when
   LedgerStateJudgement = TooOld, subject to conditions in
   `LedgerPeers.ledgerPeersThread`.
-* Diffusion run function in P2P mode has new paramaters:
+* Diffusion run function in P2P mode has new parameters:
     * `daPeerTargets` - replaces daPeerSelectionTargets. `Configuration`
         module provides an API. Used by peer selection & churn governors. Given
         required arguments, it returns the correct target basis to use for churn
@@ -589,7 +589,7 @@ ouroboros-network:
 * `Ouroboros.Network.NodeToClient.connectTo` takes
   `OuroborosApplicationWithMinimalCtx` which is using `Void` type for responder
   protocols.  It anyway only accepts `InitiatorMode`, and thus no responder
-  protocols can be specified, nontheless this might require changing type
+  protocols can be specified, nonetheless this might require changing type
   signature of the applications passed to it.  `connectTo` returns now either
   an error or the result of the first terminated mini-protocol.
 * `Ouroboros.Network.NodeToNode.connectTo` returns either an error or the
@@ -712,7 +712,7 @@ ouroboros-network:
 * Update the bigledger retry state in case of an exception
 * Reset public root retry state when transition between `LedgerStateJudgements`.
 * Reduce public root retry timer.
-* Don't classify a config file with publicRoot/bootstrapPeers IP addresss only
+* Don't classify a config file with publicRoot/bootstrapPeers IP addresses only
   as a DNS error.
 * Renamed `fuzzRnd` to `stdGen` in `PeerSelectionState`
 * split `stdGen` in `PeerSelection.Governor.wakeupAction`
@@ -799,7 +799,7 @@ ouroboros-network:
   involves the bootstrap peers flag and the ledger state judgement value.
 
 * Improved tracing when peersharing
-* set knownSuccessfulConnection for incomming peers
+* set knownSuccessfulConnection for incoming peers
 * Don't use minPeerShareTime with GuardedSkip
 
 * `PeerSharingController` is now private and `requestPeers` is exported
@@ -823,7 +823,7 @@ ouroboros-network:
 
 ### Breaking changes
 
-* Renamed `ReconnectDelay` to `RepromoteDelay` - the dalay is used after
+* Renamed `ReconnectDelay` to `RepromoteDelay` - the delay is used after
   demotion to `cold` as well as `warm` state.  A `ReconnectDelay` type alias is
   still provided but deprecated.
 
@@ -921,7 +921,7 @@ Deprecated release.
 ### Non-breaking changes
 
 * Updated KeepAlive client to collect a rtt sample for the first packet.
-* Less aggresive churning of established and known peers.
+* Less aggressive churning of established and known peers.
 * Added peer sharing to wireshark dissector.
 * Added ledger peers to diffusion simulation
 * Fixed diffusion tests.
@@ -1109,7 +1109,7 @@ Deprecated release.
 
 ### Non-breaking changes
 
-* `ghc-9.4` and `ghc-9.6` compatiblity.
+* `ghc-9.4` and `ghc-9.6` compatibility.
 
 ## 0.5.0.0 -- 2023-04-19
 

--- a/ouroboros-network/changelog.d/20260122_220351_coot_ouroboros_churn_fix.md
+++ b/ouroboros-network/changelog.d/20260122_220351_coot_ouroboros_churn_fix.md
@@ -1,4 +1,4 @@
 ### Breaking
 
-- Removed previuos targets from `TraceTargetsChanged`.
+- Removed previous targets from `TraceTargetsChanged`.
 

--- a/ouroboros-network/wireshark-plugin/README.md
+++ b/ouroboros-network/wireshark-plugin/README.md
@@ -4,10 +4,10 @@ To use it copy `ouroboros_network.lua` to `$HOME/.config/wireshark/plugins`, or
 create a symbolic link:
 
 ```bash
-ls -s $(pwd)/ouroboros_network/wireshark-plugin/ouroboros_network.lua $HOME/.config/wireshark/plugins/ouroboros_network.lua
+ln -s $(pwd)/ouroboros_network/wireshark-plugin/ouroboros_network.lua $HOME/.config/wireshark/plugins/ouroboros_network.lua
 ```
 
-## Mux disector
+## Mux dissector
 
 There is also another dissector for the mux protocol in
 `./network-mux/demo/mux-leios-demo.lua`.


### PR DESCRIPTION
## Summary

Fix 38 typos across 13 documentation files:

- **README.md**: `primiarly` → `primarily`, `ourobors-consensus` → `ouroboros-consensus`, broken `PeerPipelined` link reference, missing space, double space
- **CONTRIBUTING.md**: `build` → `built`, `which supposed` → `which are supposed`, `./script/` → `./scripts/` (3x), `ourobors-network` → `ouroboros-network`
- **docs/StyleGuide.md**: `discuraged` → `discouraged`, `contructors` → `constructors`, duplicate `e.` sub-label fixed (shifted f→g→h→i)
- **docs/network-spec/General.md**: `protcol` → `protocol`
- **ouroboros-network/wireshark-plugin/README.md**: `ls -s` → `ln -s`, `disector` → `dissector`
- **ouroboros-network/CHANGELOG.md**: 17 fixes (`where` → `were`, `newtork`, `paramenter`, `faulures`, `assiging`, `Addded`, `ledgerp pers`, `efficieny`, `Addapted` (2x), `paramaters`, `nontheless`, `addresss`, `incomming`, `dalay`, `aggresive`, `compatiblity`, missing backticks)
- **network-mux/CHANGELOG.md**: `kernal` → `kernel`
- **cardano-ping/CHANGELOG.md**: `Addapted` → `Adapted`, `quering` → `querying`, `miliseconds` → `milliseconds`
- **cardano-diffusion/CHANGELOG.md**: `ourorboros` → `ouroboros`, `Addapted` → `Adapted`
- **ntp-client/CHANGELOG.md**: `compatiblity` → `compatibility`
- **3 changelog.d fragments**: `Addapted` → `Adapted`, `Ntework` → `Network`, `previuos` → `previous`

## Test plan

- [ ] No code changes, only documentation and changelog text corrections
- [ ] Verify CI changelog check passes (modified files include CHANGELOG.md or changelog.d entries as required)