### PR TITLE
peer-selection: fix above target other

### DIFF
--- a/ouroboros-network/changelog.d/20260305_155421_crocodile-dentist_peer_selection_fix.md
+++ b/ouroboros-network/changelog.d/20260305_155421_crocodile-dentist_peer_selection_fix.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Fix to peer selection's above target other: failed to demote an established peer
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -714,13 +714,17 @@ aboveTargetOther actions@PeerSelectionActions {
     -- Or more precisely, how many established peers could we demote?
     -- We only want to pick established peers that are not active, since for
     -- active one we need to demote them first.
-  | let PeerSelectionView {
+  | let peerSelectionView@PeerSelectionView {
             viewKnownBigLedgerPeers = (bigLedgerPeersSet, _),
-            viewEstablishedLocalRootPeers = (_, numLocalWarmPeers),
             viewEstablishedPeers    = (establishedPeersSet, numEstablishedPeers),
             viewActivePeers         = (_, numActivePeers)
           }
           = peerSelectionStateToView st
+        PeerSelectionCountersHWC {
+            numberOfWarmLocalRootPeers = numLocalWarmPeers
+          }
+          =
+          snd <$> peerSelectionView
         warmPeers =
                  establishedPeersSet
           Set.\\ activePeers


### PR DESCRIPTION
# Description

Fixes
cabal run cardano-diffusion-sim-tests -- --quickcheck-replay="(SMGen 9997593625910766810 2047148039201333979,86)" -p '/progress.ledger peers.progresses towards established target (from above)/' to rerun this test only.

Reverts to bug introduced in #5325

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
