### PR TITLE
Fix severity queries for InsecureLocalSocket

### DIFF
--- a/ouroboros-network/changelog.d/20260722_134733_fabrizio.ferrai_fix_tracing_severity.md
+++ b/ouroboros-network/changelog.d/20260722_134733_fabrizio.ferrai_fix_tracing_severity.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Patch
+
+- Fixed tracing severity queries for `InsecureLocalSocket`.

--- a/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection.hs
+++ b/ouroboros-network/tracing/Ouroboros/Network/Tracing/PeerSelection.hs
@@ -161,7 +161,8 @@ instance MetaTrace (Diff.DiffusionTracer ntnAddr ntcAddr) where
     severityFor (Namespace _ ["ConfiguredLocalSocket"]) _ = Just Info
     severityFor (Namespace _ ["ListeningLocalSocket"]) _ = Just Info
     severityFor (Namespace _ ["LocalSocketUp"]) _ = Just Info
-    severityFor (Namespace _ ["InsecureLocalSocket"]) _ = Just Warning
+    severityFor (Namespace _ ["InsecureLocalSocket", "Directory"]) _ = Just Warning
+    severityFor (Namespace _ ["InsecureLocalSocket", "Permissions"]) _ = Just Warning
     severityFor (Namespace _ ["CreatingServerSocket"]) _ = Just Info
     severityFor (Namespace _ ["ListeningServerSocket"]) _ = Just Info
     severityFor (Namespace _ ["ServerSocketUp"]) _ = Just Info


### PR DESCRIPTION
# Description

Followup on #5402 where I missed these two cases.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
