### PR TITLE
tx-undecision: awaitSharedChange as an STM action

### DIFF
--- a/ouroboros-network/changelog.d/20260709_161816_coot_tx_undecision_stm.md
+++ b/ouroboros-network/changelog.d/20260709_161816_coot_tx_undecision_stm.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- `Ouroboros.Network.TxSubmission.Inbound.V2.Registry.awaitSharedChange` is now
+  an STM action, but it requires to pass a registered delay.
+
+### Non-Breaking
+
+- Added `Ouroboros.Network.RegisteredDelay` to `ouroboros-network:framework`
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-network/framework/lib/Ouroboros/Network/RegisteredDelay.hs
+++ b/ouroboros-network/framework/lib/Ouroboros/Network/RegisteredDelay.hs
@@ -1,0 +1,26 @@
+-- Register delay, API around `GHC.Conc.registerDelay`
+--
+-- The module should be imported qualified.
+module Ouroboros.Network.RegisteredDelay where
+
+import Control.Concurrent.Class.MonadSTM as LazySTM
+import Control.Monad ((>=>))
+import Control.Monad.Class.MonadTimer.SI
+import Prelude hiding (read)
+
+newtype RegisteredDelay m = RegisteredDelay { registeredDelayVar :: LazySTM.TVar m Bool }
+
+new :: MonadTimer m
+    => DiffTime
+    -> m (RegisteredDelay m)
+new = fmap RegisteredDelay . registerDelay
+
+read :: MonadSTM m
+     => RegisteredDelay m
+     -> STM m Bool
+read = LazySTM.readTVar . registeredDelayVar
+
+await :: MonadSTM m
+      => RegisteredDelay m
+      -> STM m ()
+await = read >=> check

--- a/ouroboros-network/lib/Ouroboros/Network/TxSubmission/Inbound/V2.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/TxSubmission/Inbound/V2.hs
@@ -35,6 +35,7 @@ import Network.TypedProtocol
 import Ouroboros.Network.Protocol.TxSubmission2.Server
 import Ouroboros.Network.Protocol.TxSubmission2.Type (NumTxIdsToAck,
            SizeInBytes)
+import Ouroboros.Network.RegisteredDelay qualified as RegisteredDelay
 import Ouroboros.Network.TxSubmission.Inbound.V2.Policy
 import Ouroboros.Network.TxSubmission.Inbound.V2.Registry as V2
 import Ouroboros.Network.TxSubmission.Inbound.V2.State qualified as State
@@ -125,7 +126,7 @@ collectAndContinueWithState (StatefulCollect f) !st =
 txSubmissionInboundV2
   :: forall txid tx idx m err.
      ( MonadDelay m
-     , MonadSTM m
+     , MonadTimer m
      , MonadThrow m
      , Ord txid
      , Show txid
@@ -203,7 +204,8 @@ txSubmissionInboundV2
              if cameToIdle
                 then continueWithStateM serverIdle peerState''
                 else do
-                  awaitSharedChange generation mDelay
+                  mRegisteredDelay <- traverse RegisteredDelay.new mDelay
+                  atomically $ awaitSharedChange generation mRegisteredDelay
                   continueWithStateM serverIdle peerState''
            PeerSubmitTxs txKeys ->
              continueWithStateM (submitBufferedTxs txKeys serverIdle) peerState''

--- a/ouroboros-network/lib/Ouroboros/Network/TxSubmission/Inbound/V2/Registry.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/TxSubmission/Inbound/V2/Registry.hs
@@ -12,9 +12,10 @@ module Ouroboros.Network.TxSubmission.Inbound.V2.Registry
   , newTxSubmissionCountersVar
   , txCountersThreadV2
   , withPeer
+    -- re-exports
+  , RegisteredDelay
   ) where
 
-import Control.Concurrent.Class.MonadSTM qualified as Lazy
 import Control.Concurrent.Class.MonadSTM.Strict
 import Control.Monad (when)
 import Control.Monad.Class.MonadThrow
@@ -31,6 +32,8 @@ import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
 
 import Ouroboros.Network.Protocol.TxSubmission2.Type
+import Ouroboros.Network.RegisteredDelay (RegisteredDelay)
+import Ouroboros.Network.RegisteredDelay qualified as RegisteredDelay
 import Ouroboros.Network.Tx (HasRawTxId)
 import Ouroboros.Network.TxSubmission.Inbound.V2.Policy (TxDecisionPolicy (..))
 import Ouroboros.Network.TxSubmission.Inbound.V2.State qualified as State
@@ -187,8 +190,8 @@ data PeerTxAPI m txid tx = PeerTxAPI {
     -- | Wait until either 'sharedGeneration' moves past the given
     -- value or the optional timeout expires.
     awaitSharedChange    :: Word64
-                         -> Maybe DiffTime
-                         -> m (),
+                         -> Maybe (RegisteredDelay m)
+                         -> STM m (),
 
     -- | Compute the next action for this peer in non-pipelined mode.
     runNextPeerAction    :: Time
@@ -374,20 +377,17 @@ scrubFromPeerInFlight peeraddr now pif st
 awaitSharedChangeImp :: MonadTimer m
                      => SharedTxStateVar m peeraddr txid
                      -> Word64
-                     -> Maybe DiffTime
-                     -> m ()
-awaitSharedChangeImp sharedStateVar generation mDelay =
-  case mDelay of
-       Nothing ->
-         atomically $ do
-           sharedState <- readTVar sharedStateVar
-           check (sharedGeneration sharedState /= generation)
-       Just delay -> do
-         delayVar <- registerDelay delay
-         atomically $ do
-           sharedState <- readTVar sharedStateVar
-           expired <- Lazy.readTVar delayVar
-           check (sharedGeneration sharedState /= generation || expired)
+                     -> Maybe (RegisteredDelay m)
+                     -> STM m ()
+awaitSharedChangeImp sharedStateVar generation mRegisteredDelay =
+  case mRegisteredDelay of
+       Nothing -> do
+         sharedState <- readTVar sharedStateVar
+         check (sharedGeneration sharedState /= generation)
+       Just registeredDelay -> do
+         sharedState <- readTVar sharedStateVar
+         expired <- RegisteredDelay.read registeredDelay
+         check (sharedGeneration sharedState /= generation || expired)
 
 -- | Avoid rewriting the shared TVar when the pure state step made no shared
 -- change. Callers use 'sharedGeneration' as the dirty bit for shared state.

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -368,6 +368,7 @@ library framework
     Ouroboros.Network.Protocol.Handshake.Unversioned
     Ouroboros.Network.Protocol.Handshake.Version
     Ouroboros.Network.RawBearer
+    Ouroboros.Network.RegisteredDelay
     Ouroboros.Network.RethrowPolicy
     Ouroboros.Network.Server
     Ouroboros.Network.Server.ConnectionTable


### PR DESCRIPTION
# Description

When a registered delay is created out of the scope of `awaitSharedChange` it
can become an `STM` action.  This way we won't need to `race` `IO` actions in
`dmq-node` but instead resolve the race in an STM transaction.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
