### PR TITLE
Rearrange severity query for new tracing

### DIFF
--- a/ouroboros-network/changelog.d/20260715_120250_crocodile-dentist_fix_tracing_severity.md
+++ b/ouroboros-network/changelog.d/20260715_120250_crocodile-dentist_fix_tracing_severity.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Patch
+
+- Tracing instances cleanup

--- a/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection.hs
+++ b/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection.hs
@@ -76,7 +76,7 @@ instance (Show ntnAddr, Show ntcAddr) =>
     , "mode" .= String (pack (showString "0o" . showOct mode $ ""))
     ]
   forMachine _dtal (Diff.InsecureLocalSocketPermissions localAddress mode) = mconcat
-    [ "kind" .= String "InsecureLocalSocketDirectory"
+    [ "kind" .= String "InsecureLocalSocketPermissions"
     , "path" .= String (pack . show $ localAddress)
     , "mode" .= String (pack (showString "0o" . showOct mode $ ""))
     ]
@@ -132,9 +132,9 @@ instance MetaTrace (Diff.DiffusionTracer ntnAddr ntcAddr) where
     namespaceFor Diff.LocalSocketUp {} =
       Namespace [] ["LocalSocketUp"]
     namespaceFor Diff.InsecureLocalSocketDirectory {} =
-      Namespace [] ["InsecureLocalSocketDirectory"]
+      Namespace [] ["InsecureLocalSocket", "Directory"]
     namespaceFor Diff.InsecureLocalSocketPermissions {} =
-      Namespace [] ["InsecureLocalSocketDirectory"]
+      Namespace [] ["InsecureLocalSocket", "Permissions"]
     namespaceFor Diff.CreatingServerSocket {} =
       Namespace [] ["CreatingServerSocket"]
     namespaceFor Diff.ListeningServerSocket {} =
@@ -161,7 +161,7 @@ instance MetaTrace (Diff.DiffusionTracer ntnAddr ntcAddr) where
     severityFor (Namespace _ ["ConfiguredLocalSocket"]) _ = Just Info
     severityFor (Namespace _ ["ListeningLocalSocket"]) _ = Just Info
     severityFor (Namespace _ ["LocalSocketUp"]) _ = Just Info
-    severityFor (Namespace _ ["InsecureLocalSocketDirectory"]) _ = Just Warning
+    severityFor (Namespace _ ["InsecureLocalSocket"]) _ = Just Warning
     severityFor (Namespace _ ["CreatingServerSocket"]) _ = Just Info
     severityFor (Namespace _ ["ListeningServerSocket"]) _ = Just Info
     severityFor (Namespace _ ["ServerSocketUp"]) _ = Just Info
@@ -192,13 +192,13 @@ instance MetaTrace (Diff.DiffusionTracer ntnAddr ntcAddr) where
       "ListeningLocalSocket"
     documentFor (Namespace _ ["LocalSocketUp"]) = Just
       "LocalSocketUp"
-    documentFor (Namespace _ ["InsecureLocalSocketDirectory"]) = Just $ mconcat
+    documentFor (Namespace _ ["InsecureLocalSocket", "Directory"]) = Just $ mconcat
       [ "InsecureLocalSocketDirectory: the parent directory of the local "
       , "socket has group or other write permission, leaving the socket "
       , "vulnerable to manipulation by another local user with write access "
       , "to that directory."
       ]
-    documentFor (Namespace _ ["InsecureLocalSocketPermissions"]) = Just $ mconcat
+    documentFor (Namespace _ ["InsecureLocalSocket", "Permissions"]) = Just $ mconcat
       [ "InsecureLocalSocketPermissions: the local socket has other-read or "
       , "other-write permissions."
       ]
@@ -230,7 +230,8 @@ instance MetaTrace (Diff.DiffusionTracer ntnAddr ntcAddr) where
       , Namespace [] ["ConfiguredLocalSocket"]
       , Namespace [] ["ListeningLocalSocket"]
       , Namespace [] ["LocalSocketUp"]
-      , Namespace [] ["InsecureLocalSocketDirectory"]
+      , Namespace [] ["InsecureLocalSocket", "Directory"]
+      , Namespace [] ["InsecureLocalSocket", "Permissions"]
       , Namespace [] ["CreatingServerSocket"]
       , Namespace [] ["ListeningServerSocket"]
       , Namespace [] ["ServerSocketUp"]

--- a/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection.hs
+++ b/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection.hs
@@ -152,26 +152,25 @@ instance MetaTrace (Diff.DiffusionTracer ntnAddr ntcAddr) where
     namespaceFor Diff.SystemdSocketConfiguration {} =
       Namespace [] ["SystemdSocketConfiguration"]
 
-    severityFor _ (Just Diff.RunServer{}) = Just Info
-    severityFor _ (Just Diff.RunLocalServer{}) = Just Info
-    severityFor _ (Just Diff.UsingSystemdSocket{}) = Just Info
-    severityFor _ (Just Diff.CreateSystemdSocketForSnocketPath{}) = Just Info
-    severityFor _ (Just Diff.CreatedLocalSocket{}) = Just Info
-    severityFor _ (Just Diff.ConfiguringLocalSocket{}) = Just Info
-    severityFor _ (Just Diff.ConfiguredLocalSocket{}) = Just Info
-    severityFor _ (Just Diff.ListeningLocalSocket{}) = Just Info
-    severityFor _ (Just Diff.LocalSocketUp{}) = Just Info
-    severityFor _ (Just Diff.InsecureLocalSocketDirectory{}) = Just Warning
-    severityFor _ (Just Diff.InsecureLocalSocketPermissions{}) = Just Warning
-    severityFor _ (Just Diff.CreatingServerSocket{}) = Just Info
-    severityFor _ (Just Diff.ListeningServerSocket{}) = Just Info
-    severityFor _ (Just Diff.ServerSocketUp{}) = Just Info
-    severityFor _ (Just Diff.ConfiguringServerSocket{}) = Just Info
-    severityFor _ (Just Diff.UnsupportedLocalSystemdSocket{}) = Just Warning
-    severityFor _ (Just Diff.UnsupportedReadySocketCase{}) = Just Info
-    severityFor _ (Just Diff.DiffusionErrored{}) = Just Critical
-    severityFor _ (Just Diff.SystemdSocketConfiguration{}) = Just Warning
-    severityFor _ Nothing = Nothing
+    severityFor (Namespace _ ["RunServer"]) _ = Just Info
+    severityFor (Namespace _ ["RunLocalServer"]) _ = Just Info
+    severityFor (Namespace _ ["UsingSystemdSocket"]) _ = Just Info
+    severityFor (Namespace _ ["CreateSystemdSocketForSnocketPath"]) _ = Just Info
+    severityFor (Namespace _ ["CreatedLocalSocket"]) _ = Just Info
+    severityFor (Namespace _ ["ConfiguringLocalSocket"]) _ = Just Info
+    severityFor (Namespace _ ["ConfiguredLocalSocket"]) _ = Just Info
+    severityFor (Namespace _ ["ListeningLocalSocket"]) _ = Just Info
+    severityFor (Namespace _ ["LocalSocketUp"]) _ = Just Info
+    severityFor (Namespace _ ["InsecureLocalSocketDirectory"]) _ = Just Warning
+    severityFor (Namespace _ ["CreatingServerSocket"]) _ = Just Info
+    severityFor (Namespace _ ["ListeningServerSocket"]) _ = Just Info
+    severityFor (Namespace _ ["ServerSocketUp"]) _ = Just Info
+    severityFor (Namespace _ ["ConfiguringServerSocket"]) _ = Just Info
+    severityFor (Namespace _ ["UnsupportedLocalSystemdSocket"]) _ = Just Warning
+    severityFor (Namespace _ ["UnsupportedReadySocketCase"]) _ = Just Info
+    severityFor (Namespace _ ["DiffusionErrored"]) _ = Just Critical
+    severityFor (Namespace _ ["SystemdSocketConfiguration"]) _ = Just Warning
+    severityFor _ _ = Nothing
 
     documentFor (Namespace _ ["RunServer"]) = Just
       "RunServer"


### PR DESCRIPTION
# Description

This is to satisfy the tests in `cardano-node` that check for the namespace severity being defined - e.g. see [this failing test run](https://github.com/IntersectMBO/cardano-node/actions/runs/28873986470/job/85643976289?pr=6604)

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
