### PR TITLE
Block decoder incremental vs. non-incremental benchmark

### DIFF
--- a/cardano-diffusion/api/lib/Cardano/Network/NodeToClient/Version.hs
+++ b/cardano-diffusion/api/lib/Cardano/Network/NodeToClient/Version.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NamedFieldPuns     #-}
 
 module Cardano.Network.NodeToClient.Version
   ( NodeToClientVersion (..)
@@ -21,6 +22,7 @@ import Ouroboros.Network.CodecCBORTerm
 import Ouroboros.Network.Handshake.Acceptable (Accept (..), Acceptable (..))
 import Ouroboros.Network.Handshake.Queryable (Queryable (..))
 import Ouroboros.Network.Magic
+import Ouroboros.Network.Util (PrettyShow (..))
 
 
 -- | Enumeration of node to client protocol versions.
@@ -68,7 +70,8 @@ data NodeToClientVersion
     | NodeToClientV_23
     -- ^ added @QueryDRepsDelegations@,
     -- LedgerPeerSnapshot CBOR encoding contains block hash and NetworkMagic
-  deriving (Eq, Ord, Enum, Bounded, Show, Generic, NFData)
+  deriving stock (Eq, Ord, Enum, Bounded, Show, Generic)
+  deriving anyclass (NFData, PrettyShow)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
 -- `NodeToClientVersion`.  This way connecting wrong protocol suite will fail
@@ -127,7 +130,8 @@ data NodeToClientVersionData = NodeToClientVersionData
   { networkMagic :: !NetworkMagic
   , query        :: !Bool
   }
-  deriving (Eq, Show, Generic, NFData)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (NFData, PrettyShow)
 
 instance Acceptable NodeToClientVersionData where
     acceptableVersion local remote

--- a/cardano-diffusion/api/lib/Cardano/Network/NodeToNode/Version.hs
+++ b/cardano-diffusion/api/lib/Cardano/Network/NodeToNode/Version.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NamedFieldPuns     #-}
 
 module Cardano.Network.NodeToNode.Version
   ( NodeToNodeVersion (..)
@@ -35,6 +36,7 @@ import Ouroboros.Network.Handshake.Queryable (Queryable (..))
 import Ouroboros.Network.Magic
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import Ouroboros.Network.PerasSupport
+import Ouroboros.Network.Util (PrettyShow (..))
 
 -- | Enumeration of node to node protocol versions.
 --
@@ -88,7 +90,8 @@ data NodeToNodeVersion =
     -- ^ Experimental.
     --
     -- Adds support for Peras mini-protocols (if 'PerasFlag' is set).
-  deriving (Eq, Ord, Enum, Bounded, Show, Generic, NFData, NoThunks)
+  deriving stock (Eq, Ord, Enum, Bounded, Show, Generic)
+  deriving anyclass (NFData, NoThunks, PrettyShow)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
 nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
@@ -117,9 +120,10 @@ data NodeToNodeVersionData = NodeToNodeVersionData
   , query         :: !Bool
   , perasSupport  :: !PerasSupport
   }
-  deriving (Show, Eq, Generic, NFData)
+  deriving stock (Show, Eq, Generic)
   -- 'Eq' instance is not provided, it is not what we need in version
   -- negotiation (see 'Acceptable' instance below).
+  deriving anyclass (NFData, PrettyShow)
 
 instance Acceptable NodeToNodeVersionData where
     -- | Check that both side use the same 'networkMagic'.  Choose smaller one

--- a/cardano-diffusion/changelog.d/20260520_102419_coot_tracing_instances.md
+++ b/cardano-diffusion/changelog.d/20260520_102419_coot_tracing_instances.md
@@ -1,0 +1,8 @@
+### Non-Breaking
+
+- Exported `PraosFetchMode` from `Cardano.Network.LedgerPeerConsensusInterface`
+- Added `PrettyShow` instances for
+    - `NodeToNodeVersion`
+    - `NodeToNodeVersionData`
+    - `NodeToClientVersion`
+    - `NodeToClientVersionData`

--- a/cardano-diffusion/lib/Cardano/Network/LedgerPeerConsensusInterface.hs
+++ b/cardano-diffusion/lib/Cardano/Network/LedgerPeerConsensusInterface.hs
@@ -5,6 +5,7 @@ module Cardano.Network.LedgerPeerConsensusInterface
   , GetImmutableBlockPointError (..)
     -- * Re-exports
   , FetchMode (..)
+  , PraosFetchMode (..)
   , LedgerStateJudgement (..)
   , OutboundConnectionsState (..)
   ) where
