### PR TITLE
Allow QuickCheck 2.18

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,14 +15,10 @@ repository cardano-haskell-packages
 -- repeat the index-state for hackage to work around haskell.nix parsing limitation
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2026-05-13T07:31:22Z
+  , hackage.haskell.org 2026-05-26T19:31:06Z
 
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2026-05-20T06:15:42Z
-
-active-repositories:
-  , :rest
-  , cardano-haskell-packages:override
+  , cardano-haskell-packages 2026-05-26T09:41:58Z
 
 packages: ./monoidal-synchronisation
           ./network-mux
@@ -55,9 +51,6 @@ package ouroboros-network
 package acts
   flags: -finitary
 
-allow-newer:
-  , quickcheck-instances:QuickCheck
-
 if impl (ghc >= 9.14)
   constraints:
     , containers > 0.7
@@ -66,7 +59,6 @@ if impl (ghc >= 9.14)
 
   allow-newer:
     -- https://github.com/haskell/aeson/issues/1155
-    , aeson:QuickCheck
     , aeson:base
     , aeson:bytestring
     , aeson:containers
@@ -92,10 +84,6 @@ if impl (ghc >= 9.14)
     , indexed-traversable:containers
     , indexed-traversable-instances:base
 
-    -- https://github.com/haskellari/qc-instances/issues/110
-    , quickcheck-instances:base
-    , quickcheck-instances:bytestring
-
     -- https://github.com/haskellari/these/issues/211
     , semialign:base
     , semialign:containers
@@ -111,7 +99,6 @@ if impl (ghc >= 9.14)
     , these:base
 
     -- https://github.com/haskellari/tree-diff/issues/102
-    , tree-diff:QuickCheck
     , tree-diff:base
     , tree-diff:containers
 
@@ -120,3 +107,4 @@ if impl (ghc >= 9.14)
 
     -- https://github.com/serokell/haskell-with-utf8/issues/41
     , with-utf8:base
+

--- a/cardano-diffusion/cardano-diffusion.cabal
+++ b/cardano-diffusion/cardano-diffusion.cabal
@@ -96,7 +96,7 @@ library api-tests-lib
     Cardano.Network.NodeToNode.Version.TestUtils
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     cardano-diffusion:api,
     ouroboros-network:api,
@@ -112,7 +112,7 @@ test-suite api-tests
     Test.Cardano.Network.Version
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     cardano-diffusion:{api, api-tests-lib},
     ouroboros-network:api,
@@ -371,7 +371,7 @@ library protocols-tests-lib
     Ouroboros.Network.Protocol.TxSubmission2.Test as Cardano.Network.Protocol.TxSubmission2.Test,
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     bytestring,
     cardano-diffusion:{api, api-tests-lib, protocols},
@@ -415,7 +415,7 @@ test-suite protocols-cddl
     buildable: False
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     bytestring,
     cardano-diffusion:{api, api-tests-lib, protocols, protocols-tests-lib},
@@ -478,10 +478,11 @@ library cardano-diffusion-tests-lib
   visibility: public
   hs-source-dirs: tests/lib
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     aeson,
     base >=4.14 && <4.23,
     bytestring,
+    cardano-base:testlib >=0.1.5.0,
     cardano-diffusion:{cardano-diffusion, api, orphan-instances, protocols, protocols-tests-lib},
     cardano-slotting,
     cborg,

--- a/cardano-diffusion/changelog.d/20260601_120000_fabrizio.ferrai_allow_quickcheck_2_18.md
+++ b/cardano-diffusion/changelog.d/20260601_120000_fabrizio.ferrai_allow_quickcheck_2_18.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Removed the `QuickCheck < 2.18` upper bound, allowing QuickCheck 2.18+.
+- Added `cardano-base:testlib >=0.1.5.0` dependency.

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
@@ -115,6 +115,7 @@ import Test.Ouroboros.Network.TxSubmission.TxLogic (ArbTxDecisionPolicy (..))
 import Test.Ouroboros.Network.TxSubmission.Types (Tx (..), TxId)
 import Test.Ouroboros.Network.Utils hiding (SmallDelay, debugTracer)
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.QuickCheck.Monadic as QC
 #if !MIN_VERSION_QuickCheck(2,16,0)
@@ -601,7 +602,7 @@ prop_diffusion_nofail_iosim
 --
 unit_connection_manager_trace_coverage :: Property
 unit_connection_manager_trace_coverage =
