### PR TITLE
cardano-diffusion: tx integrity test

### DIFF
--- a/cardano-diffusion/cardano-diffusion.cabal
+++ b/cardano-diffusion/cardano-diffusion.cabal
@@ -512,6 +512,7 @@ library cardano-diffusion-tests-lib
   exposed-modules:
     Test.Cardano.Network.Diffusion.Policies
     Test.Cardano.Network.Diffusion.Testnet
+    Test.Cardano.Network.Diffusion.Testnet.ChainedTxs
     Test.Cardano.Network.Diffusion.Testnet.MiniProtocols
     Test.Cardano.Network.Diffusion.Testnet.Simulation
     Test.Cardano.Network.OrphanInstances.Tests

--- a/cardano-diffusion/changelog.d/20260424_094857_karl.fb.knutsson_tx_tests.md
+++ b/cardano-diffusion/changelog.d/20260424_094857_karl.fb.knutsson_tx_tests.md
@@ -1,0 +1,5 @@
+### Non-Breaking
+
+- Add test for testing V2 tx-submission when faced with option to download TXs in different
+  orders from different peers.
+

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
@@ -97,6 +97,8 @@ import Ouroboros.Network.TxSubmission.Outbound (TxSubmissionProtocolError (..))
 
 import Simulation.Network.Snocket (BearerInfo (..), noAttenuation)
 
+import Test.Cardano.Network.Diffusion.Testnet.ChainedTxs (ChainedPeerTxs (..))
+import Test.Cardano.Network.Diffusion.Testnet.ChainedTxs qualified as ChainedTxs
 import Test.Cardano.Network.Diffusion.Testnet.Simulation
 
 import Test.Ouroboros.Network.ConnectionManager.Timeouts
@@ -179,6 +181,8 @@ tests =
     , testGroup "Tx Submission"
       [ nightlyTest $ testProperty "no protocol errors"
                                    prop_no_txSubmission_error_iosimpor
+      , nightlyTest $ testProperty "tx chain integrity"
+                                   prop_txSubmission_chainIntegrity_iosimpor
       ]
     , testGroup "Churn"
       [ nightlyTest $ testProperty "no timeouts"
@@ -265,12 +269,15 @@ tests =
                       prop_no_peershare_unwilling_iosim
       ]
     , testGroup "Tx Submission"