@@ -15,7 +16,7 @@ import Cardano.Network.LedgerStateJudgement
 import Cardano.Network.PeerSelection.LocalRootPeers
            (OutboundConnectionsState (..))
 import Ouroboros.Network.Block (Point)
-import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode (..), PraosFetchMode (..))
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type (RawBlockHash)
 
 

--- a/network-mux/changelog.d/20260513_114705_crocodile-dentist_incremental_benchmark.md
+++ b/network-mux/changelog.d/20260513_114705_crocodile-dentist_incremental_benchmark.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+### Non-Breaking
+
+- Expose `runClientBurst`, `runServerBurst` and `runCBORDecoderWithChannel` from
+  `ReqResp` for use in the incremental decoder benchmark.
+- Expose `ReqResp` in new tests-lib library.
+
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -28,13 +28,12 @@ flag tracetcpinfo
   manual: True
   default: False
 
-common demo-deps
+common lib-defaults
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   ghc-options:
-    -threaded
     -Wall
-    -fno-ignore-asserts
+    -Wno-unticked-promoted-constructors
     -Wcompat
     -Wincomplete-uni-patterns
     -Wincomplete-record-updates
@@ -48,7 +47,14 @@ common demo-deps
     ghc-options:
       -Wno-pattern-namespace-specifier
 
+common demo-deps
+  import: lib-defaults
+  ghc-options:
+    -threaded
+    -fno-ignore-asserts
+
 library
+  import: lib-defaults
   build-depends:
     -- The Windows version of network-3.1.2 is missing
     -- functions, see
@@ -105,23 +111,24 @@ library
   if os(windows)
     exposed-modules:
       Network.Mux.Bearer.NamedPipe
-  default-language: Haskell2010
-  default-extensions: ImportQualifiedPost
-  ghc-options:
-    -Wall
-    -Wcompat
-    -Widentities
-    -Wincomplete-record-updates
-    -Wincomplete-uni-patterns
-    -Wno-unticked-promoted-constructors
-    -Wpartial-fields
-    -Wredundant-constraints
-    -Wunused-packages
 
-  -- In ghc-9.14 the `pattern` namespace specifier is deprecated.
-  if impl(ghc >=9.14)
-    ghc-options:
-      -Wno-pattern-namespace-specifier
+library tests-lib
+  import: lib-defaults
+  visibility: public
+  hs-source-dirs: test
+  exposed-modules:
+    Test.Mux.ReqResp
+
+  build-depends:
+    base >=4.14 && <4.23,
+    binary,
+    bytestring >=0.10 && <0.13,
+    cborg >=0.2.8 && <0.3,
+    contra-tracer >=0.1 && <0.3,
+    io-classes ^>=1.8,
+    network-mux,
+    primitive,
+    serialise,
 
 test-suite test
   type: exitcode-stdio-1.0

--- a/network-mux/test/Test/Mux/ReqResp.hs
+++ b/network-mux/test/Test/Mux/ReqResp.hs
@@ -27,11 +27,14 @@ module Test.Mux.ReqResp
   , ReqRespClientLoop (..)
   , runClientBurstCBOR
   , runClientBurstBin
+  , runClientBurst
     -- ** Active Server
   , ReqRespServerBurst (..)
   , ReqRespServerLoop (..)
   , runServerBurstCBOR
   , runServerBurstBin
+  , runServerBurst
+  , runCBORDecoderWithChannel
   ) where
 
 import Codec.CBOR.Decoding qualified as CBOR hiding (Done, Fail)