-  withMaxSuccess 1 $
+  BaseQC.withNumTests 1 $
   let sim :: forall s. IOSim s DiffSimResult
       sim = diffusionSimulation (toBearerInfo absNoAttenuation)
                                 script
@@ -710,7 +711,7 @@ unit_connection_manager_trace_coverage =
 --
 unit_connection_manager_transitions_coverage :: Property
 unit_connection_manager_transitions_coverage =
-  withMaxSuccess 1 $
+  BaseQC.withNumTests 1 $
   let sim :: forall s. IOSim s DiffSimResult
       sim = diffusionSimulation (toBearerInfo absNoAttenuation)
                                 script
@@ -5533,7 +5534,7 @@ unit_local_root_diffusion_mode :: DiffusionMode
                                -> Property
 unit_local_root_diffusion_mode diffusionMode =
     -- this is a unit test
-    withMaxSuccess 1 $
+    BaseQC.withNumTests 1 $
     let sim = diffusionSimulation (toBearerInfo absNoAttenuation) script
 
         -- list of negotiated version data

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1779260980,
-        "narHash": "sha256-5SvJkobPmCtSYKwQWu1M/iFXj3g1PDy2bMJ9g1vm/No=",
+        "lastModified": 1779802675,
+        "narHash": "sha256-LQN0f9GBBmYMo9tQ/11EvU5tAEOhGtQnU2UP3S78cqg=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "4b6a661aa6463529c0ab0207567d62f85a6b899c",
+        "rev": "b8c7b848cdb6d08e414c37d026c300200f8c1b5b",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1778699418,
-        "narHash": "sha256-0RBSLTlZ7XSw3uSePPzdVcgN/d+h54pQf3BYFRXQSz0=",
+        "lastModified": 1779891854,
+        "narHash": "sha256-FLgT+fgCHJhwFKuaxa++r1Wd4SyYWV2ekLfRFKv8ZOs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "37678bd46977723db19f5d97ae6e8cd6847e9cbf",
+        "rev": "2108085e083f93efa157b8264c226c41b1016e33",
         "type": "github"
       },
       "original": {

--- a/network-mux/changelog.d/20260601_120001_fabrizio.ferrai_allow_quickcheck_2_18.md
+++ b/network-mux/changelog.d/20260601_120001_fabrizio.ferrai_allow_quickcheck_2_18.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Removed the `QuickCheck < 2.18` upper bound, allowing QuickCheck 2.18+.
+- Added `cardano-base:testlib >=0.1.5.0` dependency.

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -135,11 +135,12 @@ test-suite test
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     Win32-network,
     base >=4.14 && <4.23,
     binary,
     bytestring,
+    cardano-base:testlib >=0.1.5.0,
     cborg,
     containers,
     contra-tracer,

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -35,6 +35,7 @@ import Data.Maybe (fromMaybe, isNothing)
 import Data.Tuple (swap)
 import Data.Word
 import System.Random.SplitMix qualified as SM
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck hiding ((.&.))
 import Test.QuickCheck.Instances.ByteString ()
 import Test.Tasty
@@ -87,21 +88,21 @@ tests =
   [ testProperty "mux send receive"             prop_mux_snd_recv
   , testProperty "mux send receive bidir"       prop_mux_snd_recv_bi
   , testProperty "mux send receive compat"      prop_mux_snd_recv_compat
-  , testProperty "1 miniprot Queue"             (withMaxSuccess 50 prop_mux_1_mini_Queue)
-  , testProperty "2 miniprots Queue"            (withMaxSuccess 50 prop_mux_2_minis_Queue)
-  , testProperty "1 miniprot Pipe"              (withMaxSuccess 50 prop_mux_1_mini_Pipe)
-  , testProperty "2 miniprots Pipe"             (withMaxSuccess 50 prop_mux_2_minis_Pipe)
-  , testProperty "1 miniprot Socket"            (withMaxSuccess 50 prop_mux_1_mini_Socket)
-  , testProperty "1 miniprot Socket, buffered"  (withMaxSuccess 50 prop_mux_1_mini_Socket_buf)
-  , testProperty "2 miniprot Socket"            (withMaxSuccess 50 prop_mux_2_minis_Socket)
-  , testProperty "2 miniprots Socket, buffered" (withMaxSuccess 50 prop_mux_2_minis_Socket_buf)
+  , testProperty "1 miniprot Queue"             (BaseQC.withNumTests 50 prop_mux_1_mini_Queue)
+  , testProperty "2 miniprots Queue"            (BaseQC.withNumTests 50 prop_mux_2_minis_Queue)
+  , testProperty "1 miniprot Pipe"              (BaseQC.withNumTests 50 prop_mux_1_mini_Pipe)
+  , testProperty "2 miniprots Pipe"             (BaseQC.withNumTests 50 prop_mux_2_minis_Pipe)
+  , testProperty "1 miniprot Socket"            (BaseQC.withNumTests 50 prop_mux_1_mini_Socket)
+  , testProperty "1 miniprot Socket, buffered"  (BaseQC.withNumTests 50 prop_mux_1_mini_Socket_buf)
+  , testProperty "2 miniprot Socket"            (BaseQC.withNumTests 50 prop_mux_2_minis_Socket)
+  , testProperty "2 miniprots Socket, buffered" (BaseQC.withNumTests 50 prop_mux_2_minis_Socket_buf)
   , testProperty "starvation"                   prop_mux_starvation
   , testProperty "demuxing (Sim)"               prop_demux_sdu_sim
   , testProperty "demuxing (IO)"                prop_demux_sdu_io
   , testProperty "mux start and stop"           prop_mux_start
   , testProperty "mux restart"                  prop_mux_restart
   , testProperty "mux close (Sim)"              prop_mux_close_sim
-  , testProperty "mux close (IO)"               (withMaxSuccess 50 prop_mux_close_io)
+  , testProperty "mux close (IO)"               (BaseQC.withNumTests 50 prop_mux_close_io)
   , testProperty "trailing bytes (Sim)"         prop_mux_trailing_bytes_iosim
   , testProperty "trailing bytes (IO)"          prop_mux_trailing_bytes_io
   , testProperty "pure exception (Sim)"         prop_mux_pure_exception_iosim

--- a/ntp-client/changelog.d/20260601_120002_fabrizio.ferrai_allow_quickcheck_2_18.md
+++ b/ntp-client/changelog.d/20260601_120002_fabrizio.ferrai_allow_quickcheck_2_18.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Removed the `QuickCheck < 2.18` upper bound, allowing QuickCheck 2.18+.

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -62,7 +62,7 @@ test-suite test
   other-modules: Network.NTP.Client.Packet
   type: exitcode-stdio-1.0
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     binary >=0.8 && <0.11,
     tasty,

--- a/ouroboros-network/changelog.d/20260601_120003_fabrizio.ferrai_allow_quickcheck_2_18.md
+++ b/ouroboros-network/changelog.d/20260601_120003_fabrizio.ferrai_allow_quickcheck_2_18.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Removed the `QuickCheck < 2.18` upper bound, allowing QuickCheck 2.18+.
+- Added `cardano-base:testlib >=0.1.5.0` dependency.

--- a/ouroboros-network/framework/io-tests/Test/Ouroboros/Network/Driver.hs
+++ b/ouroboros-network/framework/io-tests/Test/Ouroboros/Network/Driver.hs
@@ -63,6 +63,7 @@ import Control.Tracer
 import Test.Ouroboros.Network.Orphans ()
 import Test.Ouroboros.Network.Utils (sayTracer)
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -77,7 +78,7 @@ tests =
   testGroup "Ouroboros.Network.Driver"
   [ testGroup "Simple"
     [ testProperty "channel ReqResp ST"              prop_channel_simple_reqresp_ST
-    , testProperty "channel ReqResp IO"              (withMaxSuccess 33 prop_channel_simple_reqresp_IO)
+    , testProperty "channel ReqResp IO"              (BaseQC.withNumTests 33 prop_channel_simple_reqresp_IO)
     , testProperty "channel PingPong ST"             prop_channel_ping_pong_ST
     , testProperty "channel PingPong IO"             prop_channel_ping_pong_IO
     ]
@@ -88,7 +89,7 @@ tests =
     ]
   , testGroup "Stateful"
     [ testProperty "channel Stateful ReqResp ST"     prop_channel_stateful_reqresp_ST
-    , testProperty "channel Stateful ReqResp IO"     (withMaxSuccess 33 prop_channel_stateful_reqresp_IO)
+    , testProperty "channel Stateful ReqResp IO"     (BaseQC.withNumTests 33 prop_channel_stateful_reqresp_IO)
     ]
   ]
 

--- a/ouroboros-network/framework/io-tests/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/framework/io-tests/Test/Ouroboros/Network/Socket.hs
@@ -67,6 +67,7 @@ import Ouroboros.Network.Protocol.Handshake.Unversioned
 
 import Test.Ouroboros.Network.Orphans ()
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty (DependencyType (..), TestTree, after, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -92,9 +93,9 @@ tests =
   , testProperty "socket send receive Unix"              prop_socket_send_recv_unix
 #endif
   , after AllFinish LAST_IP_TEST $
-    testProperty "socket error during receive"           (withMaxSuccess 10 prop_socket_recv_error)
+    testProperty "socket error during receive"           (BaseQC.withNumTests 10 prop_socket_recv_error)
   , after AllFinish "socket error during receive" $
-    testProperty "socket error during send"              (withMaxSuccess 10 prop_socket_send_error)
+    testProperty "socket error during send"              (BaseQC.withNumTests 10 prop_socket_send_error)
   , after AllFinish "socket error during send" $
     testProperty "socket client connection failure"      prop_socket_client_connect_error
   ]

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -143,7 +143,7 @@ library api-tests-lib
     Ouroboros.Network.Mock.ConcreteBlock
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base,
     bytestring,
     cardano-slotting:testlib ^>=0.2.0,
@@ -169,7 +169,7 @@ test-suite api-tests
     Test.Ouroboros.Network.PeerSelection.RelayAccessPoint
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     aeson,
     base >=4.14 && <4.23,
     bytestring,
@@ -443,7 +443,7 @@ library tests-lib
     TypeInType
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     cborg >=0.2.1 && <0.3,
     containers,
@@ -481,7 +481,7 @@ test-suite tests-lib-tests
   hs-source-dirs: tests-lib/tests
   other-modules: Test.Ouroboros.Network.Data.AbsBearerInfo.Test
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     ouroboros-network:tests-lib,
     tasty,
@@ -507,7 +507,7 @@ library framework-tests-lib
     Test.Ouroboros.Network.RawBearer.Utils
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     bytestring,
     cborg,
@@ -540,7 +540,7 @@ test-suite framework-sim-tests
     Test.Simulation.Network.Snocket
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     bytestring,
     cborg,
@@ -584,9 +584,10 @@ test-suite framework-io-tests
     Test.Ouroboros.Network.Socket
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     bytestring,
+    cardano-base:testlib >=0.1.5.0,
     contra-tracer,
     directory,
     io-classes:{io-classes, si-timers, strict-stm},
@@ -739,7 +740,7 @@ executable demo-tx-submission
     Demo.TxSubmission.Outbound
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     async,
     base,
     bytestring,
@@ -904,9 +905,10 @@ library protocols-tests-lib
     Test.Ouroboros.Network.Protocol.Utils
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     bytestring,
+    cardano-base:testlib >=0.1.5.0,
     cardano-strict-containers,
     cborg,
     containers,
@@ -949,11 +951,12 @@ library ouroboros-network-tests-lib
   visibility: public
   hs-source-dirs: tests/lib
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     aeson,
     array,
     base >=4.14 && <4.23,
     bytestring,
+    cardano-base:testlib >=0.1.5.0,
     cardano-strict-containers,
     cborg,
     containers,
@@ -1048,9 +1051,10 @@ test-suite ouroboros-network-io-tests
     Test.Ouroboros.Network.Socket
 
   build-depends:
-    QuickCheck <2.18,
+    QuickCheck,
     base >=4.14 && <4.23,
     bytestring,
+    cardano-base:testlib >=0.1.5.0,
     cborg,
     contra-tracer,
     deepseq,

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -49,6 +49,7 @@ import Test.Data.PipeliningDepth (PipeliningDepth (..))
 import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -72,14 +73,14 @@ tests =
         , testProperty "pipe IO"             prop_pipe_IO
         , testProperty "codec"               prop_codec_BlockFetch
         , testProperty "codec 2-splits"      prop_codec_splits2_BlockFetch
-        , testProperty "codec 3-splits"    $ withMaxSuccess 30
+        , testProperty "codec 3-splits"    $ BaseQC.withNumTests 30
                                              prop_codec_splits3_BlockFetch
         , testProperty "codec cbor"          prop_codec_cbor_BlockFetch
         , testProperty "codec valid cbor"    prop_codec_valid_cbor_BlockFetch
 
         , testProperty "codecSerialised"                   prop_codec_BlockFetchSerialised
         , testProperty "codecSerialised 2-splits"          prop_codec_splits2_BlockFetchSerialised
-        , testProperty "codecSerialised 3-splits"        $ withMaxSuccess 30
+        , testProperty "codecSerialised 3-splits"        $ BaseQC.withNumTests 30
                                                            prop_codec_splits3_BlockFetchSerialised
         , testProperty "codecSerialised cbor"              prop_codec_cbor_BlockFetchSerialised
         , testProperty "codec/codecSerialised bin compat"  prop_codec_binary_compat_BlockFetch_BlockFetchSerialised

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -66,6 +66,7 @@ import Ouroboros.Network.Protocol.Handshake.Version
 
 import Codec.CBOR.Write qualified as CBOR
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -98,7 +99,7 @@ tests =
         , testProperty "codec RefuseReason"    prop_codec_RefuseReason
         , testProperty "codec"                 prop_codec_Handshake
         , testProperty "codec 2-splits"        prop_codec_splits2_Handshake
-        , testProperty "codec 3-splits"      $ withMaxSuccess 30
+        , testProperty "codec 3-splits"      $ BaseQC.withNumTests 30
                                                prop_codec_splits3_Handshake
         , testProperty "codec cbor"            prop_codec_cbor
         , testProperty "codec valid cbor"      prop_codec_valid_cbor

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/KeepAlive/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/KeepAlive/Test.hs
@@ -38,6 +38,7 @@ import Test.Ouroboros.Network.Protocol.Utils (prop_codec_valid_cbor_encoding,
            splits2, splits3)
 
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -56,7 +57,7 @@ tests = testGroup "Ouroboros.Network.Protocol.KeepAlive"
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "codec v2"            prop_codec_v2
   , testProperty "codec v2 2-splits"   prop_codec_v2_splits2
-  , testProperty "codec v2 3-splits"   (withMaxSuccess 33 prop_codec_v2_splits3)
+  , testProperty "codec v2 3-splits"   (BaseQC.withNumTests 33 prop_codec_v2_splits3)
   , testProperty "codec v2 valid CBOR" prop_codec_v2_valid_cbor
   , testProperty "byteLimits"          prop_byteLimits
   ]

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
@@ -60,6 +60,7 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type
 
 import Test.Ouroboros.Network.Protocol.Utils
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck as QC hiding (Result)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -78,7 +79,7 @@ tests =
         , testProperty "connect"             prop_connect
         , testProperty "codec"               prop_codec_LocalStateQuery
         , testProperty "codec 2-splits"      prop_codec_splits2
