### PR TITLE
Fix race condition for new connections

### DIFF
--- a/network-mux/changelog.d/20260630_134726_karl.fb.knutsson_n2c_ig_race_main.md
+++ b/network-mux/changelog.d/20260630_134726_karl.fb.knutsson_n2c_ig_race_main.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Add non-blocking hasStopped function
+

--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -43,6 +43,7 @@ module Network.Mux
     -- * Monitoring
   , miniProtocolStateMap
   , stopped
+  , hasStopped
     -- * Errors
   , Error (..)
   , RuntimeError (..)
@@ -124,6 +125,20 @@ stopped Mux { muxStatus } =
       Failed err -> return (Just err)
       Stopping   -> retry
       Stopped    -> return Nothing
+
+
+-- | Non-blocking check whether the mux has already reached a terminal state
+-- (stopped cleanly or failed).  Unlike 'stopped', this never blocks (retries)
+-- while the mux is still running or stopping; it returns 'False' in those
+-- cases.
+--
+hasStopped :: MonadSTM m => Mux mode m -> STM m Bool
+hasStopped Mux { muxStatus } =
+    readTVar muxStatus >>= \case
+      Ready    -> return False
+      Stopping -> return False
+      Stopped  -> return True
+      Failed _ -> return True
 
 
 -- | Create a mux handle in `Mode` and register mini-protocols.

--- a/ouroboros-network/changelog.d/20260630_134407_karl.fb.knutsson_n2c_ig_race_main.md
+++ b/ouroboros-network/changelog.d/20260630_134407_karl.fb.knutsson_n2c_ig_race_main.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Fix race condition for new connections in the inbound govenor.
+

--- a/ouroboros-network/framework/lib/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network/framework/lib/Ouroboros/Network/InboundGovernor.hs
@@ -390,7 +390,19 @@ with
                             Duplex         -> OrdPSQ.insert (remoteAddress connId) time csVersionData
                                                             (freshDuplexPeers state)
                       }
-                return . Just $ StateWithPeerTransition state' connId
+
+                -- If the mux already reached a terminal state before we
+                -- registered the connection, the tracer dropped its stop event
+                -- (lookup miss), so unregister now; checked in the same atomic
+                -- as we make the new connection visible.
+                state'' <- atomically $ do
+                  muxIsStopped <- Mux.hasStopped csMux
+                  let s = if muxIsStopped
+                             then unregisterConnection True connId state'
+                             else state'
+                  writeTVar stateVar s
+                  return s
+                return . Just $ StateWithPeerTransition state'' connId
 
           MuxFinished connId result -> do
 


### PR DESCRIPTION
# Description

There is a race conditions between new connections and terminating connections.
By creating them and checking if they still exist in the same atomic we avoid it.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