--- a/ouroboros-network/changelog.d/20260520_102411_coot_tracing_instances.md
+++ b/ouroboros-network/changelog.d/20260520_102411_coot_tracing_instances.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Added `JSONField` instance for `NoExtraFlags`

--- a/ouroboros-network/lib/Ouroboros/Network/KeepAlive.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/KeepAlive.hs
@@ -9,6 +9,7 @@ module Ouroboros.Network.KeepAlive
   , keepAliveClient
   , keepAliveServer
   , TraceKeepAliveClient (..)
+  , module Registry
   ) where
 
 import Control.Concurrent.Class.MonadSTM qualified as Lazy
@@ -21,6 +22,7 @@ import Data.Map.Strict qualified as M
 import Data.Maybe (fromJust)
 import System.Random (StdGen, random)
 
+import Ouroboros.Network.KeepAlive.Registry as Registry
 import Ouroboros.Network.ControlMessage (ControlMessage (..), ControlMessageSTM)
 import Ouroboros.Network.DeltaQ
 import Ouroboros.Network.Protocol.KeepAlive.Client

--- a/ouroboros-network/orphan-instances/Ouroboros/Network/OrphanInstances.hs
+++ b/ouroboros-network/orphan-instances/Ouroboros/Network/OrphanInstances.hs
@@ -74,7 +74,7 @@ import Ouroboros.Network.DeltaQ (GSV (GSV),
 import Ouroboros.Network.Diffusion.Topology (LocalRootPeersGroup (..),
            LocalRootPeersGroups (..), LocalRoots (..), NetworkTopology (..),
            PublicRootPeers (..), RootConfig (..))
-import Ouroboros.Network.Diffusion.Types (DiffusionTracer (..))
+import Ouroboros.Network.Diffusion.Types (DiffusionTracer (..), NoExtraFlags)
 import Ouroboros.Network.DiffusionMode
 import Ouroboros.Network.Driver.Simple
 import Ouroboros.Network.ExitPolicy (RepromoteDelay (repromoteDelay))
@@ -453,6 +453,9 @@ instance ToJSON addr => ToJSON (PeerSharingResult addr) where
 -- `LocalRootConfig`.
 class JSONField extraFlags where
   fieldName :: Proxy extraFlags -> Maybe Key
+
+instance JSONField NoExtraFlags where
+  fieldName _ = Nothing
 
 instance (JSONField extraFlags, ToJSON extraFlags) => ToJSON (LocalRootConfig extraFlags) where
   toJSON LocalRootConfig { peerAdvertise,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -233,7 +233,6 @@ library
     Ouroboros.Network.Diffusion.Utils
     Ouroboros.Network.ExitPolicy
     Ouroboros.Network.KeepAlive
-    Ouroboros.Network.KeepAlive.Registry
     Ouroboros.Network.PeerSelection
     Ouroboros.Network.PeerSelection.Churn
     Ouroboros.Network.PeerSelection.Governor
@@ -267,6 +266,7 @@ library
     Ouroboros.Network.TxSubmission.Outbound
 
   other-modules:
+    Ouroboros.Network.KeepAlive.Registry
     Ouroboros.Network.PeerSelection.Governor.BigLedgerPeers
     Ouroboros.Network.PeerSelection.Governor.EstablishedPeers
     Ouroboros.Network.PeerSelection.Governor.KnownPeers


### PR DESCRIPTION
# Description

This PR introduces a benchmark for comparing incremental and non-incremental CBOR block decoder performance. One mechanism of how to reduce block processing time is to decode it while it is streamed across the network, in between SDU arrival times. Tests on one machine indicate that for roughly full Praos blocks a few milliseconds may be saved, with more material savings for future larger blocks, esp. for Leios.

resolves #5280 

Actual performance in a real system may vary, but in a benchmark setting the results for incrementally decoding a full Praos block are minor, on the order of several ms. More impressive gains materialize for much larger blocks, ie. several MB in size, where time saved appears to be on the order of several hundred ms.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