-        , testProperty "codec 3-splits"    $ withMaxSuccess 30
+        , testProperty "codec 3-splits"    $ BaseQC.withNumTests 30
                                              prop_codec_splits3
         , testProperty "codec cbor"          prop_codec_cbor
         , testProperty "codec valid cbor"    prop_codec_valid_cbor

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/PeerSharing/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/PeerSharing/Test.hs
@@ -37,12 +37,13 @@ import Ouroboros.Network.Protocol.PeerSharing.Examples
            (peerSharingClientCollect, peerSharingServerReplicate)
 import Ouroboros.Network.Protocol.PeerSharing.Server (peerSharingServerPeer)
 import Ouroboros.Network.Protocol.PeerSharing.Type
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 import Test.QuickCheck.Function (Fun, applyFun)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (Arbitrary (..), Property, ioProperty, oneof,
-           testProperty, withMaxSuccess, (===))
+           testProperty, (===))
 
 tests :: TestTree
 tests =
@@ -56,7 +57,7 @@ tests =
         , testProperty "codec cbor"       prop_codec_cbor
         , testProperty "codec valid cbor" prop_codec_valid_cbor
         , testProperty "codec 2-splits"   prop_codec_splits2
-        , testProperty "codec 3-splits"   (withMaxSuccess 33 prop_codec_splits3)
+        , testProperty "codec 3-splits"   (BaseQC.withNumTests 33 prop_codec_splits3)
         , testProperty "byteLimits"       prop_byteLimits
         ]
     ]

