### PR TITLE
network-mux: test suite memory overhead after Hackage bump

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,6 +34,8 @@ packages: ./monoidal-synchronisation
 tests: True
 benchmarks: True
 
+constraints: tasty == 1.5.3
+
 package bitvec
   flags: -simd
 

--- a/nix/ouroboros-network.nix
+++ b/nix/ouroboros-network.nix
@@ -97,7 +97,7 @@ let
         preCheck =
           lib.mkForce
             (if buildSystem == "x86_64-linux"
-            then "export GHCRTS=-M1500M"
+            then "export GHCRTS=-M900M"
             else "");
         doCheck = !pkgs.stdenv.hostPlatform.isWindows;
 


### PR DESCRIPTION
## Findings

The OOM of `network-mux:test:test` at `GHCRTS=-M900M` on x86_64-linux CI is **not caused by contra-tracer 0.2**. It is caused by **tasty 1.5.4**, which was pulled in alongside contra-tracer 0.2 due to the index-state bump in this PR (#5368).

### Evidence

Measured GHC RTS stats (`+RTS -s`) for `network-mux:test:test`, parallel Tasty execution (no concurrency limit):

| Commit | contra-tracer | tasty | Max residency | Total memory in use |
|---|---|---|---|---|
| `e8d59d8a2` (ct01) | 0.1 | 1.5.3 | 127 MiB | 308 MiB |
| `e12f0e80b` (ct02) | 0.2.1.0 | **1.5.4** | **510 MiB** | **1273 MiB** |
| `e12f0e80b` (ct02) | 0.2.1.0 | 1.5.3 (pinned) | 160 MiB | 358 MiB |

With tasty pinned back to 1.5.3, ct02 parallel memory is comparable to ct01 (358 MiB vs 308 MiB). The 4× blowup is entirely attributable to tasty 1.5.4's changes to parallel test execution.

Sequential runs (`TASTY_NUM_THREADS=1`) showed no significant difference between ct01 and ct02, confirming the issue is specific to parallel execution.

### Fix

- Pin `tasty == 1.5.3` in `cabal.project`
- Restore `GHCRTS=-M900M` (reverts the 1500M bump added as a workaround)

### Reproducing

From the repo root, enter the dev shell:

```
nix develop
```

Create worktrees for each commit under investigation:

```
git worktree add /tmp/mux-ct01 e8d59d8a219563760fc21ba5bc86fab77d886742
git worktree add /tmp/mux-ct02 e12f0e80b336b117836b98b09bc27ddf3e7916d0
```

Both worktrees have an index-state that includes tasty 1.5.4. Pin ct01 explicitly to 1.5.3 to establish the pre-regression baseline:

```
echo "constraints: tasty == 1.5.3" >> /tmp/mux-ct01/cabal.project
```

Build and run ct01:

```
cd /tmp/mux-ct01
cabal build network-mux:test:test
GHCRTS="-s" cabal run network-mux:test:test --verbose=0 2>&1 | grep -E "(bytes allocated|maximum residency|total memory in use)"
```

Build and run ct02 with its default (tasty 1.5.4) to reproduce the regression:

```
cd /tmp/mux-ct02
cabal build network-mux:test:test
GHCRTS="-s" cabal run network-mux:test:test --verbose=0 2>&1 | grep -E "(bytes allocated|maximum residency|total memory in use)"
```

Then pin ct02 to 1.5.3 and rerun to confirm the fix:

```
echo "constraints: tasty == 1.5.3" >> /tmp/mux-ct02/cabal.project
cabal build network-mux:test:test
GHCRTS="-s" cabal run network-mux:test:test --verbose=0 2>&1 | grep -E "(bytes allocated|maximum residency|total memory in use)"
```

Each command produces two stat blocks; the first belongs to the test binary, the second to the cabal wrapper.