### PR TITLE
Bump trace-generators to 2.13

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ index-state:
   , hackage.haskell.org 2026-06-29T22:49:53Z
 
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2026-06-29T12:05:19Z
+  , cardano-haskell-packages 2026-07-02T10:10:00Z
 
 active-repositories:
   , :rest

--- a/cardano-diffusion/cardano-diffusion.cabal
+++ b/cardano-diffusion/cardano-diffusion.cabal
@@ -596,7 +596,7 @@ library tracing
     base >=4.14 && <4.23,
     cardano-diffusion,
     text,
-    trace-dispatcher ^>=2.12.0,
+    trace-dispatcher ^>=2.13.0,
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts

--- a/cardano-diffusion/changelog.d/20260703_161906_fabrizio.ferrai_bump_trace_dispatcher.md
+++ b/cardano-diffusion/changelog.d/20260703_161906_fabrizio.ferrai_bump_trace_dispatcher.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Bumped `trace-dispatcher` to `^>=2.13`.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1782769557,
-        "narHash": "sha256-tCYMTwH15mNajHybvC3KGVPBPMlLlqIOYE0ZgcqRkJU=",
+        "lastModified": 1782990451,
+        "narHash": "sha256-U0o77JuGp6ADqym7TtGV3AwzRn5SFuiTRyCOR6qfxGA=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "3ee6b1ecce230d62f0083590f38c4ae3457da226",
+        "rev": "def6ba6e0324e451802f5a17b12a00bd64639e14",
         "type": "github"
       },
       "original": {

--- a/ouroboros-network/changelog.d/20260703_161906_fabrizio.ferrai_bump_trace_dispatcher.md
+++ b/ouroboros-network/changelog.d/20260703_161906_fabrizio.ferrai_bump_trace_dispatcher.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Bumped `trace-dispatcher` to `^>=2.13`.

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -651,7 +651,7 @@ library tracing
     network-mux,
     ouroboros-network:{ouroboros-network, api, framework, orphan-instances, protocols},
     text,
-    trace-dispatcher ^>=2.12.0,
+    trace-dispatcher ^>=2.13.0,
     typed-protocols:{typed-protocols, stateful},
 
   if flag(asserts)


### PR DESCRIPTION
# Description

Bump `trace-generators` to 2.13 for compat with the upcoming `cardano-config` library.

cc @mgmeier 

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
