### PR TITLE
Efficient common case for setCurrentTime

### DIFF
--- a/ouroboros-network/changelog.d/20260611_111433_karl.fb.knutsson_knownpeers.md
+++ b/ouroboros-network/changelog.d/20260611_111433_karl.fb.knutsson_knownpeers.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Efficient handling of the common case in setCurrentTime. Used by the governor.
+

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/State/EstablishedPeers.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/State/EstablishedPeers.hs
@@ -38,7 +38,6 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.OrdPSQ (OrdPSQ)
 import Data.OrdPSQ qualified as PSQ
-import Data.Semigroup (Min (..))
 import Data.Set (Set)
 import Data.Set qualified as Set
 
@@ -220,13 +219,14 @@ setCurrentTime :: Ord peeraddr
 setCurrentTime now ep@EstablishedPeers { nextPeerShareTimes
                                        , nextActivateTimes
                                        }
- -- Efficient check for the common case of there being nothing to do:
-    | Just (Min t) <- (f <$> PSQ.minView nextPeerShareTimes)
-                   <> (f <$> PSQ.minView nextActivateTimes)
-    , t > now
+    -- Efficient check for the common case of there being nothing to do: either
+    -- nothing is scheduled, or the earliest scheduled time is still in the
+    -- future.
+    | noneDue nextPeerShareTimes
+    , noneDue nextActivateTimes
     = ep
   where
-    f (_,t,_,_) = Min t
+    noneDue q = maybe True (\(_,t,_) -> t > now) (PSQ.findMin q)
 
 setCurrentTime now ep@EstablishedPeers { nextPeerShareTimes
                                        , availableForPeerShare

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
@@ -309,6 +309,19 @@ setCurrentTime :: Ord peeraddr
                -> KnownPeers peeraddr
                -> KnownPeers peeraddr
 setCurrentTime now knownPeers@KnownPeers {
+                     nextConnectTimes,
+                     clearFailCountTimes
+                   }
+    -- Efficient check for the common case of there being nothing to do: either
+    -- nothing is scheduled, or the earliest scheduled time is still in the
+    -- future.
+    | noneDue nextConnectTimes
+    , noneDue clearFailCountTimes
+    = knownPeers
+  where
+    noneDue q = maybe True (\(_,t,_) -> t > now) (PSQ.findMin q)
+
+setCurrentTime now knownPeers@KnownPeers {
                      availableToConnect,
                      nextConnectTimes,
                      clearFailCountTimes


### PR DESCRIPTION
# Description

KnownPeers.setCurrentTime and EstablishedPeers.setCurrentTime run on every governor loop iteration. Add a fast path to KnownPeers for the common case where nothing is scheduled or the earliest scheduled time is still in the future; previously it always ran the general path, rebuilding the record and (with +asserts) checking the invariant.

In EstablishedPeers use findMin instead of minView in the existing fast-path guard: an O(1) peek that avoids allocating the deletion of the minimum. The fast path now also covers the empty-queue case, which previously fell through to the general path.


# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
