### PR TITLE
Add `NodeToClientV_24` for `ValidateTx` query

### DIFF
--- a/cardano-diffusion/api/lib/Cardano/Network/NodeToClient/Version.hs
+++ b/cardano-diffusion/api/lib/Cardano/Network/NodeToClient/Version.hs
@@ -63,6 +63,8 @@ data NodeToClientVersion
     | NodeToClientV_23
     -- ^ added @QueryDRepsDelegations@,
     -- LedgerPeerSnapshot CBOR encoding contains block hash and NetworkMagic
+    | NodeToClientV_24
+    -- ^ added @ValidateTx@ query
   deriving (Eq, Ord, Enum, Bounded, Show, Generic, NFData)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
@@ -84,6 +86,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
           NodeToClientV_21 -> enc 21
           NodeToClientV_22 -> enc 22
           NodeToClientV_23 -> enc 23
+          NodeToClientV_24 -> enc 24
         where
           enc :: Int -> CBOR.Term
           enc = CBOR.TInt . (`setBit` nodeToClientVersionBit)
@@ -98,6 +101,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
             21 -> Right NodeToClientV_21
             22 -> Right NodeToClientV_22
             23 -> Right NodeToClientV_23
+            24 -> Right NodeToClientV_24
             n  -> Left (unknownTag n)
         where
           dec :: CBOR.Term -> Either (Text, Maybe Int) Int

--- a/cardano-diffusion/orphan-instances/Cardano/Network/OrphanInstances.hs
+++ b/cardano-diffusion/orphan-instances/Cardano/Network/OrphanInstances.hs
@@ -79,6 +79,7 @@ instance FromJSON NodeToClientVersion where
     Number 21 -> pure NodeToClientV_21
     Number 22 -> pure NodeToClientV_22
     Number 23 -> pure NodeToClientV_23
+    Number 24 -> pure NodeToClientV_24
     Number x  -> fail $ "FromJSON.NodeToClientVersion: unsupported node-to-client protocol version " ++ show x
     x         -> fail $ "FromJSON.NodeToClientVersion: error parsing NodeToClientVersion: " ++ show x
 
@@ -92,6 +93,7 @@ instance ToJSON NodeToClientVersion where
     NodeToClientV_21 -> Number 21
     NodeToClientV_22 -> Number 22
     NodeToClientV_23 -> Number 23
+    NodeToClientV_24 -> Number 24
 
 instance ToJSON NodeToNodeVersionData where
   toJSON (NodeToNodeVersionData (NetworkMagic m) dm ps q) = object


### PR DESCRIPTION
# Description

Adds `NodeToClientV_24` to the node-to-client protocol version enumeration, needed for the new `ValidateTx` query in the `LocalStateQuery` protocol.

Part of [IntersectMBO/cardano-cli#1380](https://github.com/IntersectMBO/cardano-cli/issues/1380).

**Big picture:** `transaction validate` currently applies `applyTx` client-side with an empty UTxO set, making it unable to properly validate transactions. This cross-repo change adds a new `ValidateTx` query to the `LocalStateQuery` protocol so the node validates transactions against its real ledger state and UTxO set.

`transaction validate` PR list:
- [ouroboros-network] **(this PR)**
- [ouroboros-consensus] https://github.com/IntersectMBO/ouroboros-consensus/pull/2052
- [cardano-api] https://github.com/IntersectMBO/cardano-api/pull/1228
- [cardano-cli] https://github.com/IntersectMBO/cardano-cli/pull/1386
- [cardano-node] https://github.com/IntersectMBO/cardano-node/pull/6582

## What this PR does

- Adds `NodeToClientV_24` constructor to the `NodeToClientVersion` enum
- Adds CBOR codec entries (encode/decode) for the new version
- Adds JSON serialisation instances (`FromJSON`/`ToJSON`) for `NodeToClientV_24`

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation