### PR TITLE
Expose pingClient - a way to run a single ping client

### DIFF
--- a/cardano-diffusion/changelog.d/20260617_114429_coot_cardano_ping_api.md
+++ b/cardano-diffusion/changelog.d/20260617_114429_coot_cardano_ping_api.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Added `pingClient` to `cardano-diffusion:ping`
+- `cardano-diffusion:ping` now exports also
+  - `Stage`
+  - `ResolvedSRVOrFilePath`
+  - `PingClientException`
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -20,6 +20,8 @@
 
 module Cardano.Network.Ping
   ( PingOpts (..)
+  , Stage (..)
+  , ResolvedSRVOrFilePath (..)
   , Address
   , cmdlineParser
   , PingMode (..)

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -25,6 +25,7 @@ module Cardano.Network.Ping
   , PingMode (..)
   , LogFormat (..)
   , ColorMode (..)
+  , WithHost (..)
   , LogMsg (..)
   , StatPoint (..)
   , ProtocolFlavour (..)
@@ -72,7 +73,7 @@ import Network.DNS qualified as DNS
 import Network.Mux (MiniProtocolInfo (..))
 import Network.Mux qualified as Mx
 import Network.Mux.Bearer (MakeBearer (..), makeSocketBearer)
-import Network.Socket (AddrInfo, StructLinger (..))
+import Network.Socket (AddrInfo, SockAddr, StructLinger (..))
 import Network.Socket qualified as Socket
 import Options.Applicative
 import Options.Applicative.Help.Pretty qualified as Pretty
@@ -336,7 +337,7 @@ data PingWarning = FilePathDoesNotExist FilePath
                  | DNSResolution DNS.Domain [IP] Word
                  | MissingPort IP
                  | Error SomeException
-                 | ConnectError Socket.SockAddr SomeException
+                 | ConnectError SockAddr SomeException
 
 
 formatPingWarning :: PingWarning -> String
@@ -558,7 +559,7 @@ data PingClientError
 
   | forall versionNumber.
     Show versionNumber
-  => PingClientHandshakeProtocolError (HandshakeProtocolError versionNumber) (Address Resolved)
+  => PingClientHandshakeProtocolError (HandshakeProtocolError versionNumber) SockAddr
   -- ^ handshake protocol error
 
 deriving instance Show PingClientError
@@ -793,42 +794,41 @@ pingClients opts@PingOpts { pingOptsJson } addresses = do
       <- catMaybes
          <$> traverse
                (\case
-                  addr@(IP ip@IPv4{} port) ->
-                    fmap (addr,) . maybeHead <$> Socket.getAddrInfo
+                  (IP ip@IPv4{} port) ->
+                    maybeHead <$> Socket.getAddrInfo
                       (Just Socket.defaultHints { Socket.addrFamily = Socket.AF_INET })
                       (Just (show ip))
                       (Just (show port))
-                  addr@(IP ip@IPv6{} port) ->
-                    fmap (addr,) . maybeHead <$> Socket.getAddrInfo
+                  (IP ip@IPv6{} port) ->
+                    maybeHead <$> Socket.getAddrInfo
                       (Just Socket.defaultHints { Socket.addrFamily = Socket.AF_INET6 })
                       (Just (show ip))
                       (Just (show port))
-                  addr@(FilePath path) -> do
-                    return $ Just
-                      ( addr
-                      , Socket.AddrInfo
-                         []
-                         Socket.AF_UNIX
-                         Socket.Stream
-                         Socket.defaultProtocol
-                         (Socket.SockAddrUnix path)
-                         Nothing
-                      )
+                  (FilePath path) -> do
+                    return $ Just $
+                      Socket.AddrInfo
+                       []
+                       Socket.AF_UNIX
+                       Socket.Stream
+                       Socket.defaultProtocol
+                       (Socket.SockAddrUnix path)
+                       Nothing
                )
                resolvedAddresses
 
     headerVar <- newHeaderVar
-    signalVar <- newSignalVar (fst <$> sockAddrs)
+    signalVar <- newSignalVar (Socket.addrAddress <$> sockAddrs)
     mapConcurrently_ (\case
                       -- ignore exceptions so other ping clients can
                       -- continue
-                      addr@(IP {}, _) ->
-                        void $ try @_ @SomeException $
-                        pingClient NodeToNode stdout stderr opts signalVar headerVar addr
-                      addr@(FilePath {}, _) ->
+                      addr | Socket.AF_UNIX <- Socket.addrFamily addr ->
                         void $ try @_ @SomeException $
                         pingClient NodeToClient stdout stderr opts signalVar headerVar addr
+                      addr ->
+                        void $ try @_ @SomeException $
+                        pingClient NodeToNode stdout stderr opts signalVar headerVar addr
                    ) sockAddrs
+
 
 pingClient
   :: forall versionNumber versionData.
@@ -844,17 +844,17 @@ pingClient
   -> Tracer IO (WithHost LogMsg)
   -> Tracer IO PingWarning
   -> PingOpts
-  -> SignalVar (Address Resolved)
+  -> SignalVar SockAddr
   -> HeaderVar
-  -> (Address Resolved, AddrInfo)
+  -> AddrInfo
   -> IO ()
-pingClient protocol stdout stderr opts@PingOpts{..} signalVar headerVar (addr, peer) =
+pingClient protocol stdout stderr opts@PingOpts{..} signalVar headerVar addrInfo =
   withSignal signalVar addr $ \sig ->
     bracket
-      (Socket.socket (Socket.addrFamily peer) Socket.Stream Socket.defaultProtocol)
+      (Socket.socket (Socket.addrFamily addrInfo) Socket.Stream Socket.defaultProtocol)
       Socket.close
       (\sd -> do
-        when (Socket.addrFamily peer /= Socket.AF_UNIX) $ do
+        when (Socket.addrFamily addrInfo /= Socket.AF_UNIX) $ do
           Socket.setSocketOption sd Socket.NoDelay 1
           Socket.setSockOpt sd Socket.Linger
             StructLinger
@@ -864,6 +864,9 @@ pingClient protocol stdout stderr opts@PingOpts{..} signalVar headerVar (addr, p
         runPingClient sig sd
       )
   where
+    addr :: SockAddr
+    addr = Socket.addrAddress addrInfo
+
     runPingClient :: Signal -> Socket.Socket -> IO ()
     runPingClient sig sd = do
       let logMsg :: (ToText msg, ToJSON msg) => msg -> IO ()
@@ -873,10 +876,10 @@ pingClient protocol stdout stderr opts@PingOpts{..} signalVar headerVar (addr, p
       !t0_s <- getMonotonicTime
 
       handleJust (\e -> case fromException e of { Just SomeAsyncException {} -> Nothing; _ -> Just e })
-                 (\e  -> traceWith stderr (ConnectError (Socket.addrAddress peer) e)
+                 (\e  -> traceWith stderr (ConnectError addr e)
                       >> throwIO e
                  ) $
-        Socket.connect sd (Socket.addrAddress peer)
+        Socket.connect sd addr
       !t0_e <- getMonotonicTime
 
       logMsg $ NetworkRTT (toSample t0_e t0_s)
@@ -1066,7 +1069,7 @@ format AsText = toText
 class ToText a where
   toText :: a -> TL.Text
 
-data WithHost a = WithHost (Address Resolved) a
+data WithHost a = WithHost SockAddr a
 
 instance ToText a => ToText (WithHost a) where
   toText (WithHost host a) =
@@ -1129,7 +1132,7 @@ instance ToJSON HandshakeRTT where
 -- note: use `logMsg` defined above in terms of `logMsgWithPeer`
 logMsgWithPeer :: (ToText msg, ToJSON msg)
                => PingOpts
-               -> Address Resolved
+               -> SockAddr
                -> msg
                -> IO ()
 logMsgWithPeer PingOpts { pingOptsQuiet, pingOptsJson } addr msg =

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -28,7 +28,9 @@ module Cardano.Network.Ping
   , WithHost (..)
   , LogMsg (..)
   , StatPoint (..)
+  , PingClientError (..)
   , pingClients
+  , pingClient
   , mainnetMagic
   , NetworkMagic (..)
   ) where
@@ -830,27 +832,39 @@ pingClients opts@PingOpts { pingOptsJson } addresses = do
 
     headerVar <- newHeaderVar
     signalVar <- newSignalVar (Socket.addrAddress <$> sockAddrs)
-    mapConcurrently_ (\case
+    mapConcurrently_ (
                       -- ignore exceptions so other ping clients can
                       -- continue
-                      addr | Socket.AF_UNIX <- Socket.addrFamily addr ->
-                        void $ try @_ @SomeException $
-                        pingClient stdout stderr opts signalVar headerVar addr
-                      addr ->
-                        void $ try @_ @SomeException $
-                        pingClient stdout stderr opts signalVar headerVar addr
-                   ) sockAddrs
+                        void . try @_ @SomeException .
+                        pingClient' stdout stderr opts signalVar headerVar
+                     ) sockAddrs
 
 
+-- | Run a single ping client.
+--
 pingClient
-  -> Tracer IO (WithHost LogMsg)
+  :: Tracer IO (WithHost LogMsg)
+  -> Tracer IO PingWarning
+  -> PingOpts
+  -> AddrInfo
+  -> IO ()
+pingClient stdout stderr opts addrInfo = do
+  signalVar <- newSignalVar [Socket.addrAddress addrInfo]
+  headerVar <- newHeaderVar
+  pingClient' stdout stderr opts signalVar headerVar addrInfo
+
+
+-- | Low level API to run a single ping client.
+--
+pingClient'
+  :: Tracer IO (WithHost LogMsg)
   -> Tracer IO PingWarning
   -> PingOpts
   -> SignalVar SockAddr
   -> HeaderVar
   -> AddrInfo
   -> IO ()
-pingClient stdout stderr opts@PingOpts{..} signalVar headerVar addrInfo =
+pingClient' stdout stderr opts@PingOpts{..} signalVar headerVar addrInfo =
   withSignal signalVar addr $ \sig ->
     bracket
       (Socket.socket (Socket.addrFamily addrInfo) Socket.Stream Socket.defaultProtocol)

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -28,7 +28,6 @@ module Cardano.Network.Ping
   , WithHost (..)
   , LogMsg (..)
   , StatPoint (..)
-  , ProtocolFlavour (..)
   , pingClients
   , mainnetMagic
   , NetworkMagic (..)
@@ -574,6 +573,19 @@ data ProtocolFlavour version versionData where
     NodeToNode   :: ProtocolFlavour NodeToNodeVersion   NodeToNodeVersionData
     NodeToClient :: ProtocolFlavour NodeToClientVersion NodeToClientVersionData
 
+data SomeProtocolFlavour where
+    SomeProtocolFlavour :: forall versionNumber versionData.
+                           ( Acceptable versionData
+                           , Queryable versionData
+                           , NFData versionData
+                           , Ord versionNumber
+                           , Show versionNumber
+                           , NFData versionNumber
+                           , ToJSON versionNumber
+                           )
+                        => ProtocolFlavour versionNumber versionData
+                        -> SomeProtocolFlavour
+
 --
 -- ChainSync Tip Sampling
 --
@@ -823,24 +835,14 @@ pingClients opts@PingOpts { pingOptsJson } addresses = do
                       -- continue
                       addr | Socket.AF_UNIX <- Socket.addrFamily addr ->
                         void $ try @_ @SomeException $
-                        pingClient NodeToClient stdout stderr opts signalVar headerVar addr
+                        pingClient stdout stderr opts signalVar headerVar addr
                       addr ->
                         void $ try @_ @SomeException $
-                        pingClient NodeToNode stdout stderr opts signalVar headerVar addr
+                        pingClient stdout stderr opts signalVar headerVar addr
                    ) sockAddrs
 
 
 pingClient
-  :: forall versionNumber versionData.
-     ( Acceptable versionData
-     , Queryable versionData
-     , NFData versionData
-     , Ord versionNumber
-     , Show versionNumber
-     , NFData versionNumber
-     , ToJSON versionNumber
-     )
-  => ProtocolFlavour versionNumber versionData
   -> Tracer IO (WithHost LogMsg)
   -> Tracer IO PingWarning
   -> PingOpts
@@ -848,7 +850,7 @@ pingClient
   -> HeaderVar
   -> AddrInfo
   -> IO ()
-pingClient protocol stdout stderr opts@PingOpts{..} signalVar headerVar addrInfo =
+pingClient stdout stderr opts@PingOpts{..} signalVar headerVar addrInfo =
   withSignal signalVar addr $ \sig ->
     bracket
       (Socket.socket (Socket.addrFamily addrInfo) Socket.Stream Socket.defaultProtocol)
@@ -861,14 +863,31 @@ pingClient protocol stdout stderr opts@PingOpts{..} signalVar headerVar addrInfo
               { sl_onoff  = 1
               , sl_linger = 0
               }
-        runPingClient sig sd
+        let someProtocol :: SomeProtocolFlavour
+            someProtocol = case Socket.addrFamily addrInfo of
+              Socket.AF_UNIX -> SomeProtocolFlavour NodeToClient
+              _              -> SomeProtocolFlavour NodeToNode
+        case someProtocol of
+          SomeProtocolFlavour protocol -> runPingClient protocol sig sd
       )
   where
     addr :: SockAddr
     addr = Socket.addrAddress addrInfo
 
-    runPingClient :: Signal -> Socket.Socket -> IO ()
-    runPingClient sig sd = do
+    runPingClient :: forall versionNumber versionData.
+                     ( Acceptable versionData
+                     , Queryable versionData
+                     , NFData versionData
+                     , Ord versionNumber
+                     , Show versionNumber
+                     , NFData versionNumber
+                     , ToJSON versionNumber
+                     )
+                  => ProtocolFlavour versionNumber versionData
+                  -> Signal
+                  -> Socket.Socket
+                  -> IO ()
+    runPingClient protocol sig sd = do
       let logMsg :: (ToText msg, ToJSON msg) => msg -> IO ()
           logMsg = logMsgWithPeer opts addr
           stdout' = WithHost addr >$< stdout

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -19,7 +19,11 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Network.Ping
-  ( PingOpts (..)
+  ( -- * API
+    pingClients
+  , pingClient
+    -- * Options and arguments
+  , PingOpts (..)
   , Stage (..)
   , ResolvedSRVOrFilePath (..)
   , Address
@@ -27,13 +31,16 @@ module Cardano.Network.Ping
   , PingMode (..)
   , LogFormat (..)
   , ColorMode (..)
+    -- * Log messages
+  , PingWarning (..)
   , WithHost (..)
   , LogMsg (..)
   , StatPoint (..)
+    -- * Exceptions
   , PingClientException (..)
-  , pingClients
-  , pingClient
+    -- * Cardano main-net configuration
   , mainnetMagic
+    -- * Re-exports
   , NetworkMagic (..)
   ) where
 

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -28,7 +28,7 @@ module Cardano.Network.Ping
   , WithHost (..)
   , LogMsg (..)
   , StatPoint (..)
-  , PingClientError (..)
+  , PingClientException (..)
   , pingClients
   , pingClient
   , mainnetMagic
@@ -46,6 +46,7 @@ import Control.Monad.Class.MonadTime.SI
 import Control.Monad.Class.MonadTimer.SI
 import Control.Tracer (Tracer, mkTracer, nullTracer, traceWith, (>$<))
 
+import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Term qualified as CBOR
 import Codec.Serialise qualified as Serialise
 import Data.Aeson (KeyValue ((.=)), ToJSON (toJSON), Value, object)
@@ -554,22 +555,37 @@ idleTimeout :: DiffTime
 idleTimeout = 1
 
 
-data PingClientError
-  = PingClientProtocolLimitFailure ProtocolLimitFailure
+data PingClientException
+  = ProtocolLimitException ProtocolLimitFailure
   -- ^ protocol limit error
 
   | forall versionNumber.
     Show versionNumber
-  => PingClientHandshakeProtocolError (HandshakeProtocolError versionNumber) SockAddr
+  => HandshakeException (HandshakeProtocolError versionNumber) SockAddr
   -- ^ handshake protocol error
 
-deriving instance Show PingClientError
+  | IOException IOError
+  -- ^ IO errors
 
-instance Exception PingClientError where
-  displayException (PingClientProtocolLimitFailure err) =
+  | DecodingException CBOR.DeserialiseFailure
+  -- ^ cbor exceptions
+
+  | MuxException Mx.Error
+  -- ^ mux exceptions
+
+deriving instance Show PingClientException
+
+instance Exception PingClientException where
+  displayException (ProtocolLimitException err) =
     displayException err
-  displayException (PingClientHandshakeProtocolError err addr) =
+  displayException (HandshakeException err addr) =
     printf "%s handshake error: %s" (show addr) (show err)
+  displayException (IOException err) =
+    displayException err
+  displayException (DecodingException err) =
+    displayException err
+  displayException (MuxException err) =
+    displayException err
 
 data ProtocolFlavour version versionData where
     NodeToNode   :: ProtocolFlavour NodeToNodeVersion   NodeToNodeVersionData
@@ -847,11 +863,19 @@ pingClient
   -> Tracer IO PingWarning
   -> PingOpts
   -> AddrInfo
-  -> IO ()
-pingClient stdout stderr opts addrInfo = do
-  signalVar <- newSignalVar [Socket.addrAddress addrInfo]
-  headerVar <- newHeaderVar
-  pingClient' stdout stderr opts signalVar headerVar addrInfo
+  -> IO (Either PingClientException ())
+pingClient stdout stderr opts addrInfo =
+  do
+    signalVar <- newSignalVar [Socket.addrAddress addrInfo]
+    headerVar <- newHeaderVar
+    Right <$> pingClient' stdout stderr opts signalVar headerVar addrInfo
+  `catch` \case
+    err | Just e <- fromException err -> return (Left (IOException e))
+        | Just e <- fromException err -> return (Left (DecodingException e))
+        | Just e <- fromException err -> return (Left (MuxException e))
+        | Just e <- fromException err -> return (Left e)
+        | otherwise
+        -> throwIO err
 
 
 -- | Low level API to run a single ping client.
@@ -977,10 +1001,10 @@ pingClient' stdout stderr opts@PingOpts{..} signalVar headerVar addrInfo =
         )
       case r of
         Left err -> do
-          throwIO (PingClientProtocolLimitFailure err)
+          throwIO (ProtocolLimitException err)
         Right (Left err', rtt) -> do
           logMsg (HandshakeRTT rtt)
-          throwIO (PingClientHandshakeProtocolError err' addr)
+          throwIO (HandshakeException err' addr)
         Right (Right r', rtt) -> do
           logMsg (HandshakeRTT rtt)
           case r' of

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -555,6 +555,8 @@ instance ( Show peerAddr
 
 -- | Record of arguments of 'peerSelectionActions'.
 --
+-- It is instantiated for production in `Ouroboros.Network.Diffusion`.
+--
 data PeerStateActionsArguments muxMode socket responderCtx peerAddr extraFlags versionData versionNumber m a b =
     PeerStateActionsArguments {
 
@@ -562,10 +564,16 @@ data PeerStateActionsArguments muxMode socket responderCtx peerAddr extraFlags v
 
       -- | Peer deactivation timeout: timeouts stopping hot protocols.
       --
+      -- We use `Ouroboros.Network.Diffusion.Policies.deactivateTimeout` in
+      -- `Ouroboros.Network.Diffusion`.
+      --
       spsDeactivateTimeout      :: DiffTime,
 
       -- | Timeout on closing connection: timeouts stopping established and warm
       -- peer protocols.
+      --
+      -- We use `Ouroboros.Network.Diffusion.Policies.closeConnectionTimeout` in
+      -- `Ouroboros.Network.Diffusion`.
       --
       spsCloseConnectionTimeout :: DiffTime,
 


### PR DESCRIPTION
# Description

- **peer-state-actions: improved haddocks**
- **cardano-diffusion:ping - don't use Address in pingClient**
- **cardano-diffusion:ping - don't require ProtocolFlavour by pingClient**
- **cardano-diffusion:ping - export pingClient**
- **cardano-diffusion:ping - Export Stage, ResolvedSRVOrFilePath**

I cherry-picked the commit from #5385, but modified it so we don't export `Address` constructors.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
