### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,7 +270,7 @@ For a general architectural overview of the network code contact either:
 We officially support:
 
 * `Linux` (`x86_64-linux`)
-* `MacOS` (`x86_64-darwin` and `aarch64-darwin`)
+* `MacOS` (`aarch64-darwin`)
 * `Windows` (using [`msys2`] software distribution, and cross-compiled on linux with `nix`)
 
 On 32-bit platforms, you might expect some issues (currently memory requirement

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
     let # all platforms on which we build
       supportedSystems = [
         "x86_64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
     in


### PR DESCRIPTION
# Description

- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] ~~New tests are added and existing tests are updated.~~
* [x] Self-reviewed the PR.

### Maintenance
* [x] ~~Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.~~
* [x] ~~Added labels.~~
* [x] ~~Updated changelog files.~~
* [x] ~~The documentation has been properly updated, see [ref][contrib#documentation].~~

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