--- a/ouroboros-network/protocols/tests-lib/Test/ChainProducerState.hs
+++ b/ouroboros-network/protocols/tests-lib/Test/ChainProducerState.hs
@@ -14,6 +14,7 @@ module Test.ChainProducerState
 import Data.List (unfoldr)
 import Data.Map qualified as Map
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck
@@ -34,7 +35,7 @@ tests =
     [ testProperty "ChainProducerStateForkTest's generator"
                    prop_arbitrary_ChainProducerStateForkTest
     , testProperty "ChainProducerStateForkTest's shrinker"
-                   (withMaxSuccess 25 prop_shrink_ChainProducerStateForkTest)
+                   (BaseQC.withNumTests 25 prop_shrink_ChainProducerStateForkTest)
     ]
   , testProperty "check initial follower state" prop_init_lookup
   , testProperty "check second follower state"  prop_init_next_lookup

--- a/ouroboros-network/tests/io/Test/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/tests/io/Test/Ouroboros/Network/Pipe.hs
@@ -22,6 +22,7 @@ import Control.Monad.Class.MonadTimer.SI
 import Data.ByteString.Lazy qualified as BL
 import Data.Monoid.Synchronisation
 import Data.Void (Void)
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -71,7 +72,7 @@ activeTracer = nullTracer
 
 tests :: TestTree
 tests = testGroup "Pipe"
