### PR TITLE
Export Stage, ResolvedSRVOrFilePath, and Address constructors from Cardano.Network.Ping

### DIFF
--- a/cardano-diffusion/changelog.d/20260616_000000_jordan.millar_export-address-constructors.md
+++ b/cardano-diffusion/changelog.d/20260616_000000_jordan.millar_export-address-constructors.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Export `Stage (..)`, `ResolvedSRVOrFilePath (..)`, and `Address (..)` constructors from `Cardano.Network.Ping`.

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -20,7 +20,9 @@
 
 module Cardano.Network.Ping
   ( PingOpts (..)
-  , Address
+  , Stage (..)
+  , ResolvedSRVOrFilePath (..)
+  , Address (..)
   , cmdlineParser
   , PingMode (..)
   , LogFormat (..)


### PR DESCRIPTION
## Summary

- Export `Stage (..)`, `ResolvedSRVOrFilePath (..)`, and `Address (..)` constructors from `Cardano.Network.Ping`
- Without these exports, downstream consumers cannot pattern-match on `Address` values or write type signatures involving `Address Resolved` / `Address (Unresolved _)`

## Changelog

Added a non-breaking changelog fragment under `cardano-diffusion/changelog.d/`.