### PR TITLE
Fix initial syncing targets

### DIFF
--- a/cardano-diffusion/changelog.d/20260430_150857_crocodile-dentist.md
+++ b/cardano-diffusion/changelog.d/20260430_150857_crocodile-dentist.md
@@ -1,0 +1,26 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+### Non-Breaking
+
+- When a node is started and syncing begins using bootstrap peers, only two outbound active connections
+  should be established to reduce the load on bootstray relays. Prior to this change, until the first
+  churn cycle 15 minutes into operation, a full set of active peers would be connected to.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/cardano-diffusion/changelog.d/20260505_072906_crocodile-dentist_fix_targets_sync.md
+++ b/cardano-diffusion/changelog.d/20260505_072906_crocodile-dentist_fix_targets_sync.md
@@ -1,0 +1,25 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+### Non-Breaking
+
+- Minor tweaks to tracing irregularities
+
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/cardano-diffusion/lib/Cardano/Network/PeerSelection/Churn.hs
+++ b/cardano-diffusion/lib/Cardano/Network/PeerSelection/Churn.hs
@@ -27,6 +27,7 @@ import Data.Void (Void)
 
 import Control.Applicative (Alternative)
 import Control.Concurrent.Class.MonadSTM.Strict
+import Control.Monad (when)
 import Control.Monad.Class.MonadThrow
 import Control.Monad.Class.MonadTime.SI
 import Control.Monad.Class.MonadTimer.SI
