### PR TITLE
Win32-network-0.1 support

### DIFF
--- a/network-mux/changelog.d/20260212_095548_coot_Win32_network_0_1.md
+++ b/network-mux/changelog.d/20260212_095548_coot_Win32_network_0_1.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Support `Win32-network ^>=0.1`.
+

--- a/network-mux/demo/mux-demo.hs
+++ b/network-mux/demo/mux-demo.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE PackageImports     #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
@@ -28,7 +29,11 @@ import Data.Bits
 import System.IOManager
 import System.Win32
 import System.Win32.Async qualified as Win32.Async
-import System.Win32.NamedPipes
+#if MIN_VERSION_Win32_network(0,2,0)
+import "Win32" System.Win32.NamedPipes
+#else
+import "Win32-network" System.Win32.NamedPipes
+#endif
 #else
 import Network.Socket (Family (AF_UNIX), SockAddr (..))
 import Network.Socket qualified as Socket

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -67,7 +67,7 @@ library
   if os(windows)
     build-depends:
       Win32 >=2.5.4.1 && <3.0,
-      Win32-network >=0.2 && <0.3,
+      Win32-network >=0.1 && <0.3,
 
   if flag(tracetcpinfo)
     cpp-options: -DMUX_TRACE_TCPINFO

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE PackageImports             #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TupleSections              #-}
@@ -53,7 +54,11 @@ import Control.Tracer
 #if defined(mingw32_HOST_OS)
 import System.Win32.Async qualified as Win32.Async
 import System.Win32.File qualified as Win32.File
-import System.Win32.NamedPipes qualified as Win32.NamedPipes
+#if MIN_VERSION_Win32_network(0,2,0)
+import "Win32" System.Win32.NamedPipes qualified as Win32.NamedPipes
+#else
+import "Win32-network" System.Win32.NamedPipes qualified as Win32.NamedPipes
+#endif
 #else
 import System.IO (hClose)
 import System.Process (createPipe)

--- a/ouroboros-network/changelog.d/20260212_095553_coot_Win32_network_0_1.md
+++ b/ouroboros-network/changelog.d/20260212_095553_coot_Win32_network_0_1.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Support `Win32-network ^>=0.1`.

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -363,7 +363,7 @@ library framework
   -- other-extensions:
   build-depends:
     -- ^ only to derive nothunk instances
-    Win32-network ^>=0.2,
+    Win32-network >=0.1 && <0.3,
     base >=4.12 && <4.23,
     bytestring >=0.10 && <0.13,
     cardano-strict-containers,

--- a/ouroboros-network/tests/io/Test/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/tests/io/Test/Ouroboros/Network/Pipe.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
@@ -38,7 +39,11 @@ import Data.Bits ((.|.))
 import System.IOManager
 import System.Win32 qualified as Win32
 import System.Win32.Async qualified as Win32.Async
-import System.Win32.NamedPipes qualified as Win32.NamedPipes
+#if MIN_VERSION_Win32_network(0,2,0)
+import "Win32" System.Win32.NamedPipes qualified as Win32.NamedPipes
+#else
+import "Win32-network" System.Win32.NamedPipes qualified as Win32.NamedPipes
+#endif
 #else
 import System.IO (hClose)
 import System.Process (createPipe)


### PR DESCRIPTION
As requested by the `node` team, I'm adding `Win32-network-0.1` support.  This is because they are using `proto-lens`, which builds against a `ghc` library version, which pulls `Win32 < 2.14` (e.g. no `NamedPipes` support).

I didn't add CI to build against `Win32-network-0.1`, only tested it locally with `nix` and in GHA with an earlier version of this branch, which included `constraint Win32-network < 0.2`: https://github.com/IntersectMBO/ouroboros-network/actions/runs/21940311210


