### PR TITLE
Renamed `selectEnvTargets` to `selectGovTargets` and used it in place of `selectGovState` where possible

### DIFF
--- a/cardano-diffusion/changelog.d/20260518_5372_dancewithheart_selectGovTargets.md
+++ b/cardano-diffusion/changelog.d/20260518_5372_dancewithheart_selectGovTargets.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Rename the peer-selection target signal helper from `selectEnvTargets` to `selectGovTargets`.

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/PeerSelection.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/PeerSelection.hs
@@ -1188,11 +1188,11 @@ prop_governor_target_root_below env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfRootPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfRootPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govLocalRootPeersSig :: Signal (Set PeerAddr)
         govLocalRootPeersSig =
@@ -1700,11 +1700,11 @@ prop_governor_target_known_2_opportunity_taken (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfKnownPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
@@ -2078,11 +2078,11 @@ prop_governor_target_known_4_results_used (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfKnownPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
@@ -2169,11 +2169,11 @@ prop_governor_target_known_5_no_shrink_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfKnownPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
@@ -2263,11 +2263,11 @@ prop_governor_target_known_5_no_shrink_big_ledger_peers_below (MaxTime maxTime) 
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownBigLedgerPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfKnownBigLedgerPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
@@ -2349,11 +2349,11 @@ prop_governor_target_known_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal PeerSelectionTargets
         govTargetsSig =
-          selectGovState Governor.targets
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets id
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govLocalRootPeersSig :: Signal (Set PeerAddr)
         govLocalRootPeersSig =
@@ -2469,11 +2469,11 @@ prop_governor_target_known_big_ledger_peers_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal PeerSelectionTargets
         govTargetsSig =
-          selectGovState Governor.targets
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets id
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
@@ -2582,11 +2582,11 @@ prop_governor_target_established_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfEstablishedPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerTrustable PeerAddr)
         govLocalRootPeersSig =
@@ -2706,11 +2706,11 @@ prop_governor_target_established_big_ledger_peers_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedBigLedgerPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfEstablishedBigLedgerPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
@@ -2820,11 +2820,11 @@ prop_governor_target_active_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActivePeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfActivePeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerTrustable PeerAddr)
         govLocalRootPeersSig =
@@ -2959,11 +2959,11 @@ prop_governor_target_active_big_ledger_peers_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActiveBigLedgerPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfActiveBigLedgerPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
@@ -3073,11 +3073,11 @@ prop_governor_target_established_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfEstablishedPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govDemotionsInProgressSig :: Signal (Set PeerAddr)
         govDemotionsInProgressSig =
@@ -3188,11 +3188,11 @@ prop_governor_target_established_big_ledger_peers_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedBigLedgerPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfEstablishedBigLedgerPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
@@ -3275,11 +3275,11 @@ prop_governor_target_active_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActivePeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfActivePeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerTrustable PeerAddr)
         govLocalRootPeersSig =
@@ -3357,11 +3357,11 @@ prop_governor_target_active_big_ledger_peers_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActiveBigLedgerPeers . Governor.targets)
-                         (Cardano.ExtraState.empty (consensusMode env)
-                                                   (NumberOfBigLedgerPeers 0))
-                         Cardano.ExtraPeers.empty
-                         events
+          selectGovTargets targetNumberOfActiveBigLedgerPeers
+                           (Cardano.ExtraState.empty (consensusMode env)
+                                                     (NumberOfBigLedgerPeers 0))
+                           Cardano.ExtraPeers.empty
+                           events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/PeerSelection/Utils.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/PeerSelection/Utils.hs
@@ -68,19 +68,13 @@ selectGovState f es ep =
       (\case GovernorDebug (Governor.TraceGovernorState _ _ st) -> Just $! f st
              _                                                  -> Nothing)
 
-selectEnvTargets :: Eq a
+selectGovTargets :: Eq a
                  => (PeerSelectionTargets -> a)
+                 -> extraState
+                 -> extraPeers
                  -> Events (TestTraceEvent extraState extraFlags extraPeers)
                  -> Signal a
-selectEnvTargets f =
-    Signal.nub
-  . fmap f
-  . Signal.fromChangeEvents Governor.nullPeerSelectionTargets
-  . Signal.selectEvents
-      (\case TraceEnvSetTargets targets -> Just $! targets
-             _                          -> Nothing)
-  . selectEnvEvents
-
+selectGovTargets f = selectGovState (f . Governor.targets)
 
 selectForgottenPeers :: Events (TestTraceEvent extraState extraFlags extraPeers)
                      -> Signal (Set PeerAddr)


### PR DESCRIPTION
# Description

Fixes #4713

`selectEnvTargets` was already replaced by `selectGovState` in https://github.com/IntersectMBO/ouroboros-network/commit/3d270bd97

Renamed `selectEnvTargets`  to `selectGovTargets` and used it in place of `selectGovState` where possible as @coot proposed in comment below.

Verified using:
```sh
cabal build all
cabal run cardano-diffusion:test:cardano-diffusion-sim-tests -- -p '/PeerSelection/'
```

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
