### PR TITLE
cardano-diffusion:ping - allow for optparse-applicative-fork

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,11 @@ index-state:
   , hackage.haskell.org 2026-05-26T19:31:06Z
 
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2026-05-26T09:41:58Z
+  , cardano-haskell-packages 2026-06-23T21:17:32Z
+
+active-repositories:
+  , :rest
+  , cardano-haskell-packages:override
 
 packages: ./monoidal-synchronisation
           ./network-mux

--- a/cardano-diffusion/cardano-diffusion.cabal
+++ b/cardano-diffusion/cardano-diffusion.cabal
@@ -27,6 +27,11 @@ flag cddl
   -- These tests need the cddl and the cbor-diag Ruby-package
   default: True
 
+flag optparse-applicative-fork
+  description: Use optparse-applicative-fork
+  manual: True
+  default: False
+
 common ghc-options
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -609,13 +614,21 @@ library ping
     iproute ^>=1.7.15,
     network ^>=3.2.7,
     network-mux,
-    optparse-applicative,
     ouroboros-network:{api, framework} >=1.0.0.0 && <1.2.0.0,
     random,
     serialise,
     tdigest ^>=0.3,
     text >=1.2.4 && <2.2,
     time >=1.9.1 && <1.16,
+
+  -- Until https://github.com/IntersectMBO/cardano-cli/pull/1390 is merged we
+  -- need to allow for `optparse-applicative-fork`
+  if flag(optparse-applicative-fork)
+    build-depends:
+      optparse-applicative-fork
+  else
+    build-depends:
+      optparse-applicative
 
 executable cardano-ping
   import: ghc-options
@@ -624,4 +637,10 @@ executable cardano-ping
   build-depends:
     base >=4.14 && <4.23,
     cardano-diffusion:ping,
-    optparse-applicative,
+
+  if flag(optparse-applicative-fork)
+    build-depends:
+      optparse-applicative-fork
+  else
+    build-depends:
+      optparse-applicative

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1779802675,
-        "narHash": "sha256-LQN0f9GBBmYMo9tQ/11EvU5tAEOhGtQnU2UP3S78cqg=",
+        "lastModified": 1782333501,
+        "narHash": "sha256-ncdhrFEJTsm0j1K6SBE0Er2kk2QmBx5Hoks+S5zMMB8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "b8c7b848cdb6d08e414c37d026c300200f8c1b5b",
+        "rev": "8d07b33ab9e158fe20a6715125eb2bf615116919",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

`cardano-cli` is using `optparse-applicative-fork`, at least until IntersectMBO/cardano-cli#1390 is merged.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