@@ -173,23 +174,41 @@ peerChurnGovernor PeerChurnArgs {
   -- TVar must not be `nullPeerselectionTargets` otherwise targetPeers in
   -- Monitor will not work due to a check!
   atomically $ do
+    churnMode <- updateChurnMode
     ledgerStateJudgement0 <- getLedgerStateJudgement
+    HotValency ltt <- getLocalRootHotTarget
+    regime <- pickChurnRegime churnMode <$> getUseBootstrapPeers
     let targets0 = getPeerSelectionTargets consensusMode ledgerStateJudgement0 peerSelectionTargets genesisPeerSelectionTargets
         targets0' = case consensusMode of
           -- In the `PraosMode` give a head start to big ledger & local root
           -- peers by disabling root peers.
-          PraosMode  -> targets0 { targetNumberOfRootPeers = 0 }
+          PraosMode -> case regime of
+            ChurnDefault   -> targets0 { targetNumberOfRootPeers = 0 }
+            ChurnPraosSync -> targets0 { targetNumberOfRootPeers = 0 }
+            ChurnBootstrapPraosSync ->
+              targets0 {
+                targetNumberOfActivePeers =
+                  min ((max 1 ltt) + 1) (targetNumberOfActivePeers targets0),
+                targetNumberOfActiveBigLedgerPeers =
+                  min 1 (targetNumberOfActiveBigLedgerPeers targets0)
+                }
           _otherwise -> targets0
     writeTVar peerSelectionVar targets0'
 
   threadDelay 3
 
   atomically $ do
+    churnMode <- updateChurnMode
     ledgerStateJudgement <- getLedgerStateJudgement
-    let targets = getPeerSelectionTargets consensusMode ledgerStateJudgement
-                                          peerSelectionTargets
-                                          genesisPeerSelectionTargets
-    writeTVar peerSelectionVar targets
+    regime <- pickChurnRegime churnMode <$> getUseBootstrapPeers
+    targets <- readTVar peerSelectionVar
+    let targets'
+          | ChurnBootstrapPraosSync <- regime = targets
+          | otherwise = getPeerSelectionTargets consensusMode
+                                                ledgerStateJudgement
+                                                peerSelectionTargets
+                                                genesisPeerSelectionTargets
+    when (targets' /= targets) $ writeTVar peerSelectionVar targets'
 
   endTs0 <- getMonotonicTime
   fuzzyDelay inRng (endTs0 `diffTime` startTs0) >>= churnLoop

--- a/cardano-diffusion/tracing/Cardano/Network/Tracing/Churn.hs
+++ b/cardano-diffusion/tracing/Cardano/Network/Tracing/Churn.hs
@@ -22,12 +22,12 @@ instance LogFormatting TraceChurnMode where
 
 instance MetaTrace TraceChurnMode where
   namespaceFor TraceChurnMode {} =
-    Namespace [] ["PeerSelection", "ChurnMode"]
+    Namespace [] []
 
   severityFor _ (Just TraceChurnMode {}) = Just Info
   severityFor _ Nothing                  = Nothing
 
-  documentFor (Namespace _ ["PeerSelection", "ChurnMode"]) = Just $ mconcat
+  documentFor (Namespace [] []) = Just $ mconcat
     [ "Affects churning strategy. For a synced node or operating in GenesisMode "
     , " consensus mode, the default strategy is used. Otherwise for a syncing PraosMode"
     , " node, the legacy bulk sync churning intervals are used whose durations"
@@ -36,5 +36,5 @@ instance MetaTrace TraceChurnMode where
   documentFor _ = Nothing
 
   allNamespaces = [
-      Namespace [] ["PeerSelection", "ChurnMode"]
+      Namespace [] []
     ]

--- a/ouroboros-network/changelog.d/20260505_095902_crocodile-dentist_fix_targets_sync.md
+++ b/ouroboros-network/changelog.d/20260505_095902_crocodile-dentist_fix_targets_sync.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+### Non-Breaking
+
+- Minor tweaks to tracing irregularities
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection/Governor/TracePeerSelection.hs
+++ b/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection/Governor/TracePeerSelection.hs
@@ -379,7 +379,8 @@ instance ( Show extraDebugState
 
   forMachine dtal (ExtraTrace tr) = forMachine dtal tr
 
-  forHuman = pack . show
+  forHuman (ExtraTrace tr) = pack . show $ tr
+  forHuman tr              = pack . show $ tr
 
   asMetrics (TraceChurnAction duration action _) =
     [ DoubleM ("peerSelection.churn" <> pack (show action) <> ".duration")
@@ -511,8 +512,8 @@ instance MetaTrace (ToExtraTrace extraPeers)
       Namespace [] ["ChurnTimeout"]
     namespaceFor TraceDebugState {} =
       Namespace [] ["DebugState"]
-    namespaceFor (ExtraTrace _) =
-      Namespace [] []
+    namespaceFor (ExtraTrace et) =
+      nsCast $ namespaceFor et
 
     severityFor (Namespace [] ["LocalRootPeersChanged"]) _ = Just Notice
     severityFor (Namespace [] ["TargetsChanged"]) _ = Just Notice
@@ -575,7 +576,10 @@ instance MetaTrace (ToExtraTrace extraPeers)
     severityFor (Namespace [] ["ChurnAction"]) _ = Just Info
     severityFor (Namespace [] ["ChurnTimeout"]) _ = Just Notice
     severityFor (Namespace [] ["DebugState"]) _ = Just Info
-    severityFor _ _ = Nothing
+    severityFor ns tr = case tr of
+      Just (ExtraTrace et) -> severityFor (nsCast ns :: Namespace (ToExtraTrace extraPeers)) (Just et)
+      Just _ -> Nothing
+      Nothing -> severityFor (nsCast ns :: Namespace (ToExtraTrace extraPeers)) Nothing
 
     documentFor (Namespace [] ["LocalRootPeersChanged"]) = Just  ""
     documentFor (Namespace [] ["TargetsChanged"]) = Just  ""
@@ -640,7 +644,7 @@ instance MetaTrace (ToExtraTrace extraPeers)
       "Outbound Governor was killed unexpectedly"
     documentFor (Namespace [] ["DebugState"]) = Just
       "peer selection internal state"
-    documentFor _ = Nothing
+    documentFor ns = documentFor (nsCast ns :: Namespace (ToExtraTrace extraPeers))
 
     metricsDocFor (Namespace [] ["ChurnAction"]) =
      [ ("peerSelection.churn.DecreasedActivePeers.duration", "")
@@ -650,7 +654,7 @@ instance MetaTrace (ToExtraTrace extraPeers)
      , ("peerSelection.churn.DecreasedKnownPeers.duration", "")
      , ("peerSelection.churn.DecreasedKnownBigLedgerPeers.duration", "")
      ]
-    metricsDocFor _ = []
+    metricsDocFor ns = metricsDocFor (nsCast ns :: Namespace (ToExtraTrace extraPeers))
 
     allNamespaces = [
         Namespace [] ["LocalRootPeersChanged"]


### PR DESCRIPTION
# Description

For syncing in Praos mode with bootstrap peers, set active peers and active big ledger peers to a lower value than the default targets to decrease the load on the bootstrap relays. Previously, these would be only set after the first churn cycle, ie. by default 15 minutes after startup.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