-      [ testProperty "no protocol errors"
+      [ ChainedTxs.tests
+      , testProperty "no protocol errors"
                      prop_no_txSubmission_error_iosim
       , testProperty "all transactions"
                      prop_txSubmission_allTransactions
       , testProperty "inflight coverage"
                      prop_check_inflight_ratio
+      , testProperty "tx chain integrity"
+                     prop_txSubmission_chainIntegrity_iosim
       ]
     , testGroup "Churn"
       [ testProperty "no timeouts" prop_churn_notimeouts_iosim
@@ -1078,6 +1085,215 @@ prop_txSubmission_allTransactions (ArbTxDecisionPolicy decisionPolicy)
                   acceptedTxidsB === validSortedTxidsA
            Nothing | [] <- validSortedTxidsA -> property True
                    | otherwise -> counterexample "Didn't found any entry in the map!" False
+
+
+-- | Three-node diffusion topology used by the Tx Chain Integrity
+-- property: one node (0.0.0.0) downloading txs from two downstream
+-- peers (0.0.0.1 and 0.0.0.2). The node has no outbound txs of its own;
+-- each downstream peer advertises the tx list it was assigned by
+-- 'ChainedPeerTxs'.
+txChainIntegrityDiffScript :: ArbTxDecisionPolicy
+                           -> ChainedPeerTxs
+                           -> DiffusionScript
+txChainIntegrityDiffScript (ArbTxDecisionPolicy decisionPolicy)
+                           (ChainedPeerTxs chainedTxsB chainedTxsC) =
+  let localRootConfig = LocalRootConfig
+                          DoNotAdvertisePeer
+                          InitiatorAndResponderDiffusionMode
+                          Outbound
+                          IsNotTrustable
+
+      noPeerTargets = PeerSelectionTargets {
+          targetNumberOfRootPeers                 = 0,
+          targetNumberOfKnownPeers                = 0,
+          targetNumberOfEstablishedPeers          = 0,
+          targetNumberOfActivePeers               = 0,
+          targetNumberOfKnownBigLedgerPeers       = 0,
+          targetNumberOfEstablishedBigLedgerPeers = 0,
+          targetNumberOfActiveBigLedgerPeers      = 0
+        }
+
+      upstreamTargets = PeerSelectionTargets {
+          targetNumberOfRootPeers                 = 1,
+          targetNumberOfKnownPeers                = 1,
+          targetNumberOfEstablishedPeers          = 1,
+          targetNumberOfActivePeers               = 1,
+          targetNumberOfKnownBigLedgerPeers       = 0,
+          targetNumberOfEstablishedBigLedgerPeers = 0,
+          targetNumberOfActiveBigLedgerPeers      = 0
+        }
+
+  in DiffusionScript
+       (SimArgs 1 10 decisionPolicy)
+       (singletonTimedScript Map.empty)
+       [ ( NodeArgs
+             (-1)
+             InitiatorAndResponderDiffusionMode
+             Map.empty
+             PraosMode
+             (Script (DontUseBootstrapPeers :| []))
+             (TestAddress (IPAddr (read "0.0.0.0") 0))
+             PeerSharingDisabled
+             []
+             (Script (LedgerPools [] :| []))
+             (noPeerTargets, noPeerTargets)
+             (Script (DNSTimeout {getDNSTimeout = 10} :| []))
+             (Script (DNSLookupDelay {getDNSLookupDelay = 0} :| []))
+             Nothing
+             False
+             (Script (PraosFetchMode FetchModeDeadline :| []))
+             []
+         , [JoinNetwork 0] )
+       , ( NodeArgs
+             (-2)
+             InitiatorAndResponderDiffusionMode
+             Map.empty
+             PraosMode
+             (Script (DontUseBootstrapPeers :| []))
+             (TestAddress (IPAddr (read "0.0.0.1") 0))
+             PeerSharingDisabled
+             [(1, 1, Map.fromList
+                 [(RelayAccessAddress "0.0.0.0" 0, localRootConfig)])]
+             (Script (LedgerPools [] :| []))
+             (upstreamTargets, upstreamTargets)
+             (Script (DNSTimeout {getDNSTimeout = 10} :| []))
+             (Script (DNSLookupDelay {getDNSLookupDelay = 0} :| []))
+             Nothing
+             False
+             (Script (PraosFetchMode FetchModeDeadline :| []))
+             chainedTxsB
+         , [JoinNetwork 0] )
+       , ( NodeArgs
+             (-3)
+             InitiatorAndResponderDiffusionMode
+             Map.empty
+             PraosMode
+             (Script (DontUseBootstrapPeers :| []))
+             (TestAddress (IPAddr (read "0.0.0.2") 0))
+             PeerSharingDisabled
+             [(1, 1, Map.fromList
+                 [(RelayAccessAddress "0.0.0.0" 0, localRootConfig)])]
+             (Script (LedgerPools [] :| []))
+             (upstreamTargets, upstreamTargets)
+             (Script (DNSTimeout {getDNSTimeout = 10} :| []))
+             (Script (DNSLookupDelay {getDNSLookupDelay = 0} :| []))
+             Nothing
+             False
+             (Script (PraosFetchMode FetchModeDeadline :| []))
+             chainedTxsC
+         , [JoinNetwork 0] )
+       ]
+
+-- | Txs guaranteed to reach the node's mempool: at least one downstream
+-- peer carries the tx together with all of its ancestors, and every
+-- member of that chain is valid. Txs whose chain isn't fully represented
+-- on either downstream peer are legitimately unreachable and correctly
+-- excluded from this lower bound. V2 may deliver additional txs when a
+-- split chain is assembled across downstream peers via favourable
+-- ordering, but those are not guaranteed.
+txChainIntegrityExpected :: ChainedPeerTxs -> Set TxId
+txChainIntegrityExpected (ChainedPeerTxs chainedTxsB chainedTxsC) =
+  Set.union
+    (perPeerDeliverable chainedTxsB)
+    (perPeerDeliverable chainedTxsC)
+  where
+    perPeerDeliverable :: [Tx TxId] -> Set TxId
+    perPeerDeliverable peerTxs =
+      let txMap = Map.fromList [(getTxId t, t) | t <- peerTxs]
+          complete tid = case Map.lookup tid txMap of
+            Nothing -> False
+            Just t  -> getTxValid t
+                    && maybe True complete (getTxParent t) in
+      Set.fromList [ getTxId t | t <- peerTxs, complete (getTxId t) ]
+
+checkTxChainIntegrity :: forall r.
+                         ChainedPeerTxs
+                      -> Set TxId
+                      -> SimTrace r
+                      -> Int
+                      -> Property
+checkTxChainIntegrity (ChainedPeerTxs chainedTxsB chainedTxsC)
+                      expectedAtReceiver
+                      ioSimTrace
+                      traceNumber =
+  let trace = Trace.take traceNumber ioSimTrace
+
+      events = fmap (\(WithTime t (WithName name b)) ->
+                      WithName name (WithTime t b))
+             . withTimeNameTraceEvents
+                @DiffusionTestTrace
+                @NtNAddr
+             $ trace
+
+      sortedAcceptedTxidsMap :: Map NtNAddr [TxId]
+      sortedAcceptedTxidsMap =
+          foldr (\l r ->
+            List.foldl' (\rr (WithName n (WithTime _ x)) ->
+              case x of
+                DiffusionTxSubmissionInbound (TraceTxInboundAddedToMempool txids _) ->
+                  Map.alter (maybe (Just txids) (Just . sort . (txids ++))) n rr
+                _ -> rr) r l
+          ) Map.empty
+        . Trace.toList
+        . splitWithNameTrace
+        $ events
+
+      receiverAddr = TestAddress (IPAddr (read "0.0.0.0") 0)
+      accepted     = Map.lookup receiverAddr sortedAcceptedTxidsMap
+      actualSet    = maybe Set.empty Set.fromList accepted
+      missing      = expectedAtReceiver `Set.difference` actualSet in
+
+  counterexample ("accepted txids map: " ++ show sortedAcceptedTxidsMap)
+   $ counterexample ("downstream peer B outbound: " ++ show chainedTxsB)
+   $ counterexample ("downstream peer C outbound: " ++ show chainedTxsC)
+   $ counterexample ("expected (reliably deliverable): "
+                     ++ show (Set.toList expectedAtReceiver))
+   $ counterexample ("missing from node: " ++ show (Set.toList missing))
+   $ label ("expected count: "
+           ++ renderRanges 5 (Set.size expectedAtReceiver))
+   $ label ("accepted count: "
+           ++ renderRanges 5 (Set.size actualSet))
+   $ counterexample "node (0.0.0.0)"
+   $ property (Set.null missing)
+
+-- | Tx Chain Integrity property: the node's mempool accumulates every
+-- transaction reachable via a complete, valid ancestor chain on at least
+-- one of its downstream peers.
+--
+-- This exercises V2's cross-peer retry path: if an adversarial downstream
+-- peer delivers a child out-of-order and the mempool rejects with
+-- 'MissingParent', the tx must still reach the node via the well-behaved
+-- downstream peer's re-advertisement.
+prop_txSubmission_chainIntegrity :: ArbTxDecisionPolicy
+                                 -> ChainedPeerTxs
+                                 -> Property
+prop_txSubmission_chainIntegrity argPolicy chainedTxs =
+  let diffScript = txChainIntegrityDiffScript argPolicy chainedTxs
+      expected   = txChainIntegrityExpected chainedTxs in
+  checkTxChainIntegrity
+    chainedTxs
+    expected
+    (runSimTrace (diffusionSimulation noAttenuation diffScript))
+    long_trace
+
+prop_txSubmission_chainIntegrity_iosimpor :: ArbTxDecisionPolicy
+                                          -> ChainedPeerTxs
+                                          -> Property
+prop_txSubmission_chainIntegrity_iosimpor argPolicy chainedTxs =
+  let diffScript = txChainIntegrityDiffScript argPolicy chainedTxs
+      expected   = txChainIntegrityExpected chainedTxs
+      sim :: forall s. IOSim s DiffSimResult
+      sim = do
+        exploreRaces
+        diffusionSimulation noAttenuation diffScript
+   in labelDiffusionScript diffScript
+    $ exploreSimTrace (\a -> a { explorationScheduleBound = 10 }) sim $ \_ trace ->
+        checkTxChainIntegrity chainedTxs expected trace long_trace
+
+prop_txSubmission_chainIntegrity_iosim :: ArbTxDecisionPolicy
+                                       -> ChainedPeerTxs
+                                       -> Property
+prop_txSubmission_chainIntegrity_iosim = prop_txSubmission_chainIntegrity
 
 
 -- | This test checks the ratio of the inflight txs against the allowed by the

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet/ChainedTxs.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet/ChainedTxs.hs
@@ -1,0 +1,259 @@
+module Test.Cardano.Network.Diffusion.Testnet.ChainedTxs
+  ( ChainedPeerTxs (..)
+  , tests
+  ) where
+
+import Data.Function (on)
+import Data.List as List (foldl', nub, nubBy)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+
+import Test.Ouroboros.Network.TxSubmission.Types (Tx (..), TxId)
+
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+
+-- | A randomly generated transaction forest distributed across two peers,
+-- used by chain-integrity tests at the diffusion layer.
+--
+-- Each tx may carry a parent pointer ('getTxParent') to any earlier tx in
+-- the forest, with some probability of having no parent at all. Invalidity
+-- propagates down the chain at generation time: a descendant of an invalid
+-- tx is itself generated as invalid, matching mainnet semantics where a tx
+-- that consumes an invalid parent's output is itself invalid by construction.
+--
+-- Peer assignment reflects realistic mainnet conditions:
+--
+--   * Each peer carries a random subset of the forest (peers may lack txs
+--     that, for example, were already included in an adopted block).
+--   * Well-behaved peers (the common case) advertise their subset in
+--     chain-topological order: parents before children.
+--   * Adversarial or buggy peers (the occasional case) advertise in a
+--     shuffled order to stress V2's handling of out-of-order streams.
+--   * Every tx is carried by at least one /well-behaved/ peer so the full
+--     forest is reachable via the reliable path, even when adversarial
+--     peers misorder or mishandle their share.
+data ChainedPeerTxs = ChainedPeerTxs {
+    chainedTxsA :: [Tx TxId]
+  , chainedTxsB :: [Tx TxId]
+  }
+  deriving Show
+
+instance Arbitrary ChainedPeerTxs where
+  arbitrary = do
+    chainLen <- choose (3, 15)
+    chain    <- genChainedTxs chainLen
+    perPeer  <- distributeAcrossPeers 2 chain
+    case perPeer of
+      [txsA, txsB] -> return (ChainedPeerTxs txsA txsB)
+      _            -> error "ChainedPeerTxs: distributeAcrossPeers invariant broken"
+
+  shrink (ChainedPeerTxs txsA txsB) =
+    [ ChainedPeerTxs (dropDoomed txsA) (dropDoomed txsB)
+    | tid <- nub (map getTxId (txsA ++ txsB))
+    , let doomed    = transitiveDescendants tid (txsA ++ txsB)
+          dropDoomed = filter (\t -> getTxId t `Set.notMember` doomed)
+    ]
+    where
+      -- | All txids reachable as descendants of @root@, including @root@
+      -- itself. Used so that dropping a parent also drops every
+      -- transitive child, avoiding dangling parent pointers in the
+      -- shrunken value.
+      transitiveDescendants :: TxId -> [Tx TxId] -> Set TxId
+      transitiveDescendants root txs =
+        let children p = [ getTxId t | t <- txs, getTxParent t == Just p ]
+            go acc p
+              | p `Set.member` acc = acc
+              | otherwise          = List.foldl' go (Set.insert p acc) (children p) in
+        go Set.empty root
+
+
+-- | Generate a forest of @n@ transactions.
+--
+-- Tx 0 has no parent. Each subsequent tx picks its parent uniformly from
+-- @{Nothing}@ unioned with the ids of earlier txs, weighted so a parent
+-- link is more common than no parent. Invalidity is propagated: if the
+-- parent is invalid, the tx is also invalid regardless of its own drawn
+-- validity.
+genChainedTxs :: Int -> Gen [Tx TxId]
+genChainedTxs n = go 0 Map.empty []
+  where
+    baseId :: TxId
+    baseId = 1
+
+    go :: Int -> Map TxId Bool -> [Tx TxId] -> Gen [Tx TxId]
+    go i validMap acc
+      | i >= n = return (reverse acc)
+      | otherwise = do
+          let txid = baseId + i
+          parent <- if i == 0
+                      then return Nothing
+                      else frequency
+                             [ (1, return Nothing)
+                             , (3, Just . (baseId +) <$> choose (0, i - 1))
+                             ]
+          ownValid <- frequency [ (3, return True), (1, return False) ]
+          size     <- chooseEnum (0, 1024)
+          let parentValid    = maybe True (validMap Map.!) parent
+              effectiveValid = ownValid && parentValid
+              tx = Tx
+                { getTxId      = txid
+                , getTxSize    = size
+                , getTxAdvSize = size
+                , getTxValid   = effectiveValid
+                , getTxParent  = parent
+                }
+          go (i + 1) (Map.insert txid effectiveValid validMap) (tx : acc)
+
+
+-- | Per-peer behaviour selected up front so chain-coverage constraints
+-- can be satisfied against the well-behaved subset before any lists are
+-- emitted.
+data PeerBehaviour = WellBehaved | Adversarial
+  deriving (Eq, Show)
+
+-- | Distribute a forest across @peerCount@ peers.
+--
+-- Each peer is classified as well-behaved (advertises in chain-topological
+-- order, the common case) or adversarial (advertises in a shuffled order,
+-- the occasional case).  To keep the property invariant clean, every tx
+-- is guaranteed to be carried by at least one /well-behaved/ peer:
+-- adversarial peers add noise and races but cannot singly strand a tx.  At
+-- least one peer is always well-behaved.
+--
+-- Adversarial peers may duplicate txs already carried by well-behaved
+-- peers; this exercises V2's cross-peer retry path when an adversarial
+-- peer's out-of-order delivery causes a rejection.
+distributeAcrossPeers :: Int -> [Tx TxId] -> Gen [[Tx TxId]]
+distributeAcrossPeers peerCount chain = do
+  behaviours <- ensureSomeWellBehaved <$>
+                  vectorOf peerCount
+                    (frequency [ (4, pure WellBehaved)
+                               , (1, pure Adversarial) ])
+
+  subsets <- vectorOf peerCount (sublistOf chain)
+
+  let wellBehavedIxs =
+        [ i | (i, WellBehaved) <- zip [0..] behaviours ]
+      wellBehavedCov =
+        Set.unions
+          [ Set.fromList (map getTxId (subsets !! i))
+          | i <- wellBehavedIxs ]
+      uncovered =
+        [ t | t <- chain, getTxId t `Set.notMember` wellBehavedCov ]
+  additions <- traverse
+                 (\t -> do i <- elements wellBehavedIxs; pure (i, t))
+                 uncovered
+
+  let subsetsWithCoverage :: [[Tx TxId]]
+      subsetsWithCoverage =
+        zipWith
+          (\i base -> base ++ [ t | (p, t) <- additions, p == i ])
+          [0 .. peerCount - 1]
+          subsets
+
+      inChainOrder :: Set TxId -> [Tx TxId]
+      inChainOrder peerSet =
+        filter (\t -> getTxId t `Set.member` peerSet) chain
+
+  traverse
+    (\(b, s) -> case b of
+        WellBehaved -> pure (inChainOrder (Set.fromList (map getTxId s)))
+        Adversarial -> shuffle s)
+    (zip behaviours subsetsWithCoverage)
+  where
+    ensureSomeWellBehaved bs
+      | WellBehaved `elem` bs = bs
+      | otherwise             = WellBehaved : drop 1 bs
+
+
+--
+-- Meta-tests: verify generator and shrinker invariants.
+--
+
+-- | Every parent pointer in the combined peer lists resolves to a tx that
+-- also appears somewhere in the union. No dangling parents.
+prop_parentsResolvable :: ChainedPeerTxs -> Bool
+prop_parentsResolvable (ChainedPeerTxs txsA txsB) =
+  let ids     = Set.fromList (map getTxId (txsA ++ txsB))
+      parents = [ p | t <- txsA ++ txsB, Just p <- [getTxParent t] ] in
+  all (`Set.member` ids) parents
+
+-- | Invalidity propagates along the dependency chain: if a tx's parent is
+-- present in the union and invalid, the tx itself must be invalid too.
+prop_invalidityPropagates :: ChainedPeerTxs -> Bool
+prop_invalidityPropagates (ChainedPeerTxs txsA txsB) =
+  let allTxs = nubBy ((==) `on` getTxId) (txsA ++ txsB)
+      txMap  = Map.fromList [(getTxId t, t) | t <- allTxs] in
+  all (\t -> case getTxParent t of
+               Nothing -> True
+               Just p  -> case Map.lookup p txMap of
+                 Nothing -> True
+                 Just pt -> getTxValid pt || not (getTxValid t))
+                         -- not (getTxValid pt) => not (getTxValid t)
+      allTxs
+
+-- | At least one peer's tx list is in chain-topological order (parents
+-- before children), and the union of all such peers' txids covers every
+-- tx in the value. This is the external face of the "every tx is carried
+-- by at least one well-behaved peer" guarantee from
+-- 'distributeAcrossPeers': adversarial peers may exist and misorder, but
+-- the full forest is always reachable via the chain-ordered subset.
+prop_wellBehavedCoverage :: ChainedPeerTxs -> Property
+prop_wellBehavedCoverage (ChainedPeerTxs txsA txsB) =
+  let allIds          = Set.fromList (map getTxId (txsA ++ txsB))
+      chainOrdered    = filter isChainOrdered [txsA, txsB]
+      coverage        = Set.unions
+                          [ Set.fromList (map getTxId txs) | txs <- chainOrdered ] in
+  counterexample ("peer A: " ++ show txsA)
+   $ counterexample ("peer B: " ++ show txsB)
+   $ counterexample ("chain-ordered peers: " ++ show (length chainOrdered))
+   $ counterexample ("coverage: " ++ show (Set.toList coverage))
+   $ counterexample ("all ids: "  ++ show (Set.toList allIds))
+   $ property (not (null chainOrdered) && coverage == allIds)
+  where
+    isChainOrdered :: [Tx TxId] -> Bool
+    isChainOrdered txs =
+      let positions = Map.fromList (zip (map getTxId txs) [(0 :: Int) ..]) in
+      all (\t -> case getTxParent t of
+                   Nothing -> True
+                   Just p  -> case Map.lookup p positions of
+                     Nothing   -> True
+                     Just ppos -> ppos < positions Map.! getTxId t)
+          txs
+
+
+-- | Every shrink of a value satisfies the same structural invariants as
+-- a freshly generated one.
+prop_shrinkPreservesInvariants :: ChainedPeerTxs -> Property
+prop_shrinkPreservesInvariants cpt =
+  conjoin
+    [ counterexample ("shrunk: " ++ show s) $
+           prop_parentsResolvable s
+      .&&. prop_invalidityPropagates s
+      .&&. prop_wellBehavedCoverage s
+    | s <- shrink cpt
+    ]
+
+-- | Each shrink strictly reduces the total tx count so shrinking converges.
+prop_shrinkMakesProgress :: ChainedPeerTxs -> Property
+prop_shrinkMakesProgress cpt =
+  let size (ChainedPeerTxs a b) = length a + length b
+      origSize                  = size cpt in
+  conjoin
+    [ counterexample ("shrunk: " ++ show s) (size s < origSize)
+    | s <- shrink cpt
+    ]
+
+tests :: TestTree
+tests = testGroup "ChainedTxs"
+  [ testProperty "parents resolvable"          prop_parentsResolvable
+  , testProperty "invalidity propagates"       prop_invalidityPropagates
+  , testProperty "well-behaved coverage"       prop_wellBehavedCoverage
+  , testProperty "shrink preserves invariants" prop_shrinkPreservesInvariants
+  , testProperty "shrink makes progress"       prop_shrinkMakesProgress
+  ]

--- a/ouroboros-network/changelog.d/20260424_094524_karl.fb.knutsson_tx_tests.md
+++ b/ouroboros-network/changelog.d/20260424_094524_karl.fb.knutsson_tx_tests.md
@@ -1,0 +1,8 @@
+### Breaking
+
+- Add getTxParent to test suit's Tx type
+
+### Non-Breaking
+
+- Fix test suits mempool writer's counting of valid and invalid txs
+

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -967,6 +967,7 @@ library ouroboros-network-tests-lib
     Test.Ouroboros.Network.TxSubmission.AppV1
     Test.Ouroboros.Network.TxSubmission.AppV2
     Test.Ouroboros.Network.TxSubmission.Mempool.Simple
+    Test.Ouroboros.Network.TxSubmission.MempoolWriter
     Test.Ouroboros.Network.TxSubmission.TxLogic
     Test.Ouroboros.Network.TxSubmission.Types
 

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission.hs
@@ -2,6 +2,7 @@ module Test.Ouroboros.Network.TxSubmission (tests) where
 
 import Test.Ouroboros.Network.TxSubmission.AppV1 qualified as AppV1
 import Test.Ouroboros.Network.TxSubmission.AppV2 qualified as AppV2
+import Test.Ouroboros.Network.TxSubmission.MempoolWriter qualified as MempoolWriter
 import Test.Ouroboros.Network.TxSubmission.TxLogic qualified as TxLogic
 
 import Test.Tasty (TestTree, testGroup)
@@ -9,6 +10,7 @@ import Test.Tasty (TestTree, testGroup)
 tests :: TestTree
 tests = testGroup "Ouroboros.Network.TxSubmission"
   [ AppV1.tests
+  , MempoolWriter.tests
   , TxLogic.tests
   , AppV2.tests
   ]

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/MempoolWriter.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/MempoolWriter.hs
@@ -42,5 +42,6 @@ unit_getMempoolWriter_recordsOnlyValidDuplicates step = do
           getTxId = txid,
           getTxSize = SizeInBytes 1,
           getTxAdvSize = SizeInBytes 1,
-          getTxValid = isValid
+          getTxValid = isValid,
+          getTxParent = Nothing
         }

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/MempoolWriter.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/MempoolWriter.hs
@@ -1,0 +1,46 @@
+module Test.Ouroboros.Network.TxSubmission.MempoolWriter (tests) where
+
+import Control.Concurrent.Class.MonadSTM (newTVarIO, readTVarIO)
+import Control.Monad.IOSim (runSimOrThrow)
+
+import Ouroboros.Network.Protocol.TxSubmission2.Type (SizeInBytes (..))
+import Ouroboros.Network.TxSubmission.Inbound.V1
+           (TxSubmissionMempoolWriter (..))
+
+import Test.Ouroboros.Network.TxSubmission.Types
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCaseSteps, (@?=))
+
+
+tests :: TestTree
+tests = testGroup "MempoolWriter"
+  [ testCaseSteps "getMempoolWriter records only valid duplicates" unit_getMempoolWriter_recordsOnlyValidDuplicates
+  ]
+
+
+unit_getMempoolWriter_recordsOnlyValidDuplicates :: (String -> IO ()) -> IO ()
+unit_getMempoolWriter_recordsOnlyValidDuplicates step = do
+  step "Populate the inbound mempool with one valid tx and submit one invalid duplicate plus one valid duplicate"
+  let (accepted, rejected, duplicateTxIds) =
+        runSimOrThrow $ do
+          duplicateVar <- newTVarIO []
+          mempool <- newMempool [mkTx 17 True]
+          let writer = getMempoolWriter duplicateVar mempool
+          result <- mempoolAddTxs writer [mkTx 17 False, mkTx 17 True]
+          duplicates <- readTVarIO duplicateVar
+          pure (fst result, snd result, duplicates)
+
+  step "Assert both submissions are rejected as duplicates but only the valid duplicate is recorded for result accounting"
+  accepted @?= []
+  rejected @?= [(17, DuplicateTx), (17, DuplicateTx)]
+  duplicateTxIds @?= [17]
+  where
+    mkTx :: TxId -> Bool -> Tx TxId
+    mkTx txid isValid =
+      Tx {
+          getTxId = txid,
+          getTxSize = SizeInBytes 1,
+          getTxAdvSize = SizeInBytes 1,
+          getTxValid = isValid
+        }

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/TxLogic.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/TxLogic.hs
@@ -835,7 +835,8 @@ instance Arbitrary ArbCollectTxs where
                                               getTxSize    = size,
                                               -- `availableTxIds` contains advertised sizes
                                               getTxAdvSize = availableTxIds Map.! txid,
