### PR TITLE
Removed AcquireConnectionError

### DIFF
--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
@@ -1709,11 +1709,6 @@ prop_peer_selection_action_trace_coverage defaultBearerInfo diffScript =
         "PeerMonitoringError " ++ show e
       peerSelectionActionsTraceMap (PeerMonitoringResult _ _res)  =
         "PeerMonitoringResult"
-      peerSelectionActionsTraceMap (AcquireConnectionError e)
-        | Just ioe <- fromException e
-        = "AcquireConnectionError: " ++ show (ioe_type ioe)
-        | otherwise
-        = "AcquireConnectionError"
       peerSelectionActionsTraceMap (PeerHotDuration _id _dt) =
         "PeerHotDuration"
 
@@ -4502,7 +4497,6 @@ prop_diffusion_peer_selection_actions_no_dodgy_traces ioSimTrace traceNumber =
                 WithTime _ (PeerStatusChangeFailure type_ _) -> getConnId type_
                 WithTime _ (PeerMonitoringError connId _)    -> Just connId
                 WithTime _ (PeerMonitoringResult connId _)   -> Just connId
-                WithTime _ (AcquireConnectionError _)        -> Nothing
                 WithTime _ (PeerHotDuration connId _)        -> Just connId)
          $ peerSelectionActionsEvents
          )

--- a/ouroboros-network/changelog.d/20260401_214923_coot_haddocks_update.md
+++ b/ouroboros-network/changelog.d/20260401_214923_coot_haddocks_update.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Removed `AcquireConnectionError` trace from `PeerSelectionActionsTrace`, a more
+  detailed trace is provided by `TrConnectError` by `ConnectionManager.Tracer`
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-network/framework/lib/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network/framework/lib/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1421,7 +1421,8 @@ with args@Arguments {
         traverse_ (either (traceWith trTracer) (traceWith tracer)) trace
         traceCounters stateVar
         case eHandleWedge of
-          Left e ->
+          Left e -> do
+            traceWith tracer (TrConnectError Nothing peerAddr (toException e))
             throwIO e
 
           -- connection manager does not have a connection with @peerAddr@.
@@ -1506,7 +1507,7 @@ with args@Arguments {
                                             , remoteAddress = peerAddr
                                             }
                   updated <- atomically $ modifyTMVarPure stateVar (swap . State.updateLocalAddr connId)
-                  unless updated $
+                  unless updated $ do
                     -- there exists a connection with exact same
                     -- `ConnectionId`
                     --
@@ -1518,7 +1519,9 @@ with args@Arguments {
                     -- open?).  Since the `accept` call never returns, the
                     -- `connId` slot must have been available, and thus
                     -- `State.updateLocalAddr` must have returned `True`.
-                    throwIO (withCallStack $ ConnectionExists provenance peerAddr)
+                    let e = withCallStack $ ConnectionExists provenance peerAddr
+                    traceWith tracer (TrConnectError addr peerAddr (toException e))
+                    throwIO e
 
                   --
                   -- fork connection handler; it will unmask exceptions
@@ -2416,6 +2419,8 @@ data Trace peerAddr handlerTrace
   | TrConnectError                 (Maybe peerAddr) -- ^ local address
                                    peerAddr         -- ^ remote address
                                    SomeException
+    -- ^ Traces error thrown by `acquireConnection`, including, but not limited
+    -- to the `connect` call.
   | TrTerminatingConnection        Provenance (ConnectionId peerAddr)
   | TrTerminatedConnection         Provenance peerAddr
   | TrConnectionHandler            (ConnectionId peerAddr) handlerTrace

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -53,7 +53,6 @@ import Data.ByteString.Lazy (ByteString)
 import Data.Functor (void, ($>))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (isNothing)
 import Data.Typeable (Typeable, cast)
 
 import Network.Mux qualified as Mux
@@ -788,8 +787,6 @@ withPeerStateActions PeerStateActionsArguments {
                          provenance
           case res of
             Left e -> do
-              when (isNothing $ fromException @SomeAsyncException e) $
-                traceWith spsTracer (AcquireConnectionError e)
               case runRethrowPolicy spsRethrowPolicy OutboundError e of
                 ShutdownNode -> throwTo spsMainThreadId e
                              >> throwIO e
@@ -1233,6 +1230,5 @@ data PeerSelectionActionsTrace peerAddr vNumber =
     | PeerStatusChangeFailure (PeerStatusChangeType peerAddr) (FailureType vNumber)
     | PeerMonitoringError     (ConnectionId peerAddr) SomeException
     | PeerMonitoringResult    (ConnectionId peerAddr) (Maybe (WithSomeProtocolTemperature FirstToFinishResult))
-    | AcquireConnectionError  SomeException
     | PeerHotDuration         (ConnectionId peerAddr) DiffTime
   deriving Show

--- a/ouroboros-network/orphan-instances/Ouroboros/Network/OrphanInstances.hs
+++ b/ouroboros-network/orphan-instances/Ouroboros/Network/OrphanInstances.hs
@@ -1263,10 +1263,6 @@ instance (ToJSON peerAddr, Show peerAddr, Show versionNumber)
             , "connectionId" .= toJSON connId
             , "withProtocolTemp" .= show wf
             ]
-  toJSON (AcquireConnectionError exception) =
-    object [ "kind" .= String "AcquireConnectionError"
-           , "error" .= displayException exception
-           ]
   toJSON (PeerHotDuration connId duration) =
     object [ "kind" .= String "PeerHotDuration"
            , "connId" .= connId

--- a/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection/PeerStateActions.hs
@@ -4,7 +4,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Network.Tracing.PeerSelection.PeerStateActions () where
 
-import Control.Exception (displayException)
 import Data.Aeson (ToJSON (..), Value (String), (.=))
 import Data.Text (pack)
 
@@ -41,10 +40,6 @@ instance (Show lAddr, Show peeraddr, ToJSON peeraddr)
              , "connectionId" .= toJSON connId
              , "withProtocolTemp" .= show wf
              ]
-  forMachine _dtal (AcquireConnectionError exception) =
-    mconcat [ "kind" .= String "AcquireConnectionError"
-            , "error" .= displayException exception
-            ]
   forMachine _dtal (PeerHotDuration connId dt) =
     mconcat [ "kind" .= String "PeerHotDuration"
             , "connectionId" .= toJSON connId
@@ -56,7 +51,6 @@ instance MetaTrace (PeerSelectionActionsTrace peeraddr lAddr) where
     namespaceFor PeerStatusChangeFailure {} = Namespace [] ["StatusChangeFailure"]
     namespaceFor PeerMonitoringError {} = Namespace [] ["MonitoringError"]
     namespaceFor PeerMonitoringResult {} = Namespace [] ["MonitoringResult"]
-    namespaceFor AcquireConnectionError {} = Namespace [] ["ConnectionError"]
     namespaceFor PeerHotDuration {} = Namespace [] ["PeerHotDuration"]
 
     severityFor (Namespace _ ["StatusChanged"]) _       = Just Info


### PR DESCRIPTION
# Description

A more detailed trace is provided by ConnectionManager - `TrConnectError`.
I also expanded it to cover three other cases which `AcquireConnectionError`
covered.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
