### PR TITLE
Avoid thunk in ChainSelStarvationEndedAt

### DIFF
--- a/ouroboros-network/api/lib/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network/api/lib/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -153,7 +153,7 @@ data BlockFetchConsensusInterface peer header block m =
 -- represent this piece of information.
 data ChainSelStarvation
   = ChainSelStarvationOngoing
-  | ChainSelStarvationEndedAt Time
+  | ChainSelStarvationEndedAt !Time
   deriving (Eq, Show, NoThunks, Generic)
 
 


### PR DESCRIPTION
# Description

This thunk shows up in NoThunk tests in Consensus
```
        Follower switches to new chain
          model:                                                                                      OK
          system:                                                                                     FAIL
            Exception: ExceptionInLinkedThread "ThreadId 2191" StrictTVar invariant violation: ThunkInfo {thunkContext = ["Time","ChainSelStarvation"], thunkInfo = Nothing}
            Use -p '/Follower switches to new chain.system/' to rerun this test only.
        https://github.com/IntersectMBO/ouroboros-network/issues/4183
          model:                                                                                      OK
          system:                                                                                     FAIL
            Exception: ExceptionInLinkedThread "ThreadId 2197" StrictTVar invariant violation: ThunkInfo {thunkContext = ["Time","ChainSelStarvation"], thunkInfo = Nothing}
            Use -p '/https:\/\/github.com\/IntersectMBO\/ouroboros-network\/issues\/4183.system/' to rerun this test only.
        https://github.com/IntersectMBO/ouroboros-network/issues/3999
          model:                                                                                      OK
          system:                                                                                     FAIL
            Exception: ExceptionInLinkedThread "ThreadId 2203" StrictTVar invariant violation: ThunkInfo {thunkContext = ["Time","ChainSelStarvation"], thunkInfo = Nothing}
            Use -p '/https:\/\/github.com\/IntersectMBO\/ouroboros-network\/issues\/3999.system/' to rerun this test only.
        ChainDB.waitForImmutableBlock
          Existing block, returns same
            system:                                                                                   FAIL
              Exception: ExceptionInLinkedThread "ThreadId 2208" StrictTVar invariant violation: ThunkInfo {thunkContext = ["Time","ChainSelStarvation"], thunkInfo = Nothing}
              Use -p '/Existing block, returns same.system/' to rerun this test only.
          Existing block, returns same, call 'wait' concurrently with adding blocks
            system:                                                                                   FAIL
              Exception: ExceptionInLinkedThread "ThreadId 2213" StrictTVar invariant violation: ThunkInfo {thunkContext = ["Time","ChainSelStarvation"], thunkInfo = Nothing}
              Use -p '/Existing block, returns same, call '\''wait'\'' concurrently with adding blocks.system/' to rerun this test only.
```

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