-   [ testProperty "pipe sync demo" (withMaxSuccess 32 prop_pipe_demo)
+   [ testProperty "pipe sync demo" (BaseQC.withNumTests 32 prop_pipe_demo)
    ]
 
 --

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/MockNode.hs
@@ -25,6 +25,7 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (isNothing, listToMaybe)
 import Data.Tuple (swap)
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -55,7 +56,7 @@ tests =
     [ testProperty "core -> relay" prop_coreToRelay
     , testProperty "core -> relay -> relay" prop_coreToRelay2
     ]
-  , testProperty "arbtirary node graph" (withMaxSuccess 50 prop_networkGraph)
+  , testProperty "arbtirary node graph" (BaseQC.withNumTests 50 prop_networkGraph)
   , testProperty "blockGenerator invariant IOSim" prop_blockGenerator_ST
   , testProperty "blockGenerator invariant IO" prop_blockGenerator_IO
   ]

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/AppV2.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/AppV2.hs
@@ -66,6 +66,7 @@ import Test.Ouroboros.Network.TxSubmission.TxLogic hiding (tests)
 import Test.Ouroboros.Network.TxSubmission.Types
 import Test.Ouroboros.Network.Utils hiding (debugTracer)
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 #if !MIN_VERSION_QuickCheck(2,16,0)
 import "quickcheck-monoids" Test.QuickCheck.Monoids