-                                              getTxValid   = valid })
+                                              getTxValid   = valid,
+                                              getTxParent  = Nothing })
 
         pure $ assert (foldMap getTxAdvSize receivedTx <= requestedTxsInflightSize)
              $ ArbCollectTxs mempoolHasTxFun

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/Types.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/Types.hs
@@ -17,6 +17,7 @@ module Test.Ouroboros.Network.TxSubmission.Types
   , readMempool
   , getMempoolReader
   , getMempoolWriter
+  , InvalidTx (..)
   , maxTxSize
   , LargeNonEmptyList (..)
   , SimResults (..)
@@ -31,6 +32,7 @@ import Prelude hiding (seq)
 import NoThunks.Class
 
 import Control.Concurrent.Class.MonadSTM
+import Control.Concurrent.Class.MonadSTM.Strict qualified as StrictSTM
 import Control.DeepSeq
 import Control.Exception (SomeException (..))
 import Control.Monad.Class.MonadAsync
@@ -48,6 +50,10 @@ import Codec.CBOR.Encoding qualified as CBOR
 import Codec.CBOR.Read qualified as CBOR
 
 import Data.ByteString.Lazy (ByteString)
+import Data.Either (partitionEithers)
+import Data.List qualified as List
+import Data.Sequence qualified as Seq
+import Data.Set qualified as Set
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 
@@ -138,18 +144,73 @@ getMempoolWriter :: forall txid m.
                  => TVar m [txid]
                  -> Mempool m txid (Tx txid)
                  -> TxSubmissionMempoolWriter txid (Tx txid) Integer m InvalidTx
