### PR TITLE
Remove duplicate tracing namespace declarations

### DIFF
--- a/ouroboros-network/changelog.d/20260311_142224_crocodile-dentist_10_7_integration.md
+++ b/ouroboros-network/changelog.d/20260311_142224_crocodile-dentist_10_7_integration.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Cleaned up tracing namespaces
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection/Governor/TracePeerSelection.hs
+++ b/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection/Governor/TracePeerSelection.hs
@@ -567,7 +567,6 @@ instance MetaTrace (ToExtraTrace extraPeers)
     severityFor (Namespace [] ["ChurnAction"]) _ = Just Info
     severityFor (Namespace [] ["ChurnTimeout"]) _ = Just Notice
     severityFor (Namespace [] ["DebugState"]) _ = Just Info
-    severityFor (Namespace [] ["ExtraTrace"]) _ = Just Info
     severityFor _ _ = Nothing
 
     documentFor (Namespace [] ["LocalRootPeersChanged"]) = Just  ""


### PR DESCRIPTION
These are already defined in `cardano-diffusion`,
in `instance MetaTrace (ToExtraTrace (ExtraPeers peeraddr))`.

I need this to make `cabal test -O0 cardano-node-test` to pass. Otherwise it fails with:

```
  ✗ goodConfig.yaml failed at test/Test/Cardano/Tracing/NewTracing/Consistency.hs:51:17
    after 1 test.
    shrink path: 1:

       ┏━━ test/Test/Cardano/Tracing/NewTracing/Consistency.hs ━━━
    45 ┃ goldenTestJSON :: SubdirSelection -> [Text] -> FilePath -> Property
    46 ┃ goldenTestJSON subDir expectedOutcome goldenFileBaseName =
    47 ┃   H.withTests 1 $ H.withShrinks 0 $ H.property $ do
    48 ┃     base          <- resolveDir
    49 ┃     goldenFp      <- H.note $ base </> goldenFileBaseName
       ┃     │ test/Test/Cardano/Tracing/NewTracing/data/goodConfig.yaml
    50 ┃     actualValue   <- H.evalIO $ checkNodeTraceConfiguration goldenFp
    51 ┃     actualValue H.=== expectedOutcome
       ┃     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       ┃     │ ━━━ Failed (- lhs) (+ rhs) ━━━
       ┃     │ - [ "System namespace error: Duplicate namespace Net.PeerSelection.Selection.LedgerStateJudgementChanged"
       ┃     │ - , "System namespace error: Duplicate namespace Net.PeerSelection.Selection.UseBootstrapPeersChanged"
       ┃     │ - ]
       ┃     │ + []
    52 ┃   where
    53 ┃     resolveDir = case subDir of
    54 ┃       ExternalSubdir d -> do
    55 ┃         base <- H.evalIO . IO.canonicalizePath =<< H.getProjectBase
    56 ┃         pure $ base </> d
    57 ┃       InternalSubdir d ->
    58 ┃         pure d
```