@@ -79,7 +80,7 @@ tests = testGroup "AppV2"
   [ testProperty "txSubmission"  prop_txSubmission
   , testProperty "inflight"      prop_txSubmission_inflight
   , testProperty "SharedTxState" $ withMaxSize 25
-                                 $ withMaxSuccess 25
+                                 $ BaseQC.withNumTests 25
                                  prop_sharedTxStateInvariant
   ]
 

--- a/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/TxLogic.hs
+++ b/ouroboros-network/tests/lib/Test/Ouroboros/Network/TxSubmission/TxLogic.hs
@@ -59,6 +59,7 @@ import Ouroboros.Network.TxSubmission.Inbound.V2.Types qualified as TXS
 
 import Test.Ouroboros.Network.TxSubmission.Types
 
+import Test.Cardano.Base.QuickCheck qualified as BaseQC
 import Test.QuickCheck
 import Test.QuickCheck.Function (apply)
 import Test.QuickCheck.Gen (Gen (..))
@@ -78,7 +79,7 @@ tests = testGroup "AppV2"
       [ testGroup "Arbitrary"
         [ testGroup "ArbSharedTxState"
           [ testProperty "generator"              prop_SharedTxState_generator
-          , testProperty "shrinker"             $ withMaxSuccess 10
+          , testProperty "shrinker"             $ BaseQC.withNumTests 10
                                                   prop_SharedTxState_shrinker
           , testProperty "nothunks"               prop_SharedTxState_nothunks
           ]
@@ -87,7 +88,7 @@ tests = testGroup "AppV2"
           ]
         , testGroup "ArbCollectTxs"
           [ testProperty "generator"              prop_collectTxs_generator
-          , testProperty "shrinker"             $ withMaxSuccess 10
+          , testProperty "shrinker"             $ BaseQC.withNumTests 10
                                                   prop_collectTxs_shrinker
           ]
         ]
@@ -103,7 +104,7 @@ tests = testGroup "AppV2"
     , testGroup "Decisions"
       [ testGroup "ArbDecisionContexts"
         [ testProperty "generator"               prop_ArbDecisionContexts_generator
-        , testProperty "shrinker"              $ withMaxSuccess 33
+        , testProperty "shrinker"              $ BaseQC.withNumTests 33
                                                  prop_ArbDecisionContexts_shrinker
         ]
       , testProperty "shared state invariant"    prop_makeDecisions_sharedstate


### PR DESCRIPTION
# Description

We allow `QuickCheck@2.18` by using the machinery introduced in https://github.com/IntersectMBO/cardano-base/pull/652

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