-getMempoolWriter duplicateVar =
-  Mempool.getWriter DuplicateTx
-                    getTxId
-                    (\_ txs -> return
-                                [ if getTxValid tx
-                                  then Right tx
-                                  else Left (getTxId tx, InvalidTx)
-                                | tx <- txs
-                                ]
-                    )
-                    (\t -> atomically $ modifyTVar' duplicateVar
-                      (map fst (filter ((== DuplicateTx) . snd) t) <>))
+getMempoolWriter duplicateVar (Mempool.Mempool mempoolVar) =
+  TxSubmissionMempoolWriter {
+      txId = getTxId,
+      mempoolAddTxs = \txs -> do
+        (acceptedTxs, rejectedTxs, duplicateValidTxIds) <- atomically $ do
+          Mempool.MempoolSeq { Mempool.mempoolSet, Mempool.mempoolSeq, Mempool.nextIdx } <-
+            StrictSTM.readTVar mempoolVar
+
+          let (duplicateTxs, txsToValidate) =
+                List.partition (\tx -> getTxId tx `Set.member` mempoolSet) txs
+              duplicateRejectedTxs =
+                [ (getTxId tx, DuplicateTx)
+                | tx <- duplicateTxs
+                ]
+              duplicateValidTxIds =
+                [ getTxId tx
+                | tx <- duplicateTxs
+                , getTxValid tx
+                ]
+              (invalidRejectedTxs, validTxs) =
+                partitionEithers
+                  [ if getTxValid tx
+                      then Right tx
+                      else Left (getTxId tx, InvalidTx)
+                  | tx <- txsToValidate
+                  ]
+
+              (delta, mempoolSeq', nextIdx', acceptedTxs, duplicateValidTxIds') =
+                List.foldl'
+                  (\(set, seq, idx, accepted, duplicates) tx ->
+                    let txid = getTxId tx in
+                    if txid `Set.member` set
+                      then ( set
+                           , seq
+                           , idx
+                           , accepted
+                           , txid : duplicates
+                           )
+                      else ( Set.insert txid set
+                           , seq Seq.|> Mempool.WithIndex idx tx
+                           , succ idx
+                           , txid : accepted
+                           , duplicates
+                           )
+                  )
+                  (Set.empty, mempoolSeq, nextIdx, [], [])
+                  validTxs
+
+          StrictSTM.writeTVar
+            mempoolVar
+            Mempool.MempoolSeq {
+              Mempool.mempoolSet = mempoolSet `Set.union` delta,
+              Mempool.mempoolSeq = mempoolSeq',
+              Mempool.nextIdx = nextIdx'
+            }
+
+          pure
+            ( acceptedTxs
+            , invalidRejectedTxs
+                ++ duplicateRejectedTxs
+                ++ [ (txid, DuplicateTx) | txid <- duplicateValidTxIds' ]
+            , duplicateValidTxIds ++ duplicateValidTxIds'
+            )
+
+        atomically $ modifyTVar' duplicateVar (duplicateValidTxIds <>)
+        pure (acceptedTxs, rejectedTxs)
+    }
 
 
 txSubmissionCodec2 :: MonadST m

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/Types.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/Types.hs
@@ -79,7 +79,12 @@ data Tx txid = Tx {
     -- | If false this means that when this tx will be submitted to a remote
     -- mempool it will not be valid.  The outbound mempool might contain
     -- invalid tx's in this sense.
-    getTxValid   :: !Bool
+    getTxValid   :: !Bool,
+    -- | Optional parent dependency: this tx may only be accepted into a
+    -- mempool once its parent is already present (either from an earlier
+    -- batch or earlier in the same batch).  'Nothing' means no dependency.
+    -- Used by chain-aware tests to model transaction chains.
+    getTxParent  :: !(Maybe txid)
   }
   deriving (Eq, Ord, Show, Generic, NFData)
 
@@ -102,6 +107,9 @@ instance Arbitrary txid => Arbitrary (Tx txid) where
          <*> frequency [ (3, pure True)
                        , (1, pure False)
                        ]
+         <*> pure Nothing
+           -- ^ Generic Arbitrary produces standalone txs with no parent.
+           -- Chain-aware generators construct parents explicitly.
 
 -- maximal tx size
 maxTxSize :: SizeInBytes
@@ -129,7 +137,7 @@ getMempoolReader :: forall txid m.
 getMempoolReader = Mempool.getReader getTxId getTxAdvSize
 
 
-data InvalidTx = InvalidTx | DuplicateTx
+data InvalidTx = InvalidTx | DuplicateTx | MissingParent
   deriving (Eq, Show)
 
 getMempoolWriter :: forall txid m.
@@ -171,9 +179,9 @@ getMempoolWriter duplicateVar (Mempool.Mempool mempoolVar) =
                   | tx <- txsToValidate
                   ]
 
-              (delta, mempoolSeq', nextIdx', acceptedTxs, duplicateValidTxIds') =
+              (delta, mempoolSeq', nextIdx', acceptedTxs, duplicateValidTxIds', missingParentIds) =
                 List.foldl'
-                  (\(set, seq, idx, accepted, duplicates) tx ->
+                  (\(set, seq, idx, accepted, duplicates, missing) tx ->
                     let txid = getTxId tx in
                     if txid `Set.member` set
                       then ( set
@@ -181,15 +189,31 @@ getMempoolWriter duplicateVar (Mempool.Mempool mempoolVar) =
                            , idx
                            , accepted
                            , txid : duplicates
+                           , missing
                            )
-                      else ( Set.insert txid set
-                           , seq Seq.|> Mempool.WithIndex idx tx
-                           , succ idx
-                           , txid : accepted
-                           , duplicates
-                           )
+                      else case getTxParent tx of
+                        Just p
+                          | not (p `Set.member` set)
+                            && not (p `Set.member` mempoolSet) ->
+                              -- Parent is not in the mempool and has not
+                              -- been accepted earlier in this batch.
+                              ( set
+                              , seq
+                              , idx
+                              , accepted
+                              , duplicates
+                              , txid : missing
+                              )
+                        _ ->
+                          ( Set.insert txid set
+                          , seq Seq.|> Mempool.WithIndex idx tx
+                          , succ idx
+                          , txid : accepted
+                          , duplicates
+                          , missing
+                          )
                   )
-                  (Set.empty, mempoolSeq, nextIdx, [], [])
+                  (Set.empty, mempoolSeq, nextIdx, [], [], [])
                   validTxs
 
           StrictSTM.writeTVar
@@ -204,7 +228,8 @@ getMempoolWriter duplicateVar (Mempool.Mempool mempoolVar) =
             ( acceptedTxs
             , invalidRejectedTxs
                 ++ duplicateRejectedTxs
-                ++ [ (txid, DuplicateTx) | txid <- duplicateValidTxIds' ]
+                ++ [ (txid, DuplicateTx)   | txid <- duplicateValidTxIds' ]
+                ++ [ (txid, MissingParent) | txid <- missingParentIds ]
             , duplicateValidTxIds ++ duplicateValidTxIds'
             )
 
@@ -220,12 +245,13 @@ txSubmissionCodec2 =
     codecTxSubmission2 CBOR.encodeInt CBOR.decodeInt
                        encodeTx decodeTx
   where
-    encodeTx Tx {getTxId, getTxSize, getTxAdvSize, getTxValid} =
-         CBOR.encodeListLen 4
+    encodeTx Tx {getTxId, getTxSize, getTxAdvSize, getTxValid, getTxParent} =
+         CBOR.encodeListLen 5
       <> CBOR.encodeInt getTxId
       <> CBOR.encodeWord32 (getSizeInBytes getTxSize)
       <> CBOR.encodeWord32 (getSizeInBytes getTxAdvSize)
       <> CBOR.encodeBool getTxValid
+      <> encodeMaybeInt getTxParent
 
     decodeTx = do
       _ <- CBOR.decodeListLen
@@ -233,6 +259,17 @@ txSubmissionCodec2 =
          <*> (SizeInBytes <$> CBOR.decodeWord32)
          <*> (SizeInBytes <$> CBOR.decodeWord32)
          <*> CBOR.decodeBool
+         <*> decodeMaybeInt
+
+    encodeMaybeInt Nothing  = CBOR.encodeListLen 0
+    encodeMaybeInt (Just i) = CBOR.encodeListLen 1 <> CBOR.encodeInt i
+
+    decodeMaybeInt = do
+      n <- CBOR.decodeListLen
+      case n of
+        0 -> pure Nothing
+        1 -> Just <$> CBOR.decodeInt
+        _ -> fail "decodeMaybeInt: unexpected list length"
 
 
 newtype LargeNonEmptyList a = LargeNonEmpty { getLargeNonEmpty :: [a] }


### PR DESCRIPTION
# Description

Property based test for verifying that TXs eventually reach the mempool in the right order. 

Broken out from #5336

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
