### PR TITLE
[experiment] contra-tracer 0.2 pre-May18 fixes: does network-mux:test:test OOM at 900 MB?

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
+-- experiment branch: contra-tracer 0.2 without May-18 test fixes, 900M limit
 -- Custom repository for cardano haskell packages, see CONTRIBUTING for more
 repository cardano-haskell-packages
   url: https://chap.intersectmbo.org/


### PR DESCRIPTION
Throwaway experiment branch — **do not merge, close after CI results**.

## Hypothesis

The OOM on `network-mux:test:test` at `GHCRTS=-M900M` may have been introduced by the May 18 test fixes (`bab044045`, `705ab8a97`) rather than by the contra-tracer 0.2 upgrade itself:

- `bab044045`: changed `prop_mux_trailing_bytes` to loop-accumulate bytes, potentially holding more concurrent live data.
- `705ab8a97`: handled a previously-failing `CloseOnRead/Shutdown None` case, meaning more QC inputs run to completion, increasing overlap with parallel tests.

## What this branch is

State at `e12f0e80b` (right after the contra-tracer 0.2.1 upgrade, before the May 18 fixes):

- contra-tracer 0.2.1.0 from avieth's repo (no `INLINE runTracerA`)
- `GHCRTS=-M900M` (original 900 MB limit)
- No `TASTY_NUM_THREADS=1`
- No May 18 test fixes

## Interpretation

- `network-mux:test:test` **passes** → May 18 fixes caused the OOM, not contra-tracer 0.2.
- `network-mux:test:test` **OOMs** → parallel execution on many-core Hydra machines is the root cause regardless of test changes.